### PR TITLE
feat: site recommendations (#2)

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -36,6 +36,11 @@ export function openDb(dbPath) {
       accessed_at  TEXT NOT NULL DEFAULT (datetime('now'))
     );
 
+    CREATE TABLE IF NOT EXISTS recommendation_dismissals (
+      url           TEXT PRIMARY KEY,
+      dismissed_at  TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
     CREATE TABLE IF NOT EXISTS page_visits (
       url            TEXT PRIMARY KEY,
       title          TEXT,

--- a/server/index.js
+++ b/server/index.js
@@ -29,6 +29,7 @@ import {
 } from './db.js';
 import { summarizeWithClaude } from './claude.js';
 import { FifoQueue } from './queue.js';
+import { recommendationsFor, dismissRecommendation, clearDismissals } from './recommendations.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PORT = Number(process.env.MEMORIA_PORT ?? 5180);
@@ -200,6 +201,25 @@ app.get('/api/trends/timeline', (c) => {
 app.get('/api/trends/domains', (c) => {
   const days = Number(c.req.query('days')) || 30;
   return c.json({ items: trendsDomains(db, { sinceDays: days }) });
+});
+
+// ---- recommendations ------------------------------------------------------
+
+app.get('/api/recommendations', (c) => {
+  const force = c.req.query('force') === '1';
+  return c.json({ items: recommendationsFor(db, HTML_DIR, { force }) });
+});
+
+app.post('/api/recommendations/dismiss', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  if (!body?.url) return c.json({ error: 'url required' }, 400);
+  dismissRecommendation(db, body.url);
+  return c.json({ ok: true });
+});
+
+app.delete('/api/recommendations/dismissals', (c) => {
+  clearDismissals(db);
+  return c.json({ ok: true });
 });
 
 // ---- queue status ---------------------------------------------------------

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -12,6 +12,7 @@ const state = {
   visitsSelected: new Set(),
   visitsRange: '7',
   trendsRange: '30',
+  recommendations: [],
 };
 
 const $ = (id) => document.getElementById(id);
@@ -393,9 +394,90 @@ function switchTab(tab) {
   $('queueView').classList.toggle('hidden', tab !== 'queue');
   $('visitsView').classList.toggle('hidden', tab !== 'visits');
   $('trendsView').classList.toggle('hidden', tab !== 'trends');
+  $('recommendView').classList.toggle('hidden', tab !== 'recommend');
   if (tab === 'queue') renderQueue();
   if (tab === 'visits') loadVisits();
   if (tab === 'trends') loadTrends();
+  if (tab === 'recommend') loadRecommendations();
+}
+
+async function loadRecommendations(force = false) {
+  try {
+    const url = '/api/recommendations' + (force ? '?force=1' : '');
+    const { items } = await api(url);
+    state.recommendations = items;
+    renderRecommendations();
+  } catch (e) {
+    console.error('rec load failed', e);
+  }
+}
+
+function renderRecommendations() {
+  const items = state.recommendations;
+  const list = $('recList');
+  const empty = $('recEmpty');
+  const badge = $('tabRecommendCount');
+  if (items.length > 0) {
+    badge.classList.remove('hidden');
+    badge.textContent = items.length;
+  } else {
+    badge.classList.add('hidden');
+  }
+  if (items.length === 0) {
+    list.innerHTML = '';
+    empty.classList.remove('hidden');
+    return;
+  }
+  empty.classList.add('hidden');
+  list.innerHTML = items.map(r => {
+    const sources = (r.sources || []).map(s => escapeHtml(s.title)).slice(0, 3).join(' / ');
+    return `
+      <div class="rec-card" data-url="${escapeHtml(r.url)}">
+        <div class="domain">${escapeHtml(r.domain)}<span class="rec-score">${r.source_count} 件の記事から</span></div>
+        <div class="anchor">${escapeHtml(r.anchor || r.url)}</div>
+        <div class="url">${escapeHtml(r.url)}</div>
+        <div class="why">参照元: ${sources}${(r.sources || []).length > 3 ? ' …' : ''}</div>
+        <div class="actions">
+          <button class="rec-save">保存</button>
+          <a class="ghost rec-open" href="${escapeHtml(r.url)}" target="_blank" rel="noreferrer">開く</a>
+          <button class="ghost rec-dismiss">却下</button>
+        </div>
+      </div>
+    `;
+  }).join('');
+  list.querySelectorAll('.rec-card').forEach(card => {
+    const url = card.dataset.url;
+    card.querySelector('.rec-save').addEventListener('click', async () => {
+      card.querySelector('.rec-save').disabled = true;
+      try {
+        await api('/api/visits/bookmark', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ urls: [url] }),
+        });
+        card.remove();
+        state.recommendations = state.recommendations.filter(r => r.url !== url);
+        renderRecommendations();
+        await refreshQueue();
+      } catch (e) {
+        alert(`保存失敗: ${e.message}`);
+      }
+    });
+    card.querySelector('.rec-dismiss').addEventListener('click', async () => {
+      try {
+        await api('/api/recommendations/dismiss', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ url }),
+        });
+        card.remove();
+        state.recommendations = state.recommendations.filter(r => r.url !== url);
+        renderRecommendations();
+      } catch (e) {
+        alert(`却下失敗: ${e.message}`);
+      }
+    });
+  });
 }
 
 // ── trends ─────────────────────────────────────────────────────────────
@@ -649,6 +731,7 @@ $('trendsRange').addEventListener('change', (e) => {
   state.trendsRange = e.target.value;
   loadTrends();
 });
+$('recRefresh').addEventListener('click', () => loadRecommendations(true));
 $('visitsBookmark').addEventListener('click', bookmarkSelectedVisits);
 $('visitsDelete').addEventListener('click', deleteSelectedVisits);
 $('visitsAll').addEventListener('click', (e) => {

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -44,6 +44,10 @@
           <span id="tabVisitsCount" class="tab-count hidden">0</span>
         </button>
         <button class="tab" data-tab="trends">傾向</button>
+        <button class="tab" data-tab="recommend">
+          おすすめ
+          <span id="tabRecommendCount" class="tab-count hidden">0</span>
+        </button>
       </nav>
 
       <div id="bookmarksView">
@@ -114,6 +118,16 @@
             <div id="trendDomains" class="chart"></div>
           </section>
         </div>
+      </div>
+
+      <div id="recommendView" class="hidden">
+        <div class="rec-bar">
+          <span>保存済 HTML から外部リンクを抽出し、未訪問のサイトを推薦。スコアは「同じリンクが何件の保存記事に出現したか」。</span>
+          <span class="grow"></span>
+          <button id="recRefresh" class="ghost">再計算</button>
+        </div>
+        <div id="recList" class="rec-list"></div>
+        <div id="recEmpty" class="queue-empty hidden">推薦できる未訪問リンクがありません。保存記事を増やすと候補が出ます。</div>
       </div>
 
       <div id="queueView" class="hidden">

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -362,6 +362,56 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 .trend-diff .delta.up { color: #2a8847; }
 .trend-diff .delta.down { color: var(--danger); }
 .trend-diff .ratio { color: var(--muted); font-size: 11px; }
+
+.rec-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+  color: var(--muted);
+  font-size: 13px;
+}
+.rec-bar .grow { flex: 1; }
+.rec-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+  gap: 12px;
+}
+.rec-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  box-shadow: var(--shadow);
+}
+.rec-card .domain { font-size: 11px; color: var(--accent); font-weight: 600; }
+.rec-card .anchor { font-weight: 600; line-height: 1.3; word-break: break-all; }
+.rec-card .url { font-size: 11px; color: var(--muted); word-break: break-all; }
+.rec-card .why {
+  font-size: 11px;
+  color: var(--muted);
+  background: var(--accent-bg);
+  border-radius: 4px;
+  padding: 4px 8px;
+}
+.rec-card .actions {
+  display: flex;
+  gap: 6px;
+  margin-top: auto;
+}
+.rec-card .actions button { padding: 6px 10px; font-size: 12px; }
+.rec-score {
+  display: inline-block;
+  background: var(--accent-bg);
+  color: var(--accent);
+  border-radius: 999px;
+  padding: 1px 8px;
+  font-size: 11px;
+  margin-left: 6px;
+}
 .visits-actions {
   display: flex;
   gap: 10px;

--- a/server/recommendations.js
+++ b/server/recommendations.js
@@ -1,0 +1,126 @@
+// Site recommendations: extract outbound links from saved HTML pages, drop
+// anything already saved/visited/dismissed, score by how many of the user's
+// pages link to a given URL.
+//
+// Result is cached in memory for `CACHE_TTL_MS` to avoid re-walking 100s of
+// HTML files on every refresh. Dismissals invalidate the cache.
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parse as parseHtml } from 'node-html-parser';
+
+const CACHE_TTL_MS = 30 * 60 * 1000;
+const MAX_SOURCE_DOCS = 250;
+const MAX_RESULTS = 100;
+const PER_DOC_LINK_CAP = 80; // an article with 5000 links is almost always a navigation page
+
+let cache = { computedAt: 0, dismissalSig: '', items: [] };
+
+export function recommendationsFor(db, htmlDir, { force = false } = {}) {
+  const dismissed = db.prepare(`SELECT url FROM recommendation_dismissals`).all().map(r => r.url);
+  const sig = String(dismissed.length) + '|' + (dismissed[0] ?? '') + '|' + (dismissed.at(-1) ?? '');
+  if (!force
+      && cache.computedAt
+      && Date.now() - cache.computedAt < CACHE_TTL_MS
+      && cache.dismissalSig === sig) {
+    return cache.items;
+  }
+  const items = compute(db, htmlDir, new Set(dismissed));
+  cache = { computedAt: Date.now(), dismissalSig: sig, items };
+  return items;
+}
+
+export function dismissRecommendation(db, url) {
+  db.prepare(`INSERT OR IGNORE INTO recommendation_dismissals (url) VALUES (?)`).run(url);
+  cache = { computedAt: 0, dismissalSig: '', items: [] };
+}
+
+export function clearDismissals(db) {
+  db.prepare(`DELETE FROM recommendation_dismissals`).run();
+  cache = { computedAt: 0, dismissalSig: '', items: [] };
+}
+
+function compute(db, htmlDir, dismissed) {
+  const sources = db.prepare(`
+    SELECT id, url, title, html_path, created_at FROM bookmarks
+    ORDER BY created_at DESC
+    LIMIT ?
+  `).all(MAX_SOURCE_DOCS);
+  const savedUrls = new Set(db.prepare(`SELECT url FROM bookmarks`).all().map(r => r.url));
+  const visitedUrls = new Set(db.prepare(`SELECT url FROM page_visits`).all().map(r => r.url));
+
+  const linkStats = new Map(); // url -> { count, sources: Map<bookmarkId, {title}>, anchor }
+
+  for (const b of sources) {
+    let html;
+    try { html = readFileSync(join(htmlDir, b.html_path), 'utf8'); } catch { continue; }
+
+    const root = parseHtml(html, { lowerCaseTagName: false });
+    const anchors = root.querySelectorAll('a[href]');
+    if (!anchors || anchors.length === 0) continue;
+
+    const seen = new Set();
+    let added = 0;
+    for (const a of anchors) {
+      if (added >= PER_DOC_LINK_CAP) break;
+      const href = a.getAttribute('href');
+      if (!href) continue;
+      let abs;
+      try { abs = stripFragmentAndQuery(new URL(href, b.url).href); } catch { continue; }
+      if (!/^https?:\/\//.test(abs)) continue;
+      if (sameDomain(abs, b.url)) continue;
+      if (savedUrls.has(abs) || visitedUrls.has(abs) || dismissed.has(abs)) continue;
+      if (seen.has(abs)) continue;
+      seen.add(abs);
+
+      let stat = linkStats.get(abs);
+      if (!stat) {
+        stat = { count: 0, sources: new Map(), anchor: '' };
+        linkStats.set(abs, stat);
+      }
+      stat.count++;
+      if (!stat.sources.has(b.id)) {
+        stat.sources.set(b.id, { id: b.id, title: b.title });
+      }
+      if (!stat.anchor) stat.anchor = (a.text || '').trim().replace(/\s+/g, ' ').slice(0, 200);
+      added++;
+    }
+  }
+
+  return [...linkStats.entries()]
+    .map(([url, s]) => ({
+      url,
+      domain: domainOf(url),
+      count: s.count,
+      source_count: s.sources.size,
+      anchor: s.anchor,
+      sources: [...s.sources.values()].slice(0, 5),
+    }))
+    .filter(r => r.source_count >= 2 || r.count >= 3)
+    .sort((a, b) => b.source_count - a.source_count || b.count - a.count)
+    .slice(0, MAX_RESULTS);
+}
+
+function stripFragmentAndQuery(url) {
+  try {
+    const u = new URL(url);
+    u.hash = '';
+    // Drop tracking-style query strings while keeping legitimate ones short.
+    const params = [...u.searchParams.entries()].filter(([k]) => !/^utm_|fbclid|gclid|ref|source/i.test(k));
+    u.search = '';
+    if (params.length > 0) {
+      const sp = new URLSearchParams(params);
+      u.search = '?' + sp.toString();
+    }
+    return u.href;
+  } catch { return url; }
+}
+
+function domainOf(url) {
+  try { return new URL(url).hostname.toLowerCase(); } catch { return ''; }
+}
+function sameDomain(a, b) {
+  const da = domainOf(a), db_ = domainOf(b);
+  if (!da || !db_) return false;
+  return da === db_ || da.endsWith('.' + db_) || db_.endsWith('.' + da);
+}


### PR DESCRIPTION
Closes #2

## Summary
- 保存済 HTML から外部リンクを抽出し、未訪問サイトを推薦する「おすすめ」タブ
- 出現件数 + ソース記事数でスコアリング
- 30 分メモリキャッシュ、再計算ボタンで明示更新
- 却下した URL は recommendation_dismissals に記録して以降除外

## Test plan
- [x] CI: syntax + smoke
- [ ] 手動: 既存 250 ブックマークから候補が出るか