### PR TITLE
feat(content-filter): regex (re: prefix) + whitelist bypass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,8 +88,12 @@
 
 # NG ワード/ドメインの追加リスト (既定値はソース内、外部ファイルでマージ可)
 # 1 行 1 語 (# でコメント) または JSON 配列。
+# 行頭 `re:` で続く文字列を JS 正規表現として解釈 (例: `re:tracking-[0-9]+`)
 # MEMORIA_NGWORDS_FILE=./ngwords.txt
 # MEMORIA_NG_DOMAINS_FILE=./ngdomains.txt
+
+# 誤検出を逃がすホワイトリスト。マッチすると当該ブックマークは絶対 reject されない。
+# MEMORIA_WHITELIST_FILE=./whitelist.txt
 
 # 0 にすると NG フィルタを完全に無効化。
 # MEMORIA_CONTENT_FILTER=1

--- a/service/__tests__/content-filter.test.mjs
+++ b/service/__tests__/content-filter.test.mjs
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { checkContent, resetFilterCache } from '../content-filter.js';
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'memoria-cf-'));
+  resetFilterCache();
+  delete process.env.MEMORIA_NGWORDS_FILE;
+  delete process.env.MEMORIA_NG_DOMAINS_FILE;
+  delete process.env.MEMORIA_WHITELIST_FILE;
+  delete process.env.MEMORIA_CONTENT_FILTER;
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  resetFilterCache();
+});
+
+describe('content-filter', () => {
+  it('passes a clean bookmark', () => {
+    const r = checkContent({
+      url: 'https://example.com/article',
+      title: 'Normal article',
+      html: '<html><body>nothing weird</body></html>',
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it('blocks a default NG word in title', () => {
+    const r = checkContent({
+      url: 'https://example.com/x',
+      title: 'アダルト動画まとめ',
+      html: '<html></html>',
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('ng_word_in_url_or_title');
+    expect(r.matches).toContain('アダルト');
+  });
+
+  it('blocks a default NG domain', () => {
+    const r = checkContent({ url: 'https://pornhub.com/anything', title: 'x', html: '' });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('blocked_domain');
+  });
+
+  it('supports a regex pattern via re: prefix', () => {
+    const file = join(tmpDir, 'ng.txt');
+    // Catch ID-shaped tracker tokens anywhere in URL/title.
+    writeFileSync(file, 're:secret-[0-9]+\n', 'utf8');
+    process.env.MEMORIA_NGWORDS_FILE = file;
+    resetFilterCache();
+    const blocked = checkContent({
+      url: 'https://example.com/path?ref=secret-12345',
+      title: 'page',
+      html: '<html></html>',
+    });
+    expect(blocked.ok).toBe(false);
+    expect(blocked.matches.some((m) => m.startsWith('re:'))).toBe(true);
+    // Non-matching URL still passes.
+    const ok = checkContent({
+      url: 'https://example.com/normal',
+      title: 'page',
+      html: '<html></html>',
+    });
+    expect(ok.ok).toBe(true);
+  });
+
+  it('whitelist short-circuits a NG word', () => {
+    const file = join(tmpDir, 'wl.txt');
+    writeFileSync(file, 'アダルト水泳教室\n', 'utf8');
+    process.env.MEMORIA_WHITELIST_FILE = file;
+    resetFilterCache();
+    const r = checkContent({
+      url: 'https://example.com/swim',
+      title: 'アダルト水泳教室',
+      html: '<html></html>',
+    });
+    expect(r.ok).toBe(true);
+    expect(r.whitelisted).toBe('アダルト水泳教室');
+  });
+
+  it('disabled filter passes everything', () => {
+    process.env.MEMORIA_CONTENT_FILTER = '0';
+    resetFilterCache();
+    const r = checkContent({
+      url: 'https://pornhub.com/anything',
+      title: 'アダルト',
+      html: '<html><body>cp porn</body></html>',
+    });
+    expect(r.ok).toBe(true);
+  });
+});

--- a/service/content-filter.js
+++ b/service/content-filter.js
@@ -1,6 +1,15 @@
 // Content filter — refuses bookmarks whose URL/title/body contain banned keywords.
-// Hardcoded defaults can be overridden via MEMORIA_NGWORDS_FILE (newline / JSON
-// array). Domain blocklist similarly via MEMORIA_NG_DOMAINS_FILE.
+//
+// 機能:
+//   1. NG ワード substring (case-insensitive)
+//   2. NG ワード regex pattern (`re:` 接頭辞)
+//   3. NG ドメイン (host suffix 一致)
+//   4. ホワイトリストワード — マッチすると当該ブックマークは絶対 reject されない
+//      (例: "アダルト水泳教室" を許容したい場合 "アダルト水泳教室" を whitelist に)
+//
+// 設定ファイル形式:
+//   - 1 行 1 語、`#` でコメント、または JSON 配列
+//   - 行頭 `re:` で続く文字列を JS 正規表現として解釈 (例: `re:^xxx[0-9]{3}$`)
 //
 // We intentionally keep this simple — it's a courtesy filter for a personal
 // tool, not a content moderation system. R18 detection is best-effort.
@@ -22,48 +31,116 @@ const DEFAULT_NG_DOMAINS = [
   'onlyfans.com',
 ];
 
+const DEFAULT_WHITELIST = [
+  // Common false positives — leave space for the user to extend.
+];
+
 let cached = null;
 
 export function loadFilter({
   ngWordsFile = process.env.MEMORIA_NGWORDS_FILE,
   ngDomainsFile = process.env.MEMORIA_NG_DOMAINS_FILE,
+  whitelistFile = process.env.MEMORIA_WHITELIST_FILE,
   enabled = process.env.MEMORIA_CONTENT_FILTER !== '0',
 } = {}) {
   if (cached) return cached;
-  const words = new Set(DEFAULT_NG_WORDS.map(w => w.toLowerCase()));
-  const domains = new Set(DEFAULT_NG_DOMAINS.map(d => d.toLowerCase()));
 
-  if (ngWordsFile && existsSync(ngWordsFile)) {
-    for (const w of parseListFile(ngWordsFile)) {
-      words.add(w.toLowerCase());
-    }
-  }
-  if (ngDomainsFile && existsSync(ngDomainsFile)) {
-    for (const d of parseListFile(ngDomainsFile)) {
-      domains.add(d.toLowerCase());
-    }
-  }
-  cached = { enabled, words: [...words], domains: [...domains] };
+  const wordEntries = mergeEntries(DEFAULT_NG_WORDS, ngWordsFile);
+  const wlEntries   = mergeEntries(DEFAULT_WHITELIST, whitelistFile);
+  const domainSet   = new Set([...DEFAULT_NG_DOMAINS, ...readEntries(ngDomainsFile)]
+    .map((d) => String(d).toLowerCase()));
+
+  cached = {
+    enabled,
+    words:     buildPatterns(wordEntries),
+    whitelist: buildPatterns(wlEntries),
+    domains:   [...domainSet],
+  };
   return cached;
 }
 
-function parseListFile(path) {
-  const raw = readFileSync(path, 'utf8').trim();
+/** Reset the cached filter — useful for tests / hot reload. */
+export function resetFilterCache() { cached = null; }
+
+function mergeEntries(defaults, file) {
+  const out = [...defaults];
+  for (const e of readEntries(file)) out.push(e);
+  return out;
+}
+
+function readEntries(file) {
+  if (!file || !existsSync(file)) return [];
+  const raw = readFileSync(file, 'utf8').trim();
   if (raw.startsWith('[')) {
-    try { return JSON.parse(raw); } catch {}
+    try { return JSON.parse(raw); } catch { /* fall through */ }
   }
-  return raw.split(/\r?\n/).map(s => s.replace(/#.*$/, '').trim()).filter(Boolean);
+  return raw.split(/\r?\n/).map((s) => s.replace(/#.*$/, '').trim()).filter(Boolean);
+}
+
+/**
+ * Convert raw entries into a uniform shape:
+ *   { type: 'substring', value: 'lowercased' }
+ *   { type: 'regex', value: <RegExp>, raw: 're:...' }
+ *
+ * Regex entries are written as `re:<pattern>` and treated as case-insensitive.
+ * Invalid regexes fall back to a literal substring (with the `re:` prefix
+ * stripped) so a malformed config never silently disables a check.
+ */
+function buildPatterns(entries) {
+  const out = [];
+  for (const raw of entries) {
+    const s = String(raw).trim();
+    if (!s) continue;
+    if (s.startsWith('re:')) {
+      const body = s.slice(3);
+      try {
+        out.push({ type: 'regex', value: new RegExp(body, 'i'), raw: s });
+        continue;
+      } catch {
+        // fall through — treat as substring
+      }
+    }
+    out.push({ type: 'substring', value: s.toLowerCase() });
+  }
+  return out;
+}
+
+function patternMatches(p, lowerText) {
+  if (p.type === 'regex') return p.value.test(lowerText);
+  return lowerText.includes(p.value);
+}
+
+function patternLabel(p) {
+  return p.type === 'regex' ? p.raw : p.value;
 }
 
 /**
  * Check a candidate bookmark for banned content.
  * Returns { ok: true } or { ok: false, reason, matches: [...] }.
+ *
+ * Whitelist takes precedence — a single whitelist hit anywhere in
+ * URL/title/body causes the entire candidate to be accepted.
  */
 export function checkContent({ url, title, html }) {
   const f = loadFilter();
   if (!f.enabled) return { ok: true };
 
-  // 1. URL/domain check
+  const haystackUrl   = (url ?? '').toLowerCase();
+  const haystackTitle = (title ?? '').toLowerCase();
+  const haystackBody  = typeof html === 'string' && html.length > 0
+    ? quickText(html).slice(0, 30_000).toLowerCase()
+    : '';
+
+  // 1. Whitelist short-circuit.
+  for (const wl of f.whitelist) {
+    if (patternMatches(wl, haystackUrl) ||
+        patternMatches(wl, haystackTitle) ||
+        (haystackBody && patternMatches(wl, haystackBody))) {
+      return { ok: true, whitelisted: patternLabel(wl) };
+    }
+  }
+
+  // 2. Domain check (always, even if word patterns clean).
   try {
     const host = new URL(url).hostname.toLowerCase();
     for (const bad of f.domains) {
@@ -71,26 +148,24 @@ export function checkContent({ url, title, html }) {
         return { ok: false, reason: 'blocked_domain', matches: [bad] };
       }
     }
-  } catch {}
+  } catch { /* invalid URL — handled upstream */ }
 
-  const haystackUrl = (url ?? '').toLowerCase();
-  const haystackTitle = (title ?? '').toLowerCase();
+  // 3. URL/title NG word scan.
   const matches = new Set();
-  for (const w of f.words) {
-    if (haystackUrl.includes(w) || haystackTitle.includes(w)) {
-      matches.add(w);
+  for (const p of f.words) {
+    if (patternMatches(p, haystackUrl) || patternMatches(p, haystackTitle)) {
+      matches.add(patternLabel(p));
     }
   }
   if (matches.size > 0) {
     return { ok: false, reason: 'ng_word_in_url_or_title', matches: [...matches] };
   }
 
-  // 2. Body text check (extract once, scan once)
-  if (typeof html === 'string' && html.length > 0) {
-    const text = quickText(html).slice(0, 30_000).toLowerCase();
-    for (const w of f.words) {
-      if (text.includes(w)) {
-        matches.add(w);
+  // 4. Body NG word scan.
+  if (haystackBody) {
+    for (const p of f.words) {
+      if (patternMatches(p, haystackBody)) {
+        matches.add(patternLabel(p));
         if (matches.size >= 5) break;
       }
     }
@@ -105,7 +180,7 @@ export function checkContent({ url, title, html }) {
 function quickText(html) {
   try {
     const root = parseHtml(html);
-    root.querySelectorAll('script, style, noscript').forEach(n => n.remove());
+    root.querySelectorAll('script, style, noscript').forEach((n) => n.remove());
     return root.text;
   } catch {
     return html.replace(/<[^>]+>/g, ' ');

--- a/spec/server/modules/content-filter.md
+++ b/spec/server/modules/content-filter.md
@@ -58,8 +58,28 @@ URL / title / body どこでも match で reject。例:
 - 多言語対応は単純なケース畳み込みのみ
 - 文脈は読まない (例: "アダルト水泳教室" のような誤検出はあり得る)
 
+## regex pattern (re: 接頭辞)
+
+ファイル中の行頭が `re:` で始まる場合、続く文字列が JS 正規表現として解釈される (case-insensitive)。マッチは substring と同様 (anchorless)。
+
+```
+re:tracking-[0-9]+        # トラッカー ID 形式を弾く
+re:^.+\.example\.bad$     # ホスト末尾固定マッチ
+```
+
+不正な regex は literal substring にフォールバック (`re:` を含む文字列として比較)。
+
+## whitelist (ホワイトリスト)
+
+`MEMORIA_WHITELIST_FILE` で誤検出を逃がす。URL/title/body のいずれかにヒットすると、その候補は **絶対 reject されない**。フォーマットは NG ワードと同じ (substring + `re:` 接頭辞)。
+
+例:
+```
+アダルト水泳教室     # アダルト という NG 語を含むが許容したい
+re:^https://my-trusted-domain\.com/
+```
+
 ## ロードマップ
 
-- regex pattern 対応
-- ホワイトリスト (誤検出になりやすい単語の除外)
 - claude による意味的判定 (オプション、コスト高)
+- ドメイン regex 対応


### PR DESCRIPTION
NG ワードに正規表現対応 + ホワイトリストで誤検出を逃がす。

- 行頭 `re:` で続く文字列を JS 正規表現として解釈
- `MEMORIA_WHITELIST_FILE` で URL/title/body のいずれかがマッチしたら絶対許容
- vitest: 6 テスト追加