### PR TITLE
feat: domain-based unsaved suggestion (#3)

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -197,6 +197,61 @@ export function deleteVisit(db, url) {
   db.prepare(`DELETE FROM page_visits WHERE url = ?`).run(url);
 }
 
+/**
+ * Unsaved visits enriched with domain stats and a "miss-bookmark likelihood" score.
+ * The intent is to surface URLs that the user is probably reading but hasn't bookmarked
+ * because the same domain (or path prefix) is already in their library.
+ */
+export function listSuggestedVisits(db, { sinceDays = 30 } = {}) {
+  const visits = db.prepare(`
+    SELECT v.url, v.title, v.first_seen_at, v.last_seen_at, v.visit_count
+    FROM page_visits v
+    LEFT JOIN bookmarks b ON b.url = v.url
+    WHERE b.id IS NULL
+      AND v.last_seen_at >= datetime('now', ?)
+    ORDER BY v.last_seen_at DESC
+  `).all(`-${Number(sinceDays) || 30} days`);
+
+  const bookmarkUrls = db.prepare(`SELECT url FROM bookmarks`).all().map(r => r.url);
+  const domainCounts = new Map();
+  const pathPrefixIndex = new Map();
+  for (const u of bookmarkUrls) {
+    const d = extractDomain(u);
+    if (!d) continue;
+    domainCounts.set(d, (domainCounts.get(d) || 0) + 1);
+    const segs = firstPathSegment(u);
+    if (segs) {
+      if (!pathPrefixIndex.has(d)) pathPrefixIndex.set(d, new Set());
+      pathPrefixIndex.get(d).add(segs);
+    }
+  }
+
+  return visits.map(v => {
+    const domain = extractDomain(v.url);
+    const firstSeg = firstPathSegment(v.url);
+    const sameDomain = domain ? (domainCounts.get(domain) || 0) : 0;
+    const samePrefix = (domain && firstSeg && pathPrefixIndex.get(domain)?.has(firstSeg)) ? 1 : 0;
+    const score = sameDomain * 10 + samePrefix * 8 + Math.min(v.visit_count || 1, 20) * 2;
+    return {
+      ...v,
+      domain,
+      same_domain_bookmarks: sameDomain,
+      same_path_prefix_bookmarks: samePrefix,
+      score,
+    };
+  }).sort((a, b) => b.score - a.score || (a.last_seen_at < b.last_seen_at ? 1 : -1));
+}
+
+function extractDomain(url) {
+  try { return new URL(url).hostname.toLowerCase(); } catch { return null; }
+}
+function firstPathSegment(url) {
+  try {
+    const segs = new URL(url).pathname.split('/').filter(Boolean);
+    return segs[0] || null;
+  } catch { return null; }
+}
+
 export function recordAccess(db, bookmarkId) {
   const tx = db.transaction(() => {
     db.prepare(`INSERT INTO accesses (bookmark_id) VALUES (?)`).run(bookmarkId);

--- a/server/index.js
+++ b/server/index.js
@@ -20,6 +20,7 @@ import {
   insertImportedBookmark,
   upsertVisit,
   listUnsavedVisits,
+  listSuggestedVisits,
   deleteVisit,
 } from './db.js';
 import { summarizeWithClaude } from './claude.js';
@@ -213,6 +214,11 @@ app.post('/api/access', async (c) => {
 app.get('/api/visits/unsaved', (c) => {
   const since = c.req.query('since');
   return c.json({ items: listUnsavedVisits(db, { since }) });
+});
+
+app.get('/api/visits/suggested', (c) => {
+  const days = Number(c.req.query('days')) || 30;
+  return c.json({ items: listSuggestedVisits(db, { sinceDays: days }) });
 });
 
 app.get('/api/visits/unsaved/count', (c) => {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -10,6 +10,7 @@ const state = {
   queue: { items: [], history: [] },
   visits: [],
   visitsSelected: new Set(),
+  visitsRange: '7',
 };
 
 const $ = (id) => document.getElementById(id);
@@ -396,15 +397,25 @@ function switchTab(tab) {
 
 async function loadVisits() {
   try {
-    const { items } = await api('/api/visits/unsaved');
+    let items;
+    if (state.visitsRange === 'today') {
+      ({ items } = await api('/api/visits/unsaved'));
+      // Today endpoint doesn't include score; synthesize zero so render works.
+      items = items.map(i => ({ ...i, domain: hostOf(i.url), same_domain_bookmarks: 0, same_path_prefix_bookmarks: 0, score: 0 }));
+    } else {
+      ({ items } = await api(`/api/visits/suggested?days=${encodeURIComponent(state.visitsRange)}`));
+    }
     state.visits = items;
-    // prune selected for items no longer present
     const urls = new Set(items.map(i => i.url));
     state.visitsSelected = new Set([...state.visitsSelected].filter(u => urls.has(u)));
     renderVisits();
   } catch (e) {
     console.error(e);
   }
+}
+
+function hostOf(url) {
+  try { return new URL(url).hostname; } catch { return ''; }
 }
 
 function renderVisits() {
@@ -429,12 +440,18 @@ function renderVisits() {
   empty.classList.add('hidden');
   list.innerHTML = items.map(v => {
     const sel = state.visitsSelected.has(v.url);
+    const dom = v.domain || hostOf(v.url);
+    const hot = (v.score ?? 0) >= 10;
+    const badge = hot
+      ? `<span class="suggest-badge">同ドメイン保存 ${v.same_domain_bookmarks}</span>`
+      : '';
     return `
-      <li class="${sel ? 'selected' : ''}" data-url="${escapeHtml(v.url)}">
+      <li class="${sel ? 'selected' : ''} ${hot ? 'hot' : ''}" data-url="${escapeHtml(v.url)}">
         <input type="checkbox" class="vchk" ${sel ? 'checked' : ''} />
         <div style="min-width:0">
-          <div class="title">${escapeHtml(v.title || '(タイトル未取得)')}</div>
+          <div class="title">${escapeHtml(v.title || '(タイトル未取得)')} ${badge}</div>
           <div class="url">${escapeHtml(v.url)}</div>
+          <div class="visits-meta">${escapeHtml(dom)}${v.score ? ` · score ${v.score}` : ''}</div>
         </div>
         <div class="when">
           ${fmtDate(v.last_seen_at)}<br>
@@ -509,6 +526,10 @@ document.querySelectorAll('.tab').forEach(t => {
 });
 
 $('visitsRefresh').addEventListener('click', loadVisits);
+$('visitsRange').addEventListener('change', (e) => {
+  state.visitsRange = e.target.value;
+  loadVisits();
+});
 $('visitsBookmark').addEventListener('click', bookmarkSelectedVisits);
 $('visitsDelete').addEventListener('click', deleteSelectedVisits);
 $('visitsAll').addEventListener('click', (e) => {

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -40,7 +40,7 @@
           <span id="tabQueueCount" class="tab-count hidden">0</span>
         </button>
         <button class="tab" data-tab="visits">
-          本日の未保存
+          未保存履歴
           <span id="tabVisitsCount" class="tab-count hidden">0</span>
         </button>
       </nav>
@@ -57,7 +57,14 @@
 
       <div id="visitsView" class="hidden">
         <div class="visits-bar">
-          <span>本日アクセスした URL のうち、まだ保存していないもの。</span>
+          <span>アクセスした URL のうち、まだ保存していないもの。同ドメインで既にブックマークがあるものほど上位。</span>
+          <span class="grow"></span>
+          <select id="visitsRange">
+            <option value="today">今日のみ</option>
+            <option value="7" selected>過去 7 日</option>
+            <option value="30">過去 30 日</option>
+            <option value="90">過去 90 日</option>
+          </select>
           <button id="visitsRefresh" class="ghost">更新</button>
         </div>
         <div class="visits-actions">

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -258,11 +258,31 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 .visits-bar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 8px;
   margin-bottom: 12px;
   color: var(--muted);
   font-size: 13px;
 }
+.visits-bar .grow { flex: 1; }
+.visits-bar select {
+  padding: 4px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+}
+.suggest-badge {
+  display: inline-block;
+  background: #fff5e1;
+  border: 1px solid #f0c97a;
+  color: #8a5a00;
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  margin-left: 6px;
+  vertical-align: middle;
+}
+.visits-list li.hot { border-left: 4px solid #d68a00; }
+.visits-meta { font-size: 11px; color: var(--muted); margin-top: 2px; }
 .visits-actions {
   display: flex;
   gap: 10px;


### PR DESCRIPTION
Closes #3

未保存履歴タブを「保存漏れサジェスト」化。期間切替と同ドメイン保存数によるスコアリングを追加。

## Test plan
- [x] CI: server/extension JS syntax + smoke test
- [ ] UI: visits タブで期間を切り替え、score 高 (同ドメイン既保存) のものが先頭
- [ ] visits-bar から「今日のみ」を選ぶと従来 endpoint にフォールバック