### PR TITLE
feat: "ディグる" deep research tab (#4)

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -36,6 +36,18 @@ export function openDb(dbPath) {
       accessed_at  TEXT NOT NULL DEFAULT (datetime('now'))
     );
 
+    CREATE TABLE IF NOT EXISTS dig_sessions (
+      id            INTEGER PRIMARY KEY AUTOINCREMENT,
+      query         TEXT NOT NULL,
+      created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+      status        TEXT NOT NULL DEFAULT 'pending',
+      error         TEXT,
+      result_json   TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_dig_sessions_created
+      ON dig_sessions(created_at DESC);
+
     CREATE TABLE IF NOT EXISTS recommendation_dismissals (
       url           TEXT PRIMARY KEY,
       dismissed_at  TEXT NOT NULL DEFAULT (datetime('now'))
@@ -257,6 +269,37 @@ export function listSuggestedVisits(db, { sinceDays = 30 } = {}) {
     };
   }).sort((a, b) => b.score - a.score || (a.last_seen_at < b.last_seen_at ? 1 : -1));
 }
+
+// ── dig sessions ----------------------------------------------------------
+
+export function insertDigSession(db, query) {
+  return db.prepare(`INSERT INTO dig_sessions (query) VALUES (?)`).run(query).lastInsertRowid;
+}
+
+export function setDigResult(db, id, { status, result, error }) {
+  db.prepare(`
+    UPDATE dig_sessions SET status = ?, result_json = ?, error = ?
+    WHERE id = ?
+  `).run(status, result ? JSON.stringify(result) : null, error ?? null, id);
+}
+
+export function getDigSession(db, id) {
+  const row = db.prepare(`SELECT * FROM dig_sessions WHERE id = ?`).get(id);
+  if (!row) return null;
+  return {
+    ...row,
+    result: row.result_json ? safeParse(row.result_json) : null,
+  };
+}
+
+export function listDigSessions(db, limit = 30) {
+  return db.prepare(`
+    SELECT id, query, status, created_at FROM dig_sessions
+    ORDER BY id DESC LIMIT ?
+  `).all(limit);
+}
+
+function safeParse(s) { try { return JSON.parse(s); } catch { return null; } }
 
 // ── chunks / embeddings ----------------------------------------------------
 

--- a/server/dig.js
+++ b/server/dig.js
@@ -1,0 +1,85 @@
+// Dig (deep research) — drive the claude CLI with WebSearch + WebFetch tools
+// allowed, ask it to return a JSON list of sources for a topic.
+//
+// We do NOT depend on a particular search engine API; the heavy lifting is
+// claude's, and the prompt asks for JSON-only output that we then parse.
+
+import { spawn } from 'node:child_process';
+
+const PROMPT_TEMPLATE = (query) => [
+  'You are a research agent. Use Web search and fetching to gather authoritative sources for the topic the user provides.',
+  'Return STRICTLY one JSON object and nothing else (no prose, no code fences):',
+  '',
+  '{',
+  '  "query": "<the original query>",',
+  '  "summary": "1〜3 段落で領域を概観 (日本語)",',
+  '  "sources": [',
+  '    {',
+  '      "url": "https://...",',
+  '      "title": "...",',
+  '      "snippet": "1〜2 文で、なぜこのソースが関連するか",',
+  '      "topics": ["keyword1", "keyword2", "keyword3"]',
+  '    }',
+  '  ]',
+  '}',
+  '',
+  '- 8〜12 件のソースを返す。',
+  '- ドメインや視点が偏らないよう多様性を意識する。',
+  '- 各ソースの topics は 2〜4 個。後でグラフ化に使う。',
+  '- 重複 URL や無関係な広告ページは除外。',
+  '',
+  `QUERY: ${query}`,
+].join('\n');
+
+export async function runDig({ query, claudeBin = 'claude', timeoutMs = 600_000 }) {
+  const prompt = PROMPT_TEMPLATE(query);
+  const stdout = await spawnClaude(claudeBin, prompt, timeoutMs);
+  return parseJsonStrict(stdout);
+}
+
+function spawnClaude(bin, prompt, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      bin,
+      ['-p', prompt, '--allowedTools', 'WebSearch,WebFetch'],
+      { stdio: ['ignore', 'pipe', 'pipe'], shell: false },
+    );
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`claude CLI timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    child.stdout.on('data', d => { stdout += d.toString('utf8'); });
+    child.stderr.on('data', d => { stderr += d.toString('utf8'); });
+    child.on('error', err => { clearTimeout(timer); reject(err); });
+    child.on('close', code => {
+      clearTimeout(timer);
+      if (code !== 0) reject(new Error(`claude exited ${code}: ${stderr.slice(0, 400)}`));
+      else resolve(stdout);
+    });
+  });
+}
+
+function parseJsonStrict(raw) {
+  let text = raw.trim();
+  const fence = text.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/);
+  if (fence) text = fence[1].trim();
+  const first = text.indexOf('{');
+  const last = text.lastIndexOf('}');
+  if (first >= 0 && last > first) text = text.slice(first, last + 1);
+  let obj;
+  try { obj = JSON.parse(text); }
+  catch (e) { throw new Error(`Failed to parse claude output as JSON: ${e.message}\nRaw: ${raw.slice(0, 400)}`); }
+  if (!Array.isArray(obj.sources)) throw new Error('claude output missing sources[]');
+  return {
+    query: String(obj.query ?? ''),
+    summary: String(obj.summary ?? '').trim(),
+    sources: obj.sources.map((s, i) => ({
+      url: String(s.url ?? '').trim(),
+      title: String(s.title ?? '').trim() || `source-${i + 1}`,
+      snippet: String(s.snippet ?? '').trim(),
+      topics: Array.isArray(s.topics) ? s.topics.map(t => String(t).trim()).filter(Boolean).slice(0, 6) : [],
+    })).filter(s => /^https?:\/\//.test(s.url)),
+  };
+}

--- a/server/index.js
+++ b/server/index.js
@@ -30,9 +30,11 @@ import {
 import { summarizeWithClaude, htmlToText } from './claude.js';
 import { FifoQueue } from './queue.js';
 import { recommendationsFor, dismissRecommendation, clearDismissals } from './recommendations.js';
+import { runDig } from './dig.js';
 import { embed, chunkText, cosine, vecToBuffer, bufferToVec, getModelName } from './embeddings.js';
 import {
   deleteChunks, insertChunk, listChunkRows, bookmarksMissingEmbeddings, chunkStats,
+  insertDigSession, setDigResult, getDigSession, listDigSessions,
 } from './db.js';
 import { spawn } from 'node:child_process';
 
@@ -416,6 +418,48 @@ function claudeAnswer(prompt, timeoutMs = 180_000) {
   });
 }
 
+// ---- dig (deep research) -------------------------------------------------
+
+const digQueue = new FifoQueue();
+
+function enqueueDig(id, query) {
+  digQueue.enqueue(async () => {
+    try {
+      const result = await runDig({ query, claudeBin: CLAUDE_BIN });
+      setDigResult(db, id, { status: 'done', result });
+    } catch (e) {
+      setDigResult(db, id, { status: 'error', error: e.message.slice(0, 500) });
+      throw e;
+    }
+  }, { kind: 'dig', sessionId: id, title: query });
+}
+
+app.post('/api/dig', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const query = body?.query;
+  if (!query || typeof query !== 'string') return c.json({ error: 'query required' }, 400);
+  const id = insertDigSession(db, query);
+  enqueueDig(id, query);
+  return c.json({ id, queued: true });
+});
+
+app.get('/api/dig', (c) => {
+  return c.json({ items: listDigSessions(db) });
+});
+
+app.get('/api/dig/:id', (c) => {
+  const id = Number(c.req.param('id'));
+  const s = getDigSession(db, id);
+  if (!s) return c.json({ error: 'not found' }, 404);
+  return c.json(s);
+});
+
+app.post('/api/dig/:id/save', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  if (!body || !Array.isArray(body.urls)) return c.json({ error: 'urls[] required' }, 400);
+  return c.json({ results: await bulkSaveUrls(body.urls) });
+});
+
 // ---- queue status ---------------------------------------------------------
 
 app.get('/api/queue', (c) => {
@@ -489,19 +533,15 @@ app.delete('/api/visits', async (c) => {
   return c.json({ ok: true, removed: body.urls.length });
 });
 
-app.post('/api/visits/bookmark', async (c) => {
-  const body = await c.req.json().catch(() => null);
-  if (!body || !Array.isArray(body.urls)) return c.json({ error: 'urls[] required' }, 400);
-
+async function bulkSaveUrls(urls) {
   const results = [];
-  for (const url of body.urls) {
+  for (const url of urls) {
     if (typeof url !== 'string' || !/^https?:\/\//.test(url)) {
       results.push({ url, status: 'skipped', error: 'invalid url' });
       continue;
     }
     const existing = findBookmarkByUrl(db, url);
     if (existing) {
-      // Already bookmarked → just clean up the visit row.
       deleteVisit(db, url);
       results.push({ url, status: 'duplicate', id: existing.id });
       continue;
@@ -518,14 +558,19 @@ app.post('/api/visits/bookmark', async (c) => {
       const id = insertBookmark(db, { url, title, htmlPath: safe });
       recordAccess(db, id);
       enqueueSummary(id);
-      // Visit row no longer needed once bookmarked.
       deleteVisit(db, url);
       results.push({ url, status: 'queued', id });
     } catch (e) {
       results.push({ url, status: 'error', error: e.message });
     }
   }
-  return c.json({ results });
+  return results;
+}
+
+app.post('/api/visits/bookmark', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  if (!body || !Array.isArray(body.urls)) return c.json({ error: 'urls[] required' }, 400);
+  return c.json({ results: await bulkSaveUrls(body.urls) });
 });
 
 async function fetchPageHtml(url, timeoutMs = 30_000) {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -16,6 +16,10 @@ const state = {
   ragStatus: null,
   ragResults: [],
   ragAnswer: null,
+  digSession: null,
+  digHistory: [],
+  digSelected: new Set(),
+  digPolling: null,
 };
 
 const $ = (id) => document.getElementById(id);
@@ -399,11 +403,195 @@ function switchTab(tab) {
   $('trendsView').classList.toggle('hidden', tab !== 'trends');
   $('recommendView').classList.toggle('hidden', tab !== 'recommend');
   $('ragView').classList.toggle('hidden', tab !== 'rag');
+  $('digView').classList.toggle('hidden', tab !== 'dig');
   if (tab === 'queue') renderQueue();
   if (tab === 'visits') loadVisits();
   if (tab === 'trends') loadTrends();
   if (tab === 'recommend') loadRecommendations();
   if (tab === 'rag') loadRagStatus();
+  if (tab === 'dig') loadDigHistory();
+}
+
+// ── Dig (deep research) ──────────────────────────────────────────────────
+
+async function loadDigHistory() {
+  try {
+    const { items } = await api('/api/dig');
+    state.digHistory = items;
+    renderDigHistory();
+  } catch (e) { console.error(e); }
+}
+
+function renderDigHistory() {
+  const el = $('digHistory');
+  if (!state.digHistory.length) {
+    el.innerHTML = '<span style="color:var(--muted);font-size:11px">過去のディグなし</span>';
+    return;
+  }
+  el.innerHTML = state.digHistory.map(s =>
+    `<span class="pill ${s.status}" data-id="${s.id}" title="${escapeHtml(s.created_at)}">
+      ${escapeHtml(s.query.slice(0, 30))}${s.query.length > 30 ? '…' : ''}
+    </span>`
+  ).join('');
+  el.querySelectorAll('.pill').forEach(p => {
+    p.addEventListener('click', () => loadDigSession(Number(p.dataset.id)));
+  });
+}
+
+async function startDig() {
+  const q = $('digQuery').value.trim();
+  if (!q) return;
+  $('digRun').disabled = true;
+  $('digRun').textContent = '掘削中…';
+  try {
+    const r = await api('/api/dig', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: q }),
+    });
+    await loadDigHistory();
+    pollDigSession(r.id);
+  } catch (e) {
+    alert(`dig 失敗: ${e.message}`);
+  } finally {
+    $('digRun').disabled = false;
+    $('digRun').textContent = 'ディグる';
+  }
+}
+
+function pollDigSession(id) {
+  if (state.digPolling) clearInterval(state.digPolling);
+  loadDigSession(id);
+  state.digPolling = setInterval(async () => {
+    const s = await api(`/api/dig/${id}`).catch(() => null);
+    if (!s) return;
+    if (s.status !== 'pending') {
+      clearInterval(state.digPolling);
+      state.digPolling = null;
+      state.digSession = s;
+      renderDigSession();
+      loadDigHistory();
+    }
+  }, 5000);
+}
+
+async function loadDigSession(id) {
+  try {
+    const s = await api(`/api/dig/${id}`);
+    state.digSession = s;
+    state.digSelected = new Set();
+    renderDigSession();
+    if (s.status === 'pending') pollDigSession(id);
+  } catch (e) { console.error(e); }
+}
+
+function renderDigSession() {
+  const s = state.digSession;
+  const el = $('digResult');
+  if (!s) { el.innerHTML = ''; return; }
+  if (s.status === 'pending') {
+    el.innerHTML = `<div class="dig-pending"><div class="pulse"></div>「${escapeHtml(s.query)}」を掘っています…claude が Web 検索 + 取得を行うため数十秒〜数分かかります。</div>`;
+    return;
+  }
+  if (s.status === 'error') {
+    el.innerHTML = `<div class="dig-pending" style="border-color:var(--danger);color:var(--danger)">エラー: ${escapeHtml(s.error || '不明')}</div>`;
+    return;
+  }
+  const r = s.result || {};
+  const sources = r.sources || [];
+  const summaryBlock = r.summary
+    ? `<div class="summary">${escapeHtml(r.summary)}</div>`
+    : '';
+  const graph = sources.length > 0 ? digGraph(s.query, sources) : '';
+  const sourceCards = sources.map((src, i) => {
+    const sel = state.digSelected.has(src.url);
+    const topics = (src.topics || []).map(t => `<span class="topic">${escapeHtml(t)}</span>`).join('');
+    return `
+      <div class="dig-source ${sel ? 'selected' : ''}" data-url="${escapeHtml(src.url)}" data-i="${i}">
+        <div class="top-line">
+          <input type="checkbox" class="dig-chk" ${sel ? 'checked' : ''} />
+          <div class="title">${escapeHtml(src.title)}</div>
+        </div>
+        <div class="url"><a href="${escapeHtml(src.url)}" target="_blank" rel="noreferrer">${escapeHtml(src.url)}</a></div>
+        <div class="snippet">${escapeHtml(src.snippet)}</div>
+        <div class="topics">${topics}</div>
+      </div>
+    `;
+  }).join('');
+  el.innerHTML = `
+    ${summaryBlock}
+    ${graph}
+    <div class="dig-actions">
+      <span id="digSelCount">0</span> 件選択中
+      <span class="grow"></span>
+      <button id="digSaveBtn">選択をブックマーク化</button>
+    </div>
+    <div class="dig-sources">${sourceCards}</div>
+  `;
+  el.querySelectorAll('.dig-source').forEach(card => {
+    const url = card.dataset.url;
+    card.addEventListener('click', (e) => {
+      if (e.target.tagName === 'A') return;
+      if (e.target.tagName !== 'INPUT') {
+        const cb = card.querySelector('.dig-chk');
+        cb.checked = !cb.checked;
+      }
+      const sel = card.querySelector('.dig-chk').checked;
+      if (sel) state.digSelected.add(url); else state.digSelected.delete(url);
+      card.classList.toggle('selected', sel);
+      $('digSelCount').textContent = state.digSelected.size;
+    });
+  });
+  $('digSaveBtn')?.addEventListener('click', async () => {
+    const urls = [...state.digSelected];
+    if (!urls.length) return;
+    $('digSaveBtn').disabled = true;
+    try {
+      const r = await api(`/api/dig/${s.id}/save`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ urls }),
+      });
+      const ok = r.results.filter(x => x.status === 'queued').length;
+      alert(`${ok} 件をブックマーク化しました (キュー投入)。`);
+      state.digSelected.clear();
+      renderDigSession();
+      await refreshQueue();
+    } finally {
+      const btn = $('digSaveBtn');
+      if (btn) btn.disabled = false;
+    }
+  });
+}
+
+function digGraph(query, sources) {
+  const w = 700, h = 360, cx = w / 2, cy = h / 2, r = 130;
+  const center = { x: cx, y: cy, label: query.slice(0, 24), klass: 'center', size: 10 };
+  const nodes = sources.map((s, i) => {
+    const a = (i / sources.length) * Math.PI * 2 - Math.PI / 2;
+    return {
+      x: cx + Math.cos(a) * r,
+      y: cy + Math.sin(a) * r,
+      label: shortDomain(s.url),
+      klass: '',
+      size: 6,
+    };
+  });
+  const edges = nodes.map(n =>
+    `<line class="edge" x1="${cx}" y1="${cy}" x2="${n.x.toFixed(1)}" y2="${n.y.toFixed(1)}" />`
+  ).join('');
+  const dots = [center, ...nodes].map(n =>
+    `<circle class="node ${n.klass}" cx="${n.x}" cy="${n.y}" r="${n.size}" />`
+  ).join('');
+  const labels = [center, ...nodes].map(n => {
+    const dy = n === center ? -16 : (n.y < cy ? -10 : 18);
+    return `<text class="node-label" x="${n.x}" y="${n.y + dy}" text-anchor="middle">${escapeHtml(n.label)}</text>`;
+  }).join('');
+  return `<div class="dig-graph"><svg viewBox="0 0 ${w} ${h}" preserveAspectRatio="xMidYMid meet">${edges}${dots}${labels}</svg></div>`;
+}
+
+function shortDomain(url) {
+  try { return new URL(url).hostname.replace(/^www\./, ''); } catch { return url.slice(0, 20); }
 }
 
 // ── RAG ────────────────────────────────────────────────────────────────
@@ -841,6 +1029,10 @@ $('trendsRange').addEventListener('change', (e) => {
   loadTrends();
 });
 $('recRefresh').addEventListener('click', () => loadRecommendations(true));
+$('digRun').addEventListener('click', startDig);
+$('digQuery').addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') { e.preventDefault(); startDig(); }
+});
 $('ragSearchBtn').addEventListener('click', ragSearch);
 $('ragAskBtn').addEventListener('click', ragAsk);
 $('ragQuery').addEventListener('keydown', (e) => {

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -49,6 +49,7 @@
           <span id="tabRecommendCount" class="tab-count hidden">0</span>
         </button>
         <button class="tab" data-tab="rag">RAG</button>
+        <button class="tab" data-tab="dig">ディグる</button>
       </nav>
 
       <div id="bookmarksView">
@@ -119,6 +120,15 @@
             <div id="trendDomains" class="chart"></div>
           </section>
         </div>
+      </div>
+
+      <div id="digView" class="hidden">
+        <div class="dig-input">
+          <input id="digQuery" type="text" placeholder="掘りたい単語または質問を入力 (例: WebGPU compute shader readback)" />
+          <button id="digRun">ディグる</button>
+        </div>
+        <div id="digHistory" class="dig-history"></div>
+        <div id="digResult" class="dig-result"></div>
       </div>
 
       <div id="ragView" class="hidden">

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -508,6 +508,99 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   color: var(--accent);
   white-space: nowrap;
 }
+
+.dig-input {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.dig-input input {
+  flex: 1;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 14px;
+}
+.dig-input button { padding: 12px 20px; font-size: 14px; }
+.dig-history {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+.dig-history .pill {
+  background: var(--accent-bg);
+  color: var(--accent);
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+.dig-history .pill:hover { border-color: var(--accent); }
+.dig-history .pill.pending { background: #fff5e1; color: #8a5a00; }
+.dig-history .pill.error { background: #fae6e6; color: var(--danger); }
+.dig-result .summary {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 16px;
+  white-space: pre-wrap;
+  margin-bottom: 12px;
+  line-height: 1.6;
+  font-size: 13px;
+}
+.dig-graph {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-bottom: 12px;
+  padding: 8px;
+}
+.dig-graph svg { width: 100%; height: 360px; display: block; }
+.dig-graph .edge { stroke: #c5cad4; stroke-width: 1; }
+.dig-graph .node { fill: var(--accent); }
+.dig-graph .node.center { fill: #1f56c0; }
+.dig-graph .node-label { fill: var(--text); font-size: 11px; pointer-events: none; }
+.dig-sources { display: grid; grid-template-columns: repeat(auto-fill, minmax(360px, 1fr)); gap: 12px; }
+.dig-source {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.dig-source.selected { border-color: var(--accent); background: var(--accent-bg); }
+.dig-source .top-line { display: flex; justify-content: space-between; align-items: flex-start; gap: 8px; }
+.dig-source .title { font-weight: 600; line-height: 1.3; word-break: break-all; flex: 1; }
+.dig-source .url { font-size: 11px; color: var(--muted); word-break: break-all; }
+.dig-source .snippet { font-size: 12px; color: #2c3344; line-height: 1.5; }
+.dig-source .topics { display: flex; gap: 4px; flex-wrap: wrap; }
+.dig-source .topic {
+  background: var(--bg);
+  color: var(--muted);
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 999px;
+}
+.dig-actions { display: flex; gap: 8px; margin-top: 12px; align-items: center; }
+.dig-actions .grow { flex: 1; }
+.dig-pending {
+  background: var(--panel);
+  border: 1px solid var(--accent);
+  border-radius: 8px;
+  padding: 16px;
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.dig-pending .pulse {
+  width: 12px; height: 12px; border-radius: 50%; background: var(--accent);
+  animation: pulse 1.4s ease-in-out infinite;
+}
 .visits-actions {
   display: flex;
   gap: 10px;


### PR DESCRIPTION
Closes #4

## Summary
- claude CLI を WebSearch+WebFetch 許可で起動して 8〜12 件のソース JSON を取得
- dig_sessions テーブルで履歴保持、キュー経由で実行
- UI: 入力欄 + 履歴 pill + 結果サマリ + 放射状グラフ + ソースカード (チェック → /api/dig/:id/save でブックマーク化)
- bulkSaveUrls() を抽出して /api/visits/bookmark と共有

## Test plan
- [x] CI: syntax + smoke
- [ ] 手動: ディグるタブで適当なクエリ → ソース返却を確認
- [ ] 選択して保存 → 通常のブックマークとして登録され要約キューに入る