### PR TITLE
docs: sync spec + README to read-public/write-auth + relay flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,15 +305,32 @@ Claude Code は `~/.claude/mcp.json` (プロジェクト固有なら `.claude/mc
 ### local (既定)
 単一ユーザー、認証なし、すべてのエンドポイント解放、URL アクセスを `page_visits` に蓄積。Chrome 拡張のオプションで「URL をトラッキングしない」をオンにすると `/api/access` の送信を停止できます。
 
-### online
+### online (read-public + write-auth + relay)
 オンライン共有想定。`MEMORIA_MODE=online` + `MEMORIA_JWT_SECRET` を設定して起動。
 
-- すべての `/api/*` で `Authorization: Bearer <JWT>` 必須 (HS256)
+- **読み取り (GET) は誰でも開放** — Web UI を匿名でも閲覧可能
+- **書込 (PATCH/POST/DELETE) は Bearer JWT 必須** (HS256)
+- `POST /api/bookmark` (HTML 直送) は **410 Gone** — Imperativus 経由のみ許可
 - 訪問履歴 (`/api/visits/*`) は 403 で完全停止、`/api/access` は no-op
 - ブックマークは JWT の `sub` (user_id) でスコープ
 - Cernere 統合: `@ludiars/cernere-service-adapter` を **同一プロセスで lazy import** し、admission + peer adapter の両方を起動。`CERNERE_*` env が揃った時のみ有効化、SDK 未インストール時は自前 HS256 検証にフォールバック
 - 開発用 token: `cd service && npm run issue-token alice` で `sub=alice` の JWT を発行
 - Peer adapter で公開するコマンドと発行イベントは [spec/events.md](spec/events.md) 参照
+
+### Web UI のサインイン (online モード)
+- 匿名でアクセスすると **read-only** モード — 一覧 / 検索 / 履歴閲覧 / 傾向 / 推薦表示は可
+- ヘッダーの「サインイン」ボタンから service_token を貼り付けると、メモ編集 / カテゴリ編集 / 削除 / 再要約 / Import / Export / Dig / RAG ask が解放
+- token は `localStorage` に保存され、401 を受けたら自動破棄
+
+### Chrome 拡張の保存ルート
+拡張オプションで 2 モード切替:
+
+| mode | 送信先 | 認証 | アクセス追跡 |
+|------|--------|------|--------------|
+| `local` (既定) | `${server}/api/bookmark` | なし | `/api/access` を送る |
+| `relay` | `${imperativusUrl}/api/relay/memoria/save_html` | Cernere `Bearer JWT` 必須 | 送らない (privacy) |
+
+`relay` モードでは Memoria への直接書込はできない。Imperativus が peer.invoke で memoria.save_html を呼び、user_id をトークンから強制設定する。
 
 ### コンテンツフィルタ
 NG / R18 ワードがブックマークの URL / タイトル / 本文に含まれる場合、422 で保存を拒否します。`MEMORIA_NGWORDS_FILE` / `MEMORIA_NG_DOMAINS_FILE` で追加可能。

--- a/spec/server/api.md
+++ b/spec/server/api.md
@@ -1,18 +1,29 @@
 # Backend HTTP API
 
-すべて `/api/*` 配下、JSON 入出力。`online` モードでは `Authorization: Bearer <JWT>` 必須。
+すべて `/api/*` 配下、JSON 入出力。
+
+| モード | GET (read) | PATCH/POST/DELETE (write) |
+|-------|------------|---------------------------|
+| `local` (既定) | open | open |
+| `online` | open (auth 不要) | `Authorization: Bearer <JWT>` 必須 |
+
+`online` で書込を auth なしで叩くと **401**。`POST /api/bookmark` は更に厳しく **410 Gone** で拒否し、Imperativus relay (`POST /api/relay/memoria/save_html`) を使うよう促す。
 
 ## システム
 
 | Method | Path | 用途 |
 |--------|------|------|
-| `GET` | `/api/mode` | 現在のモード + RAG 有効/無効 + user_id |
+| `GET` | `/api/mode` | mode / rag_enabled / user_id / authenticated / caps[] (capability list) |
+
+`caps` は次のいずれか:
+- `read` (常に含まれる)
+- `write` / `memo` / `import` / `export` / `dig` / `rag.ask` (online + auth 済 or local モード)
 
 ## Bookmarks
 
 | Method | Path | 用途 |
 |--------|------|------|
-| `POST` | `/api/bookmark` | HTML+URL+title を保存。NG フィルタ → 重複チェック → 要約キュー投入 |
+| `POST` | `/api/bookmark` | HTML+URL+title を保存。NG フィルタ → 重複チェック → 要約キュー投入。**online で 410** (relay へ誘導) |
 | `GET` | `/api/bookmarks?category=&sort=` | 一覧 (user_id でスコープ) |
 | `GET` | `/api/bookmarks/:id` | 詳細 |
 | `PATCH` | `/api/bookmarks/:id` | メモ・カテゴリ更新 |

--- a/spec/server/modules/auth.md
+++ b/spec/server/modules/auth.md
@@ -11,12 +11,12 @@
 
 ## モード
 
-| モード | 認証 | userId |
-|-------|------|--------|
-| `local` (既定) | なし | `null` (全データを単一テナント扱い) |
-| `online` | `Authorization: Bearer <JWT>` 必須 | JWT.sub |
+| モード | GET (read) | 書込 (PATCH/POST/DELETE) | userId |
+|-------|------------|-------------------------|--------|
+| `local` (既定) | 開放 | 開放 | `null` (単一テナント) |
+| `online` | **公開 (auth 不要)** | Bearer JWT 必須 (`requireAuth(c)`) | JWT.sub |
 
-`MEMORIA_MODE=online` のときに `MEMORIA_JWT_SECRET` 不在ならプロセスを fatal exit する。
+`MEMORIA_MODE=online` のときに `MEMORIA_JWT_SECRET` 不在ならプロセスを fatal exit する (誤起動防止)。
 
 ## JWT 仕様
 
@@ -25,16 +25,31 @@
 - 有効期限: `exp` 必須 (秒, 過去なら 401)
 - claim: `sub` (= user_id), `iat`, `iss` (任意)
 
-## Hono middleware (`authMiddleware`)
+## Hono middleware (`authMiddleware`) — fail-open
 
 ```
-local モード: c.set('userId', null), next()
+local モード:
+  c.set('userId', null), c.set('mode', 'local'), next()
+
 online モード:
-  - Authorization 不在 → 401 'bearer token required'
-  - JWT 検証失敗      → 401 'unauthorized: <reason>'
-  - sub 不在          → 401 'unauthorized: token missing sub'
-  - OK                → c.set('userId', sub), next()
+  - Authorization 不在  → userId=null で next() (= 読み取り専用扱い)
+  - 不正 / 期限切れ JWT → userId=null で next()
+  - 有効な JWT          → c.set('userId', sub), next()
 ```
+
+middleware 自体は **拒否しない** ところがポイント。read endpoint は誰でも呼べる必要があるため、認可は **書込ハンドラ内で `requireAuth(c)` を呼ぶ** 形にした。
+
+## requireAuth(c) ヘルパー
+
+```js
+function requireAuth(c) {
+  if ((c.get('mode') ?? 'local') !== 'online') return null;  // local では常に通す
+  if (c.get('userId')) return null;                          // 認証済 OK
+  return c.json({ error: 'unauthorized: sign-in required for write actions' }, 401);
+}
+```
+
+書込ルート (`POST /api/bookmark` 等) の冒頭で `const denied = requireAuth(c); if (denied) return denied;` で 1 行ガード。
 
 ## 続いて admission revoke check (`index.js`)
 

--- a/spec/server/modules/cernere-bridge.md
+++ b/spec/server/modules/cernere-bridge.md
@@ -43,13 +43,36 @@
 | Command | 入力 | 出力 |
 |---------|------|------|
 | `memoria.search` | `{user_id, query, limit?}` | `{items: BookmarkRow[]}` |
-| `memoria.save_url` | `{user_id, url}` | `{status: queued/duplicate/blocked, id?, ...}` |
+| `memoria.save_url` | `{user_id, url}` | `{status: queued/duplicate/blocked, id?, ...}` (Memoria が server-side fetch) |
+| `memoria.save_html` | `{user_id, url, title, html}` | `{id, queued: true / duplicate: true}` (Imperativus が拡張から受け取った HTML を中継する primary パス) |
 | `memoria.list_categories` | `{}` | `{items: [{category, count}]}` |
 | `memoria.recent_bookmarks` | `{user_id, limit?}` | `{items: BookmarkRow[]}` |
 | `memoria.get_bookmark` | `{user_id, id}` | `BookmarkRow` |
 | `memoria.dig` | `{user_id, query}` | `{id, queued: true}` |
 | `memoria.unsaved_visits` | `{days?}` | `{items: VisitRow[]}` (online で throws) |
 | `ping` | `{...}` | `{ok, from, echo, ts}` |
+
+### Imperativus 経由の HTTP relay
+
+`POST /api/relay/memoria/save_html` (Imperativus 側) から呼ばれた場合の流れ:
+
+```
+[拡張]
+  ↓ POST <imperativus>/api/relay/memoria/save_html
+  ↓ Authorization: Bearer <Cernere service_token>
+  ↓ body: { url, title, html }
+[Imperativus PeerRelayAPI]
+  - JWT 検証 → user_id 確定
+  - allowlist (memoria.* のうち save_html を許可)
+  - rate limit 60/min × user × command
+  - peer.invoke('memoria', 'memoria.save_html', { url, title, html, user_id })
+[Memoria peer handler]
+  - saveBookmarkFromHtml({...}) を呼ぶ
+  - NG フィルタ → 重複チェック → 要約キュー投入
+  - emitEvent(memoria.bookmark.saved)
+```
+
+online モードで `POST /api/bookmark` の HTTP 直叩きは **410 Gone** で拒否されるため、relay 以外のルートで書込まれることはない。
 
 ## emitEvent (`service/cernere.js`)
 


### PR DESCRIPTION
PR #17 で導入された read-public / write-auth + Imperativus relay の挙動を仕様書側に反映。コード変更なし。

- spec/server/modules/auth.md — fail-open + requireAuth ヘルパー
- spec/server/api.md — 認証表 + /api/mode caps + 410 Gone
- spec/server/modules/cernere-bridge.md — memoria.save_html + relay 流れ図
- README.md — online モード再記述 + 拡張モード表