### PR TITLE
feat: Cernere service-adapter integration (admission + peer + events)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,8 +45,37 @@
 # MEMORIA_MODE=local
 
 # online モード時の JWT (HS256) 検証用シークレット。
-# 本番では Cernere `@ludiars/cernere-service-adapter` の SERVICE_JWT_SECRET と同じ値を使う。
+# Cernere admission adapter から発行される service_token もこの鍵で署名されるため、
+# Cernere SDK 連携時は SERVICE_JWT_SECRET と必ず同じ値にする。
 # MEMORIA_JWT_SECRET=change-me-very-long-random-string
+
+# service_token の有効期間 (秒、既定 900 = 15 分)。Cernere 連携時のみ使用。
+# MEMORIA_TOKEN_EXP_SEC=900
+
+# ─────────────────────────────────────────────────────────────────────────
+# Cernere integration (optional — uses @ludiars/cernere-service-adapter)
+# ─────────────────────────────────────────────────────────────────────────
+# Memoria server は @ludiars/cernere-service-adapter を optionalDependency として
+# 取り込みます。SDK が未インストール (NPM_TOKEN 未設定など) の環境では
+# 何も起動せず、自前 HS256 検証で動作します。
+
+# 1. Admission adapter — Cernere → Memoria の WS 接続。3 つすべて設定が必要。
+#    onUserAdmission を受けて service_token を発行し、Chrome 拡張へ渡す前提。
+# CERNERE_WS_URL=ws://cernere:8080/ws/service
+# CERNERE_SERVICE_CODE=memoria
+# CERNERE_SERVICE_SECRET=memoria-service-secret-from-cernere-admin
+
+# 2. Peer adapter — Imperativus 等からの直接 WS 呼び出しを受け付ける。
+# CERNERE_PROJECT_ID=memoria-project-client-id
+# CERNERE_PROJECT_SECRET=memoria-project-client-secret
+# CERNERE_BASE_URL=http://cernere:8080
+# MEMORIA_SA_PUBLIC_URL=ws://memoria.internal:{port}
+# MEMORIA_SA_HOST=0.0.0.0
+# MEMORIA_SA_PORT=0
+
+# 3. Event relay target — Memoria が出すイベント (memoria.bookmark.saved 等) を
+#    どの peer に push するか。Imperativus でユーザごとのフックを管理する想定。
+# MEMORIA_HOOK_TARGET=imperativus
 
 # ─────────────────────────────────────────────────────────────────────────
 # Content filter (NG / R18)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,12 @@ jobs:
 
       - name: Install server deps
         working-directory: server
-        run: npm ci
+        env:
+          # Optional: pull @ludiars/* from GitHub Packages if NPM_TOKEN is set.
+          # CI runs fine without it; the SDK is in optionalDependencies and
+          # missing-optional packages are silently skipped.
+          NPM_TOKEN: ${{ secrets.LUDIARS_NPM_TOKEN || '' }}
+        run: npm ci --no-optional || npm ci --omit=optional
 
       - name: Install mcp-server deps
         working-directory: mcp-server

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# LUDIARS の private packages (@ludiars/...) は GitHub Packages を参照する。
+# トークンは環境変数 NPM_TOKEN から渡す想定。
+@ludiars:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NPM_TOKEN}

--- a/README.md
+++ b/README.md
@@ -301,8 +301,9 @@ Claude Code は `~/.claude/mcp.json` (プロジェクト固有なら `.claude/mc
 - すべての `/api/*` で `Authorization: Bearer <JWT>` 必須 (HS256)
 - 訪問履歴 (`/api/visits/*`) は 403 で完全停止、`/api/access` は no-op
 - ブックマークは JWT の `sub` (user_id) でスコープ
-- Cernere 統合: 本番では [`@ludiars/cernere-service-adapter`](https://github.com/LUDIARS/Cernere/tree/main/packages/service-adapter) を別プロセスで起動し、Cernere admission flow → Memoria JWT 発行 → Memoria 側は受け取った JWT を `MEMORIA_JWT_SECRET` で検証する構成
+- Cernere 統合: `@ludiars/cernere-service-adapter` を **同一プロセスで lazy import** し、admission + peer adapter の両方を起動。`CERNERE_*` env が揃った時のみ有効化、SDK 未インストール時は自前 HS256 検証にフォールバック
 - 開発用 token: `cd server && npm run issue-token alice` で `sub=alice` の JWT を発行
+- Peer adapter で公開するコマンドと発行イベントは [docs/events.md](docs/events.md) 参照
 
 ### コンテンツフィルタ
 NG / R18 ワードがブックマークの URL / タイトル / 本文に含まれる場合、422 で保存を拒否します。`MEMORIA_NGWORDS_FILE` / `MEMORIA_NG_DOMAINS_FILE` で追加可能。

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,101 @@
+# Memoria — Peer Adapter Events & Commands
+
+Memoria が `@ludiars/cernere-service-adapter` の `PeerAdapter` 経由で公開する API と、Memoria 側から発行するイベントの一覧。
+
+接続確立は Cernere の challenge プロトコルに従う ([Cernere Service Adapter README](https://github.com/LUDIARS/Cernere/blob/main/packages/service-adapter/README.md))。
+データ経路は Cernere に介在せず、Memoria↔他サービス間で直接 WebSocket を維持する。
+
+---
+
+## 1. Memoria が受信するコマンド (peer.handle)
+
+呼び出し側 (Imperativus 等) は `peerAdapter.invoke("memoria", "<command>", payload)` で叩く。
+ペイロードには **必ず `user_id`** を含めること (peer 通信は server-to-server なので、呼び出し元ですでにユーザー特定済み前提)。
+
+| Command | 入力 | 出力 |
+|---------|------|------|
+| `memoria.search` | `{ user_id, query, limit? }` | `{ items: BookmarkRow[] }` (タイトル/URL/要約/メモを substring 検索) |
+| `memoria.save_url` | `{ user_id, url }` | `{ status: 'queued' / 'duplicate' / 'blocked', id?, reason?, matches? }` (HTML を fetch して保存、要約キュー投入。NG ワードは `blocked`) |
+| `memoria.list_categories` | `{}` | `{ items: [{ category, count }] }` |
+| `memoria.recent_bookmarks` | `{ user_id, limit? }` | `{ items: BookmarkRow[] }` |
+| `memoria.get_bookmark` | `{ user_id, id }` | `BookmarkRow` |
+| `memoria.dig` | `{ user_id, query }` | `{ id, queued: true }` (完了時に `memoria.dig.completed` を発火) |
+| `memoria.unsaved_visits` | `{ days? }` | `{ items: VisitRow[] }` (※ online モードでは throws) |
+| `ping` | `{ ... any }` | `{ ok: true, from, echo, ts }` (疎通確認) |
+
+`accept` リストはデフォルトで `imperativus` のみ許可。`MEMORIA_SA_ACCEPT_*` 環境変数 (今後追加予定) で柔軟に変更可。
+
+---
+
+## 2. Memoria が発行するイベント (peer.invoke target)
+
+Memoria は事象が発生したら `MEMORIA_HOOK_TARGET` に指定された peer (例: `imperativus`) に対して `events.emit` を invoke する。
+受信側は **per-user の event hook 設定** に従ってリレー先を決定する責任を持つ (Imperativus 仕様)。
+
+イベントペイロードの統一形式:
+
+```json
+{
+  "source": "memoria",
+  "event": "<event_name>",
+  "user_id": "<sub from JWT>",
+  "payload": { /* event-specific */ },
+  "ts": 1700000000000
+}
+```
+
+| Event | 発火タイミング | payload |
+|-------|--------------|---------|
+| `memoria.bookmark.saved` | `/api/bookmark` 成功時 (重複でない新規保存) | `{ id, url, title }` |
+| `memoria.summary.done` | claude による要約 + カテゴリ生成完了 | `{ id, url, title, summary, categories }` |
+| `memoria.dig.completed` | ディグるセッション完了 | `{ session_id, query, source_count }` |
+| `memoria.recommendation.created` | (将来) 関連サイト推薦が新規生成された時 | `{ url, score, source_count }` |
+
+---
+
+## 3. Imperativus 側に実装が必要なエンドポイント
+
+Imperativus が Memoria からのイベントを受け取るためには、PeerAdapter で次の handler を提供する想定:
+
+```typescript
+peer.handle('events.emit', async (caller, msg) => {
+  // caller.projectKey === 'memoria' を確認
+  // msg.event のフックが user_id に対して設定されているかチェック
+  // 設定されていればルーティングして実行
+  return { ok: true };
+});
+```
+
+Imperativus 側で:
+
+- ユーザーごとに `event_hooks(user_id, source, event_pattern, target_action)` を保存
+- 受信した event_name にマッチするフックを検索 → 各 target_action を発火
+  - target_action 例: 「Slack に通知」「カレンダーに予定追加 (Actio へ peer.invoke)」「ボイスで読み上げ」
+
+---
+
+## 4. 接続図
+
+```
+                       ┌──────────────────────────────────┐
+                       │            Cernere               │
+                       │  (managed_projects, challenge)   │
+                       └──────────────────────────────────┘
+                            │  peer establish via WS
+                            │  (Cernere challenge → WS direct)
+                            ▼
+        ┌─────────────────────────────────────────────────────┐
+        │                                                     │
+        ▼                                                     ▼
+┌─────────────────┐    invoke memoria.*         ┌─────────────────┐
+│   Imperativus   │ ─────────────────────────►  │     Memoria     │
+│   (per-user     │                             │   (peer adapter │
+│   event hooks)  │ ◄─────────────────────────  │   + admission)  │
+└─────────────────┘    invoke events.emit       └─────────────────┘
+        ▲                  (memoria.*)
+        │
+        │ Chrome 拡張 / Web UI
+        │ (HTTP + service_token)
+        │
+   [ End user ]
+```

--- a/server/cernere.js
+++ b/server/cernere.js
@@ -1,0 +1,184 @@
+// Cernere integration bridge for Memoria.
+//
+// Two SDK adapters are wired here:
+//
+//   1. CernereServiceAdapter  — receives user_admission / user_revoke from
+//      Cernere via WebSocket, issues HS256 service_token (using MEMORIA_JWT_SECRET).
+//      The token is what Memoria's auth middleware verifies.
+//
+//   2. PeerAdapter            — accepts backend-to-backend invocations from
+//      sibling LUDIARS services (Imperativus etc.) over WS, after a Cernere
+//      challenge handshake. Used so that Imperativus can call into Memoria
+//      without an extra HTTP hop.
+//
+// Both adapters are loaded LAZILY via dynamic import. The SDK lives in a
+// private GitHub Packages registry; in environments without NPM_TOKEN
+// (e.g. public CI) the package is silently absent and Memoria continues in
+// stand-alone mode using its own HS256 verifier.
+//
+// Toggles via env vars (see .env.example for the full list):
+//
+//   CERNERE_WS_URL, CERNERE_SERVICE_CODE, CERNERE_SERVICE_SECRET   (admission)
+//   CERNERE_PROJECT_ID, CERNERE_PROJECT_SECRET, CERNERE_BASE_URL    (peer)
+//   MEMORIA_HOOK_TARGET                                             (events)
+
+import { join } from 'node:path';
+import { writeFileSync } from 'node:fs';
+
+let SDK = null; // lazily resolved module namespace
+let admission = null; // CernereServiceAdapter instance
+let peer = null;      // PeerAdapter instance
+let eventTarget = null;
+
+async function loadSdk() {
+  if (SDK !== null) return SDK;
+  try {
+    SDK = await import('@ludiars/cernere-service-adapter');
+    return SDK;
+  } catch (e) {
+    SDK = false; // memoize "not installed"
+    return null;
+  }
+}
+
+export function isReady() {
+  return { admission: !!admission, peer: !!peer, eventTarget };
+}
+
+export function getAdmissionAdapter() { return admission; }
+export function getPeerAdapter() { return peer; }
+
+/**
+ * Start whatever Cernere bits we have configuration for. Safe to call when
+ * env is incomplete: missing pieces just stay null.
+ *
+ * @param {object} ctx — runtime callbacks the adapters need.
+ *   - upsertUser(user, organizationId, scopes) — store admitted user
+ *   - revokeUser(userId)
+ *   - peerHandlers — Record<string, (caller, payload) => any>
+ *   - acceptList   — PeerAdapter `accept` config (per-service allow list)
+ */
+export async function startCernere(ctx) {
+  const sdk = await loadSdk();
+  if (!sdk) {
+    console.log('[memoria-cernere] @ludiars/cernere-service-adapter not installed — Cernere integration disabled (Memoria runs in stand-alone JWT mode).');
+    return { admission: false, peer: false };
+  }
+
+  const env = process.env;
+  const jwtSecret = env.MEMORIA_JWT_SECRET ?? '';
+
+  // ─── 1. Admission adapter (Cernere → Memoria) ──────────────────────────
+  if (env.CERNERE_WS_URL && env.CERNERE_SERVICE_CODE && env.CERNERE_SERVICE_SECRET) {
+    if (!jwtSecret) {
+      console.warn('[memoria-cernere] CERNERE_* set but MEMORIA_JWT_SECRET is empty — admission adapter NOT started.');
+    } else {
+      const { CernereServiceAdapter } = sdk;
+      admission = new CernereServiceAdapter({
+        cernereWsUrl: env.CERNERE_WS_URL,
+        serviceCode: env.CERNERE_SERVICE_CODE,
+        serviceSecret: env.CERNERE_SERVICE_SECRET,
+        jwtSecret,
+        tokenExpiresIn: Number(env.MEMORIA_TOKEN_EXP_SEC) || 900,
+      }, {
+        onUserAdmission: async (user, orgId, scopes) => {
+          try { await ctx.upsertUser(user, orgId, scopes); }
+          catch (e) { console.error('[memoria-cernere] upsertUser failed:', e); }
+        },
+        onUserRevoke: async (uid) => {
+          try { await ctx.revokeUser(uid); }
+          catch (e) { console.error('[memoria-cernere] revokeUser failed:', e); }
+        },
+        onConnected: (sid) => console.log(`[memoria-cernere] admission connected (service_id=${sid})`),
+        onDisconnected: () => console.log('[memoria-cernere] admission disconnected'),
+        onError: (code, msg) => console.error(`[memoria-cernere] admission error ${code}: ${msg}`),
+      });
+      admission.connect();
+    }
+  } else {
+    console.log('[memoria-cernere] admission adapter skipped (CERNERE_WS_URL / SERVICE_CODE / SERVICE_SECRET not all set)');
+  }
+
+  // ─── 2. Peer adapter (Imperativus → Memoria backend invokes) ───────────
+  if (env.CERNERE_PROJECT_ID && env.CERNERE_PROJECT_SECRET && env.CERNERE_BASE_URL) {
+    const { PeerAdapter } = sdk;
+    peer = new PeerAdapter({
+      projectId: env.CERNERE_PROJECT_ID,
+      projectSecret: env.CERNERE_PROJECT_SECRET,
+      cernereBaseUrl: env.CERNERE_BASE_URL,
+      saListenHost: env.MEMORIA_SA_HOST ?? '0.0.0.0',
+      saListenPort: Number(env.MEMORIA_SA_PORT) || 0,
+      saPublicBaseUrl: env.MEMORIA_SA_PUBLIC_URL ?? 'ws://127.0.0.1:{port}',
+      accept: ctx.acceptList ?? {
+        // Default: only Imperativus may call Memoria, and only the published
+        // commands. Tighten via env in production.
+        imperativus: [
+          'memoria.search',
+          'memoria.save_url',
+          'memoria.list_categories',
+          'memoria.recent_bookmarks',
+          'memoria.get_bookmark',
+          'memoria.dig',
+          'memoria.unsaved_visits',
+          'ping',
+        ],
+      },
+    });
+    // Always-on ping for connection diagnostics.
+    peer.handle('ping', async (caller, payload) => ({
+      ok: true, from: caller.projectKey, echo: payload, ts: Date.now(),
+    }));
+    for (const [cmd, fn] of Object.entries(ctx.peerHandlers ?? {})) {
+      peer.handle(cmd, fn);
+    }
+    await peer.start();
+    console.log(`[memoria-cernere] peer adapter started on port ${peer.boundListenPort}`);
+  } else {
+    console.log('[memoria-cernere] peer adapter skipped (CERNERE_PROJECT_ID / PROJECT_SECRET / BASE_URL not all set)');
+  }
+
+  eventTarget = env.MEMORIA_HOOK_TARGET || null;
+  if (peer && eventTarget) {
+    console.log(`[memoria-cernere] events will be relayed to "${eventTarget}" via peer adapter`);
+  }
+
+  return { admission: !!admission, peer: !!peer };
+}
+
+export async function stopCernere() {
+  try { if (peer) await peer.stop(); } catch {}
+  try { if (admission) admission.disconnect?.(); } catch {}
+  peer = null;
+  admission = null;
+}
+
+/**
+ * Emit a Memoria-side event to the configured peer (typically Imperativus).
+ * Per-user routing is the receiver's responsibility — Memoria just publishes
+ * `{event, user_id, payload}` and trusts Imperativus to dispatch.
+ *
+ * If the peer adapter isn't running, or no target is configured, this is a
+ * silent no-op (best-effort).
+ */
+export async function emitEvent(eventName, { userId = null, payload = {} } = {}) {
+  if (!peer || !eventTarget) return { delivered: false, reason: 'peer-disabled' };
+  try {
+    const r = await peer.invoke(eventTarget, 'events.emit', {
+      source: 'memoria',
+      event: eventName,
+      user_id: userId,
+      payload,
+      ts: Date.now(),
+    });
+    return { delivered: true, target: eventTarget, response: r };
+  } catch (e) {
+    console.warn(`[memoria-cernere] event "${eventName}" → ${eventTarget} failed:`, e?.message ?? e);
+    return { delivered: false, reason: e?.message ?? String(e) };
+  }
+}
+
+export function isAdmissionRevoked(userId) {
+  if (!admission) return false;
+  try { return admission.isRevoked?.(userId) === true; }
+  catch { return false; }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -33,6 +33,7 @@ import { recommendationsFor, dismissRecommendation, clearDismissals } from './re
 import { runDig } from './dig.js';
 import { authMiddleware, readMode, MODES } from './auth.js';
 import { checkContent } from './content-filter.js';
+import { startCernere, stopCernere, emitEvent, isAdmissionRevoked } from './cernere.js';
 import { embed, chunkText, cosine, vecToBuffer, bufferToVec, getModelName } from './embeddings.js';
 import {
   deleteChunks, insertChunk, listChunkRows, bookmarksMissingEmbeddings, chunkStats,
@@ -125,6 +126,11 @@ function enqueueSummary(id) {
       // Schedule embedding generation in the background; if disabled or
       // not yet configured, embeddingQueue will simply error out per-job.
       if (RAG_ENABLED) enqueueEmbedding(id);
+      // Notify subscribers (Imperativus etc.) — best-effort.
+      emitEvent('memoria.summary.done', {
+        userId: cur.user_id ?? null,
+        payload: { id, url: cur.url, title: cur.title, summary, categories },
+      });
     } catch (e) {
       setSummary(db, id, { summary: null, categories: [], status: 'error', error: e.message.slice(0, 500) });
       throw e;
@@ -153,6 +159,15 @@ app.use('/api/*', cors({
   allowHeaders: ['Content-Type', 'Authorization'],
 }));
 app.use('/api/*', authMiddleware({ mode: MODE, secret: JWT_SECRET }));
+// Cernere admission tracks revoked users; deny their service tokens even if
+// the JWT signature still verifies.
+app.use('/api/*', async (c, next) => {
+  const uid = c.get('userId');
+  if (uid && isAdmissionRevoked(uid)) {
+    return c.json({ error: 'unauthorized: user revoked' }, 401);
+  }
+  return next();
+});
 
 // Block visit-history endpoints in online mode — that data is local-only.
 const blockInOnline = (c, next) => {
@@ -202,6 +217,11 @@ app.post('/api/bookmark', async (c) => {
   const id = insertBookmark(db, { url, title, htmlPath: safe, userId });
   recordAccess(db, id);
   enqueueSummary(id);
+
+  emitEvent('memoria.bookmark.saved', {
+    userId,
+    payload: { id, url, title },
+  });
 
   return c.json({ id, queued: true, queueDepth: summaryQueue.depth });
 });
@@ -459,11 +479,15 @@ function claudeAnswer(prompt, timeoutMs = 180_000) {
 
 const digQueue = new FifoQueue();
 
-function enqueueDig(id, query) {
+function enqueueDig(id, query, userId = null) {
   digQueue.enqueue(async () => {
     try {
       const result = await runDig({ query, claudeBin: CLAUDE_BIN });
       setDigResult(db, id, { status: 'done', result });
+      emitEvent('memoria.dig.completed', {
+        userId,
+        payload: { session_id: id, query, source_count: result.sources.length },
+      });
     } catch (e) {
       setDigResult(db, id, { status: 'error', error: e.message.slice(0, 500) });
       throw e;
@@ -476,7 +500,7 @@ app.post('/api/dig', async (c) => {
   const query = body?.query;
   if (!query || typeof query !== 'string') return c.json({ error: 'query required' }, 400);
   const id = insertDigSession(db, query);
-  enqueueDig(id, query);
+  enqueueDig(id, query, c.get('userId') ?? null);
   return c.json({ id, queued: true });
 });
 
@@ -717,10 +741,98 @@ app.post('/api/import', async (c) => {
 app.use('/*', serveStatic({ root: './public' }));
 app.get('/', serveStatic({ path: './public/index.html' }));
 
-serve({ fetch: app.fetch, port: PORT }, (info) => {
+serve({ fetch: app.fetch, port: PORT }, async (info) => {
   console.log(`Memoria server listening on http://localhost:${info.port}`);
   console.log(`  mode: ${MODE}${ONLINE ? ' (auth required)' : ' (no auth)'}`);
   console.log(`  data dir: ${DATA_DIR}`);
   console.log(`  claude bin: ${CLAUDE_BIN}`);
   console.log(`  rag: ${RAG_ENABLED ? 'enabled' : 'disabled'}`);
+
+  // Boot Cernere adapters last so the HTTP API is already accepting requests
+  // when admission events start arriving.
+  try {
+    await startCernere({
+      upsertUser: async (user) => {
+        // Memoria tracks the user_id only — personal data lives in Cernere
+        // (per LUDIARS personal-data rule). We don't need a users table.
+        console.log(`[memoria] admission: ${user.id} (${user.login})`);
+      },
+      revokeUser: async (uid) => {
+        console.log(`[memoria] revoke: ${uid}`);
+      },
+      peerHandlers: buildPeerHandlers(),
+    });
+  } catch (e) {
+    console.error('[memoria] cernere start failed:', e);
+  }
 });
+
+process.on('SIGINT', async () => { await stopCernere(); process.exit(0); });
+process.on('SIGTERM', async () => { await stopCernere(); process.exit(0); });
+
+// ---- peer handlers ---------------------------------------------------------
+//
+// These are the surface other LUDIARS services (Imperativus etc.) call into.
+// All take an explicit user_id in the payload — the peer channel is server-
+// to-server, so the caller must already know who the request is for.
+
+function buildPeerHandlers() {
+  const requireUserId = (p) => {
+    if (!p?.user_id || typeof p.user_id !== 'string') {
+      throw new Error('user_id required');
+    }
+    return p.user_id;
+  };
+
+  return {
+    'memoria.search': async (_caller, p) => {
+      const userId = requireUserId(p);
+      const items = listBookmarks(db, { userId });
+      const q = String(p.query ?? '').toLowerCase();
+      if (!q) return { items: items.slice(0, p.limit ?? 20) };
+      const filtered = items.filter(b =>
+        (b.title || '').toLowerCase().includes(q) ||
+        (b.url || '').toLowerCase().includes(q) ||
+        (b.summary || '').toLowerCase().includes(q) ||
+        (b.memo || '').toLowerCase().includes(q)
+      ).slice(0, p.limit ?? 20);
+      return { items: filtered };
+    },
+    'memoria.save_url': async (_caller, p) => {
+      const userId = requireUserId(p);
+      const url = String(p.url ?? '');
+      if (!/^https?:\/\//.test(url)) throw new Error('valid http(s) url required');
+      const [r] = await bulkSaveUrls([url], { userId });
+      return r;
+    },
+    'memoria.list_categories': async (_caller, _p) => {
+      return { items: listAllCategories(db) };
+    },
+    'memoria.recent_bookmarks': async (_caller, p) => {
+      const userId = requireUserId(p);
+      const items = listBookmarks(db, { userId, sort: 'created_desc' });
+      return { items: items.slice(0, p.limit ?? 10) };
+    },
+    'memoria.get_bookmark': async (_caller, p) => {
+      const userId = requireUserId(p);
+      const id = Number(p.id);
+      const b = getBookmark(db, id, { userId });
+      if (!b) throw new Error('not found');
+      return b;
+    },
+    'memoria.dig': async (_caller, p) => {
+      const userId = requireUserId(p);
+      const query = String(p.query ?? '');
+      if (!query) throw new Error('query required');
+      const id = insertDigSession(db, query);
+      enqueueDig(id, query, userId);
+      return { id, queued: true };
+    },
+    'memoria.unsaved_visits': async (_caller, p) => {
+      // Local-only feature — explicit refusal in online mode mirrors the HTTP
+      // surface so Imperativus can show a clear error to the user.
+      if (ONLINE) throw new Error('unsaved_visits is disabled in online mode');
+      return { items: listSuggestedVisits(db, { sinceDays: Number(p?.days) || 7 }) };
+    },
+  };
+}

--- a/server/package.json
+++ b/server/package.json
@@ -14,5 +14,8 @@
     "better-sqlite3": "^11.3.0",
     "hono": "^4.6.10",
     "node-html-parser": "^6.1.13"
+  },
+  "optionalDependencies": {
+    "@ludiars/cernere-service-adapter": "^0.2.0"
   }
 }


### PR DESCRIPTION
## Summary
@ludiars/cernere-service-adapter を Memoria プロセスに lazy import で取り込み、
admission (Cernere → Memoria) と peer (Imperativus ↔ Memoria) を同時に立ち上げる。

### 連携アーキテクチャ
- **Admission**: Cernere の WS から user_admission を受信 → MEMORIA_JWT_SECRET で
  service_token (HS256) を発行 → Chrome 拡張がそれを使う既存フローへ流れ込む
- **Peer**: Imperativus が memoria.search / save_url / list_categories / recent_bookmarks /
  get_bookmark / dig / unsaved_visits / ping を直接 invoke 可能
- **Event emission**: bookmark.saved / summary.done / dig.completed を MEMORIA_HOOK_TARGET
  (例: imperativus) に events.emit で push。per-user フックは Imperativus 側責任

### Imperativus 側で必要な対応
docs/events.md 参照。最低限 `peer.handle('events.emit', …)` を実装し、
ユーザごとの event_hooks を引いてリレー先 (Slack/Actio/voice 等) にディスパッチする。

### Fallback / CI
- SDK は optionalDependencies、未インストール時は no-op でログ出力のみ
- CI は `npm ci --omit=optional`、private registry の NPM_TOKEN 未設定でも green
- 単独 HS256 検証 (PR #14) はそのまま残るので Cernere 無し開発も可

## Test plan
- [x] CI: lint + smoke (SDK なしで完走)
- [x] cernere.js が SDK 未インストール時に no-op で stop まで通る
- [ ] 手動: Cernere standalone を立てて NPM_TOKEN + CERNERE_* env を入れて起動 → admission 接続ログ確認
- [ ] 手動: FakeCernere ベースの integration テスト (将来 PR)