### PR TITLE
feat: online sharing mode + Cernere JWT auth + NG filter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,31 @@
 # MEMORIA_RAG=1
 
 # ─────────────────────────────────────────────────────────────────────────
+# Mode (local / online)
+# ─────────────────────────────────────────────────────────────────────────
+
+# local (既定): 単一ユーザー、認証なし、全エンドポイント解放、訪問履歴あり
+# online      : 多ユーザー、Authorization: Bearer <JWT> 必須、/api/visits/* は 403、
+#               /api/access はノーオペ、ブックマークは user_id でスコープ
+# MEMORIA_MODE=local
+
+# online モード時の JWT (HS256) 検証用シークレット。
+# 本番では Cernere `@ludiars/cernere-service-adapter` の SERVICE_JWT_SECRET と同じ値を使う。
+# MEMORIA_JWT_SECRET=change-me-very-long-random-string
+
+# ─────────────────────────────────────────────────────────────────────────
+# Content filter (NG / R18)
+# ─────────────────────────────────────────────────────────────────────────
+
+# NG ワード/ドメインの追加リスト (既定値はソース内、外部ファイルでマージ可)
+# 1 行 1 語 (# でコメント) または JSON 配列。
+# MEMORIA_NGWORDS_FILE=./ngwords.txt
+# MEMORIA_NG_DOMAINS_FILE=./ngdomains.txt
+
+# 0 にすると NG フィルタを完全に無効化。
+# MEMORIA_CONTENT_FILTER=1
+
+# ─────────────────────────────────────────────────────────────────────────
 # MCP server (mcp-server/)
 # ─────────────────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ CLAUDE_CODE_GIT_BASH_PATH=C:\Program Files\Git\bin\bash.exe
 | `MEMORIA_CLAUDE_BIN` | `claude` | claude CLI のパス |
 | `CLAUDE_CODE_GIT_BASH_PATH` | (未設定) | Windows 用、bash.exe の絶対パス |
 | `MEMORIA_RAG` | `1` | RAG (意味検索 + Q&A) の有効/無効。`0` で完全に無効化 |
+| `MEMORIA_MODE` | `local` | `local` / `online`。`online` は JWT 認証必須、訪問履歴系を全停止 |
+| `MEMORIA_JWT_SECRET` | (未設定) | `online` 時の JWT (HS256) 検証鍵。Cernere の SERVICE_JWT_SECRET と同期 |
+| `MEMORIA_CONTENT_FILTER` | `1` | NG/R18 ワードフィルタ。`0` で無効化 |
+| `MEMORIA_NGWORDS_FILE` | (未設定) | NG ワード追加リストのパス (1 行 1 語 / JSON 配列) |
+| `MEMORIA_NG_DOMAINS_FILE` | (未設定) | NG ドメイン追加リストのパス |
 
 例:
 
@@ -284,6 +289,23 @@ Claude Code は `~/.claude/mcp.json` (プロジェクト固有なら `.claude/mc
 | `recent_bookmarks` | 最新の保存 |
 
 `memoria://bookmark/<id>` リソースで個別ブックマークの Markdown 表現も取得できます。
+
+## 動作モード
+
+### local (既定)
+単一ユーザー、認証なし、すべてのエンドポイント解放、URL アクセスを `page_visits` に蓄積。Chrome 拡張のオプションで「URL をトラッキングしない」をオンにすると `/api/access` の送信を停止できます。
+
+### online
+オンライン共有想定。`MEMORIA_MODE=online` + `MEMORIA_JWT_SECRET` を設定して起動。
+
+- すべての `/api/*` で `Authorization: Bearer <JWT>` 必須 (HS256)
+- 訪問履歴 (`/api/visits/*`) は 403 で完全停止、`/api/access` は no-op
+- ブックマークは JWT の `sub` (user_id) でスコープ
+- Cernere 統合: 本番では [`@ludiars/cernere-service-adapter`](https://github.com/LUDIARS/Cernere/tree/main/packages/service-adapter) を別プロセスで起動し、Cernere admission flow → Memoria JWT 発行 → Memoria 側は受け取った JWT を `MEMORIA_JWT_SECRET` で検証する構成
+- 開発用 token: `cd server && npm run issue-token alice` で `sub=alice` の JWT を発行
+
+### コンテンツフィルタ
+NG / R18 ワードがブックマークの URL / タイトル / 本文に含まれる場合、422 で保存を拒否します。`MEMORIA_NGWORDS_FILE` / `MEMORIA_NG_DOMAINS_FILE` で追加可能。
 
 ## ロードマップ
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -13,6 +13,18 @@ async function getServer() {
   return (server || DEFAULT_SERVER).replace(/\/+$/, '');
 }
 
+async function getAuthHeaders() {
+  const { authToken } = await chrome.storage.sync.get({ authToken: '' });
+  const h = { 'Content-Type': 'application/json' };
+  if (authToken) h['Authorization'] = `Bearer ${authToken}`;
+  return h;
+}
+
+async function isTrackingDisabled() {
+  const { disableTracking } = await chrome.storage.sync.get({ disableTracking: false });
+  return !!disableTracking;
+}
+
 function isPingable(url) {
   if (!url) return false;
   return url.startsWith('http://') || url.startsWith('https://');
@@ -20,15 +32,17 @@ function isPingable(url) {
 
 async function pingAccess(url, title) {
   if (!isPingable(url)) return;
+  if (await isTrackingDisabled()) return;
   const now = Date.now();
   const prev = lastPing.get(url) ?? 0;
   if (now - prev < PING_THROTTLE_MS) return;
   lastPing.set(url, now);
   try {
     const server = await getServer();
+    const headers = await getAuthHeaders();
     await fetch(`${server}/api/access`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers,
       body: JSON.stringify({ url, title: title ?? null }),
     });
   } catch {
@@ -63,9 +77,10 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   (async () => {
     try {
       const server = await getServer();
+      const headers = await getAuthHeaders();
       const res = await fetch(`${server}/api/bookmark`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers,
         body: JSON.stringify(msg.payload || {}),
       });
       if (!res.ok) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Memoria Bookmarker",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Save the current page to a local Memoria server with auto summary and categories.",
   "permissions": ["activeTab", "scripting", "storage", "tabs", "alarms"],
   "host_permissions": ["http://localhost/*", "http://127.0.0.1/*"],

--- a/extension/options.html
+++ b/extension/options.html
@@ -16,7 +16,33 @@
   <h1>Memoria 設定</h1>
   <label for="server">Memoria サーバー URL</label>
   <input id="server" type="url" placeholder="http://localhost:5180" />
-  <div>
+
+  <fieldset style="border:1px solid #ddd;padding:8px 12px;margin-top:16px;border-radius:6px">
+    <legend style="padding:0 6px;font-size:12px;color:#555">プライバシー</legend>
+    <label style="display:flex;align-items:center;gap:8px;font-size:13px">
+      <input id="disableTracking" type="checkbox" />
+      URL をトラッキングしない (アクセスログをサーバーに送信しない)
+    </label>
+    <p style="font-size:11px;color:#777;margin:6px 0 0">
+      ON にすると、タブ切替時の <code>/api/access</code> 送信を完全に止めます。
+      未保存履歴・最終アクセス日・アクセス回数は更新されません。
+      手動で「このページを保存」した場合のみサーバーへ送ります。
+    </p>
+  </fieldset>
+
+  <fieldset style="border:1px solid #ddd;padding:8px 12px;margin-top:12px;border-radius:6px">
+    <legend style="padding:0 6px;font-size:12px;color:#555">認証 (オンラインモード)</legend>
+    <label style="display:block;font-size:12px;color:#555;margin-bottom:4px">
+      Bearer JWT (Cernere 等が発行)
+    </label>
+    <input id="authToken" type="password" placeholder="(空欄ならローカル無認証モード)" />
+    <p style="font-size:11px;color:#777;margin:6px 0 0">
+      サーバーが <code>MEMORIA_MODE=online</code> で起動している場合に必要。
+      この JWT は <code>Authorization: Bearer ...</code> ヘッダーで送信されます。
+    </p>
+  </fieldset>
+
+  <div style="margin-top:14px">
     <button id="save">保存</button>
     <span id="msg" class="saved"></span>
   </div>

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,16 +1,28 @@
 const DEFAULT_SERVER = 'http://localhost:5180';
 
 const serverInput = document.getElementById('server');
+const trackingInput = document.getElementById('disableTracking');
+const tokenInput = document.getElementById('authToken');
 const msg = document.getElementById('msg');
 
 (async () => {
-  const { server } = await chrome.storage.sync.get({ server: DEFAULT_SERVER });
-  serverInput.value = server;
+  const cfg = await chrome.storage.sync.get({
+    server: DEFAULT_SERVER,
+    disableTracking: false,
+    authToken: '',
+  });
+  serverInput.value = cfg.server;
+  trackingInput.checked = !!cfg.disableTracking;
+  tokenInput.value = cfg.authToken || '';
 })();
 
 document.getElementById('save').addEventListener('click', async () => {
   const server = serverInput.value.trim() || DEFAULT_SERVER;
-  await chrome.storage.sync.set({ server });
+  await chrome.storage.sync.set({
+    server,
+    disableTracking: !!trackingInput.checked,
+    authToken: tokenInput.value.trim(),
+  });
   msg.textContent = '保存しました';
   setTimeout(() => { msg.textContent = ''; }, 1500);
 });

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -5,6 +5,13 @@ async function getServer() {
   return server.replace(/\/+$/, '');
 }
 
+async function getAuthHeaders() {
+  const { authToken } = await chrome.storage.sync.get({ authToken: '' });
+  const h = { 'Content-Type': 'application/json' };
+  if (authToken) h['Authorization'] = `Bearer ${authToken}`;
+  return h;
+}
+
 const statusEl = document.getElementById('status');
 const saveBtn = document.getElementById('save');
 const openUi = document.getElementById('openUi');
@@ -33,9 +40,10 @@ saveBtn.addEventListener('click', async () => {
       }),
     });
     statusEl.textContent = '送信中...';
+    const headers = await getAuthHeaders();
     const res = await fetch(`${server}/api/bookmark`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers,
       body: JSON.stringify(result),
     });
     if (!res.ok) {

--- a/server/auth.js
+++ b/server/auth.js
@@ -1,0 +1,97 @@
+// Lightweight Bearer/JWT auth middleware.
+//
+// Memoria has two run modes:
+//
+//   MEMORIA_MODE=local   (default) — single-user, no auth, all endpoints open
+//   MEMORIA_MODE=online            — multi-user, every API call must carry
+//                                    a Bearer JWT signed with MEMORIA_JWT_SECRET
+//                                    (HS256). The token's `sub` claim is used
+//                                    as the user_id.
+//
+// In production this secret should be the SAME secret used by the Cernere
+// service-adapter when issuing service-scoped JWTs (see Cernere
+// `@ludiars/cernere-service-adapter`). Memoria itself does not call Cernere
+// directly — it only verifies the resulting JWT.
+//
+// For local development, a token can be minted with `node scripts/issue-token.mjs`.
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+export const MODES = { LOCAL: 'local', ONLINE: 'online' };
+
+export function readMode() {
+  const m = (process.env.MEMORIA_MODE ?? 'local').toLowerCase();
+  return m === 'online' ? MODES.ONLINE : MODES.LOCAL;
+}
+
+/** Sign a payload with HS256. Used by the dev token issuer; production tokens
+ *  come from the Cernere admission flow. */
+export function signJwt(payload, secret, { expSeconds = 60 * 60 } = {}) {
+  const now = Math.floor(Date.now() / 1000);
+  const body = { iat: now, exp: now + expSeconds, ...payload };
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const enc = (o) => base64UrlEncode(Buffer.from(JSON.stringify(o)));
+  const signingInput = `${enc(header)}.${enc(body)}`;
+  const sig = createHmac('sha256', secret).update(signingInput).digest();
+  return `${signingInput}.${base64UrlEncode(sig)}`;
+}
+
+/** Verify HS256 JWT. Throws on any failure. Returns the decoded payload. */
+export function verifyJwt(token, secret) {
+  const parts = token.split('.');
+  if (parts.length !== 3) throw new Error('malformed token');
+  const [hB, pB, sB] = parts;
+  const expectedSig = createHmac('sha256', secret).update(`${hB}.${pB}`).digest();
+  const givenSig = base64UrlDecode(sB);
+  if (expectedSig.length !== givenSig.length || !timingSafeEqual(expectedSig, givenSig)) {
+    throw new Error('bad signature');
+  }
+  let payload;
+  try { payload = JSON.parse(base64UrlDecode(pB).toString('utf8')); }
+  catch { throw new Error('bad payload'); }
+  if (typeof payload.exp !== 'number' || payload.exp < Math.floor(Date.now() / 1000)) {
+    throw new Error('token expired');
+  }
+  return payload;
+}
+
+function base64UrlEncode(buf) {
+  return buf.toString('base64').replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+function base64UrlDecode(s) {
+  const pad = s.length % 4 === 0 ? '' : '='.repeat(4 - (s.length % 4));
+  return Buffer.from(s.replace(/-/g, '+').replace(/_/g, '/') + pad, 'base64');
+}
+
+/**
+ * Hono middleware. In ONLINE mode, requires a valid Bearer token; sets
+ * `c.set("userId", ...)` for downstream handlers. In LOCAL mode this is a
+ * no-op and userId stays null.
+ */
+export function authMiddleware({ mode, secret }) {
+  return async (c, next) => {
+    if (mode !== MODES.ONLINE) {
+      c.set('userId', null);
+      c.set('mode', mode);
+      return next();
+    }
+    if (!secret) {
+      return c.json({ error: 'server misconfigured: MEMORIA_JWT_SECRET not set' }, 500);
+    }
+    const auth = c.req.header('Authorization') || c.req.header('authorization') || '';
+    const m = auth.match(/^Bearer\s+(.+)$/i);
+    if (!m) {
+      return c.json({ error: 'unauthorized: bearer token required' }, 401);
+    }
+    let payload;
+    try { payload = verifyJwt(m[1], secret); }
+    catch (e) { return c.json({ error: `unauthorized: ${e.message}` }, 401); }
+    if (!payload.sub) {
+      return c.json({ error: 'unauthorized: token missing sub' }, 401);
+    }
+    c.set('userId', String(payload.sub));
+    c.set('mode', mode);
+    return next();
+  };
+}

--- a/server/content-filter.js
+++ b/server/content-filter.js
@@ -1,0 +1,113 @@
+// Content filter — refuses bookmarks whose URL/title/body contain banned keywords.
+// Hardcoded defaults can be overridden via MEMORIA_NGWORDS_FILE (newline / JSON
+// array). Domain blocklist similarly via MEMORIA_NG_DOMAINS_FILE.
+//
+// We intentionally keep this simple — it's a courtesy filter for a personal
+// tool, not a content moderation system. R18 detection is best-effort.
+
+import { readFileSync, existsSync } from 'node:fs';
+import { parse as parseHtml } from 'node-html-parser';
+
+const DEFAULT_NG_WORDS = [
+  // Adult / R18 (lower-case, substring match against lower-cased text)
+  'porn', 'pornhub', 'xvideos', 'xnxx', 'redtube', 'youporn',
+  'onlyfans', 'sex.com', 'r18', 'r-18', 'adult-only',
+  'アダルト', '成人向け', 'エロ動画', 'エロ漫画', 'エッチ',
+  // Illegal substance trafficking — keep conservative, expand via env file
+  'cp porn', 'child porn',
+];
+
+const DEFAULT_NG_DOMAINS = [
+  'pornhub.com', 'xvideos.com', 'xnxx.com', 'redtube.com', 'youporn.com',
+  'onlyfans.com',
+];
+
+let cached = null;
+
+export function loadFilter({
+  ngWordsFile = process.env.MEMORIA_NGWORDS_FILE,
+  ngDomainsFile = process.env.MEMORIA_NG_DOMAINS_FILE,
+  enabled = process.env.MEMORIA_CONTENT_FILTER !== '0',
+} = {}) {
+  if (cached) return cached;
+  const words = new Set(DEFAULT_NG_WORDS.map(w => w.toLowerCase()));
+  const domains = new Set(DEFAULT_NG_DOMAINS.map(d => d.toLowerCase()));
+
+  if (ngWordsFile && existsSync(ngWordsFile)) {
+    for (const w of parseListFile(ngWordsFile)) {
+      words.add(w.toLowerCase());
+    }
+  }
+  if (ngDomainsFile && existsSync(ngDomainsFile)) {
+    for (const d of parseListFile(ngDomainsFile)) {
+      domains.add(d.toLowerCase());
+    }
+  }
+  cached = { enabled, words: [...words], domains: [...domains] };
+  return cached;
+}
+
+function parseListFile(path) {
+  const raw = readFileSync(path, 'utf8').trim();
+  if (raw.startsWith('[')) {
+    try { return JSON.parse(raw); } catch {}
+  }
+  return raw.split(/\r?\n/).map(s => s.replace(/#.*$/, '').trim()).filter(Boolean);
+}
+
+/**
+ * Check a candidate bookmark for banned content.
+ * Returns { ok: true } or { ok: false, reason, matches: [...] }.
+ */
+export function checkContent({ url, title, html }) {
+  const f = loadFilter();
+  if (!f.enabled) return { ok: true };
+
+  // 1. URL/domain check
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    for (const bad of f.domains) {
+      if (host === bad || host.endsWith('.' + bad)) {
+        return { ok: false, reason: 'blocked_domain', matches: [bad] };
+      }
+    }
+  } catch {}
+
+  const haystackUrl = (url ?? '').toLowerCase();
+  const haystackTitle = (title ?? '').toLowerCase();
+  const matches = new Set();
+  for (const w of f.words) {
+    if (haystackUrl.includes(w) || haystackTitle.includes(w)) {
+      matches.add(w);
+    }
+  }
+  if (matches.size > 0) {
+    return { ok: false, reason: 'ng_word_in_url_or_title', matches: [...matches] };
+  }
+
+  // 2. Body text check (extract once, scan once)
+  if (typeof html === 'string' && html.length > 0) {
+    const text = quickText(html).slice(0, 30_000).toLowerCase();
+    for (const w of f.words) {
+      if (text.includes(w)) {
+        matches.add(w);
+        if (matches.size >= 5) break;
+      }
+    }
+    if (matches.size > 0) {
+      return { ok: false, reason: 'ng_word_in_body', matches: [...matches] };
+    }
+  }
+
+  return { ok: true };
+}
+
+function quickText(html) {
+  try {
+    const root = parseHtml(html);
+    root.querySelectorAll('script, style, noscript').forEach(n => n.remove());
+    return root.text;
+  } catch {
+    return html.replace(/<[^>]+>/g, ' ');
+  }
+}

--- a/server/db.js
+++ b/server/db.js
@@ -93,11 +93,28 @@ export function openDb(dbPath) {
   if (!cols.includes('access_count')) {
     db.exec(`ALTER TABLE bookmarks ADD COLUMN access_count INTEGER NOT NULL DEFAULT 0`);
   }
+  if (!cols.includes('user_id')) {
+    db.exec(`ALTER TABLE bookmarks ADD COLUMN user_id TEXT`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_bookmarks_user ON bookmarks(user_id)`);
+  }
+
+  // page_visits also needs user_id for proper online-mode isolation.
+  const visitCols = db.prepare(`PRAGMA table_info(page_visits)`).all().map(c => c.name);
+  if (!visitCols.includes('user_id')) {
+    db.exec(`ALTER TABLE page_visits ADD COLUMN user_id TEXT`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_visits_user ON page_visits(user_id)`);
+  }
 
   return db;
 }
 
-export function listBookmarks(db, { category, sort = 'created_desc' } = {}) {
+/** Build the WHERE fragment + binding for user scoping. Pass null for local mode. */
+function userClause(userId, alias = 'b') {
+  if (userId == null) return { where: '', args: [] };
+  return { where: ` AND ${alias}.user_id = ?`, args: [userId] };
+}
+
+export function listBookmarks(db, { category, sort = 'created_desc', userId = null } = {}) {
   const orderClauses = {
     created_desc: 'b.created_at DESC',
     created_asc: 'b.created_at ASC',
@@ -106,23 +123,29 @@ export function listBookmarks(db, { category, sort = 'created_desc' } = {}) {
     title_asc: 'b.title ASC',
   };
   const orderBy = orderClauses[sort] ?? orderClauses.created_desc;
+  const u = userClause(userId);
   let rows;
   if (category) {
     rows = db.prepare(`
       SELECT b.* FROM bookmarks b
       JOIN bookmark_categories bc ON bc.bookmark_id = b.id
-      WHERE bc.category = ?
+      WHERE bc.category = ?${u.where}
       ORDER BY ${orderBy}
-    `).all(category);
+    `).all(category, ...u.args);
   } else {
-    rows = db.prepare(`SELECT b.* FROM bookmarks b ORDER BY ${orderBy}`).all();
+    rows = db.prepare(`
+      SELECT b.* FROM bookmarks b
+      WHERE 1=1${u.where}
+      ORDER BY ${orderBy}
+    `).all(...u.args);
   }
   return rows.map(r => ({ ...r, categories: getCategories(db, r.id) }));
 }
 
-export function getBookmark(db, id) {
+export function getBookmark(db, id, { userId = null } = {}) {
   const row = db.prepare(`SELECT * FROM bookmarks WHERE id = ?`).get(id);
   if (!row) return null;
+  if (userId != null && row.user_id !== userId) return null;
   return { ...row, categories: getCategories(db, id) };
 }
 
@@ -141,15 +164,20 @@ export function listAllCategories(db) {
   `).all();
 }
 
-export function insertBookmark(db, { url, title, htmlPath }) {
+export function insertBookmark(db, { url, title, htmlPath, userId = null }) {
   const stmt = db.prepare(`
-    INSERT INTO bookmarks (url, title, html_path) VALUES (?, ?, ?)
+    INSERT INTO bookmarks (url, title, html_path, user_id) VALUES (?, ?, ?, ?)
   `);
-  const info = stmt.run(url, title, htmlPath);
+  const info = stmt.run(url, title, htmlPath, userId);
   return info.lastInsertRowid;
 }
 
-export function findBookmarkByUrl(db, url) {
+export function findBookmarkByUrl(db, url, { userId = null } = {}) {
+  if (userId != null) {
+    return db.prepare(
+      `SELECT * FROM bookmarks WHERE url = ? AND user_id = ? ORDER BY id DESC LIMIT 1`
+    ).get(url, userId) ?? null;
+  }
   return db.prepare(`SELECT * FROM bookmarks WHERE url = ? ORDER BY id DESC LIMIT 1`).get(url) ?? null;
 }
 
@@ -191,15 +219,15 @@ export function updateMemoAndCategories(db, id, { memo, categories }) {
 }
 
 /** Upsert a visit row for any URL (whether bookmarked or not). */
-export function upsertVisit(db, { url, title }) {
+export function upsertVisit(db, { url, title, userId = null }) {
   db.prepare(`
-    INSERT INTO page_visits (url, title)
-    VALUES (?, ?)
+    INSERT INTO page_visits (url, title, user_id)
+    VALUES (?, ?, ?)
     ON CONFLICT(url) DO UPDATE SET
       title = COALESCE(NULLIF(excluded.title, ''), page_visits.title),
       last_seen_at = datetime('now'),
       visit_count = page_visits.visit_count + 1
-  `).run(url, title ?? null);
+  `).run(url, title ?? null, userId);
 }
 
 /**

--- a/server/index.js
+++ b/server/index.js
@@ -31,6 +31,8 @@ import { summarizeWithClaude, htmlToText } from './claude.js';
 import { FifoQueue } from './queue.js';
 import { recommendationsFor, dismissRecommendation, clearDismissals } from './recommendations.js';
 import { runDig } from './dig.js';
+import { authMiddleware, readMode, MODES } from './auth.js';
+import { checkContent } from './content-filter.js';
 import { embed, chunkText, cosine, vecToBuffer, bufferToVec, getModelName } from './embeddings.js';
 import {
   deleteChunks, insertChunk, listChunkRows, bookmarksMissingEmbeddings, chunkStats,
@@ -45,6 +47,13 @@ const HTML_DIR = join(DATA_DIR, 'html');
 const DB_PATH = join(DATA_DIR, 'memoria.db');
 const CLAUDE_BIN = process.env.MEMORIA_CLAUDE_BIN ?? 'claude';
 const RAG_ENABLED = process.env.MEMORIA_RAG !== '0';
+const MODE = readMode();
+const JWT_SECRET = process.env.MEMORIA_JWT_SECRET ?? '';
+const ONLINE = MODE === MODES.ONLINE;
+if (ONLINE && !JWT_SECRET) {
+  console.error('[memoria] FATAL: MEMORIA_MODE=online requires MEMORIA_JWT_SECRET');
+  process.exit(2);
+}
 
 mkdirSync(HTML_DIR, { recursive: true });
 const db = openDb(DB_PATH);
@@ -138,11 +147,29 @@ function enqueueSummary(id) {
 }
 
 const app = new Hono();
-app.use('/api/*', cors({ origin: '*', allowMethods: ['GET','POST','PATCH','DELETE','OPTIONS'] }));
+app.use('/api/*', cors({
+  origin: '*',
+  allowMethods: ['GET','POST','PATCH','DELETE','OPTIONS'],
+  allowHeaders: ['Content-Type', 'Authorization'],
+}));
+app.use('/api/*', authMiddleware({ mode: MODE, secret: JWT_SECRET }));
+
+// Block visit-history endpoints in online mode — that data is local-only.
+const blockInOnline = (c, next) => {
+  if (ONLINE) return c.json({ error: 'visits endpoints are disabled in online mode' }, 403);
+  return next();
+};
+
+app.get('/api/mode', (c) => c.json({
+  mode: MODE,
+  rag_enabled: RAG_ENABLED,
+  user_id: c.get('userId') ?? null,
+}));
 
 // ---- bookmark CRUD ---------------------------------------------------------
 
 app.post('/api/bookmark', async (c) => {
+  const userId = c.get('userId') ?? null;
   const body = await c.req.json().catch(() => null);
   if (!body || typeof body.html !== 'string' || typeof body.url !== 'string') {
     return c.json({ error: 'html, url, title required' }, 400);
@@ -151,57 +178,67 @@ app.post('/api/bookmark', async (c) => {
   const title = (body.title || url).slice(0, 500);
   const html = body.html;
 
-  const existing = findBookmarkByUrl(db, url);
+  // Reject NG / R18 content before touching disk or DB.
+  const filt = checkContent({ url, title, html });
+  if (!filt.ok) {
+    return c.json({
+      error: 'content blocked by NG word filter',
+      reason: filt.reason,
+      matches: filt.matches,
+    }, 422);
+  }
+
+  const existing = findBookmarkByUrl(db, url, { userId });
   if (existing) {
-    // Same URL — record access and return existing.
     recordAccess(db, existing.id);
     return c.json({ id: existing.id, duplicate: true });
   }
 
-  // Save HTML to disk first, then DB row, then kick off summarization.
   const ts = new Date().toISOString().replace(/[:.]/g, '-');
   const safe = ts + '_' + Math.random().toString(36).slice(2, 8) + '.html';
   const htmlPath = join(HTML_DIR, safe);
   writeFileSync(htmlPath, html, 'utf8');
 
-  const id = insertBookmark(db, { url, title, htmlPath: safe });
-
-  // First access = creation.
+  const id = insertBookmark(db, { url, title, htmlPath: safe, userId });
   recordAccess(db, id);
-
-  // Hand off to the FIFO queue so summarizations run strictly one at a time.
   enqueueSummary(id);
 
   return c.json({ id, queued: true, queueDepth: summaryQueue.depth });
 });
 
 app.get('/api/bookmarks', (c) => {
+  const userId = c.get('userId') ?? null;
   const category = c.req.query('category') || undefined;
   const sort = c.req.query('sort') || undefined;
-  return c.json({ items: listBookmarks(db, { category, sort }) });
+  return c.json({ items: listBookmarks(db, { category, sort, userId }) });
 });
 
 app.get('/api/bookmarks/:id', (c) => {
   const id = Number(c.req.param('id'));
-  const b = getBookmark(db, id);
+  const b = getBookmark(db, id, { userId: c.get('userId') ?? null });
   if (!b) return c.json({ error: 'not found' }, 404);
   return c.json(b);
 });
 
 app.patch('/api/bookmarks/:id', async (c) => {
   const id = Number(c.req.param('id'));
-  const b = getBookmark(db, id);
+  const userId = c.get('userId') ?? null;
+  const b = getBookmark(db, id, { userId });
   if (!b) return c.json({ error: 'not found' }, 404);
   const body = await c.req.json().catch(() => ({}));
   updateMemoAndCategories(db, id, {
     memo: typeof body.memo === 'string' ? body.memo : undefined,
     categories: Array.isArray(body.categories) ? body.categories : undefined,
   });
-  return c.json(getBookmark(db, id));
+  return c.json(getBookmark(db, id, { userId }));
 });
 
 app.delete('/api/bookmarks/:id', (c) => {
   const id = Number(c.req.param('id'));
+  const userId = c.get('userId') ?? null;
+  if (!getBookmark(db, id, { userId })) {
+    return c.json({ error: 'not found' }, 404);
+  }
   const htmlName = deleteBookmark(db, id);
   if (htmlName) {
     const p = join(HTML_DIR, htmlName);
@@ -227,7 +264,7 @@ app.post('/api/bookmarks/:id/resummarize', async (c) => {
 
 app.get('/api/bookmarks/:id/html', (c) => {
   const id = Number(c.req.param('id'));
-  const b = getBookmark(db, id);
+  const b = getBookmark(db, id, { userId: c.get('userId') ?? null });
   if (!b) return c.text('not found', 404);
   const p = join(HTML_DIR, b.html_path);
   if (!existsSync(p)) return c.text('html missing', 404);
@@ -457,7 +494,7 @@ app.get('/api/dig/:id', (c) => {
 app.post('/api/dig/:id/save', async (c) => {
   const body = await c.req.json().catch(() => null);
   if (!body || !Array.isArray(body.urls)) return c.json({ error: 'urls[] required' }, 400);
-  return c.json({ results: await bulkSaveUrls(body.urls) });
+  return c.json({ results: await bulkSaveUrls(body.urls, { userId: c.get('userId') ?? null }) });
 });
 
 // ---- queue status ---------------------------------------------------------
@@ -489,14 +526,17 @@ app.get('/api/categories', (c) => {
 // ---- access ping (from extension) -----------------------------------------
 
 app.post('/api/access', async (c) => {
+  // In online mode the visit-tracking surface is intentionally disabled —
+  // the privacy contract is that we don't aggregate non-bookmarked URLs
+  // server-side for shared deployments.
+  if (ONLINE) return c.json({ matched: false, disabled: true });
+
   const body = await c.req.json().catch(() => null);
   if (!body || typeof body.url !== 'string') return c.json({ error: 'url required' }, 400);
   if (!/^https?:\/\//.test(body.url)) return c.json({ matched: false, ignored: true });
 
-  // Always upsert into page_visits so unsaved URLs are tracked too.
   upsertVisit(db, { url: body.url, title: typeof body.title === 'string' ? body.title : null });
 
-  // If this URL is already bookmarked, also bump its bookmark access counter.
   const b = findBookmarkByUrl(db, body.url);
   if (!b) return c.json({ matched: false });
   recordAccess(db, b.id);
@@ -504,18 +544,20 @@ app.post('/api/access', async (c) => {
 });
 
 // ---- visit history (unsaved URLs) -----------------------------------------
+// All visit-history endpoints are local-only: they expose the user's raw
+// browsing trail and have no place in a multi-user deployment.
 
-app.get('/api/visits/unsaved', (c) => {
+app.get('/api/visits/unsaved', blockInOnline, (c) => {
   const since = c.req.query('since');
   return c.json({ items: listUnsavedVisits(db, { since }) });
 });
 
-app.get('/api/visits/suggested', (c) => {
+app.get('/api/visits/suggested', blockInOnline, (c) => {
   const days = Number(c.req.query('days')) || 30;
   return c.json({ items: listSuggestedVisits(db, { sinceDays: days }) });
 });
 
-app.get('/api/visits/unsaved/count', (c) => {
+app.get('/api/visits/unsaved/count', blockInOnline, (c) => {
   const row = db.prepare(`
     SELECT COUNT(*) AS n
     FROM page_visits v
@@ -526,21 +568,21 @@ app.get('/api/visits/unsaved/count', (c) => {
   return c.json({ count: row?.n ?? 0 });
 });
 
-app.delete('/api/visits', async (c) => {
+app.delete('/api/visits', blockInOnline, async (c) => {
   const body = await c.req.json().catch(() => null);
   if (!body || !Array.isArray(body.urls)) return c.json({ error: 'urls[] required' }, 400);
   for (const url of body.urls) deleteVisit(db, url);
   return c.json({ ok: true, removed: body.urls.length });
 });
 
-async function bulkSaveUrls(urls) {
+async function bulkSaveUrls(urls, { userId = null } = {}) {
   const results = [];
   for (const url of urls) {
     if (typeof url !== 'string' || !/^https?:\/\//.test(url)) {
       results.push({ url, status: 'skipped', error: 'invalid url' });
       continue;
     }
-    const existing = findBookmarkByUrl(db, url);
+    const existing = findBookmarkByUrl(db, url, { userId });
     if (existing) {
       deleteVisit(db, url);
       results.push({ url, status: 'duplicate', id: existing.id });
@@ -551,11 +593,17 @@ async function bulkSaveUrls(urls) {
       const fetched = await fetchPageHtml(url);
       const title = (visit?.title || fetched.title || url).slice(0, 500);
 
+      const filt = checkContent({ url, title, html: fetched.html });
+      if (!filt.ok) {
+        results.push({ url, status: 'blocked', reason: filt.reason, matches: filt.matches });
+        continue;
+      }
+
       const ts = new Date().toISOString().replace(/[:.]/g, '-');
       const safe = ts + '_' + Math.random().toString(36).slice(2, 8) + '.html';
       writeFileSync(join(HTML_DIR, safe), fetched.html, 'utf8');
 
-      const id = insertBookmark(db, { url, title, htmlPath: safe });
+      const id = insertBookmark(db, { url, title, htmlPath: safe, userId });
       recordAccess(db, id);
       enqueueSummary(id);
       deleteVisit(db, url);
@@ -567,10 +615,10 @@ async function bulkSaveUrls(urls) {
   return results;
 }
 
-app.post('/api/visits/bookmark', async (c) => {
+app.post('/api/visits/bookmark', blockInOnline, async (c) => {
   const body = await c.req.json().catch(() => null);
   if (!body || !Array.isArray(body.urls)) return c.json({ error: 'urls[] required' }, 400);
-  return c.json({ results: await bulkSaveUrls(body.urls) });
+  return c.json({ results: await bulkSaveUrls(body.urls, { userId: c.get('userId') ?? null }) });
 });
 
 async function fetchPageHtml(url, timeoutMs = 30_000) {
@@ -671,6 +719,8 @@ app.get('/', serveStatic({ path: './public/index.html' }));
 
 serve({ fetch: app.fetch, port: PORT }, (info) => {
   console.log(`Memoria server listening on http://localhost:${info.port}`);
+  console.log(`  mode: ${MODE}${ONLINE ? ' (auth required)' : ' (no auth)'}`);
   console.log(`  data dir: ${DATA_DIR}`);
   console.log(`  claude bin: ${CLAUDE_BIN}`);
+  console.log(`  rag: ${RAG_ENABLED ? 'enabled' : 'disabled'}`);
 });

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "start": "node --env-file-if-exists=.env --env-file-if-exists=../.env index.js",
-    "dev": "node --watch --env-file-if-exists=.env --env-file-if-exists=../.env index.js"
+    "dev": "node --watch --env-file-if-exists=.env --env-file-if-exists=../.env index.js",
+    "issue-token": "node --env-file-if-exists=.env --env-file-if-exists=../.env scripts/issue-token.mjs"
   },
   "dependencies": {
     "@hono/node-server": "^1.13.7",

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -20,6 +20,7 @@ const state = {
   digHistory: [],
   digSelected: new Set(),
   digPolling: null,
+  mode: 'local',
 };
 
 const $ = (id) => document.getElementById(id);
@@ -277,6 +278,27 @@ $('importInput').addEventListener('change', async (e) => {
   if (f) await importFile(f);
   e.target.value = '';
 });
+
+async function applyMode() {
+  try {
+    const r = await api('/api/mode');
+    state.mode = r.mode;
+    const isOnline = r.mode === 'online';
+    // Hide visit-related UI in online mode.
+    document.querySelector('.tab[data-tab="visits"]')?.classList.toggle('hidden', isOnline);
+    if (isOnline && state.tab === 'visits') switchTab('bookmarks');
+    if (isOnline) {
+      document.body.dataset.mode = 'online';
+      const brand = document.querySelector('.brand');
+      if (brand && !brand.dataset.modeAnnotated) {
+        brand.insertAdjacentHTML('afterend', '<span class="mode-pill" title="Online sharing mode">online</span>');
+        brand.dataset.modeAnnotated = '1';
+      }
+    }
+  } catch (e) { console.warn('mode check failed', e); }
+}
+
+applyMode();
 
 load().catch(err => {
   console.error(err);

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -138,6 +138,17 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 }
 .tab:hover { background: #f0f2f7; color: var(--text); }
 .tab.active { color: var(--accent); border-bottom-color: var(--accent); font-weight: 600; }
+.tab.hidden { display: none !important; }
+.mode-pill {
+  background: #fdecea;
+  color: #b13c2a;
+  border: 1px solid #f0a6a0;
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  margin-left: 8px;
+  font-weight: 600;
+}
 .tab-count {
   background: #fff5e1;
   color: #8a5a00;

--- a/server/scripts/issue-token.mjs
+++ b/server/scripts/issue-token.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+// Mint a Memoria JWT for development / testing.
+//
+// Usage:
+//   node scripts/issue-token.mjs <user_id> [--exp 86400]
+//
+// Reads MEMORIA_JWT_SECRET from .env / ../.env via Node --env-file-if-exists.
+
+import { signJwt } from '../auth.js';
+
+const args = process.argv.slice(2);
+const userId = args[0];
+if (!userId) {
+  console.error('usage: node scripts/issue-token.mjs <user_id> [--exp <seconds>]');
+  process.exit(1);
+}
+const expIdx = args.indexOf('--exp');
+const expSeconds = expIdx >= 0 ? Number(args[expIdx + 1]) : 24 * 60 * 60;
+
+const secret = process.env.MEMORIA_JWT_SECRET;
+if (!secret) {
+  console.error('MEMORIA_JWT_SECRET is not set. Add it to .env first.');
+  process.exit(2);
+}
+
+const token = signJwt({ sub: userId, iss: 'memoria-dev' }, secret, { expSeconds });
+console.log(token);


### PR DESCRIPTION
## Summary
オンライン共有モード (`MEMORIA_MODE=online`) を追加。Chrome 拡張側でも URL トラッキング opt-out / Bearer JWT 設定欄を提供。

### モード比較
| | local (既定) | online |
|---|---|---|
| 認証 | なし | Bearer JWT (HS256) 必須 |
| /api/visits/* | 開放 | 403 |
| /api/access | upsert + アクセス記録 | no-op |
| user_id スコープ | NULL (単一ユーザー) | JWT.sub で per-user |
| /api/mode | local / null | online / sub |

### コンテンツフィルタ
URL/タイトル/本文に NG/R18 ワードがあれば 422 を返して保存しない。`MEMORIA_NGWORDS_FILE` / `MEMORIA_NG_DOMAINS_FILE` で追加可、`MEMORIA_CONTENT_FILTER=0` で全停止。

### Cernere 統合
本番では [@ludiars/cernere-service-adapter](https://github.com/LUDIARS/Cernere/tree/main/packages/service-adapter) を別プロセスで起動して admission flow → サービス JWT 発行。Memoria は受け取った JWT を `MEMORIA_JWT_SECRET` で検証する薄い層に徹する。

### 拡張 v0.4.0
- options に「URL をトラッキングしない」チェック + Bearer JWT 入力
- background/popup が `disableTracking` 尊重 + Authorization 自動付与

## Test plan
- [x] CI: syntax + smoke (local モード)
- [ ] 手動: `MEMORIA_MODE=online MEMORIA_JWT_SECRET=xxx npm start` → `/api/bookmarks` が 401 → `npm run issue-token alice` の JWT で 200