### PR TITLE
feat(extension v0.6): Cernere SSO popup via chrome.identity

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 3,
   "name": "Memoria Bookmarker",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Save the current page to a local Memoria server with auto summary and categories.",
-  "permissions": ["activeTab", "scripting", "storage", "tabs", "alarms"],
+  "permissions": ["activeTab", "scripting", "storage", "tabs", "alarms", "identity"],
   "host_permissions": ["http://localhost/*", "http://127.0.0.1/*"],
   "background": {
     "service_worker": "background.js",

--- a/extension/options.html
+++ b/extension/options.html
@@ -49,9 +49,15 @@
         Cernere service_token (Bearer JWT)
         <input id="authToken" type="password" placeholder="eyJhbGciOiJIUzI1NiIs..." />
       </label>
+      <div style="margin-top:6px;display:flex;gap:8px;align-items:center">
+        <button id="ssoBtn" type="button">Cernere でサインイン</button>
+        <span id="ssoStatus" style="font-size:11px;color:#555"></span>
+      </div>
       <p style="font-size:11px;color:#777;margin:6px 0 0">
         リレーモードでは保存リクエストは Imperativus の <code>/api/relay/memoria/save_html</code> に送られます。
         Memoria サーバーへの直接 POST は無効化されます。
+        サインインボタンは <code>chrome.identity.launchWebAuthFlow</code> で
+        Cernere の OAuth エンドポイント (<code>/api/auth/extension</code>) にポップアップを開きます。
       </p>
     </div>
   </fieldset>

--- a/extension/options.js
+++ b/extension/options.js
@@ -7,6 +7,8 @@ const imperativusInput = document.getElementById('imperativusUrl');
 const modeLocal        = document.getElementById('modeLocal');
 const modeRelay        = document.getElementById('modeRelay');
 const relayFields      = document.getElementById('relayFields');
+const ssoBtn           = document.getElementById('ssoBtn');
+const ssoStatus        = document.getElementById('ssoStatus');
 const msg              = document.getElementById('msg');
 
 function applyModeToggle() {
@@ -19,7 +21,7 @@ function applyModeToggle() {
     disableTracking: false,
     authToken: '',
     imperativusUrl: '',
-    mode: 'local', // 'local' | 'relay'
+    mode: 'local',
   });
   serverInput.value      = cfg.server;
   trackingInput.checked  = !!cfg.disableTracking;
@@ -42,17 +44,69 @@ document.getElementById('save').addEventListener('click', async () => {
     mode,
   };
   if (mode === 'relay' && !cfg.imperativusUrl) {
-    msg.textContent = 'リレーモードでは Imperativus URL が必須です';
-    msg.style.color = '#c33';
+    showMsg('リレーモードでは Imperativus URL が必須です', 'err');
     return;
   }
   if (mode === 'relay' && !cfg.authToken) {
-    msg.textContent = 'リレーモードでは Cernere service_token が必須です';
-    msg.style.color = '#c33';
+    showMsg('リレーモードでは Cernere service_token が必須です', 'err');
     return;
   }
   await chrome.storage.sync.set(cfg);
-  msg.textContent = '保存しました';
-  msg.style.color = '#2a7';
-  setTimeout(() => { msg.textContent = ''; }, 1500);
+  showMsg('保存しました', 'ok');
 });
+
+ssoBtn?.addEventListener('click', async () => {
+  ssoStatus.textContent = 'Cernere ベース URL を取得中...';
+  ssoStatus.style.color = '#555';
+  try {
+    const cernereBase = await discoverCernereBase();
+    if (!cernereBase) throw new Error('Cernere base URL を取得できません (Memoria の env CERNERE_BASE_URL 設定を確認)');
+
+    const redirectUri = chrome.identity.getRedirectURL('cernere-cb');
+    const url =
+      `${cernereBase.replace(/\/+$/, '')}/api/auth/extension?service=memoria` +
+      `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+      `&state=${Math.random().toString(36).slice(2)}`;
+
+    ssoStatus.textContent = 'Cernere のポップアップでサインイン...';
+    chrome.identity.launchWebAuthFlow({ url, interactive: true }, async (responseUrl) => {
+      if (chrome.runtime.lastError) {
+        ssoStatus.textContent = `失敗: ${chrome.runtime.lastError.message}`;
+        ssoStatus.style.color = '#c33';
+        return;
+      }
+      try {
+        const u = new URL(responseUrl);
+        const params = new URLSearchParams(u.hash.replace(/^#/, '') || u.search);
+        const token = params.get('token') || params.get('access_token') || params.get('service_token');
+        if (!token) throw new Error('redirect URL に token がありません');
+        await chrome.storage.sync.set({ authToken: token });
+        tokenInput.value = token;
+        ssoStatus.textContent = 'サインイン成功 (token 保存済み)';
+        ssoStatus.style.color = '#2a7';
+      } catch (e) {
+        ssoStatus.textContent = `redirect 解析失敗: ${e.message}`;
+        ssoStatus.style.color = '#c33';
+      }
+    });
+  } catch (e) {
+    ssoStatus.textContent = `失敗: ${e.message}`;
+    ssoStatus.style.color = '#c33';
+  }
+});
+
+async function discoverCernereBase() {
+  const cfg = await chrome.storage.sync.get({ server: DEFAULT_SERVER });
+  try {
+    const r = await fetch(`${cfg.server.replace(/\/+$/, '')}/api/mode`).then((x) => x.json());
+    return r?.hints?.cernere_base_url || '';
+  } catch {
+    return '';
+  }
+}
+
+function showMsg(text, kind) {
+  msg.textContent = text;
+  msg.style.color = kind === 'ok' ? '#2a7' : '#c33';
+  if (kind === 'ok') setTimeout(() => { msg.textContent = ''; }, 1500);
+}

--- a/spec/frontend/extension.md
+++ b/spec/frontend/extension.md
@@ -80,8 +80,30 @@ UI:
 - `chrome://`, `chrome-extension://`, Chrome Web Store, PDF ビューア等では content script が動かない (Chrome の方針)
 - service_token の自動発行はしない — Cernere admission flow で発行されたトークンを手動で options 入力する想定。将来 `/api/auth/cernere/exchange` 的なフローを足す。
 
+## Cernere SSO (v0.6.0+, options 画面)
+
+`relay` モードのフィールドに **「Cernere でサインイン」** ボタンを追加。
+
+```
+[Cernere でサインイン] (chrome.identity.launchWebAuthFlow)
+   ↓
+Memoria の /api/mode から hints.cernere_base_url を取得
+   ↓
+${cernereBase}/api/auth/extension?service=memoria&redirect_uri=<chrome-extension://...>
+   ↓
+ユーザーが Cernere でログイン (popup)
+   ↓
+Cernere が redirect_uri に #token=<service_token> でリダイレクト
+   ↓
+拡張が token を chrome.storage.sync.authToken に保存
+```
+
+**前提:** Cernere 側に `/api/auth/extension` エンドポイントが必要。chrome-extension URL を redirect_uri allowlist に追加する設定も必要。これらが未対応な間は手動で token を貼り付ける。
+
+権限: manifest に `"identity"` を追加。
+
 ## ロードマップ
 
-- popup から「online サインイン」ボタンで Cernere 認証ポップアップを起動 → service_token を自動取得
 - 拡張のバッジ (アイコン右上) で要約待ち件数を表示
 - ホットキー対応 (Alt+S で保存)
+- token 失効時の自動再 SSO


### PR DESCRIPTION
options 画面に「Cernere でサインイン」ボタンを追加。chrome.identity.launchWebAuthFlow で Cernere の `/api/auth/extension` を popup 表示し、redirect URL から service_token を自動抽出して storage に保存。

注: Cernere 側に `/api/auth/extension` + chrome-extension:// redirect_uri の対応が必要。未対応時は従来通り手貼り可能。