### PR TITLE
feat: /api/mode hints (Cernere base / Imperativus URL)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,11 @@
 #    どの peer に push するか。Imperativus でユーザごとのフックを管理する想定。
 # MEMORIA_HOOK_TARGET=imperativus
 
+# 4. UI hints (/api/mode 経由で FE / 拡張に伝える) — 入力ヒントとして表示するだけ、
+#    バックエンドの動作には影響しない。
+# CERNERE_BASE_URL=https://cernere.example.com
+# MEMORIA_HINT_IMPERATIVUS_URL=https://imperativus.example.com
+
 # ─────────────────────────────────────────────────────────────────────────
 # Content filter (NG / R18)
 # ─────────────────────────────────────────────────────────────────────────

--- a/service/index.js
+++ b/service/index.js
@@ -183,6 +183,14 @@ app.get('/api/mode', (c) => c.json({
   // List of capabilities available to the current request — the FE uses this
   // to decide which write controls to render.
   caps: capabilitiesFor(c),
+  // Hints the FE / extension can use to direct the user to the right
+  // sign-in surface. None of these are required for Memoria itself; they
+  // are pass-through configuration sourced from env.
+  hints: {
+    cernere_base_url: process.env.CERNERE_BASE_URL || process.env.CERNERE_URL || '',
+    imperativus_url: process.env.MEMORIA_HINT_IMPERATIVUS_URL || '',
+    issue_token_command: 'cd service && npm run issue-token <user_id>',
+  },
 }));
 
 function capabilitiesFor(c) {

--- a/service/public/app.js
+++ b/service/public/app.js
@@ -304,6 +304,8 @@ async function applyMode() {
     state.mode = r.mode;
     state.user = r.user_id ? { id: r.user_id } : null;
     state.caps = r.caps || (r.mode === 'online' ? ['read'] : ['read', 'write']);
+    state.hints = r.hints || {};
+    renderSignInHints();
     const isOnline = r.mode === 'online';
     const authed = !!r.user_id;
 
@@ -341,6 +343,23 @@ async function applyMode() {
 }
 
 // ── sign-in / sign-out ──────────────────────────────────────────────────
+
+function renderSignInHints() {
+  const el = $('signInHints');
+  if (!el) return;
+  const h = state.hints || {};
+  const lines = [];
+  if (h.cernere_base_url) {
+    lines.push(`<strong>Cernere</strong>: <a href="${escapeHtml(h.cernere_base_url)}" target="_blank" rel="noreferrer">${escapeHtml(h.cernere_base_url)}</a> でログイン → 設定画面で memoria プロジェクトの service_token を取得`);
+  }
+  if (h.imperativus_url) {
+    lines.push(`<strong>Imperativus</strong> 経由 (Chrome 拡張用): <code>${escapeHtml(h.imperativus_url)}</code>`);
+  }
+  if (h.issue_token_command) {
+    lines.push(`<em>開発用</em>: <code>${escapeHtml(h.issue_token_command)}</code> で開発用 JWT を発行できます`);
+  }
+  el.innerHTML = lines.length ? lines.map((l) => `<div>${l}</div>`).join('') : '';
+}
 
 function openSignIn() {
   const overlay = $('signInOverlay');

--- a/service/public/index.html
+++ b/service/public/index.html
@@ -45,9 +45,7 @@
         <button id="signInCancel" class="ghost">キャンセル</button>
       </div>
       <div id="signInError" class="auth-error hidden"></div>
-      <p class="auth-help">
-        <em>開発用</em>: <code>cd service &amp;&amp; npm run issue-token &lt;your_id&gt;</code> で開発用 JWT を発行できます。
-      </p>
+      <div id="signInHints" class="auth-help"></div>
     </div>
   </div>
 


### PR DESCRIPTION
サインイン modal が "token はどこで取れるの?" の hint を持っていなかったので、サーバー env (`CERNERE_BASE_URL`, `MEMORIA_HINT_IMPERATIVUS_URL`) を /api/mode に乗せて FE が表示できるように。

- backend: /api/mode に hints {} を追加
- FE: signIn modal の auth-help セクションを動的描画
- .env.example: 新 env を例示

## Test plan
- [x] CI: lint + smoke
- [ ] 手動: env 設定 → modal にリンクが出る