### PR TITLE
feat: trend dashboard (#1)

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -242,6 +242,112 @@ export function listSuggestedVisits(db, { sinceDays = 30 } = {}) {
   }).sort((a, b) => b.score - a.score || (a.last_seen_at < b.last_seen_at ? 1 : -1));
 }
 
+// ── trends -----------------------------------------------------------------
+
+/** Top categories by save count within `sinceDays`. */
+export function trendsCategories(db, { sinceDays = 30, limit = 12 } = {}) {
+  return db.prepare(`
+    SELECT bc.category, COUNT(*) AS count
+    FROM bookmark_categories bc
+    JOIN bookmarks b ON b.id = bc.bookmark_id
+    WHERE b.created_at >= datetime('now', ?)
+    GROUP BY bc.category
+    ORDER BY count DESC
+    LIMIT ?
+  `).all(`-${Number(sinceDays) || 30} days`, Number(limit) || 12);
+}
+
+/**
+ * Compare category counts in the current window with the previous window of
+ * the same length. Returns categories with the largest absolute delta.
+ */
+export function trendsCategoryDiff(db, { sinceDays = 7, limit = 8 } = {}) {
+  const days = Number(sinceDays) || 7;
+  const cur = db.prepare(`
+    SELECT bc.category, COUNT(*) AS n
+    FROM bookmark_categories bc
+    JOIN bookmarks b ON b.id = bc.bookmark_id
+    WHERE b.created_at >= datetime('now', ?)
+    GROUP BY bc.category
+  `).all(`-${days} days`);
+  const prev = db.prepare(`
+    SELECT bc.category, COUNT(*) AS n
+    FROM bookmark_categories bc
+    JOIN bookmarks b ON b.id = bc.bookmark_id
+    WHERE b.created_at < datetime('now', ?)
+      AND b.created_at >= datetime('now', ?)
+    GROUP BY bc.category
+  `).all(`-${days} days`, `-${days * 2} days`);
+  const map = new Map();
+  for (const r of cur) map.set(r.category, { current: r.n, previous: 0 });
+  for (const r of prev) {
+    const cur = map.get(r.category) || { current: 0, previous: 0 };
+    cur.previous = r.n;
+    map.set(r.category, cur);
+  }
+  const rows = [...map.entries()].map(([category, v]) => ({
+    category,
+    current: v.current,
+    previous: v.previous,
+    delta: v.current - v.previous,
+  }));
+  rows.sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta) || b.current - a.current);
+  return rows.slice(0, Number(limit) || 8);
+}
+
+/** Daily save and access counts (per day, local time) in the window. */
+export function trendsTimeline(db, { sinceDays = 30 } = {}) {
+  const days = Number(sinceDays) || 30;
+  const saves = db.prepare(`
+    SELECT date(created_at, 'localtime') AS d, COUNT(*) AS n
+    FROM bookmarks
+    WHERE created_at >= datetime('now', ?)
+    GROUP BY d ORDER BY d ASC
+  `).all(`-${days} days`);
+  const accesses = db.prepare(`
+    SELECT date(accessed_at, 'localtime') AS d, COUNT(*) AS n
+    FROM accesses
+    WHERE accessed_at >= datetime('now', ?)
+    GROUP BY d ORDER BY d ASC
+  `).all(`-${days} days`);
+  // Build per-day series including zero-fill.
+  const out = [];
+  const today = new Date();
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(today.getDate() - i);
+    const key = d.toISOString().slice(0, 10);
+    const local = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    out.push({
+      date: local,
+      saves: saves.find(r => r.d === local)?.n ?? 0,
+      accesses: accesses.find(r => r.d === local)?.n ?? 0,
+    });
+  }
+  return out;
+}
+
+/** Top accessed domains in window. Joins accesses with bookmarks to get URLs. */
+export function trendsDomains(db, { sinceDays = 30, limit = 12 } = {}) {
+  const rows = db.prepare(`
+    SELECT b.url, COUNT(a.id) AS hits
+    FROM accesses a
+    JOIN bookmarks b ON b.id = a.bookmark_id
+    WHERE a.accessed_at >= datetime('now', ?)
+    GROUP BY b.id
+  `).all(`-${Number(sinceDays) || 30} days`);
+  const tally = new Map();
+  for (const r of rows) {
+    const d = extractDomain(r.url);
+    if (!d) continue;
+    tally.set(d, (tally.get(d) ?? 0) + r.hits);
+  }
+  return [...tally.entries()]
+    .map(([domain, hits]) => ({ domain, hits }))
+    .sort((a, b) => b.hits - a.hits)
+    .slice(0, Number(limit) || 12);
+}
+
 function extractDomain(url) {
   try { return new URL(url).hostname.toLowerCase(); } catch { return null; }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -22,6 +22,10 @@ import {
   listUnsavedVisits,
   listSuggestedVisits,
   deleteVisit,
+  trendsCategories,
+  trendsCategoryDiff,
+  trendsTimeline,
+  trendsDomains,
 } from './db.js';
 import { summarizeWithClaude } from './claude.js';
 import { FifoQueue } from './queue.js';
@@ -174,6 +178,28 @@ app.get('/api/bookmarks/:id/html', (c) => {
 app.get('/api/bookmarks/:id/accesses', (c) => {
   const id = Number(c.req.param('id'));
   return c.json({ items: listAccesses(db, id) });
+});
+
+// ---- trends ---------------------------------------------------------------
+
+app.get('/api/trends/categories', (c) => {
+  const days = Number(c.req.query('days')) || 30;
+  return c.json({ items: trendsCategories(db, { sinceDays: days }) });
+});
+
+app.get('/api/trends/category-diff', (c) => {
+  const days = Number(c.req.query('days')) || 7;
+  return c.json({ items: trendsCategoryDiff(db, { sinceDays: days }) });
+});
+
+app.get('/api/trends/timeline', (c) => {
+  const days = Number(c.req.query('days')) || 30;
+  return c.json({ items: trendsTimeline(db, { sinceDays: days }) });
+});
+
+app.get('/api/trends/domains', (c) => {
+  const days = Number(c.req.query('days')) || 30;
+  return c.json({ items: trendsDomains(db, { sinceDays: days }) });
 });
 
 // ---- queue status ---------------------------------------------------------

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -11,6 +11,7 @@ const state = {
   visits: [],
   visitsSelected: new Set(),
   visitsRange: '7',
+  trendsRange: '30',
 };
 
 const $ = (id) => document.getElementById(id);
@@ -391,8 +392,122 @@ function switchTab(tab) {
   $('bookmarksView').classList.toggle('hidden', tab !== 'bookmarks');
   $('queueView').classList.toggle('hidden', tab !== 'queue');
   $('visitsView').classList.toggle('hidden', tab !== 'visits');
+  $('trendsView').classList.toggle('hidden', tab !== 'trends');
   if (tab === 'queue') renderQueue();
   if (tab === 'visits') loadVisits();
+  if (tab === 'trends') loadTrends();
+}
+
+// ── trends ─────────────────────────────────────────────────────────────
+
+async function loadTrends() {
+  const days = state.trendsRange;
+  try {
+    const [cats, diff, timeline, domains] = await Promise.all([
+      api(`/api/trends/categories?days=${encodeURIComponent(days)}`),
+      api(`/api/trends/category-diff?days=7`),
+      api(`/api/trends/timeline?days=${encodeURIComponent(days)}`),
+      api(`/api/trends/domains?days=${encodeURIComponent(days)}`),
+    ]);
+    renderTrendCategories(cats.items);
+    renderTrendDiff(diff.items);
+    renderTrendTimeline(timeline.items);
+    renderTrendDomains(domains.items);
+  } catch (e) {
+    console.error('trends load failed', e);
+  }
+}
+
+function renderTrendCategories(items) {
+  $('trendCategories').innerHTML = svgHorizontalBar(items, c => c.category, c => c.count);
+}
+
+function renderTrendDomains(items) {
+  $('trendDomains').innerHTML = svgHorizontalBar(items, c => c.domain, c => c.hits, 'alt');
+}
+
+function svgHorizontalBar(items, labelFn, valueFn, klass = '') {
+  if (!items.length) return '<div class="queue-empty">データなし</div>';
+  const max = Math.max(...items.map(valueFn), 1);
+  const rowH = 22, padTop = 4, padLeft = 130, padRight = 40, w = 460;
+  const h = padTop * 2 + items.length * rowH;
+  const rows = items.map((it, i) => {
+    const v = valueFn(it);
+    const len = Math.round((v / max) * (w - padLeft - padRight));
+    const y = padTop + i * rowH;
+    const label = String(labelFn(it)).slice(0, 18);
+    return `
+      <text class="label" x="${padLeft - 8}" y="${y + 14}" text-anchor="end">${escapeHtml(label)}</text>
+      <rect class="bar ${klass}" x="${padLeft}" y="${y + 4}" width="${len}" height="14" rx="2" />
+      <text class="label" x="${padLeft + len + 6}" y="${y + 14}">${v}</text>
+    `;
+  }).join('');
+  return `<svg viewBox="0 0 ${w} ${h}" preserveAspectRatio="xMinYMin meet">${rows}</svg>`;
+}
+
+function renderTrendTimeline(items) {
+  if (!items.length) { $('trendTimeline').innerHTML = '<div class="queue-empty">データなし</div>'; return; }
+  const w = 600, h = 200, padL = 32, padR = 12, padT = 12, padB = 24;
+  const innerW = w - padL - padR, innerH = h - padT - padB;
+  const max = Math.max(1, ...items.flatMap(d => [d.saves, d.accesses]));
+  const xStep = innerW / Math.max(1, items.length - 1);
+  function pts(key) {
+    return items.map((d, i) => {
+      const x = padL + i * xStep;
+      const y = padT + innerH - (d[key] / max) * innerH;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    }).join(' ');
+  }
+  function dots(key, klass) {
+    return items.map((d, i) => {
+      const x = padL + i * xStep;
+      const y = padT + innerH - (d[key] / max) * innerH;
+      return `<circle class="${klass}" cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="2.5" />`;
+    }).join('');
+  }
+  // Y axis labels (0, max/2, max)
+  const yLabels = [0, Math.round(max / 2), max].map(v => {
+    const y = padT + innerH - (v / max) * innerH;
+    return `<text class="label" x="${padL - 6}" y="${y + 3}" text-anchor="end">${v}</text>
+            <line class="grid" x1="${padL}" y1="${y}" x2="${padL + innerW}" y2="${y}" />`;
+  }).join('');
+  const xLabelStep = Math.max(1, Math.floor(items.length / 6));
+  const xLabels = items.map((d, i) => {
+    if (i % xLabelStep !== 0 && i !== items.length - 1) return '';
+    const x = padL + i * xStep;
+    const md = d.date.slice(5);
+    return `<text class="label" x="${x.toFixed(1)}" y="${h - 6}" text-anchor="middle">${md}</text>`;
+  }).join('');
+  $('trendTimeline').innerHTML = `
+    <svg viewBox="0 0 ${w} ${h}" preserveAspectRatio="xMinYMin meet">
+      ${yLabels}
+      <polyline class="line-saves" points="${pts('saves')}" />
+      <polyline class="line-accesses" points="${pts('accesses')}" />
+      ${dots('saves', 'dot')}
+      ${dots('accesses', 'dot-alt')}
+      ${xLabels}
+    </svg>
+    <div class="chart-legend">
+      <span><span class="dot saves"></span>新規保存</span>
+      <span><span class="dot accesses"></span>アクセス</span>
+    </div>
+  `;
+}
+
+function renderTrendDiff(items) {
+  if (!items.length) { $('trendDiff').innerHTML = '<li>データなし</li>'; return; }
+  $('trendDiff').innerHTML = items.map(d => {
+    const sign = d.delta > 0 ? '+' : '';
+    const cls = d.delta > 0 ? 'up' : d.delta < 0 ? 'down' : '';
+    const ratio = d.previous > 0 ? `${d.previous}→${d.current}` : `新規 ${d.current}`;
+    return `
+      <li>
+        <span>${escapeHtml(d.category)}</span>
+        <span class="ratio">${ratio}</span>
+        <span class="delta ${cls}">${sign}${d.delta}</span>
+      </li>
+    `;
+  }).join('');
 }
 
 async function loadVisits() {
@@ -529,6 +644,10 @@ $('visitsRefresh').addEventListener('click', loadVisits);
 $('visitsRange').addEventListener('change', (e) => {
   state.visitsRange = e.target.value;
   loadVisits();
+});
+$('trendsRange').addEventListener('change', (e) => {
+  state.trendsRange = e.target.value;
+  loadTrends();
 });
 $('visitsBookmark').addEventListener('click', bookmarkSelectedVisits);
 $('visitsDelete').addEventListener('click', deleteSelectedVisits);

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -43,6 +43,7 @@
           未保存履歴
           <span id="tabVisitsCount" class="tab-count hidden">0</span>
         </button>
+        <button class="tab" data-tab="trends">傾向</button>
       </nav>
 
       <div id="bookmarksView">
@@ -78,6 +79,41 @@
         <ul id="visitsList" class="visits-list"></ul>
         <div id="visitsEmpty" class="queue-empty hidden">本日の未保存履歴はありません。</div>
         <ul id="visitsResults" class="visits-results"></ul>
+      </div>
+
+      <div id="trendsView" class="hidden">
+        <div class="trends-bar">
+          <span>保存・閲覧傾向のサマリ。期間を変えると全カードが更新されます。</span>
+          <span class="grow"></span>
+          <select id="trendsRange">
+            <option value="7">過去 7 日</option>
+            <option value="30" selected>過去 30 日</option>
+            <option value="90">過去 90 日</option>
+            <option value="365">過去 1 年</option>
+          </select>
+        </div>
+
+        <div class="trends-grid">
+          <section class="trend-card">
+            <h3>保存とアクセスの推移</h3>
+            <div id="trendTimeline" class="chart"></div>
+          </section>
+
+          <section class="trend-card">
+            <h3>カテゴリ別 保存数</h3>
+            <div id="trendCategories" class="chart"></div>
+          </section>
+
+          <section class="trend-card">
+            <h3>増えた・減ったカテゴリ (7 日比較)</h3>
+            <ul id="trendDiff" class="trend-diff"></ul>
+          </section>
+
+          <section class="trend-card">
+            <h3>よく訪れているドメイン</h3>
+            <div id="trendDomains" class="chart"></div>
+          </section>
+        </div>
       </div>
 
       <div id="queueView" class="hidden">

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -283,6 +283,85 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 }
 .visits-list li.hot { border-left: 4px solid #d68a00; }
 .visits-meta { font-size: 11px; color: var(--muted); margin-top: 2px; }
+
+.trends-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+  color: var(--muted);
+  font-size: 13px;
+}
+.trends-bar .grow { flex: 1; }
+.trends-bar select {
+  padding: 4px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+}
+.trends-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(420px, 1fr));
+  gap: 12px;
+}
+.trend-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 16px;
+  box-shadow: var(--shadow);
+}
+.trend-card h3 {
+  font-size: 12px;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0 0 12px;
+}
+.chart { width: 100%; min-height: 180px; }
+.chart svg { width: 100%; height: 220px; display: block; }
+.chart svg .axis { stroke: var(--border); stroke-width: 1; }
+.chart svg .grid { stroke: var(--border); stroke-dasharray: 2 3; opacity: 0.5; }
+.chart svg .label { fill: var(--muted); font-size: 10px; }
+.chart svg .bar { fill: var(--accent); }
+.chart svg .bar.alt { fill: #f0a04b; }
+.chart svg .line-saves { stroke: var(--accent); stroke-width: 2; fill: none; }
+.chart svg .line-accesses { stroke: #f0a04b; stroke-width: 2; fill: none; }
+.chart svg .dot { fill: var(--accent); }
+.chart svg .dot-alt { fill: #f0a04b; }
+.chart-legend {
+  display: flex;
+  gap: 16px;
+  font-size: 11px;
+  color: var(--muted);
+  margin-top: 4px;
+}
+.chart-legend .dot {
+  display: inline-block;
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  margin-right: 4px;
+  vertical-align: middle;
+}
+.chart-legend .dot.saves { background: var(--accent); }
+.chart-legend .dot.accesses { background: #f0a04b; }
+.trend-diff {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.trend-diff li {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 12px;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+}
+.trend-diff li:last-child { border-bottom: 0; }
+.trend-diff .delta { font-weight: 600; min-width: 48px; text-align: right; }
+.trend-diff .delta.up { color: #2a8847; }
+.trend-diff .delta.down { color: var(--danger); }
+.trend-diff .ratio { color: var(--muted); font-size: 11px; }
 .visits-actions {
   display: flex;
   gap: 10px;


### PR DESCRIPTION
Closes #1

## Summary
- 期間切替付きの「傾向」タブを追加
- 4 種のチャート: timeline (saves+accesses), top categories, 7-day diff, top domains
- 依存追加なし、SVG 自前描画

## Test plan
- [x] CI: syntax + smoke
- [ ] UI: 傾向タブ → 期間 select で再描画