### PR TITLE
feat: read-public + write-auth + Imperativus relay path (ext v0.5)

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,28 +1,27 @@
 // Memoria background service worker.
-// On every tab activation/URL change, ping the local server with the current URL
-// so it can record an access if that URL is bookmarked.
+//
+// Two send modes (configured in extension options):
+//
+//   local : POST <memoriaServer>/api/bookmark          (no auth, single-user)
+//   relay : POST <imperativusUrl>/api/relay/memoria/save_html
+//                                                       (Cernere JWT, multi-user)
+//
+// In `relay` mode the access ping (`/api/access`) is also disabled — that
+// data is local-only by design.
 
 const DEFAULT_SERVER = 'http://localhost:5180';
 
-// Per-URL throttle: same URL won't ping more than once every N ms across the whole browser.
 const PING_THROTTLE_MS = 60 * 1000;
 const lastPing = new Map();
 
-async function getServer() {
-  const { server } = await chrome.storage.sync.get({ server: DEFAULT_SERVER });
-  return (server || DEFAULT_SERVER).replace(/\/+$/, '');
-}
-
-async function getAuthHeaders() {
-  const { authToken } = await chrome.storage.sync.get({ authToken: '' });
-  const h = { 'Content-Type': 'application/json' };
-  if (authToken) h['Authorization'] = `Bearer ${authToken}`;
-  return h;
-}
-
-async function isTrackingDisabled() {
-  const { disableTracking } = await chrome.storage.sync.get({ disableTracking: false });
-  return !!disableTracking;
+async function readConfig() {
+  return chrome.storage.sync.get({
+    server: DEFAULT_SERVER,
+    disableTracking: false,
+    authToken: '',
+    imperativusUrl: '',
+    mode: 'local',
+  });
 }
 
 function isPingable(url) {
@@ -32,17 +31,19 @@ function isPingable(url) {
 
 async function pingAccess(url, title) {
   if (!isPingable(url)) return;
-  if (await isTrackingDisabled()) return;
+  const cfg = await readConfig();
+  // Tracking is meaningful only in local mode (single-user). The relay mode
+  // is for shared deployments where we don't aggregate raw browsing data.
+  if (cfg.mode !== 'local') return;
+  if (cfg.disableTracking) return;
   const now = Date.now();
   const prev = lastPing.get(url) ?? 0;
   if (now - prev < PING_THROTTLE_MS) return;
   lastPing.set(url, now);
   try {
-    const server = await getServer();
-    const headers = await getAuthHeaders();
-    await fetch(`${server}/api/access`, {
+    await fetch(`${cfg.server.replace(/\/+$/, '')}/api/access`, {
       method: 'POST',
-      headers,
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ url, title: title ?? null }),
     });
   } catch {
@@ -71,24 +72,54 @@ chrome.windows.onFocusChanged.addListener(async (windowId) => {
   } catch {}
 });
 
-// Save bookmark on behalf of the content script (bypasses page CORS).
-chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+/**
+ * Save bookmark on behalf of popup / content script.
+ * Routes either to Memoria HTTP directly (local) or to Imperativus relay.
+ */
+async function saveBookmark(payload) {
+  const cfg = await readConfig();
+  if (cfg.mode === 'relay') {
+    if (!cfg.imperativusUrl) throw new Error('Imperativus URL が設定されていません (オプションを開く)');
+    if (!cfg.authToken)      throw new Error('Cernere service_token が設定されていません');
+    const url = `${cfg.imperativusUrl.replace(/\/+$/, '')}/api/relay/memoria/save_html`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${cfg.authToken}`,
+      },
+      body: JSON.stringify({ url: payload.url, title: payload.title, html: payload.html }),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`Imperativus ${res.status} ${text.slice(0, 200)}`);
+    }
+    const data = await res.json();
+    // peer-relay-api wraps the peer result; extract the inner shape.
+    return { ok: true, ...(data.result || data) };
+  }
+
+  // local mode: direct POST (no auth)
+  const url = `${cfg.server.replace(/\/+$/, '')}/api/bookmark`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Memoria ${res.status} ${text.slice(0, 200)}`);
+  }
+  const data = await res.json();
+  return { ok: true, ...data };
+}
+
+chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg?.type !== 'memoria.save') return false;
   (async () => {
     try {
-      const server = await getServer();
-      const headers = await getAuthHeaders();
-      const res = await fetch(`${server}/api/bookmark`, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify(msg.payload || {}),
-      });
-      if (!res.ok) {
-        const text = await res.text().catch(() => '');
-        throw new Error(`HTTP ${res.status} ${text.slice(0, 120)}`);
-      }
-      const data = await res.json();
-      sendResponse({ ok: true, ...data });
+      const result = await saveBookmark(msg.payload || {});
+      sendResponse(result);
     } catch (e) {
       sendResponse({ ok: false, error: e.message });
     }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Memoria Bookmarker",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Save the current page to a local Memoria server with auto summary and categories.",
   "permissions": ["activeTab", "scripting", "storage", "tabs", "alarms"],
   "host_permissions": ["http://localhost/*", "http://127.0.0.1/*"],

--- a/extension/options.html
+++ b/extension/options.html
@@ -31,15 +31,29 @@
   </fieldset>
 
   <fieldset style="border:1px solid #ddd;padding:8px 12px;margin-top:12px;border-radius:6px">
-    <legend style="padding:0 6px;font-size:12px;color:#555">認証 (オンラインモード)</legend>
-    <label style="display:block;font-size:12px;color:#555;margin-bottom:4px">
-      Bearer JWT (Cernere 等が発行)
+    <legend style="padding:0 6px;font-size:12px;color:#555">送信先モード</legend>
+    <label style="display:flex;align-items:center;gap:8px;font-size:13px">
+      <input id="modeLocal" type="radio" name="mode" value="local" />
+      ローカル直送 — 上の Memoria サーバー URL に直接 POST する (個人運用)
     </label>
-    <input id="authToken" type="password" placeholder="(空欄ならローカル無認証モード)" />
-    <p style="font-size:11px;color:#777;margin:6px 0 0">
-      サーバーが <code>MEMORIA_MODE=online</code> で起動している場合に必要。
-      この JWT は <code>Authorization: Bearer ...</code> ヘッダーで送信されます。
-    </p>
+    <label style="display:flex;align-items:center;gap:8px;font-size:13px;margin-top:6px">
+      <input id="modeRelay" type="radio" name="mode" value="relay" />
+      Imperativus リレー — 共有モードで Cernere 認証を経由してサーバーへ届ける
+    </label>
+    <div id="relayFields" style="margin-top:8px;padding-left:24px;display:none">
+      <label style="display:block;font-size:12px;color:#555;margin-top:4px">
+        Imperativus URL
+        <input id="imperativusUrl" type="url" placeholder="https://imperativus.example.com" />
+      </label>
+      <label style="display:block;font-size:12px;color:#555;margin-top:6px">
+        Cernere service_token (Bearer JWT)
+        <input id="authToken" type="password" placeholder="eyJhbGciOiJIUzI1NiIs..." />
+      </label>
+      <p style="font-size:11px;color:#777;margin:6px 0 0">
+        リレーモードでは保存リクエストは Imperativus の <code>/api/relay/memoria/save_html</code> に送られます。
+        Memoria サーバーへの直接 POST は無効化されます。
+      </p>
+    </div>
   </fieldset>
 
   <div style="margin-top:14px">

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,28 +1,58 @@
 const DEFAULT_SERVER = 'http://localhost:5180';
 
-const serverInput = document.getElementById('server');
-const trackingInput = document.getElementById('disableTracking');
-const tokenInput = document.getElementById('authToken');
-const msg = document.getElementById('msg');
+const serverInput      = document.getElementById('server');
+const trackingInput    = document.getElementById('disableTracking');
+const tokenInput       = document.getElementById('authToken');
+const imperativusInput = document.getElementById('imperativusUrl');
+const modeLocal        = document.getElementById('modeLocal');
+const modeRelay        = document.getElementById('modeRelay');
+const relayFields      = document.getElementById('relayFields');
+const msg              = document.getElementById('msg');
+
+function applyModeToggle() {
+  relayFields.style.display = modeRelay.checked ? 'block' : 'none';
+}
 
 (async () => {
   const cfg = await chrome.storage.sync.get({
     server: DEFAULT_SERVER,
     disableTracking: false,
     authToken: '',
+    imperativusUrl: '',
+    mode: 'local', // 'local' | 'relay'
   });
-  serverInput.value = cfg.server;
-  trackingInput.checked = !!cfg.disableTracking;
-  tokenInput.value = cfg.authToken || '';
+  serverInput.value      = cfg.server;
+  trackingInput.checked  = !!cfg.disableTracking;
+  tokenInput.value       = cfg.authToken || '';
+  imperativusInput.value = cfg.imperativusUrl || '';
+  if (cfg.mode === 'relay') modeRelay.checked = true; else modeLocal.checked = true;
+  applyModeToggle();
 })();
 
+modeLocal.addEventListener('change', applyModeToggle);
+modeRelay.addEventListener('change', applyModeToggle);
+
 document.getElementById('save').addEventListener('click', async () => {
-  const server = serverInput.value.trim() || DEFAULT_SERVER;
-  await chrome.storage.sync.set({
-    server,
+  const mode = modeRelay.checked ? 'relay' : 'local';
+  const cfg = {
+    server: (serverInput.value.trim() || DEFAULT_SERVER).replace(/\/+$/, ''),
     disableTracking: !!trackingInput.checked,
     authToken: tokenInput.value.trim(),
-  });
+    imperativusUrl: (imperativusInput.value.trim() || '').replace(/\/+$/, ''),
+    mode,
+  };
+  if (mode === 'relay' && !cfg.imperativusUrl) {
+    msg.textContent = 'リレーモードでは Imperativus URL が必須です';
+    msg.style.color = '#c33';
+    return;
+  }
+  if (mode === 'relay' && !cfg.authToken) {
+    msg.textContent = 'リレーモードでは Cernere service_token が必須です';
+    msg.style.color = '#c33';
+    return;
+  }
+  await chrome.storage.sync.set(cfg);
   msg.textContent = '保存しました';
+  msg.style.color = '#2a7';
   setTimeout(() => { msg.textContent = ''; }, 1500);
 });

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,15 +1,11 @@
 const DEFAULT_SERVER = 'http://localhost:5180';
 
-async function getServer() {
-  const { server } = await chrome.storage.sync.get({ server: DEFAULT_SERVER });
-  return server.replace(/\/+$/, '');
-}
-
-async function getAuthHeaders() {
-  const { authToken } = await chrome.storage.sync.get({ authToken: '' });
-  const h = { 'Content-Type': 'application/json' };
-  if (authToken) h['Authorization'] = `Bearer ${authToken}`;
-  return h;
+async function readConfig() {
+  return chrome.storage.sync.get({
+    server: DEFAULT_SERVER,
+    mode: 'local',
+    imperativusUrl: '',
+  });
 }
 
 const statusEl = document.getElementById('status');
@@ -17,7 +13,9 @@ const saveBtn = document.getElementById('save');
 const openUi = document.getElementById('openUi');
 
 (async () => {
-  openUi.href = await getServer();
+  // 「Memoria を開く」 のリンクは Memoria サーバー UI を指す (relay モードでも閲覧は memoria server で).
+  const cfg = await readConfig();
+  openUi.href = cfg.server;
 })();
 
 saveBtn.addEventListener('click', async () => {
@@ -25,7 +23,6 @@ saveBtn.addEventListener('click', async () => {
   statusEl.className = '';
   statusEl.textContent = 'ページを取得中...';
   try {
-    const server = await getServer();
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
     if (!tab?.id) throw new Error('アクティブなタブが見つかりません');
     if (tab.url?.startsWith('chrome://') || tab.url?.startsWith('chrome-extension://')) {
@@ -39,20 +36,21 @@ saveBtn.addEventListener('click', async () => {
         url: location.href,
       }),
     });
+
     statusEl.textContent = '送信中...';
-    const headers = await getAuthHeaders();
-    const res = await fetch(`${server}/api/bookmark`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(result),
-    });
-    if (!res.ok) {
-      const text = await res.text().catch(() => '');
-      throw new Error(`サーバーエラー ${res.status}: ${text.slice(0, 100)}`);
+    // Delegate to background — it handles local vs relay routing in one place.
+    const res = await chrome.runtime.sendMessage({ type: 'memoria.save', payload: result });
+    if (!res?.ok) {
+      throw new Error(res?.error ?? '不明なエラー');
     }
-    const data = await res.json();
     statusEl.className = 'ok';
-    statusEl.textContent = `保存しました (id=${data.id})。要約処理中...`;
+    if (res.duplicate) {
+      statusEl.textContent = `保存済み (id=${res.id})`;
+    } else if (res.id) {
+      statusEl.textContent = `保存しました (id=${res.id})。要約処理中...`;
+    } else {
+      statusEl.textContent = '保存しました';
+    }
   } catch (e) {
     statusEl.className = 'err';
     statusEl.textContent = `エラー: ${e.message}`;

--- a/service/auth.js
+++ b/service/auth.js
@@ -2,11 +2,11 @@
 //
 // Memoria has two run modes:
 //
-//   MEMORIA_MODE=local   (default) — single-user, no auth, all endpoints open
-//   MEMORIA_MODE=online            — multi-user, every API call must carry
-//                                    a Bearer JWT signed with MEMORIA_JWT_SECRET
-//                                    (HS256). The token's `sub` claim is used
-//                                    as the user_id.
+//   MEMORIA_MODE=local   (default) — single-user, no auth, all endpoints open.
+//   MEMORIA_MODE=online            — multi-user. GET endpoints are public; any
+//                                    mutation requires a Bearer JWT signed with
+//                                    MEMORIA_JWT_SECRET (HS256). The token's
+//                                    `sub` claim is used as the user_id.
 //
 // In production this secret should be the SAME secret used by the Cernere
 // service-adapter when issuing service-scoped JWTs (see Cernere
@@ -65,33 +65,49 @@ function base64UrlDecode(s) {
 }
 
 /**
- * Hono middleware. In ONLINE mode, requires a valid Bearer token; sets
- * `c.set("userId", ...)` for downstream handlers. In LOCAL mode this is a
- * no-op and userId stays null.
+ * Fail-open auth middleware.
+ *
+ *   - LOCAL  : userId = null, mode = 'local'
+ *   - ONLINE : if a valid Bearer JWT is present → userId = sub.
+ *              Missing or invalid token → userId = null (request continues).
+ *
+ * Per-route mutation handlers should call `requireAuth(c)` and bail out on a
+ * 401 from this helper. Read endpoints stay public in online mode so the
+ * Memoria UI can serve as a viewer for unauthenticated visitors.
  */
 export function authMiddleware({ mode, secret }) {
   return async (c, next) => {
+    c.set('mode', mode);
     if (mode !== MODES.ONLINE) {
       c.set('userId', null);
-      c.set('mode', mode);
       return next();
-    }
-    if (!secret) {
-      return c.json({ error: 'server misconfigured: MEMORIA_JWT_SECRET not set' }, 500);
     }
     const auth = c.req.header('Authorization') || c.req.header('authorization') || '';
     const m = auth.match(/^Bearer\s+(.+)$/i);
-    if (!m) {
-      return c.json({ error: 'unauthorized: bearer token required' }, 401);
+    if (!m || !secret) {
+      c.set('userId', null);
+      return next();
     }
-    let payload;
-    try { payload = verifyJwt(m[1], secret); }
-    catch (e) { return c.json({ error: `unauthorized: ${e.message}` }, 401); }
-    if (!payload.sub) {
-      return c.json({ error: 'unauthorized: token missing sub' }, 401);
+    try {
+      const payload = verifyJwt(m[1], secret);
+      c.set('userId', payload.sub ? String(payload.sub) : null);
+    } catch {
+      c.set('userId', null);
     }
-    c.set('userId', String(payload.sub));
-    c.set('mode', mode);
     return next();
   };
+}
+
+/**
+ * Per-route auth gate. Use inside any handler that performs a mutation.
+ * Returns `null` when the request is allowed to proceed, or a 401 Response
+ * the caller should `return` directly.
+ *
+ * In LOCAL mode this is always a no-op (no auth concept). In ONLINE mode
+ * the request must already carry a valid Bearer JWT (verified by middleware).
+ */
+export function requireAuth(c) {
+  if ((c.get('mode') ?? 'local') !== MODES.ONLINE) return null;
+  if (c.get('userId')) return null;
+  return c.json({ error: 'unauthorized: sign-in required for write actions' }, 401);
 }

--- a/service/cernere.js
+++ b/service/cernere.js
@@ -115,6 +115,7 @@ export async function startCernere(ctx) {
         imperativus: [
           'memoria.search',
           'memoria.save_url',
+          'memoria.save_html',
           'memoria.list_categories',
           'memoria.recent_bookmarks',
           'memoria.get_bookmark',

--- a/service/index.js
+++ b/service/index.js
@@ -31,7 +31,7 @@ import { summarizeWithClaude, htmlToText } from './claude.js';
 import { FifoQueue } from './queue.js';
 import { recommendationsFor, dismissRecommendation, clearDismissals } from './recommendations.js';
 import { runDig } from './dig.js';
-import { authMiddleware, readMode, MODES } from './auth.js';
+import { authMiddleware, readMode, MODES, requireAuth } from './auth.js';
 import { checkContent } from './content-filter.js';
 import { startCernere, stopCernere, emitEvent, isAdmissionRevoked } from './cernere.js';
 import { embed, chunkText, cosine, vecToBuffer, bufferToVec, getModelName } from './embeddings.js';
@@ -179,51 +179,99 @@ app.get('/api/mode', (c) => c.json({
   mode: MODE,
   rag_enabled: RAG_ENABLED,
   user_id: c.get('userId') ?? null,
+  authenticated: !!c.get('userId'),
+  // List of capabilities available to the current request — the FE uses this
+  // to decide which write controls to render.
+  caps: capabilitiesFor(c),
 }));
+
+function capabilitiesFor(c) {
+  if (MODE !== MODES.ONLINE) return ALL_CAPS;
+  if (c.get('userId')) return ALL_CAPS;
+  return READ_CAPS;
+}
+
+const ALL_CAPS = ['read', 'write', 'memo', 'import', 'export', 'dig', 'rag.ask'];
+const READ_CAPS = ['read'];
 
 // ---- bookmark CRUD ---------------------------------------------------------
 
-app.post('/api/bookmark', async (c) => {
-  const userId = c.get('userId') ?? null;
-  const body = await c.req.json().catch(() => null);
-  if (!body || typeof body.html !== 'string' || typeof body.url !== 'string') {
-    return c.json({ error: 'html, url, title required' }, 400);
+/**
+ * Core save logic shared by the local HTTP path and the Imperativus peer
+ * relay path. Returns the same shape as `POST /api/bookmark` would.
+ *
+ * Throws a tagged error (`{ status, body }`) when the request should be
+ * refused; callers translate it into either an HTTP response or a peer
+ * exception.
+ */
+function saveBookmarkFromHtml({ url, title, html, userId }) {
+  if (typeof html !== 'string' || typeof url !== 'string') {
+    throw makeError(400, { error: 'html, url, title required' });
   }
-  const url = body.url;
-  const title = (body.title || url).slice(0, 500);
-  const html = body.html;
+  const titleStr = (title || url).slice(0, 500);
 
-  // Reject NG / R18 content before touching disk or DB.
-  const filt = checkContent({ url, title, html });
+  const filt = checkContent({ url, title: titleStr, html });
   if (!filt.ok) {
-    return c.json({
+    throw makeError(422, {
       error: 'content blocked by NG word filter',
       reason: filt.reason,
       matches: filt.matches,
-    }, 422);
+    });
   }
 
   const existing = findBookmarkByUrl(db, url, { userId });
   if (existing) {
     recordAccess(db, existing.id);
-    return c.json({ id: existing.id, duplicate: true });
+    return { id: existing.id, duplicate: true };
   }
 
   const ts = new Date().toISOString().replace(/[:.]/g, '-');
   const safe = ts + '_' + Math.random().toString(36).slice(2, 8) + '.html';
-  const htmlPath = join(HTML_DIR, safe);
-  writeFileSync(htmlPath, html, 'utf8');
+  writeFileSync(join(HTML_DIR, safe), html, 'utf8');
 
-  const id = insertBookmark(db, { url, title, htmlPath: safe, userId });
+  const id = insertBookmark(db, { url, title: titleStr, htmlPath: safe, userId });
   recordAccess(db, id);
   enqueueSummary(id);
 
   emitEvent('memoria.bookmark.saved', {
     userId,
-    payload: { id, url, title },
+    payload: { id, url, title: titleStr },
   });
 
-  return c.json({ id, queued: true, queueDepth: summaryQueue.depth });
+  return { id, queued: true, queueDepth: summaryQueue.depth };
+}
+
+function makeError(status, body) {
+  const err = new Error(body.error || 'request rejected');
+  err.status = status;
+  err.body = body;
+  return err;
+}
+
+app.post('/api/bookmark', async (c) => {
+  // In ONLINE mode the only supported save path is via the Imperativus relay
+  // (POST /api/relay/memoria/save_html → peer.invoke memoria.save_html).
+  // Direct HTTP submissions from the Chrome extension are intentionally
+  // rejected so all multi-user writes flow through the gateway.
+  if (ONLINE) {
+    return c.json({
+      error: 'direct /api/bookmark is disabled in online mode — use POST /api/relay/memoria/save_html via Imperativus',
+    }, 410);
+  }
+  const denied = requireAuth(c);
+  if (denied) return denied;
+  const userId = c.get('userId') ?? null;
+  const body = await c.req.json().catch(() => null);
+  if (!body) return c.json({ error: 'json body required' }, 400);
+  try {
+    const result = saveBookmarkFromHtml({
+      url: body.url, title: body.title, html: body.html, userId,
+    });
+    return c.json(result);
+  } catch (e) {
+    if (e?.status) return c.json(e.body, e.status);
+    throw e;
+  }
 });
 
 app.get('/api/bookmarks', (c) => {
@@ -241,6 +289,8 @@ app.get('/api/bookmarks/:id', (c) => {
 });
 
 app.patch('/api/bookmarks/:id', async (c) => {
+  const denied = requireAuth(c);
+  if (denied) return denied;
   const id = Number(c.req.param('id'));
   const userId = c.get('userId') ?? null;
   const b = getBookmark(db, id, { userId });
@@ -254,6 +304,8 @@ app.patch('/api/bookmarks/:id', async (c) => {
 });
 
 app.delete('/api/bookmarks/:id', (c) => {
+  const denied = requireAuth(c);
+  if (denied) return denied;
   const id = Number(c.req.param('id'));
   const userId = c.get('userId') ?? null;
   if (!getBookmark(db, id, { userId })) {
@@ -268,6 +320,8 @@ app.delete('/api/bookmarks/:id', (c) => {
 });
 
 app.post('/api/bookmarks/:id/resummarize', async (c) => {
+  const denied = requireAuth(c);
+  if (denied) return denied;
   const id = Number(c.req.param('id'));
   const b = getBookmark(db, id);
   if (!b) return c.json({ error: 'not found' }, 404);
@@ -326,6 +380,8 @@ app.get('/api/recommendations', (c) => {
 });
 
 app.post('/api/recommendations/dismiss', async (c) => {
+  const denied = requireAuth(c);
+  if (denied) return denied;
   const body = await c.req.json().catch(() => null);
   if (!body?.url) return c.json({ error: 'url required' }, 400);
   dismissRecommendation(db, body.url);
@@ -333,6 +389,8 @@ app.post('/api/recommendations/dismiss', async (c) => {
 });
 
 app.delete('/api/recommendations/dismissals', (c) => {
+  const denied = requireAuth(c);
+  if (denied) return denied;
   clearDismissals(db);
   return c.json({ ok: true });
 });
@@ -351,6 +409,8 @@ app.get('/api/rag/status', (c) => {
 });
 
 app.post('/api/rag/backfill', (c) => {
+  const denied = requireAuth(c);
+  if (denied) return denied;
   if (!RAG_ENABLED) return c.json({ error: 'RAG disabled (MEMORIA_RAG=0)' }, 503);
   const ids = bookmarksMissingEmbeddings(db);
   for (const id of ids) enqueueEmbedding(id);
@@ -358,6 +418,8 @@ app.post('/api/rag/backfill', (c) => {
 });
 
 app.post('/api/rag/reindex/:id', (c) => {
+  const denied = requireAuth(c);
+  if (denied) return denied;
   if (!RAG_ENABLED) return c.json({ error: 'RAG disabled' }, 503);
   const id = Number(c.req.param('id'));
   if (!getBookmark(db, id)) return c.json({ error: 'not found' }, 404);
@@ -399,6 +461,8 @@ app.get('/api/search', async (c) => {
 });
 
 app.post('/api/ask', async (c) => {
+  const denied = requireAuth(c);
+  if (denied) return denied;
   if (!RAG_ENABLED) return c.json({ error: 'RAG disabled' }, 503);
   const body = await c.req.json().catch(() => null);
   const q = body?.q;
@@ -496,6 +560,8 @@ function enqueueDig(id, query, userId = null) {
 }
 
 app.post('/api/dig', async (c) => {
+  const denied = requireAuth(c);
+  if (denied) return denied;
   const body = await c.req.json().catch(() => null);
   const query = body?.query;
   if (!query || typeof query !== 'string') return c.json({ error: 'query required' }, 400);
@@ -516,6 +582,8 @@ app.get('/api/dig/:id', (c) => {
 });
 
 app.post('/api/dig/:id/save', async (c) => {
+  const denied = requireAuth(c);
+  if (denied) return denied;
   const body = await c.req.json().catch(() => null);
   if (!body || !Array.isArray(body.urls)) return c.json({ error: 'urls[] required' }, 400);
   return c.json({ results: await bulkSaveUrls(body.urls, { userId: c.get('userId') ?? null }) });
@@ -686,6 +754,8 @@ function decodeHtmlEntities(s) {
 // ---- export / import ------------------------------------------------------
 
 app.post('/api/export', async (c) => {
+  const denied = requireAuth(c);
+  if (denied) return denied;
   const body = await c.req.json().catch(() => ({}));
   const ids = Array.isArray(body.ids) ? body.ids.map(Number).filter(Number.isFinite) : null;
   const includeHtml = body.includeHtml !== false; // default true
@@ -718,6 +788,8 @@ app.post('/api/export', async (c) => {
 });
 
 app.post('/api/import', async (c) => {
+  const denied = requireAuth(c);
+  if (denied) return denied;
   const body = await c.req.json().catch(() => null);
   if (!body || !Array.isArray(body.bookmarks)) return c.json({ error: 'bookmarks[] required' }, 400);
   const results = { imported: 0, skipped: 0, ids: [] };
@@ -804,6 +876,27 @@ function buildPeerHandlers() {
       if (!/^https?:\/\//.test(url)) throw new Error('valid http(s) url required');
       const [r] = await bulkSaveUrls([url], { userId });
       return r;
+    },
+    'memoria.save_html': async (_caller, p) => {
+      // Caller already supplies the rendered HTML (typically the Chrome
+      // extension forwarded by Imperativus). user_id comes from the verified
+      // peer JWT — the FE/extension cannot impersonate.
+      const userId = requireUserId(p);
+      try {
+        return saveBookmarkFromHtml({
+          url: String(p.url ?? ''),
+          title: String(p.title ?? ''),
+          html: String(p.html ?? ''),
+          userId,
+        });
+      } catch (e) {
+        if (e?.body) {
+          const err = new Error(e.body.error || 'rejected');
+          err.body = e.body;
+          throw err;
+        }
+        throw e;
+      }
     },
     'memoria.list_categories': async (_caller, _p) => {
       return { items: listAllCategories(db) };

--- a/service/public/app.js
+++ b/service/public/app.js
@@ -21,12 +21,28 @@ const state = {
   digSelected: new Set(),
   digPolling: null,
   mode: 'local',
+  user: null,
+  caps: ['read', 'write'],
 };
 
 const $ = (id) => document.getElementById(id);
 
-async function api(path, opts) {
-  const res = await fetch(path, opts);
+const TOKEN_KEY = 'memoria_token';
+function getToken() { try { return localStorage.getItem(TOKEN_KEY) ?? ''; } catch { return ''; } }
+function setToken(v) { try { v ? localStorage.setItem(TOKEN_KEY, v) : localStorage.removeItem(TOKEN_KEY); } catch {} }
+
+async function api(path, opts = {}) {
+  const headers = new Headers(opts.headers || {});
+  const token = getToken();
+  if (token && !headers.has('Authorization')) headers.set('Authorization', `Bearer ${token}`);
+  const res = await fetch(path, { ...opts, headers });
+  if (res.status === 401) {
+    // Token bad/expired — drop it so the FE drops back to read-only.
+    if (getToken()) {
+      setToken('');
+      applyMode();
+    }
+  }
   if (!res.ok) throw new Error(`${res.status} ${await res.text().catch(()=>'')}`);
   return res.json();
 }
@@ -159,7 +175,9 @@ async function renderDetail() {
   $('dStatus').textContent = b.status + (b.error ? ` (${b.error})` : '');
   $('dSummary').textContent = b.summary || '(要約なし)';
   $('dCategories').value = (b.categories || []).join(', ');
+  $('dCategoriesView').textContent = (b.categories || []).join(', ');
   $('dMemo').value = b.memo || '';
+  $('dMemoView').textContent = b.memo || '';
   $('dViewHtml').href = `/api/bookmarks/${id}/html`;
   $('dAccesses').innerHTML = (accesses.items || []).map(a => `<li>${fmtDate(a.accessed_at)}</li>`).join('');
 }
@@ -281,12 +299,19 @@ $('importInput').addEventListener('change', async (e) => {
 
 async function applyMode() {
   try {
+    // Mode endpoint is public — calling it without a token is fine.
     const r = await api('/api/mode');
     state.mode = r.mode;
+    state.user = r.user_id ? { id: r.user_id } : null;
+    state.caps = r.caps || (r.mode === 'online' ? ['read'] : ['read', 'write']);
     const isOnline = r.mode === 'online';
-    // Hide visit-related UI in online mode.
+    const authed = !!r.user_id;
+
+    // Visit-history tab is hidden in online mode (server-side disabled too).
     document.querySelector('.tab[data-tab="visits"]')?.classList.toggle('hidden', isOnline);
     if (isOnline && state.tab === 'visits') switchTab('bookmarks');
+
+    // Online mode badge
     if (isOnline) {
       document.body.dataset.mode = 'online';
       const brand = document.querySelector('.brand');
@@ -295,8 +320,83 @@ async function applyMode() {
         brand.dataset.modeAnnotated = '1';
       }
     }
+
+    // Read-only iff online + unauthenticated.
+    document.body.classList.toggle('readonly', isOnline && !authed);
+
+    // Sign-in / out controls visibility.
+    const signInBtn = $('signInBtn');
+    const userChip = $('userChip');
+    if (isOnline) {
+      signInBtn.classList.toggle('hidden', authed);
+      userChip.classList.toggle('hidden', !authed);
+      if (authed) {
+        $('userChipId').textContent = r.user_id;
+      }
+    } else {
+      signInBtn.classList.add('hidden');
+      userChip.classList.add('hidden');
+    }
   } catch (e) { console.warn('mode check failed', e); }
 }
+
+// ── sign-in / sign-out ──────────────────────────────────────────────────
+
+function openSignIn() {
+  const overlay = $('signInOverlay');
+  const tokenInput = $('signInToken');
+  const errEl = $('signInError');
+  errEl.classList.add('hidden');
+  tokenInput.value = '';
+  overlay.classList.remove('hidden');
+  setTimeout(() => tokenInput.focus(), 30);
+}
+
+function closeSignIn() {
+  $('signInOverlay').classList.add('hidden');
+}
+
+async function submitSignIn() {
+  const token = $('signInToken').value.trim();
+  const errEl = $('signInError');
+  if (!token) {
+    errEl.textContent = 'トークンを入力してください';
+    errEl.classList.remove('hidden');
+    return;
+  }
+  setToken(token);
+  try {
+    const r = await api('/api/mode');
+    if (!r.user_id) {
+      throw new Error('トークンは受理されましたが user_id が取得できませんでした');
+    }
+    closeSignIn();
+    await applyMode();
+    // Reload data in case some endpoints now expose more (unchanged today,
+    // but future additions may filter per-user).
+    await load();
+  } catch (e) {
+    setToken('');
+    errEl.textContent = `サインイン失敗: ${e.message}`;
+    errEl.classList.remove('hidden');
+  }
+}
+
+function signOut() {
+  setToken('');
+  applyMode();
+}
+
+$('signInBtn')?.addEventListener('click', openSignIn);
+$('signInCancel')?.addEventListener('click', closeSignIn);
+$('signInSubmit')?.addEventListener('click', submitSignIn);
+$('signInToken')?.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) submitSignIn();
+});
+$('signOutBtn')?.addEventListener('click', signOut);
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape' && !$('signInOverlay').classList.contains('hidden')) closeSignIn();
+});
 
 applyMode();
 

--- a/service/public/index.html
+++ b/service/public/index.html
@@ -19,12 +19,37 @@
         <option value="title_asc">タイトル (A→Z)</option>
       </select>
       <input id="search" type="search" placeholder="検索 (タイトル・URL・要約)" />
-      <button id="exportBtn" class="ghost" title="選択中をエクスポート">Export</button>
-      <label class="ghost file-btn">
+      <button id="exportBtn" class="ghost write-only" title="選択中をエクスポート">Export</button>
+      <label class="ghost file-btn write-only">
         Import<input id="importInput" type="file" accept="application/json" hidden />
       </label>
+      <button id="signInBtn" class="ghost auth-btn hidden" title="サインインしてメモ・インポート・エクスポートを有効化">サインイン</button>
+      <div id="userChip" class="user-chip hidden" title="サインアウト">
+        <span id="userChipId">user</span>
+        <button id="signOutBtn" type="button" aria-label="サインアウト">×</button>
+      </div>
     </div>
   </header>
+
+  <!-- Sign-in modal -->
+  <div id="signInOverlay" class="auth-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="signInTitle">
+    <div class="auth-card">
+      <h2 id="signInTitle">Memoria サインイン</h2>
+      <p>
+        Cernere の admission flow で発行された <strong>service_token</strong> (HS256 JWT) を貼り付けてください。
+        トークンは localStorage に保存され、書き込みリクエストの <code>Authorization</code> ヘッダーで送信されます。
+      </p>
+      <textarea id="signInToken" placeholder="eyJhbGciOiJIUzI1NiIs..." rows="4" autocomplete="off"></textarea>
+      <div class="auth-actions">
+        <button id="signInSubmit" class="primary">サインイン</button>
+        <button id="signInCancel" class="ghost">キャンセル</button>
+      </div>
+      <div id="signInError" class="auth-error hidden"></div>
+      <p class="auth-help">
+        <em>開発用</em>: <code>cd service &amp;&amp; npm run issue-token &lt;your_id&gt;</code> で開発用 JWT を発行できます。
+      </p>
+    </div>
+  </div>
 
   <main class="layout">
     <aside class="sidebar">
@@ -74,7 +99,7 @@
           </select>
           <button id="visitsRefresh" class="ghost">更新</button>
         </div>
-        <div class="visits-actions">
+        <div class="visits-actions write-only">
           <label class="check-inline">
             <input type="checkbox" id="visitsAll" /> 全選択
           </label>
@@ -123,9 +148,12 @@
       </div>
 
       <div id="digView" class="hidden">
-        <div class="dig-input">
+        <div class="dig-input write-only">
           <input id="digQuery" type="text" placeholder="掘りたい単語または質問を入力 (例: WebGPU compute shader readback)" />
           <button id="digRun">ディグる</button>
+        </div>
+        <div class="auth-required write-only-inverse hidden">
+          ディグる機能は <strong>サインイン後</strong> に利用できます。
         </div>
         <div id="digHistory" class="dig-history"></div>
         <div id="digResult" class="dig-result"></div>
@@ -137,7 +165,7 @@
         <div class="rag-search">
           <input id="ragQuery" type="search" placeholder="保存済みブックマークから意味検索…" />
           <button id="ragSearchBtn">検索</button>
-          <button id="ragAskBtn" class="ghost">この質問で答える</button>
+          <button id="ragAskBtn" class="ghost write-only">この質問で答える</button>
         </div>
 
         <div id="ragAnswer" class="rag-answer hidden"></div>
@@ -180,15 +208,17 @@
       </div>
       <h3>要約</h3>
       <div id="dSummary" class="summary"></div>
-      <h3>カテゴリ</h3>
-      <input id="dCategories" type="text" placeholder="カンマ区切り" />
-      <h3>メモ</h3>
-      <textarea id="dMemo" rows="6" placeholder="メモを書く"></textarea>
+      <h3 class="write-only">カテゴリ</h3>
+      <input id="dCategories" type="text" placeholder="カンマ区切り" class="write-only" />
+      <div id="dCategoriesView" class="readonly-only categories-view hidden"></div>
+      <h3 class="write-only">メモ</h3>
+      <textarea id="dMemo" rows="6" placeholder="メモを書く" class="write-only"></textarea>
+      <div id="dMemoView" class="readonly-only memo-view hidden"></div>
       <div class="detail-actions">
-        <button id="dSave">保存</button>
-        <button id="dResummarize" class="ghost">再要約</button>
+        <button id="dSave" class="write-only">保存</button>
+        <button id="dResummarize" class="ghost write-only">再要約</button>
         <a id="dViewHtml" href="#" target="_blank" class="ghost">保存 HTML を開く</a>
-        <button id="dDelete" class="danger">削除</button>
+        <button id="dDelete" class="danger write-only">削除</button>
       </div>
       <h3>アクセス履歴</h3>
       <ul id="dAccesses" class="accesses"></ul>

--- a/service/public/style.css
+++ b/service/public/style.css
@@ -149,6 +149,107 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   margin-left: 8px;
   font-weight: 600;
 }
+
+/* Read-only mode (online + unauthenticated): hide write controls. */
+body.readonly .write-only { display: none !important; }
+body:not(.readonly) .readonly-only { display: none !important; }
+body:not(.readonly) .write-only-inverse { display: none !important; }
+body.readonly .write-only-inverse { display: block !important; }
+body.readonly .auth-required {
+  background: #fff8ec;
+  border: 1px solid #f0c97a;
+  border-radius: 8px;
+  padding: 10px 14px;
+  color: #8a5a00;
+  font-size: 13px;
+  margin: 12px 0;
+}
+
+.auth-btn { padding: 6px 12px; }
+.user-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--accent-bg);
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 999px;
+  padding: 2px 4px 2px 10px;
+  font-size: 12px;
+  font-family: ui-monospace, monospace;
+}
+.user-chip.hidden { display: none; }
+.user-chip button {
+  background: transparent;
+  border: 0;
+  color: var(--accent);
+  font-size: 14px;
+  line-height: 1;
+  padding: 0 6px;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.user-chip button:hover { background: rgba(42, 109, 244, 0.15); }
+
+.auth-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(20, 25, 40, 0.55);
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.auth-overlay.hidden { display: none; }
+.auth-card {
+  background: var(--panel);
+  border-radius: 12px;
+  padding: 24px;
+  width: 480px;
+  max-width: calc(100vw - 32px);
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.25);
+}
+.auth-card h2 { margin: 0 0 8px; font-size: 18px; }
+.auth-card p { font-size: 13px; line-height: 1.6; color: var(--muted); }
+.auth-card textarea {
+  width: 100%;
+  font-family: ui-monospace, monospace;
+  font-size: 11px;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  resize: vertical;
+  margin-top: 8px;
+  box-sizing: border-box;
+}
+.auth-actions { display: flex; gap: 8px; margin-top: 12px; }
+.auth-error {
+  background: #fae6e6;
+  color: var(--danger);
+  border: 1px solid #f0a6a0;
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 12px;
+  margin-top: 10px;
+}
+.auth-help { font-size: 11px; color: var(--muted); margin-top: 12px; }
+.auth-help code { background: var(--bg); padding: 1px 4px; border-radius: 3px; }
+
+.memo-view, .categories-view {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 13px;
+  white-space: pre-wrap;
+  margin-top: 4px;
+  min-height: 1.6em;
+}
+.memo-view:empty::before, .categories-view:empty::before {
+  content: '(未設定)';
+  color: var(--muted);
+  font-style: italic;
+}
 .tab-count {
   background: #fff5e1;
   color: #8a5a00;

--- a/spec/events.md
+++ b/spec/events.md
@@ -15,7 +15,8 @@ Memoria が `@ludiars/cernere-service-adapter` の `PeerAdapter` 経由で公開
 | Command | 入力 | 出力 |
 |---------|------|------|
 | `memoria.search` | `{ user_id, query, limit? }` | `{ items: BookmarkRow[] }` (タイトル/URL/要約/メモを substring 検索) |
-| `memoria.save_url` | `{ user_id, url }` | `{ status: 'queued' / 'duplicate' / 'blocked', id?, reason?, matches? }` (HTML を fetch して保存、要約キュー投入。NG ワードは `blocked`) |
+| `memoria.save_url` | `{ user_id, url }` | `{ status: 'queued' / 'duplicate' / 'blocked', id?, reason?, matches? }` (Memoria が server-side fetch して保存、要約キュー投入。NG ワードは `blocked`) |
+| `memoria.save_html` | `{ user_id, url, title, html }` | `{ id, queued: true / duplicate: true }` (呼び出し側で rendered HTML を持っているケース。Imperativus が Chrome 拡張から受け取った HTML を中継するときの primary パス。online モードでは `POST /api/bookmark` の代替) |
 | `memoria.list_categories` | `{}` | `{ items: [{ category, count }] }` |
 | `memoria.recent_bookmarks` | `{ user_id, limit? }` | `{ items: BookmarkRow[] }` |
 | `memoria.get_bookmark` | `{ user_id, id }` | `BookmarkRow` |

--- a/spec/frontend/extension.md
+++ b/spec/frontend/extension.md
@@ -2,8 +2,25 @@
 
 ## 目的
 
-ユーザーが見ている Web ページを **ワンクリック** で Memoria サーバーへ送り、要約キューに乗せる。
-タブ切替時の URL ping でアクセス頻度を集計する。
+ユーザーが見ている Web ページを **ワンクリック** で Memoria に登録する。
+個人運用は Memoria サーバーへ直送、共有運用は Imperativus 経由でリレーする。
+
+## 動作モード (`storage.sync.mode`)
+
+| mode | 送信先 | 認証 | アクセス追跡 |
+|------|--------|------|--------------|
+| `local` (既定) | `${server}/api/bookmark` | なし | `/api/access` を送る (ON 時) |
+| `relay` | `${imperativusUrl}/api/relay/memoria/save_html` | Cernere `Bearer JWT` 必須 | 送らない (privacy) |
+
+`relay` モードでは Memoria サーバーへ直接書き込むパスは消える。
+すべての保存は Imperativus を経由し、Imperativus 内で `user_id` がトークンから強制設定される。
+
+## 旧来動作との差分
+
+| | v0.4 (PR #14) | v0.5 (本仕様) |
+|---|---|---|
+| online での書込 | 拡張から Memoria に Bearer 付き直送 | **削除** — Imperativus 中継のみ |
+| options の認証欄 | `authToken` (Memoria 用 Bearer) | `authToken` (Cernere service_token) + relay モード切替 |
 
 ## 構成
 

--- a/spec/server/modules/bookmark.md
+++ b/spec/server/modules/bookmark.md
@@ -1,9 +1,19 @@
 # Module: Bookmark
 
-`POST /api/bookmark` から始まる保存フロー全般。
+保存フロー全般 (HTTP `POST /api/bookmark` または peer `memoria.save_html`)。
 
 ## 目的
-Chrome 拡張・MCP・peer 経由で受け取った HTML/URL/title を、ファイル + DB に永続化し、要約キューへ流す。
+Chrome 拡張・MCP・Imperativus 中継経由で受け取った HTML/URL/title を、ファイル + DB に永続化し、要約キューへ流す。
+
+## 入口
+
+| エントリ | 利用シナリオ |
+|---------|------------|
+| `POST /api/bookmark` (HTTP) | **local モードのみ**。Chrome 拡張 → Memoria 直送 |
+| peer `memoria.save_html` | Chrome 拡張 → Imperativus → Memoria の中継パス。`POST /api/relay/memoria/save_html` 経由で `user_id` がトークンから強制設定される |
+| peer `memoria.save_url` | URL のみ受け取り、Memoria が server-side fetch する旧パス (ログイン不要ページ向け) |
+
+online モードで `POST /api/bookmark` を直接叩くと **410 Gone** を返して relay パスに誘導する。
 
 ## 責務
 - NG/R18 フィルタによる事前ブロック (422)


### PR DESCRIPTION
## Summary
新方針: 共有 (online) モードで Memoria は **read-only public**、書き込みは Imperativus リレー経由のみ。直接 ONLINE 書込み動線は削除。

### Backend
- 認証 middleware を fail-open に変更。online でも GET は通る (userId=null)
- 全 write エンドポイントに `requireAuth(c)` を適用
- POST /api/bookmark は online で **410 Gone** (relay へ誘導)
- 共通 `saveBookmarkFromHtml()` を抽出
- peer handler `memoria.save_html` を新規追加
- `/api/mode` が capabilities を返す (read / write / memo / import / export ...)

### Frontend
- サインイン modal で Cernere service_token を貼り付け → localStorage 保存
- `body.readonly` クラスで write UI を一括非表示
- 認証後は memo / import / export / 削除 / 再要約 / dig / RAG ask が解放

### Extension v0.5.0
- options に「ローカル直送」/「Imperativus リレー」モード切替
- relay モードでは
  - `POST <imperativusUrl>/api/relay/memoria/save_html` に Cernere JWT 付きで送信
  - `/api/access` 送信を完全停止 (privacy)

### Spec
- spec/events.md / spec/server/modules/bookmark.md / spec/frontend/extension.md を更新

## Test plan
- [x] CI: lint + smoke
- [x] 手動: online + Bearer 無し → POST 410, GET 200
- [x] 手動: online + token → /api/mode が caps を返却
- [ ] 手動: 拡張 v0.5 を local モードで保存
- [ ] 手動: Imperativus を立ち上げて relay モード (要 Cernere 配線)