### PR TITLE
feat: word cloud dig flow + per-bookmark cloud + visit-domain trends

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -42,7 +42,8 @@ export function openDb(dbPath) {
       created_at    TEXT NOT NULL DEFAULT (datetime('now')),
       status        TEXT NOT NULL DEFAULT 'pending',
       error         TEXT,
-      result_json   TEXT
+      result_json   TEXT,
+      preview_json  TEXT
     );
 
     CREATE INDEX IF NOT EXISTS idx_dig_sessions_created
@@ -84,6 +85,26 @@ export function openDb(dbPath) {
     );
     CREATE INDEX IF NOT EXISTS idx_chunks_bookmark ON chunks(bookmark_id);
 
+    CREATE TABLE IF NOT EXISTS dictionary_entries (
+      id           INTEGER PRIMARY KEY AUTOINCREMENT,
+      term         TEXT NOT NULL UNIQUE,
+      definition   TEXT,
+      notes        TEXT,
+      created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at   TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS dictionary_links (
+      entry_id      INTEGER NOT NULL REFERENCES dictionary_entries(id) ON DELETE CASCADE,
+      source_kind   TEXT NOT NULL,
+      source_id     INTEGER NOT NULL,
+      added_at      TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (entry_id, source_kind, source_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_dict_links_entry
+      ON dictionary_links(entry_id);
+    CREATE INDEX IF NOT EXISTS idx_dict_links_source
+      ON dictionary_links(source_kind, source_id);
+
     CREATE TABLE IF NOT EXISTS word_clouds (
       id                  INTEGER PRIMARY KEY AUTOINCREMENT,
       origin              TEXT NOT NULL,
@@ -108,6 +129,11 @@ export function openDb(dbPath) {
   if (!wcCols.includes('origin_bookmark_id')) {
     db.exec(`ALTER TABLE word_clouds ADD COLUMN origin_bookmark_id INTEGER`);
     db.exec(`CREATE INDEX IF NOT EXISTS idx_word_clouds_bookmark ON word_clouds(origin_bookmark_id)`);
+  }
+
+  const dsCols = db.prepare(`PRAGMA table_info(dig_sessions)`).all().map(c => c.name);
+  if (!dsCols.includes('preview_json')) {
+    db.exec(`ALTER TABLE dig_sessions ADD COLUMN preview_json TEXT`);
   }
 
   // Forward-compat: ensure newer columns exist on older DBs.
@@ -308,12 +334,18 @@ export function setDigResult(db, id, { status, result, error }) {
   `).run(status, result ? JSON.stringify(result) : null, error ?? null, id);
 }
 
+export function setDigPreview(db, id, preview) {
+  db.prepare(`UPDATE dig_sessions SET preview_json = ? WHERE id = ?`)
+    .run(preview ? JSON.stringify(preview) : null, id);
+}
+
 export function getDigSession(db, id) {
   const row = db.prepare(`SELECT * FROM dig_sessions WHERE id = ?`).get(id);
   if (!row) return null;
   return {
     ...row,
     result: row.result_json ? safeParse(row.result_json) : null,
+    preview: row.preview_json ? safeParse(row.preview_json) : null,
   };
 }
 
@@ -389,6 +421,86 @@ export function recentBookmarkWordClouds(db, { limit = 50 } = {}) {
     label: r.label,
     result: r.result_json ? safeParse(r.result_json) : null,
   }));
+}
+
+// ── dictionary -------------------------------------------------------------
+
+export function listDictionaryEntries(db, { search } = {}) {
+  const args = [];
+  let where = '';
+  if (search) {
+    where = `WHERE e.term LIKE ? OR e.definition LIKE ? OR e.notes LIKE ?`;
+    const pat = `%${search}%`;
+    args.push(pat, pat, pat);
+  }
+  const rows = db.prepare(`
+    SELECT e.*, COALESCE(l.link_count, 0) AS link_count
+    FROM dictionary_entries e
+    LEFT JOIN (
+      SELECT entry_id, COUNT(*) AS link_count
+      FROM dictionary_links GROUP BY entry_id
+    ) l ON l.entry_id = e.id
+    ${where}
+    ORDER BY e.updated_at DESC
+  `).all(...args);
+  return rows;
+}
+
+export function getDictionaryEntry(db, id) {
+  const row = db.prepare(`SELECT * FROM dictionary_entries WHERE id = ?`).get(id);
+  if (!row) return null;
+  const links = db.prepare(`
+    SELECT source_kind, source_id, added_at
+    FROM dictionary_links WHERE entry_id = ?
+    ORDER BY added_at DESC
+  `).all(id);
+  return { ...row, links };
+}
+
+export function findDictionaryEntryByTerm(db, term) {
+  return db.prepare(`SELECT * FROM dictionary_entries WHERE term = ?`).get(term) ?? null;
+}
+
+export function insertDictionaryEntry(db, { term, definition, notes }) {
+  const info = db.prepare(`
+    INSERT INTO dictionary_entries (term, definition, notes)
+    VALUES (?, ?, ?)
+  `).run(String(term).trim(), definition ?? null, notes ?? null);
+  return info.lastInsertRowid;
+}
+
+export function updateDictionaryEntry(db, id, patch) {
+  const fields = [];
+  const args = [];
+  if (typeof patch.term === 'string') { fields.push('term = ?'); args.push(patch.term.trim()); }
+  if (typeof patch.definition === 'string' || patch.definition === null) {
+    fields.push('definition = ?'); args.push(patch.definition);
+  }
+  if (typeof patch.notes === 'string' || patch.notes === null) {
+    fields.push('notes = ?'); args.push(patch.notes);
+  }
+  if (fields.length === 0) return;
+  fields.push(`updated_at = datetime('now')`);
+  args.push(id);
+  db.prepare(`UPDATE dictionary_entries SET ${fields.join(', ')} WHERE id = ?`).run(...args);
+}
+
+export function deleteDictionaryEntry(db, id) {
+  db.prepare(`DELETE FROM dictionary_entries WHERE id = ?`).run(id);
+}
+
+export function addDictionaryLink(db, { entryId, sourceKind, sourceId }) {
+  db.prepare(`
+    INSERT OR IGNORE INTO dictionary_links (entry_id, source_kind, source_id)
+    VALUES (?, ?, ?)
+  `).run(entryId, sourceKind, sourceId);
+}
+
+export function removeDictionaryLink(db, { entryId, sourceKind, sourceId }) {
+  db.prepare(`
+    DELETE FROM dictionary_links
+    WHERE entry_id = ? AND source_kind = ? AND source_id = ?
+  `).run(entryId, sourceKind, sourceId);
 }
 
 /**

--- a/server/db.js
+++ b/server/db.js
@@ -83,7 +83,32 @@ export function openDb(dbPath) {
       vec_model    TEXT NOT NULL DEFAULT 'multilingual-e5-small'
     );
     CREATE INDEX IF NOT EXISTS idx_chunks_bookmark ON chunks(bookmark_id);
+
+    CREATE TABLE IF NOT EXISTS word_clouds (
+      id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+      origin              TEXT NOT NULL,
+      origin_dig_id       INTEGER,
+      origin_bookmark_id  INTEGER REFERENCES bookmarks(id) ON DELETE CASCADE,
+      parent_cloud_id     INTEGER,
+      parent_word         TEXT,
+      label               TEXT NOT NULL,
+      status              TEXT NOT NULL DEFAULT 'pending',
+      error               TEXT,
+      result_json         TEXT,
+      created_at          TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_word_clouds_created
+      ON word_clouds(created_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_word_clouds_bookmark
+      ON word_clouds(origin_bookmark_id);
   `);
+
+  // Forward-compat: ensure newer columns exist on older word_clouds tables.
+  const wcCols = db.prepare(`PRAGMA table_info(word_clouds)`).all().map(c => c.name);
+  if (!wcCols.includes('origin_bookmark_id')) {
+    db.exec(`ALTER TABLE word_clouds ADD COLUMN origin_bookmark_id INTEGER`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_word_clouds_bookmark ON word_clouds(origin_bookmark_id)`);
+  }
 
   // Forward-compat: ensure newer columns exist on older DBs.
   const cols = db.prepare(`PRAGMA table_info(bookmarks)`).all().map(c => c.name);
@@ -300,6 +325,96 @@ export function listDigSessions(db, limit = 30) {
 }
 
 function safeParse(s) { try { return JSON.parse(s); } catch { return null; } }
+
+// ── word clouds ------------------------------------------------------------
+
+export function insertWordCloud(db, { origin, originDigId, parentCloudId, parentWord, label }) {
+  return db.prepare(`
+    INSERT INTO word_clouds (origin, origin_dig_id, parent_cloud_id, parent_word, label)
+    VALUES (?, ?, ?, ?, ?)
+  `).run(
+    origin,
+    originDigId ?? null,
+    parentCloudId ?? null,
+    parentWord ?? null,
+    label,
+  ).lastInsertRowid;
+}
+
+export function setWordCloudResult(db, id, { status, result, error }) {
+  db.prepare(`
+    UPDATE word_clouds SET status = ?, result_json = ?, error = ?
+    WHERE id = ?
+  `).run(status, result ? JSON.stringify(result) : null, error ?? null, id);
+}
+
+export function getWordCloud(db, id) {
+  const row = db.prepare(`SELECT * FROM word_clouds WHERE id = ?`).get(id);
+  if (!row) return null;
+  return {
+    ...row,
+    result: row.result_json ? safeParse(row.result_json) : null,
+  };
+}
+
+export function listWordClouds(db, limit = 30) {
+  return db.prepare(`
+    SELECT id, origin, origin_dig_id, origin_bookmark_id, parent_cloud_id, parent_word,
+           label, status, created_at
+    FROM word_clouds ORDER BY id DESC LIMIT ?
+  `).all(limit);
+}
+
+/** Latest 'done' word cloud for a single bookmark, or null. */
+export function getBookmarkWordCloud(db, bookmarkId) {
+  const row = db.prepare(`
+    SELECT * FROM word_clouds
+    WHERE origin = 'bookmark' AND origin_bookmark_id = ? AND status = 'done'
+    ORDER BY id DESC LIMIT 1
+  `).get(bookmarkId);
+  if (!row) return null;
+  return { ...row, result: row.result_json ? safeParse(row.result_json) : null };
+}
+
+/** Most recent 'done' bookmark clouds (for recommendation weighting). */
+export function recentBookmarkWordClouds(db, { limit = 50 } = {}) {
+  const rows = db.prepare(`
+    SELECT wc.* FROM word_clouds wc
+    JOIN bookmarks b ON b.id = wc.origin_bookmark_id
+    WHERE wc.origin = 'bookmark' AND wc.status = 'done'
+    ORDER BY b.created_at DESC LIMIT ?
+  `).all(Number(limit) || 50);
+  return rows.map(r => ({
+    bookmark_id: r.origin_bookmark_id,
+    label: r.label,
+    result: r.result_json ? safeParse(r.result_json) : null,
+  }));
+}
+
+/**
+ * Top domains across the page_visits log (URL-only history),
+ * regardless of whether the URL is bookmarked.
+ */
+export function trendsVisitDomains(db, { sinceDays = 30, limit = 12 } = {}) {
+  const rows = db.prepare(`
+    SELECT v.url, v.visit_count, v.last_seen_at
+    FROM page_visits v
+    WHERE v.last_seen_at >= datetime('now', ?)
+  `).all(`-${Number(sinceDays) || 30} days`);
+  const tally = new Map();
+  for (const r of rows) {
+    const d = extractDomain(r.url);
+    if (!d) continue;
+    const cur = tally.get(d) || { domain: d, visits: 0, urls: 0, last_seen_at: '' };
+    cur.visits += r.visit_count || 1;
+    cur.urls += 1;
+    if (!cur.last_seen_at || r.last_seen_at > cur.last_seen_at) cur.last_seen_at = r.last_seen_at;
+    tally.set(d, cur);
+  }
+  return [...tally.values()]
+    .sort((a, b) => b.visits - a.visits || b.urls - a.urls)
+    .slice(0, Number(limit) || 12);
+}
 
 // ── chunks / embeddings ----------------------------------------------------
 

--- a/server/dig.js
+++ b/server/dig.js
@@ -31,10 +31,87 @@ const PROMPT_TEMPLATE = (query) => [
   `QUERY: ${query}`,
 ].join('\n');
 
+const PREVIEW_PROMPT_TEMPLATE = (query) => [
+  'You are returning a SERP-style preview as fast as possible.',
+  'Use ONLY web search — do NOT fetch or read result pages.',
+  'If the search engine displays an AI overview / generative summary, capture it verbatim.',
+  '',
+  'Return STRICTLY one JSON object and nothing else (no prose, no code fences):',
+  '',
+  '{',
+  '  "ai_overview": "search engine の AI overview があればその文章 (なければ空文字)",',
+  '  "results": [',
+  '    {',
+  '      "title": "...",',
+  '      "url": "https://...",',
+  '      "snippet": "検索エンジンが返したスニペット 1〜2 文",',
+  '      "domain": "..."',
+  '    }',
+  '  ]',
+  '}',
+  '',
+  '- 上位 8〜10 件のみ。',
+  '- ai_overview は要約済みの段落 1〜3。なければ "" を返す。',
+  '- 各ページの本文を取りにいかないこと (速さが最優先)。',
+  '',
+  `QUERY: ${query}`,
+].join('\n');
+
+export async function runDigPreview({ query, claudeBin = 'claude', timeoutMs = 90_000 }) {
+  const prompt = PREVIEW_PROMPT_TEMPLATE(query);
+  const stdout = await spawnClaudeWithTools(claudeBin, prompt, ['WebSearch'], timeoutMs);
+  return parsePreview(stdout);
+}
+
 export async function runDig({ query, claudeBin = 'claude', timeoutMs = 600_000 }) {
   const prompt = PROMPT_TEMPLATE(query);
   const stdout = await spawnClaude(claudeBin, prompt, timeoutMs);
   return parseJsonStrict(stdout);
+}
+
+function spawnClaudeWithTools(bin, prompt, tools, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const args = ['-p', prompt, '--allowedTools', tools.join(',')];
+    const child = spawn(bin, args, { stdio: ['ignore', 'pipe', 'pipe'], shell: false });
+    let stdout = '', stderr = '';
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`claude CLI timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    child.stdout.on('data', d => { stdout += d.toString('utf8'); });
+    child.stderr.on('data', d => { stderr += d.toString('utf8'); });
+    child.on('error', err => { clearTimeout(timer); reject(err); });
+    child.on('close', code => {
+      clearTimeout(timer);
+      if (code !== 0) reject(new Error(`claude exited ${code}: ${stderr.slice(0, 400)}`));
+      else resolve(stdout);
+    });
+  });
+}
+
+function parsePreview(raw) {
+  let text = raw.trim();
+  const fence = text.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/);
+  if (fence) text = fence[1].trim();
+  const first = text.indexOf('{');
+  const last = text.lastIndexOf('}');
+  if (first >= 0 && last > first) text = text.slice(first, last + 1);
+  let obj;
+  try { obj = JSON.parse(text); }
+  catch (e) { throw new Error(`preview parse: ${e.message}\nRaw: ${raw.slice(0, 400)}`); }
+  return {
+    ai_overview: String(obj.ai_overview ?? '').trim(),
+    results: Array.isArray(obj.results) ? obj.results.map(r => ({
+      title: String(r.title ?? '').trim(),
+      url: String(r.url ?? '').trim(),
+      snippet: String(r.snippet ?? '').trim(),
+      domain: String(r.domain ?? '').trim() || extractDomain(r.url),
+    })).filter(r => /^https?:\/\//.test(r.url)) : [],
+  };
+}
+
+function extractDomain(url) {
+  try { return new URL(String(url)).hostname.toLowerCase(); } catch { return ''; }
 }
 
 function spawnClaude(bin, prompt, timeoutMs) {

--- a/server/index.js
+++ b/server/index.js
@@ -35,7 +35,10 @@ import { embed, chunkText, cosine, vecToBuffer, bufferToVec, getModelName } from
 import {
   deleteChunks, insertChunk, listChunkRows, bookmarksMissingEmbeddings, chunkStats,
   insertDigSession, setDigResult, getDigSession, listDigSessions,
+  insertWordCloud, setWordCloudResult, getWordCloud, listWordClouds,
+  getBookmarkWordCloud, recentBookmarkWordClouds, trendsVisitDomains,
 } from './db.js';
+import { extractWordCloud, validateWordRelevance } from './wordcloud.js';
 import { spawn } from 'node:child_process';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -50,6 +53,7 @@ mkdirSync(HTML_DIR, { recursive: true });
 const db = openDb(DB_PATH);
 const summaryQueue = new FifoQueue();
 const embeddingQueue = new FifoQueue();
+const cloudQueue = new FifoQueue();
 let chunkCache = null;
 function invalidateChunkCache() { chunkCache = null; }
 function loadChunkCache() {
@@ -203,7 +207,8 @@ app.get('/api/bookmarks/:id', (c) => {
   const id = Number(c.req.param('id'));
   const b = getBookmark(db, id);
   if (!b) return c.json({ error: 'not found' }, 404);
-  return c.json(b);
+  const cloud = getBookmarkWordCloud(db, id);
+  return c.json({ ...b, wordcloud: cloud });
 });
 
 app.patch('/api/bookmarks/:id', async (c) => {
@@ -277,6 +282,11 @@ app.get('/api/trends/timeline', (c) => {
 app.get('/api/trends/domains', (c) => {
   const days = Number(c.req.query('days')) || 30;
   return c.json({ items: trendsDomains(db, { sinceDays: days }) });
+});
+
+app.get('/api/trends/visit-domains', (c) => {
+  const days = Number(c.req.query('days')) || 30;
+  return c.json({ items: trendsVisitDomains(db, { sinceDays: days }) });
 });
 
 // ---- recommendations ------------------------------------------------------
@@ -478,6 +488,137 @@ app.post('/api/dig/:id/save', async (c) => {
   return c.json({ results: await bulkSaveUrls(body.urls) });
 });
 
+// ---- word clouds ---------------------------------------------------------
+
+const BOOKMARK_DOC_LIMIT = 80;
+const DIG_DOC_LIMIT = 30;
+const SINGLE_BOOKMARK_TEXT_LIMIT = 12000;
+
+function buildBookmarksDocs({ category, limit = BOOKMARK_DOC_LIMIT }) {
+  const items = listBookmarks(db, { category }).slice(0, limit);
+  return items.map((b, i) => {
+    const cats = (b.categories || []).join(', ');
+    const summary = (b.summary || '').slice(0, 800);
+    return `[Doc ${i + 1}] ${b.title}\nURL: ${b.url}\nCategories: ${cats}\nSummary: ${summary}`;
+  }).join('\n\n');
+}
+
+function buildDigDocs(session) {
+  const r = session.result || {};
+  const sources = (r.sources || []).slice(0, DIG_DOC_LIMIT);
+  if (sources.length === 0) return '';
+  const head = r.summary ? `OVERVIEW: ${r.summary}\n\n` : '';
+  return head + sources.map((s, i) => {
+    const topics = (s.topics || []).join(', ');
+    return `[Doc ${i + 1}] ${s.title}\nURL: ${s.url}\nTopics: ${topics}\nSnippet: ${s.snippet}`;
+  }).join('\n\n');
+}
+
+function buildBookmarkDoc(b) {
+  let bodyText = '';
+  try {
+    const html = readFileSync(join(HTML_DIR, b.html_path), 'utf8');
+    bodyText = htmlToText(html).slice(0, SINGLE_BOOKMARK_TEXT_LIMIT);
+  } catch {}
+  const cats = (b.categories || []).join(', ');
+  return `Title: ${b.title}\nURL: ${b.url}\nCategories: ${cats}\nSummary: ${b.summary || ''}\n\nBody:\n${bodyText}`;
+}
+
+function enqueueCloud(id, { docs, label }) {
+  cloudQueue.enqueue(async () => {
+    try {
+      const result = await extractWordCloud({ label, docs, claudeBin: CLAUDE_BIN });
+      setWordCloudResult(db, id, { status: 'done', result });
+    } catch (e) {
+      setWordCloudResult(db, id, { status: 'error', error: e.message.slice(0, 500) });
+      throw e;
+    }
+  }, { kind: 'wordcloud', cloudId: id, title: label });
+}
+
+app.post('/api/wordcloud', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  if (!body) return c.json({ error: 'body required' }, 400);
+  const origin = body.origin;
+  const parentCloudId = body.parentCloudId ?? null;
+  const parentWord = typeof body.parentWord === 'string' ? body.parentWord : null;
+
+  let label, docs, originDigId = null;
+
+  if (origin === 'bookmarks') {
+    const cat = body.category || null;
+    const items = listBookmarks(db, { category: cat });
+    if (items.length === 0) return c.json({ error: 'no bookmarks' }, 400);
+    label = cat ? `bookmarks:${cat}` : 'all bookmarks';
+    docs = buildBookmarksDocs({ category: cat });
+  } else if (origin === 'dig') {
+    const digId = Number(body.digId);
+    const ses = getDigSession(db, digId);
+    if (!ses) return c.json({ error: 'dig session not found' }, 404);
+    if (ses.status !== 'done') return c.json({ error: `dig status: ${ses.status}` }, 400);
+    label = ses.query;
+    originDigId = digId;
+    docs = buildDigDocs(ses);
+    if (!docs) return c.json({ error: 'dig has no sources' }, 400);
+  } else {
+    return c.json({ error: 'origin must be bookmarks or dig' }, 400);
+  }
+
+  const id = insertWordCloud(db, { origin, originDigId, parentCloudId, parentWord, label });
+  enqueueCloud(id, { docs, label });
+  return c.json({ id, queued: true });
+});
+
+app.get('/api/wordcloud', (c) => {
+  return c.json({ items: listWordClouds(db) });
+});
+
+app.get('/api/wordcloud/:id', (c) => {
+  const id = Number(c.req.param('id'));
+  const w = getWordCloud(db, id);
+  if (!w) return c.json({ error: 'not found' }, 404);
+  return c.json(w);
+});
+
+app.post('/api/wordcloud/validate-word', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const word = body?.word;
+  const context = body?.context;
+  if (!word || !context) return c.json({ error: 'word and context required' }, 400);
+  try {
+    const r = await validateWordRelevance({ word, context, claudeBin: CLAUDE_BIN });
+    return c.json(r);
+  } catch (e) {
+    return c.json({ error: e.message }, 500);
+  }
+});
+
+// Per-bookmark word cloud (default: not generated; on-demand).
+app.post('/api/bookmarks/:id/wordcloud', async (c) => {
+  const id = Number(c.req.param('id'));
+  const b = getBookmark(db, id);
+  if (!b) return c.json({ error: 'not found' }, 404);
+  const docs = buildBookmarkDoc(b);
+  const cloudId = insertWordCloud(db, {
+    origin: 'bookmark',
+    originDigId: null,
+    parentCloudId: null,
+    parentWord: null,
+    label: b.title || b.url,
+  });
+  // Stamp origin_bookmark_id (insertWordCloud schema doesn't accept it directly).
+  db.prepare(`UPDATE word_clouds SET origin_bookmark_id = ? WHERE id = ?`).run(id, cloudId);
+  enqueueCloud(cloudId, { docs, label: b.title || b.url });
+  return c.json({ id: cloudId, queued: true });
+});
+
+app.get('/api/bookmarks/:id/wordcloud', (c) => {
+  const id = Number(c.req.param('id'));
+  if (!getBookmark(db, id)) return c.json({ error: 'not found' }, 404);
+  const cloud = getBookmarkWordCloud(db, id);
+  return c.json({ cloud });
+});
+
 // ---- queue status ---------------------------------------------------------
 
 app.get('/api/queue', (c) => {
@@ -493,6 +634,7 @@ app.get('/api/queue/items', (c) => {
   return c.json({
     summary: summaryQueue.snapshot(),
     embedding: embeddingQueue.snapshot(),
+    wordcloud: cloudQueue.snapshot(),
     // Backward-compat top-level fields:
     ...summaryQueue.snapshot(),
   });

--- a/server/index.js
+++ b/server/index.js
@@ -588,7 +588,111 @@ app.get('/api/wordcloud/:id', (c) => {
   const id = Number(c.req.param('id'));
   const w = getWordCloud(db, id);
   if (!w) return c.json({ error: 'not found' }, 404);
-  return c.json(w);
+  return c.json({ ...w, related_pages: buildRelatedPages(w) });
+});
+
+function buildRelatedPages(wc, depth = 0) {
+  if (!wc || depth > 2) return [];
+  if (wc.origin === 'dig' && wc.origin_dig_id) {
+    const dig = getDigSession(db, wc.origin_dig_id);
+    if (!dig) return [];
+    const r = dig.result || {};
+    return (r.sources || []).map(s => ({
+      url: s.url, title: s.title || s.url,
+      snippet: (s.snippet || '').slice(0, 200), kind: 'dig-source',
+    }));
+  }
+  if (wc.origin === 'bookmark' && wc.origin_bookmark_id) {
+    const b = getBookmark(db, wc.origin_bookmark_id);
+    return b ? [{ url: b.url, title: b.title, snippet: (b.summary || '').slice(0, 200), kind: 'bookmark' }] : [];
+  }
+  if (wc.origin === 'bookmarks') {
+    return listBookmarks(db).slice(0, 16).map(b => ({
+      url: b.url, title: b.title, snippet: (b.summary || '').slice(0, 200), kind: 'bookmark',
+    }));
+  }
+  if (wc.origin === 'merged') {
+    const out = [];
+    const seen = new Set();
+    for (const m of (wc.result?.merged_from || [])) {
+      const child = getWordCloud(db, m.id);
+      for (const p of buildRelatedPages(child, depth + 1)) {
+        if (seen.has(p.url)) continue;
+        seen.add(p.url);
+        out.push(p);
+      }
+    }
+    return out.slice(0, 30);
+  }
+  return [];
+}
+
+app.get('/api/wordcloud/:id/graph', (c) => {
+  const id = Number(c.req.param('id'));
+  const radius = Math.min(3, Math.max(1, Number(c.req.query('radius')) || 3));
+  if (!getWordCloud(db, id)) return c.json({ error: 'not found' }, 404);
+
+  // BFS over parent_cloud_id (up) and child clouds (down).
+  const seen = new Map(); // id → depth from current
+  const queue = [{ id, depth: 0 }];
+  seen.set(id, 0);
+  while (queue.length > 0) {
+    const { id: nid, depth } = queue.shift();
+    if (depth >= radius) continue;
+    const cur = db.prepare(`SELECT parent_cloud_id FROM word_clouds WHERE id = ?`).get(nid);
+    if (cur?.parent_cloud_id && !seen.has(cur.parent_cloud_id)) {
+      seen.set(cur.parent_cloud_id, depth + 1);
+      queue.push({ id: cur.parent_cloud_id, depth: depth + 1 });
+    }
+    const children = db.prepare(`
+      SELECT id FROM word_clouds WHERE parent_cloud_id = ? AND status = 'done'
+    `).all(nid);
+    for (const ch of children) {
+      if (!seen.has(ch.id)) {
+        seen.set(ch.id, depth + 1);
+        queue.push({ id: ch.id, depth: depth + 1 });
+      }
+    }
+  }
+
+  // Count truncated branches (clouds at depth=radius that still have un-fetched
+  // children — UI uses this to draw a "..." stub).
+  const truncated = new Map(); // id → truncated_count
+  for (const [nid, depth] of seen.entries()) {
+    if (depth !== radius) continue;
+    const childCount = db.prepare(`
+      SELECT COUNT(*) AS n FROM word_clouds WHERE parent_cloud_id = ? AND status = 'done'
+    `).get(nid)?.n ?? 0;
+    if (childCount > 0) truncated.set(nid, childCount);
+  }
+
+  const nodes = [...seen.keys()].map(nid => {
+    const wc = getWordCloud(db, nid);
+    const r = wc?.result || {};
+    const topWords = (r.words || []).filter(w => w.kept)
+      .sort((a, b) => (b.weight || 0) - (a.weight || 0))
+      .slice(0, 5)
+      .map(w => ({ word: w.word, weight: w.weight }));
+    const totalWeight = topWords.reduce((s, w) => s + (w.weight || 0), 0);
+    return {
+      id: nid,
+      label: wc?.label || `cloud#${nid}`,
+      parent_cloud_id: wc?.parent_cloud_id ?? null,
+      parent_word: wc?.parent_word ?? null,
+      origin: wc?.origin || '',
+      depth: seen.get(nid),
+      total_weight: totalWeight,
+      top_words: topWords,
+      summary: (r.summary || '').slice(0, 200),
+      truncated_children: truncated.get(nid) ?? 0,
+    };
+  });
+  const idsInGraph = new Set(seen.keys());
+  const edges = nodes
+    .filter(n => n.parent_cloud_id && idsInGraph.has(n.parent_cloud_id))
+    .map(n => ({ from: n.parent_cloud_id, to: n.id, label: n.parent_word || '' }));
+
+  return c.json({ current: id, radius, nodes, edges });
 });
 
 app.get('/api/wordcloud/:id/siblings', (c) => {

--- a/server/index.js
+++ b/server/index.js
@@ -28,15 +28,18 @@ import {
   trendsDomains,
 } from './db.js';
 import { summarizeWithClaude, htmlToText } from './claude.js';
-import { FifoQueue } from './queue.js';
+import { FifoQueue, ConcurrentPool } from './queue.js';
 import { recommendationsFor, dismissRecommendation, clearDismissals } from './recommendations.js';
-import { runDig } from './dig.js';
+import { runDig, runDigPreview } from './dig.js';
 import { embed, chunkText, cosine, vecToBuffer, bufferToVec, getModelName } from './embeddings.js';
 import {
   deleteChunks, insertChunk, listChunkRows, bookmarksMissingEmbeddings, chunkStats,
-  insertDigSession, setDigResult, getDigSession, listDigSessions,
+  insertDigSession, setDigResult, setDigPreview, getDigSession, listDigSessions,
   insertWordCloud, setWordCloudResult, getWordCloud, listWordClouds,
   getBookmarkWordCloud, recentBookmarkWordClouds, trendsVisitDomains,
+  listDictionaryEntries, getDictionaryEntry, findDictionaryEntryByTerm,
+  insertDictionaryEntry, updateDictionaryEntry, deleteDictionaryEntry,
+  addDictionaryLink, removeDictionaryLink,
 } from './db.js';
 import { extractWordCloud, validateWordRelevance } from './wordcloud.js';
 import { spawn } from 'node:child_process';
@@ -447,11 +450,19 @@ function claudeAnswer(prompt, timeoutMs = 180_000) {
 }
 
 // ---- dig (deep research) -------------------------------------------------
-
-const digQueue = new FifoQueue();
+// Digs run in parallel — they're independent claude CLI invocations that
+// each spawn a separate child process. Concurrency keeps a sane upper bound.
+const DIG_CONCURRENCY = Number(process.env.MEMORIA_DIG_CONCURRENCY) || 4;
+const digQueue = new ConcurrentPool({ concurrency: DIG_CONCURRENCY });
 
 function enqueueDig(id, query) {
   digQueue.enqueue(async () => {
+    // Phase 1: SERP preview (fast — no page fetches). Persisted as soon as
+    // it lands so the FE can render before the deep claude pass finishes.
+    runDigPreview({ query, claudeBin: CLAUDE_BIN })
+      .then(preview => setDigPreview(db, id, preview))
+      .catch(err => console.warn(`[dig#${id}] preview failed: ${err.message}`));
+    // Phase 2: full deep analysis with WebFetch (existing behavior).
     try {
       const result = await runDig({ query, claudeBin: CLAUDE_BIN });
       setDigResult(db, id, { status: 'done', result });
@@ -580,6 +591,85 @@ app.get('/api/wordcloud/:id', (c) => {
   return c.json(w);
 });
 
+app.get('/api/wordcloud/:id/siblings', (c) => {
+  const id = Number(c.req.param('id'));
+  const cur = getWordCloud(db, id);
+  if (!cur) return c.json({ error: 'not found' }, 404);
+  if (!cur.parent_cloud_id) return c.json({ items: [] });
+  const rows = db.prepare(`
+    SELECT id, label, status, parent_word, created_at
+    FROM word_clouds
+    WHERE parent_cloud_id = ? AND id != ? AND status = 'done'
+    ORDER BY id DESC
+  `).all(cur.parent_cloud_id, id);
+  return c.json({ items: rows });
+});
+
+app.post('/api/wordcloud/merge', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const cloudIds = Array.isArray(body?.cloudIds)
+    ? body.cloudIds.map(Number).filter(Number.isFinite)
+    : [];
+  if (cloudIds.length < 2) return c.json({ error: 'cloudIds[] (>=2) required' }, 400);
+  const clouds = cloudIds.map(id => getWordCloud(db, id)).filter(Boolean);
+  const done = clouds.filter(c => c.status === 'done' && c.result);
+  if (done.length < 2) return c.json({ error: 'need at least 2 completed clouds' }, 400);
+
+  const merged = mergeWordCloudResults(done);
+  const label = (typeof body?.label === 'string' && body.label.trim())
+    ? body.label.trim().slice(0, 200)
+    : `merged: ${done.map(d => d.label).join(' + ').slice(0, 160)}`;
+  const id = insertWordCloud(db, {
+    origin: 'merged',
+    originDigId: null,
+    parentCloudId: done[0].parent_cloud_id ?? null,
+    parentWord: cloudIds.join(','),
+    label,
+  });
+  setWordCloudResult(db, id, { status: 'done', result: merged });
+  return c.json({ id });
+});
+
+function mergeWordCloudResults(clouds) {
+  const map = new Map(); // word_lower → aggregate
+  let firstSummary = '';
+  for (const c of clouds) {
+    const r = c.result || {};
+    if (!firstSummary && r.summary) firstSummary = r.summary;
+    for (const w of (r.words || [])) {
+      const key = String(w.word || '').toLowerCase().trim();
+      if (!key) continue;
+      const cur = map.get(key) || {
+        word: w.word, weightSum: 0, sources: 0, kept: false, count: 0, reasons: [],
+      };
+      cur.weightSum += Number(w.weight) || 0;
+      cur.sources += Number(w.sources) || 1;
+      cur.kept = cur.kept || !!w.kept;
+      cur.count += 1;
+      if (!w.kept && w.reason) cur.reasons.push(w.reason);
+      map.set(key, cur);
+    }
+  }
+  // Bonus: words appearing in more clouds get a boost.
+  const words = [...map.values()].map(w => ({
+    word: w.word,
+    weight: Math.min(100, Math.round(w.weightSum + (w.count - 1) * 8)),
+    sources: w.sources,
+    kept: w.kept,
+    reason: w.kept ? '' : (w.reasons[0] || ''),
+  }));
+  words.sort((a, b) => b.weight - a.weight);
+  const labelList = clouds.map(c => `「${c.label}」`).join(' + ');
+  return {
+    summary: clouds.length === 2
+      ? `${labelList} の合体クラウド (${words.length} 語)`
+      : `${clouds.length} 件の関連クラウドを統合 (${words.length} 語)`,
+    words: words.slice(0, 80),
+    merged_from: clouds.map(c => ({ id: c.id, label: c.label })),
+    base_summary: firstSummary,
+  };
+}
+
 app.post('/api/wordcloud/validate-word', async (c) => {
   const body = await c.req.json().catch(() => null);
   const word = body?.word;
@@ -617,6 +707,112 @@ app.get('/api/bookmarks/:id/wordcloud', (c) => {
   if (!getBookmark(db, id)) return c.json({ error: 'not found' }, 404);
   const cloud = getBookmarkWordCloud(db, id);
   return c.json({ cloud });
+});
+
+// ---- dictionary -----------------------------------------------------------
+
+app.get('/api/dictionary', (c) => {
+  const search = c.req.query('q')?.trim() || undefined;
+  return c.json({ items: listDictionaryEntries(db, { search }) });
+});
+
+app.get('/api/dictionary/:id', (c) => {
+  const id = Number(c.req.param('id'));
+  const e = getDictionaryEntry(db, id);
+  if (!e) return c.json({ error: 'not found' }, 404);
+  return c.json(e);
+});
+
+app.post('/api/dictionary', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const term = (body?.term ?? '').toString().trim();
+  if (!term) return c.json({ error: 'term required' }, 400);
+  const existing = findDictionaryEntryByTerm(db, term);
+  if (existing) {
+    // Idempotent: update if any new fields supplied, otherwise return existing.
+    const patch = {};
+    if (typeof body.definition === 'string') patch.definition = body.definition;
+    if (typeof body.notes === 'string') patch.notes = body.notes;
+    if (Object.keys(patch).length > 0) updateDictionaryEntry(db, existing.id, patch);
+    return c.json({ id: existing.id, existed: true });
+  }
+  const id = insertDictionaryEntry(db, {
+    term,
+    definition: body.definition ?? null,
+    notes: body.notes ?? null,
+  });
+  return c.json({ id, existed: false });
+});
+
+app.patch('/api/dictionary/:id', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (!getDictionaryEntry(db, id)) return c.json({ error: 'not found' }, 404);
+  const body = await c.req.json().catch(() => ({}));
+  updateDictionaryEntry(db, id, body);
+  return c.json(getDictionaryEntry(db, id));
+});
+
+app.delete('/api/dictionary/:id', (c) => {
+  const id = Number(c.req.param('id'));
+  deleteDictionaryEntry(db, id);
+  return c.json({ ok: true });
+});
+
+const VALID_DICT_SOURCE_KINDS = new Set(['cloud', 'dig', 'bookmark']);
+
+app.post('/api/dictionary/:id/links', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (!getDictionaryEntry(db, id)) return c.json({ error: 'not found' }, 404);
+  const body = await c.req.json().catch(() => null);
+  const sourceKind = body?.source_kind;
+  const sourceId = Number(body?.source_id);
+  if (!VALID_DICT_SOURCE_KINDS.has(sourceKind)) return c.json({ error: 'source_kind must be cloud|dig|bookmark' }, 400);
+  if (!Number.isFinite(sourceId)) return c.json({ error: 'source_id required' }, 400);
+  addDictionaryLink(db, { entryId: id, sourceKind, sourceId });
+  return c.json({ ok: true });
+});
+
+app.delete('/api/dictionary/:id/links', async (c) => {
+  const id = Number(c.req.param('id'));
+  const sourceKind = c.req.query('source_kind');
+  const sourceId = Number(c.req.query('source_id'));
+  if (!VALID_DICT_SOURCE_KINDS.has(sourceKind)) return c.json({ error: 'source_kind required' }, 400);
+  if (!Number.isFinite(sourceId)) return c.json({ error: 'source_id required' }, 400);
+  removeDictionaryLink(db, { entryId: id, sourceKind, sourceId });
+  return c.json({ ok: true });
+});
+
+/** Convenience: upsert a term + add a source link in one call. */
+app.post('/api/dictionary/upsert-from-source', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const term = (body?.term ?? '').toString().trim();
+  const sourceKind = body?.source_kind;
+  const sourceId = Number(body?.source_id);
+  if (!term) return c.json({ error: 'term required' }, 400);
+  if (!VALID_DICT_SOURCE_KINDS.has(sourceKind)) return c.json({ error: 'source_kind required' }, 400);
+  if (!Number.isFinite(sourceId)) return c.json({ error: 'source_id required' }, 400);
+
+  const existing = findDictionaryEntryByTerm(db, term);
+  let entryId;
+  let existed = false;
+  if (existing) {
+    entryId = existing.id;
+    existed = true;
+    if (typeof body.definition === 'string' || typeof body.notes === 'string') {
+      updateDictionaryEntry(db, entryId, {
+        definition: typeof body.definition === 'string' ? body.definition : undefined,
+        notes: typeof body.notes === 'string' ? body.notes : undefined,
+      });
+    }
+  } else {
+    entryId = insertDictionaryEntry(db, {
+      term,
+      definition: body.definition ?? null,
+      notes: body.notes ?? null,
+    });
+  }
+  addDictionaryLink(db, { entryId, sourceKind, sourceId });
+  return c.json({ id: entryId, existed });
 });
 
 // ---- queue status ---------------------------------------------------------

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -23,6 +23,7 @@ const state = {
   cloud: null,           // {id, status, label, result, parent_cloud_id, parent_word, origin, ...}
   cloudPolling: null,
   cloudShowDropped: false,
+  cloudGraph: null,
   detailCloud: null,     // word cloud for the currently open bookmark detail
   detailCloudPolling: null,
   cloudDictMode: false,
@@ -785,8 +786,12 @@ async function loadCloud(id) {
 
 async function loadCloudSiblings(id) {
   try {
-    const r = await api(`/api/wordcloud/${id}/siblings`);
-    state.cloudSiblings = r.items || [];
+    const [sibs, graph] = await Promise.all([
+      api(`/api/wordcloud/${id}/siblings`),
+      api(`/api/wordcloud/${id}/graph?radius=3`),
+    ]);
+    state.cloudSiblings = sibs.items || [];
+    state.cloudGraph = graph;
     renderCloud();
   } catch (e) { console.error(e); }
 }
@@ -853,25 +858,46 @@ function renderCloud() {
     ? '語クリックで <strong>辞書に登録</strong>'
     : '語クリックで深掘り';
 
+  const graphSvg = renderCloudGraph(state.cloudGraph, c.id);
+  const relatedPagesBlock = renderRelatedPages(c.related_pages || []);
+
   el.innerHTML = `
     <div class="cloud-head">
       <h3>ワードクラウド: ${escapeHtml(c.label || '')}</h3>
       ${breadcrumb}
     </div>
-    ${summaryBlock}
-    ${mergedFrom}
-    <div class="cloud-toolbar">
-      ${dropToggle}
-      ${dictToggle}
-      ${siblingBtn}
-      <span class="grow"></span>
-      <span style="font-size:11px;color:var(--muted)">${modeHint}</span>
-    </div>
-    <div class="cloud-words">${cloudHtml}</div>
-    <div class="cloud-manual">
-      <input id="cloudManualInput" type="text" placeholder="自分でワードを入れて掘る (claude が関連性をチェック)" />
-      <button id="cloudManualBtn">関連チェックして掘る</button>
-    </div>
+
+    <section class="cloud-section">
+      <h4 class="cloud-section-h">要約</h4>
+      ${summaryBlock || '<div class="queue-empty">要約なし</div>'}
+      ${mergedFrom}
+    </section>
+
+    <section class="cloud-section">
+      <h4 class="cloud-section-h">関連ページ</h4>
+      ${relatedPagesBlock}
+    </section>
+
+    <section class="cloud-section">
+      <h4 class="cloud-section-h">グラフ</h4>
+      ${graphSvg || '<div class="queue-empty">関連クラウドなし (このクラウドを起点に深掘りしてください)</div>'}
+    </section>
+
+    <section class="cloud-section">
+      <h4 class="cloud-section-h">タグクラウド</h4>
+      <div class="cloud-toolbar">
+        ${dropToggle}
+        ${dictToggle}
+        ${siblingBtn}
+        <span class="grow"></span>
+        <span style="font-size:11px;color:var(--muted)">${modeHint}</span>
+      </div>
+      <div class="cloud-words">${cloudHtml}</div>
+      <div class="cloud-manual">
+        <input id="cloudManualInput" type="text" placeholder="自分でワードを入れて掘る (claude が関連性をチェック)" />
+        <button id="cloudManualBtn">関連チェックして掘る</button>
+      </div>
+    </section>
   `;
 
   el.querySelector('.parent-link')?.addEventListener('click', () => {
@@ -889,6 +915,12 @@ function renderCloud() {
   el.querySelectorAll('.cloud-merged-list .pill').forEach(p => {
     p.addEventListener('click', () => loadCloud(Number(p.dataset.mid)));
   });
+  el.querySelectorAll('.cg-node').forEach(g => {
+    g.addEventListener('click', () => {
+      const nid = Number(g.dataset.id);
+      if (nid && nid !== c.id) loadCloud(nid);
+    });
+  });
   el.querySelectorAll('.cloud-word').forEach(w => {
     w.addEventListener('click', () => onCloudWordClick(w.dataset.word));
   });
@@ -896,6 +928,95 @@ function renderCloud() {
   el.querySelector('#cloudManualInput')?.addEventListener('keydown', (e) => {
     if (e.key === 'Enter') { e.preventDefault(); submitManualWord(); }
   });
+}
+
+function renderRelatedPages(pages) {
+  if (!pages.length) return '<div class="queue-empty">関連ページなし</div>';
+  return `<ul class="cloud-related">${pages.map(p => `
+    <li class="cloud-related-item">
+      <a href="${escapeHtml(p.url)}" target="_blank" rel="noreferrer" class="title">${escapeHtml(p.title)}</a>
+      <div class="url">${escapeHtml(p.url)}</div>
+      ${p.snippet ? `<div class="snippet">${escapeHtml(p.snippet)}</div>` : ''}
+    </li>
+  `).join('')}</ul>`;
+}
+
+function renderCloudGraph(graph, currentId) {
+  if (!graph || !graph.nodes || graph.nodes.length === 0) return '';
+
+  // Group nodes by depth from current. depth=0 sits at the center.
+  const byDepth = new Map();
+  for (const n of graph.nodes) {
+    if (!byDepth.has(n.depth)) byDepth.set(n.depth, []);
+    byDepth.get(n.depth).push(n);
+  }
+
+  const w = 760, h = 460;
+  const cx = w / 2, cy = h / 2;
+  const radii = [0, 110, 200, 280];
+
+  const positions = new Map(); // id -> {x,y,size,node}
+  // Depth 0 (current) at the center.
+  for (const n of (byDepth.get(0) || [])) {
+    positions.set(n.id, { x: cx, y: cy, node: n });
+  }
+  for (let d = 1; d <= 3; d++) {
+    const list = byDepth.get(d) || [];
+    list.forEach((n, i) => {
+      // Spread around the circle, with a slight angular offset per ring
+      const a = (i / Math.max(list.length, 1)) * Math.PI * 2 - Math.PI / 2 + (d * 0.18);
+      const x = cx + Math.cos(a) * radii[d];
+      const y = cy + Math.sin(a) * radii[d];
+      positions.set(n.id, { x, y, node: n });
+    });
+  }
+
+  // Node size = bounded by total_weight
+  const maxW = Math.max(1, ...graph.nodes.map(n => n.total_weight || 1));
+  function nodeRadius(n) {
+    const ratio = (n.total_weight || 1) / maxW;
+    return n.id === currentId ? 26 + ratio * 14 : 14 + ratio * 14;
+  }
+
+  // Edges
+  const edgesSvg = (graph.edges || []).map(e => {
+    const a = positions.get(e.from), b = positions.get(e.to);
+    if (!a || !b) return '';
+    const midX = (a.x + b.x) / 2;
+    const midY = (a.y + b.y) / 2;
+    const labelTxt = (e.label || '').slice(0, 14);
+    return `
+      <g class="cg-edge">
+        <line x1="${a.x.toFixed(1)}" y1="${a.y.toFixed(1)}" x2="${b.x.toFixed(1)}" y2="${b.y.toFixed(1)}" />
+        ${labelTxt ? `<text x="${midX}" y="${midY - 4}" text-anchor="middle">${escapeHtml(labelTxt)}</text>` : ''}
+      </g>
+    `;
+  }).join('');
+
+  // Nodes
+  const nodesSvg = graph.nodes.map(n => {
+    const p = positions.get(n.id);
+    if (!p) return '';
+    const r = nodeRadius(n);
+    const isCurrent = n.id === currentId;
+    const cls = `cg-node depth-${n.depth}${isCurrent ? ' current' : ''}`;
+    const top = (n.top_words || []).slice(0, 3).map(w => w.word).join(' / ');
+    const labelTxt = (n.label || '').slice(0, 18);
+    const truncMark = (n.truncated_children > 0)
+      ? `<text class="cg-trunc" x="${p.x}" y="${(p.y + r + 14).toFixed(1)}" text-anchor="middle">…+${n.truncated_children}</text>`
+      : '';
+    return `
+      <g class="${cls}" data-id="${n.id}" transform="translate(${p.x.toFixed(1)},${p.y.toFixed(1)})">
+        <circle r="${r}" />
+        <text class="cg-label" y="-${(r + 6).toFixed(1)}" text-anchor="middle">${escapeHtml(labelTxt)}</text>
+        <text class="cg-top" y="4" text-anchor="middle">${escapeHtml(top)}</text>
+        <title>${escapeHtml(n.label)}\n${escapeHtml(n.summary || '')}\n--\n${(n.top_words||[]).map(w=>`${w.word} (${w.weight})`).join(', ')}</title>
+      </g>
+      ${truncMark}
+    `;
+  }).join('');
+
+  return `<div class="cloud-graph"><svg viewBox="0 0 ${w} ${h}" preserveAspectRatio="xMidYMid meet">${edgesSvg}${nodesSvg}</svg><div class="cloud-graph-hint">クリックで雲を切り替え · 半径 3 階層まで表示 (それより遠い枝は ${'…+N'} で省略)</div></div>`;
 }
 
 function renderCloudWords(words) {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -20,6 +20,11 @@ const state = {
   digHistory: [],
   digSelected: new Set(),
   digPolling: null,
+  cloud: null,           // {id, status, label, result, parent_cloud_id, parent_word, origin, ...}
+  cloudPolling: null,
+  cloudShowDropped: false,
+  detailCloud: null,     // word cloud for the currently open bookmark detail
+  detailCloudPolling: null,
 };
 
 const $ = (id) => document.getElementById(id);
@@ -161,6 +166,61 @@ async function renderDetail() {
   $('dMemo').value = b.memo || '';
   $('dViewHtml').href = `/api/bookmarks/${id}/html`;
   $('dAccesses').innerHTML = (accesses.items || []).map(a => `<li>${fmtDate(a.accessed_at)}</li>`).join('');
+  state.detailCloud = b.wordcloud || null;
+  renderDetailCloud();
+}
+
+function renderDetailCloud() {
+  const el = $('dCloud');
+  if (!el) return;
+  const wc = state.detailCloud;
+  if (!wc) {
+    el.innerHTML = '<div class="detail-cloud-empty">未生成。生成ボタンを押すと、この記事から claude が抽出します。</div>';
+    return;
+  }
+  if (wc.status === 'pending') {
+    el.innerHTML = '<div class="detail-cloud-empty">抽出中…</div>';
+    return;
+  }
+  if (wc.status === 'error') {
+    el.innerHTML = `<div class="detail-cloud-empty" style="color:var(--danger)">失敗: ${escapeHtml(wc.error || '不明')}</div>`;
+    return;
+  }
+  const r = wc.result || {};
+  const kept = (r.words || []).filter(w => w.kept);
+  el.innerHTML = renderCloudWords(kept);
+  el.querySelectorAll('.cloud-word').forEach(w => {
+    w.addEventListener('click', () => onCloudWordClick(w.dataset.word));
+  });
+}
+
+async function generateDetailCloud() {
+  const id = state.detailId;
+  if (id == null) return;
+  const btn = $('dCloudGen');
+  if (btn) { btn.disabled = true; btn.textContent = '生成中…'; }
+  try {
+    const r = await api(`/api/bookmarks/${id}/wordcloud`, { method: 'POST' });
+    state.detailCloud = { id: r.id, status: 'pending', result: null };
+    renderDetailCloud();
+    pollDetailCloud(r.id);
+  } catch (e) {
+    alert(`生成失敗: ${e.message}`);
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = '生成'; }
+  }
+}
+
+function pollDetailCloud(cloudId) {
+  if (state.detailCloudPolling) clearInterval(state.detailCloudPolling);
+  state.detailCloudPolling = setInterval(async () => {
+    const c = await api(`/api/wordcloud/${cloudId}`).catch(() => null);
+    if (!c || c.status === 'pending') return;
+    clearInterval(state.detailCloudPolling);
+    state.detailCloudPolling = null;
+    state.detailCloud = c;
+    renderDetailCloud();
+  }, 5000);
 }
 
 function closeDetail() {
@@ -265,6 +325,7 @@ $('detailClose').addEventListener('click', closeDetail);
 $('dSave').addEventListener('click', saveDetail);
 $('dResummarize').addEventListener('click', resummarizeDetail);
 $('dDelete').addEventListener('click', deleteDetail);
+$('dCloudGen')?.addEventListener('click', generateDetailCloud);
 $('exportBtn').addEventListener('click', exportSelected);
 $('bulkExport').addEventListener('click', exportSelected);
 $('bulkClear').addEventListener('click', () => {
@@ -438,7 +499,7 @@ function renderDigHistory() {
   });
 }
 
-async function startDig() {
+async function startDig({ chainCloudId, chainParentWord } = {}) {
   const q = $('digQuery').value.trim();
   if (!q) return;
   $('digRun').disabled = true;
@@ -449,6 +510,10 @@ async function startDig() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ query: q }),
     });
+    state.digChain = {
+      cloudId: chainCloudId ?? null,
+      parentWord: chainParentWord ?? null,
+    };
     await loadDigHistory();
     pollDigSession(r.id);
   } catch (e) {
@@ -518,12 +583,18 @@ function renderDigSession() {
       </div>
     `;
   }).join('');
+  const chain = state.digChain || {};
+  const chainHint = chain.parentWord
+    ? `<span class="dig-chain-hint">親 "${escapeHtml(chain.parentWord)}" から派生</span>`
+    : '';
   el.innerHTML = `
     ${summaryBlock}
     ${graph}
     <div class="dig-actions">
       <span id="digSelCount">0</span> 件選択中
+      ${chainHint}
       <span class="grow"></span>
+      <button id="digCloudBtn" class="ghost" title="このディグの記事からワードクラウドを生成">🌐 このディグから雲を抽出</button>
       <button id="digSaveBtn">選択をブックマーク化</button>
     </div>
     <div class="dig-sources">${sourceCards}</div>
@@ -541,6 +612,10 @@ function renderDigSession() {
       card.classList.toggle('selected', sel);
       $('digSelCount').textContent = state.digSelected.size;
     });
+  });
+  $('digCloudBtn')?.addEventListener('click', () => {
+    const chain = state.digChain || {};
+    startCloudFromDig(s.id, chain.cloudId, chain.parentWord);
   });
   $('digSaveBtn')?.addEventListener('click', async () => {
     const urls = [...state.digSelected];
@@ -592,6 +667,174 @@ function digGraph(query, sources) {
 
 function shortDomain(url) {
   try { return new URL(url).hostname.replace(/^www\./, ''); } catch { return url.slice(0, 20); }
+}
+
+// ── Word cloud ─────────────────────────────────────────────────────────
+
+async function startCloudFromBookmarks() {
+  const cat = state.category;
+  if (!confirm(`${cat ? `カテゴリ「${cat}」の` : '全'}ブックマークからワードクラウドを生成します。\nclaude による解析に数十秒〜数分かかります。よろしいですか？`)) return;
+  await startCloud({ origin: 'bookmarks', category: cat });
+}
+
+async function startCloudFromDig(digId, parentCloudId, parentWord) {
+  await startCloud({ origin: 'dig', digId, parentCloudId, parentWord });
+}
+
+async function startCloud(payload) {
+  try {
+    const r = await api('/api/wordcloud', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    state.cloud = { id: r.id, status: 'pending', label: payload.category || payload.digId || '', result: null };
+    renderCloud();
+    pollCloud(r.id);
+  } catch (e) {
+    alert(`ワードクラウド生成失敗: ${e.message}`);
+  }
+}
+
+function pollCloud(id) {
+  if (state.cloudPolling) clearInterval(state.cloudPolling);
+  loadCloud(id);
+  state.cloudPolling = setInterval(async () => {
+    const c = await api(`/api/wordcloud/${id}`).catch(() => null);
+    if (!c) return;
+    if (c.status !== 'pending') {
+      clearInterval(state.cloudPolling);
+      state.cloudPolling = null;
+      state.cloud = c;
+      renderCloud();
+    }
+  }, 5000);
+}
+
+async function loadCloud(id) {
+  try {
+    const c = await api(`/api/wordcloud/${id}`);
+    state.cloud = c;
+    renderCloud();
+    if (c.status === 'pending') pollCloud(id);
+  } catch (e) { console.error(e); }
+}
+
+function renderCloud() {
+  const el = $('cloudView');
+  const c = state.cloud;
+  if (!c) { el.innerHTML = ''; return; }
+  if (c.status === 'pending') {
+    el.innerHTML = `<div class="dig-pending"><div class="pulse"></div>ワードクラウドを抽出中…「${escapeHtml(c.label || '')}」</div>`;
+    return;
+  }
+  if (c.status === 'error') {
+    el.innerHTML = `<div class="dig-pending" style="border-color:var(--danger);color:var(--danger)">クラウド失敗: ${escapeHtml(c.error || '不明')}</div>`;
+    return;
+  }
+  const r = c.result || {};
+  const allWords = r.words || [];
+  const kept = allWords.filter(w => w.kept);
+  const dropped = allWords.filter(w => !w.kept);
+  const display = state.cloudShowDropped ? allWords : kept;
+
+  const summaryBlock = r.summary ? `<div class="summary">${escapeHtml(r.summary)}</div>` : '';
+  const breadcrumbBits = [];
+  if (c.parent_cloud_id) breadcrumbBits.push(`<span class="parent-link" data-pid="${c.parent_cloud_id}">⬆ 親の雲</span>`);
+  if (c.parent_word) breadcrumbBits.push(`<span class="parent-word">→ "${escapeHtml(c.parent_word)}"</span>`);
+  const breadcrumb = breadcrumbBits.length ? `<div class="cloud-breadcrumb">${breadcrumbBits.join(' ')}</div>` : '';
+
+  const cloudHtml = renderCloudWords(display);
+
+  const dropToggle = dropped.length > 0
+    ? `<label class="check-inline cloud-dropped-toggle"><input type="checkbox" id="cloudShowDropped" ${state.cloudShowDropped ? 'checked' : ''}/> 関係薄を表示 (${dropped.length})</label>`
+    : '';
+
+  el.innerHTML = `
+    <div class="cloud-head">
+      <h3>ワードクラウド: ${escapeHtml(c.label || '')}</h3>
+      ${breadcrumb}
+    </div>
+    ${summaryBlock}
+    <div class="cloud-toolbar">
+      ${dropToggle}
+      <span class="grow"></span>
+      <span style="font-size:11px;color:var(--muted)">語をクリックで深掘り</span>
+    </div>
+    <div class="cloud-words">${cloudHtml}</div>
+    <div class="cloud-manual">
+      <input id="cloudManualInput" type="text" placeholder="自分でワードを入れて掘る (claude が関連性をチェック)" />
+      <button id="cloudManualBtn">関連チェックして掘る</button>
+    </div>
+  `;
+
+  el.querySelector('.parent-link')?.addEventListener('click', () => {
+    loadCloud(Number(el.querySelector('.parent-link').dataset.pid));
+  });
+  el.querySelector('#cloudShowDropped')?.addEventListener('change', (e) => {
+    state.cloudShowDropped = e.target.checked;
+    renderCloud();
+  });
+  el.querySelectorAll('.cloud-word').forEach(w => {
+    w.addEventListener('click', () => onCloudWordClick(w.dataset.word));
+  });
+  el.querySelector('#cloudManualBtn')?.addEventListener('click', submitManualWord);
+  el.querySelector('#cloudManualInput')?.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') { e.preventDefault(); submitManualWord(); }
+  });
+}
+
+function renderCloudWords(words) {
+  if (!words.length) return '<div class="queue-empty">該当語なし</div>';
+  const max = Math.max(1, ...words.map(w => w.weight || 1));
+  return words.map(w => {
+    const ratio = (w.weight || 1) / max;
+    const fontSize = (12 + ratio * 30).toFixed(1);
+    const opacity = w.kept ? 1 : 0.45;
+    const cls = w.kept ? 'cloud-word' : 'cloud-word dropped';
+    const title = w.kept
+      ? `weight=${w.weight}, sources=${w.sources}`
+      : `関係薄: ${w.reason || '(理由なし)'} — weight=${w.weight}`;
+    return `<span class="${cls}" data-word="${escapeHtml(w.word)}" style="font-size:${fontSize}px;opacity:${opacity}" title="${escapeHtml(title)}">${escapeHtml(w.word)}</span>`;
+  }).join(' ');
+}
+
+async function onCloudWordClick(word) {
+  if (!word) return;
+  const c = state.cloud;
+  // Drilling from cloud: words are pre-validated (kept=true). Run a dig with this word as query.
+  switchTab('dig');
+  $('digQuery').value = word;
+  await startDig({ chainCloudId: c?.id, chainParentWord: word });
+}
+
+async function submitManualWord() {
+  const input = $('cloudManualInput');
+  const word = (input?.value || '').trim();
+  if (!word) return;
+  const c = state.cloud;
+  const context = c?.result?.summary || c?.label || 'general bookmarks';
+  const btn = $('cloudManualBtn');
+  if (btn) { btn.disabled = true; btn.textContent = 'チェック中…'; }
+  try {
+    const v = await api('/api/wordcloud/validate-word', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ word, context }),
+    });
+    if (!v.related) {
+      if (!confirm(`「${word}」は関連性が低いと判定されました。\n理由: ${v.reason || '(なし)'}\nそれでも掘りますか？`)) {
+        return;
+      }
+    }
+    switchTab('dig');
+    $('digQuery').value = word;
+    await startDig({ chainCloudId: c?.id, chainParentWord: word });
+  } catch (e) {
+    alert(`関連チェック失敗: ${e.message}`);
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = '関連チェックして掘る'; }
+  }
 }
 
 // ── RAG ────────────────────────────────────────────────────────────────
@@ -782,16 +1025,18 @@ function renderRecommendations() {
 async function loadTrends() {
   const days = state.trendsRange;
   try {
-    const [cats, diff, timeline, domains] = await Promise.all([
+    const [cats, diff, timeline, domains, visitDomains] = await Promise.all([
       api(`/api/trends/categories?days=${encodeURIComponent(days)}`),
       api(`/api/trends/category-diff?days=7`),
       api(`/api/trends/timeline?days=${encodeURIComponent(days)}`),
       api(`/api/trends/domains?days=${encodeURIComponent(days)}`),
+      api(`/api/trends/visit-domains?days=${encodeURIComponent(days)}`),
     ]);
     renderTrendCategories(cats.items);
     renderTrendDiff(diff.items);
     renderTrendTimeline(timeline.items);
     renderTrendDomains(domains.items);
+    renderTrendVisitDomains(visitDomains.items);
   } catch (e) {
     console.error('trends load failed', e);
   }
@@ -803,6 +1048,10 @@ function renderTrendCategories(items) {
 
 function renderTrendDomains(items) {
   $('trendDomains').innerHTML = svgHorizontalBar(items, c => c.domain, c => c.hits, 'alt');
+}
+
+function renderTrendVisitDomains(items) {
+  $('trendVisitDomains').innerHTML = svgHorizontalBar(items, c => c.domain, c => c.visits, 'alt');
 }
 
 function svgHorizontalBar(items, labelFn, valueFn, klass = '') {
@@ -1029,10 +1278,11 @@ $('trendsRange').addEventListener('change', (e) => {
   loadTrends();
 });
 $('recRefresh').addEventListener('click', () => loadRecommendations(true));
-$('digRun').addEventListener('click', startDig);
+$('digRun').addEventListener('click', () => startDig());
 $('digQuery').addEventListener('keydown', (e) => {
   if (e.key === 'Enter') { e.preventDefault(); startDig(); }
 });
+$('digFromBookmarks')?.addEventListener('click', startCloudFromBookmarks);
 $('ragSearchBtn').addEventListener('click', ragSearch);
 $('ragAskBtn').addEventListener('click', ragAsk);
 $('ragQuery').addEventListener('keydown', (e) => {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -25,6 +25,11 @@ const state = {
   cloudShowDropped: false,
   detailCloud: null,     // word cloud for the currently open bookmark detail
   detailCloudPolling: null,
+  cloudDictMode: false,
+  cloudSiblings: [],
+  dictEntries: [],
+  dictDetail: null,
+  dictSearch: '',
 };
 
 const $ = (id) => document.getElementById(id);
@@ -465,12 +470,14 @@ function switchTab(tab) {
   $('recommendView').classList.toggle('hidden', tab !== 'recommend');
   $('ragView').classList.toggle('hidden', tab !== 'rag');
   $('digView').classList.toggle('hidden', tab !== 'dig');
+  $('dictView').classList.toggle('hidden', tab !== 'dict');
   if (tab === 'queue') renderQueue();
   if (tab === 'visits') loadVisits();
   if (tab === 'trends') loadTrends();
   if (tab === 'recommend') loadRecommendations();
   if (tab === 'rag') loadRagStatus();
   if (tab === 'dig') loadDigHistory();
+  if (tab === 'dict') loadDictionary();
 }
 
 // ── Dig (deep research) ──────────────────────────────────────────────────
@@ -527,17 +534,21 @@ async function startDig({ chainCloudId, chainParentWord } = {}) {
 function pollDigSession(id) {
   if (state.digPolling) clearInterval(state.digPolling);
   loadDigSession(id);
+  // Poll faster while waiting for preview, then settle.
   state.digPolling = setInterval(async () => {
     const s = await api(`/api/dig/${id}`).catch(() => null);
     if (!s) return;
+    const had = state.digSession;
+    state.digSession = s;
+    const previewArrived = !had?.preview && !!s.preview;
+    if (previewArrived) renderDigSession();
     if (s.status !== 'pending') {
       clearInterval(state.digPolling);
       state.digPolling = null;
-      state.digSession = s;
       renderDigSession();
       loadDigHistory();
     }
-  }, 5000);
+  }, 2000);
 }
 
 async function loadDigSession(id) {
@@ -555,7 +566,11 @@ function renderDigSession() {
   const el = $('digResult');
   if (!s) { el.innerHTML = ''; return; }
   if (s.status === 'pending') {
-    el.innerHTML = `<div class="dig-pending"><div class="pulse"></div>「${escapeHtml(s.query)}」を掘っています…claude が Web 検索 + 取得を行うため数十秒〜数分かかります。</div>`;
+    if (s.preview) {
+      el.innerHTML = renderDigPreview(s) + `<div class="dig-pending dig-pending-tight"><div class="pulse"></div>詳細解析を続行中…完了するとさらに整理された結果が表示されます。</div>`;
+    } else {
+      el.innerHTML = `<div class="dig-pending"><div class="pulse"></div>「${escapeHtml(s.query)}」を検索中…まずは Google の AI overview と上位結果のみを取得し、続けて詳細を解析します。</div>`;
+    }
     return;
   }
   if (s.status === 'error') {
@@ -595,6 +610,7 @@ function renderDigSession() {
       ${chainHint}
       <span class="grow"></span>
       <button id="digCloudBtn" class="ghost" title="このディグの記事からワードクラウドを生成">🌐 このディグから雲を抽出</button>
+      <button id="digDictBtn" class="ghost" title="このディグを辞書エントリとして記録">📖 辞書に追加</button>
       <button id="digSaveBtn">選択をブックマーク化</button>
     </div>
     <div class="dig-sources">${sourceCards}</div>
@@ -617,6 +633,7 @@ function renderDigSession() {
     const chain = state.digChain || {};
     startCloudFromDig(s.id, chain.cloudId, chain.parentWord);
   });
+  $('digDictBtn')?.addEventListener('click', () => addDigToDictionary(s));
   $('digSaveBtn')?.addEventListener('click', async () => {
     const urls = [...state.digSelected];
     if (!urls.length) return;
@@ -669,6 +686,51 @@ function shortDomain(url) {
   try { return new URL(url).hostname.replace(/^www\./, ''); } catch { return url.slice(0, 20); }
 }
 
+function renderDigPreview(session) {
+  const p = session.preview || {};
+  const overview = p.ai_overview
+    ? `<div class="dig-preview-overview"><div class="dig-preview-tag">AI overview (検索結果より)</div>${escapeHtml(p.ai_overview)}</div>`
+    : '';
+  const results = (p.results || []).map((r, i) => `
+    <li class="dig-preview-result">
+      <div class="title"><a href="${escapeHtml(r.url)}" target="_blank" rel="noreferrer">${escapeHtml(r.title || r.url)}</a></div>
+      <div class="url">${escapeHtml(r.domain || r.url)}</div>
+      <div class="snippet">${escapeHtml(r.snippet || '')}</div>
+    </li>
+  `).join('');
+  if (!overview && !results) return '';
+  return `
+    <div class="dig-preview">
+      <h3 class="dig-preview-h">⚡ クイックプレビュー</h3>
+      ${overview}
+      <ol class="dig-preview-list">${results}</ol>
+    </div>
+  `;
+}
+
+async function addDigToDictionary(session) {
+  if (!session) return;
+  const term = (session.query || '').trim();
+  if (!term) return;
+  const r = session.result || {};
+  const definition = r.summary || '';
+  try {
+    const res = await api('/api/dictionary/upsert-from-source', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        term,
+        source_kind: 'dig',
+        source_id: session.id,
+        definition,
+      }),
+    });
+    flashToast(res.existed ? `「${term}」にディグをリンクしました` : `「${term}」を辞書に追加しました`);
+  } catch (e) {
+    alert(`辞書追加失敗: ${e.message}`);
+  }
+}
+
 // ── Word cloud ─────────────────────────────────────────────────────────
 
 async function startCloudFromBookmarks() {
@@ -717,7 +779,34 @@ async function loadCloud(id) {
     state.cloud = c;
     renderCloud();
     if (c.status === 'pending') pollCloud(id);
+    if (c.status === 'done') loadCloudSiblings(id);
   } catch (e) { console.error(e); }
+}
+
+async function loadCloudSiblings(id) {
+  try {
+    const r = await api(`/api/wordcloud/${id}/siblings`);
+    state.cloudSiblings = r.items || [];
+    renderCloud();
+  } catch (e) { console.error(e); }
+}
+
+async function mergeWithSiblings() {
+  const c = state.cloud;
+  if (!c) return;
+  const sibs = state.cloudSiblings || [];
+  if (sibs.length === 0) return alert('合体できる兄弟雲がありません');
+  const ids = [c.id, ...sibs.map(s => s.id)];
+  try {
+    const r = await api('/api/wordcloud/merge', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cloudIds: ids }),
+    });
+    await loadCloud(r.id);
+  } catch (e) {
+    alert(`合体失敗: ${e.message}`);
+  }
 }
 
 function renderCloud() {
@@ -750,16 +839,33 @@ function renderCloud() {
     ? `<label class="check-inline cloud-dropped-toggle"><input type="checkbox" id="cloudShowDropped" ${state.cloudShowDropped ? 'checked' : ''}/> 関係薄を表示 (${dropped.length})</label>`
     : '';
 
+  const dictToggle = `<label class="check-inline cloud-dict-toggle"><input type="checkbox" id="cloudDictMode" ${state.cloudDictMode ? 'checked' : ''}/>📖 辞書登録モード</label>`;
+
+  const sibs = state.cloudSiblings || [];
+  const siblingBtn = sibs.length > 0
+    ? `<button id="cloudMergeBtn" class="ghost" title="親 ${escapeHtml(c.parent_word || '')} の兄弟雲 ${sibs.length} 件と合体">🔀 兄弟雲をまとめる (${sibs.length})</button>`
+    : '';
+  const mergedFrom = (r.merged_from || []).length > 0
+    ? `<div class="cloud-merged-list">合体元: ${r.merged_from.map(m => `<span class="pill" data-mid="${m.id}">${escapeHtml(m.label)}</span>`).join(' ')}</div>`
+    : '';
+
+  const modeHint = state.cloudDictMode
+    ? '語クリックで <strong>辞書に登録</strong>'
+    : '語クリックで深掘り';
+
   el.innerHTML = `
     <div class="cloud-head">
       <h3>ワードクラウド: ${escapeHtml(c.label || '')}</h3>
       ${breadcrumb}
     </div>
     ${summaryBlock}
+    ${mergedFrom}
     <div class="cloud-toolbar">
       ${dropToggle}
+      ${dictToggle}
+      ${siblingBtn}
       <span class="grow"></span>
-      <span style="font-size:11px;color:var(--muted)">語をクリックで深掘り</span>
+      <span style="font-size:11px;color:var(--muted)">${modeHint}</span>
     </div>
     <div class="cloud-words">${cloudHtml}</div>
     <div class="cloud-manual">
@@ -774,6 +880,14 @@ function renderCloud() {
   el.querySelector('#cloudShowDropped')?.addEventListener('change', (e) => {
     state.cloudShowDropped = e.target.checked;
     renderCloud();
+  });
+  el.querySelector('#cloudDictMode')?.addEventListener('change', (e) => {
+    state.cloudDictMode = e.target.checked;
+    renderCloud();
+  });
+  el.querySelector('#cloudMergeBtn')?.addEventListener('click', mergeWithSiblings);
+  el.querySelectorAll('.cloud-merged-list .pill').forEach(p => {
+    p.addEventListener('click', () => loadCloud(Number(p.dataset.mid)));
   });
   el.querySelectorAll('.cloud-word').forEach(w => {
     w.addEventListener('click', () => onCloudWordClick(w.dataset.word));
@@ -802,10 +916,47 @@ function renderCloudWords(words) {
 async function onCloudWordClick(word) {
   if (!word) return;
   const c = state.cloud;
+  if (state.cloudDictMode) {
+    await addCloudWordToDictionary(word, c);
+    return;
+  }
   // Drilling from cloud: words are pre-validated (kept=true). Run a dig with this word as query.
   switchTab('dig');
   $('digQuery').value = word;
   await startDig({ chainCloudId: c?.id, chainParentWord: word });
+}
+
+async function addCloudWordToDictionary(word, cloud) {
+  if (!cloud) return;
+  try {
+    const r = await api('/api/dictionary/upsert-from-source', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        term: word,
+        source_kind: 'cloud',
+        source_id: cloud.id,
+        notes: cloud.label ? `via cloud: ${cloud.label}` : null,
+      }),
+    });
+    flashToast(r.existed ? `「${word}」を既存エントリにリンクしました` : `「${word}」を辞書に追加しました`);
+  } catch (e) {
+    alert(`辞書登録失敗: ${e.message}`);
+  }
+}
+
+function flashToast(msg) {
+  let el = document.getElementById('memToast');
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'memToast';
+    el.className = 'mem-toast';
+    document.body.appendChild(el);
+  }
+  el.textContent = msg;
+  el.classList.add('show');
+  clearTimeout(flashToast._t);
+  flashToast._t = setTimeout(() => el.classList.remove('show'), 2400);
 }
 
 async function submitManualWord() {
@@ -834,6 +985,171 @@ async function submitManualWord() {
     alert(`関連チェック失敗: ${e.message}`);
   } finally {
     if (btn) { btn.disabled = false; btn.textContent = '関連チェックして掘る'; }
+  }
+}
+
+// ── Dictionary ─────────────────────────────────────────────────────────
+
+async function loadDictionary() {
+  try {
+    const q = state.dictSearch ? `?q=${encodeURIComponent(state.dictSearch)}` : '';
+    const r = await api(`/api/dictionary${q}`);
+    state.dictEntries = r.items || [];
+    renderDictionaryList();
+  } catch (e) { console.error(e); }
+}
+
+function renderDictionaryList() {
+  const ul = $('dictList');
+  if (!state.dictEntries.length) {
+    ul.innerHTML = '<li class="dict-empty">辞書エントリはまだありません。雲の語をクリック (辞書登録モード) や、ディグの「📖 辞書に追加」から登録できます。</li>';
+    return;
+  }
+  ul.innerHTML = state.dictEntries.map(e => `
+    <li class="dict-item ${state.dictDetail?.id === e.id ? 'selected' : ''}" data-id="${e.id}">
+      <div class="dict-term">${escapeHtml(e.term)}</div>
+      <div class="dict-snippet">${escapeHtml((e.definition || '').slice(0, 120))}</div>
+      <div class="dict-meta">
+        <span>${e.link_count} 件リンク</span>
+        <span>${fmtDate(e.updated_at)}</span>
+      </div>
+    </li>
+  `).join('');
+  ul.querySelectorAll('.dict-item').forEach(li => {
+    li.addEventListener('click', () => loadDictionaryEntry(Number(li.dataset.id)));
+  });
+}
+
+async function loadDictionaryEntry(id) {
+  try {
+    const e = await api(`/api/dictionary/${id}`);
+    state.dictDetail = e;
+    renderDictionaryList();
+    renderDictionaryDetail();
+  } catch (e) { console.error(e); }
+}
+
+async function renderDictionaryDetail() {
+  const e = state.dictDetail;
+  const panel = $('dictDetail');
+  if (!e) { panel.classList.add('hidden'); return; }
+  panel.classList.remove('hidden');
+  $('dictTerm').value = e.term || '';
+  $('dictDefinition').value = e.definition || '';
+  $('dictNotes').value = e.notes || '';
+
+  const links = e.links || [];
+  if (!links.length) {
+    $('dictLinks').innerHTML = '<li class="dict-empty">リンクなし</li>';
+    return;
+  }
+
+  // Resolve sources by kind for nicer labels.
+  const resolved = await Promise.all(links.map(async l => {
+    let label = `${l.source_kind} #${l.source_id}`;
+    let url = '';
+    try {
+      if (l.source_kind === 'cloud') {
+        const c = await api(`/api/wordcloud/${l.source_id}`);
+        label = `🌐 雲: ${c.label || ''}`;
+      } else if (l.source_kind === 'dig') {
+        const d = await api(`/api/dig/${l.source_id}`);
+        label = `🔎 dig: ${d.query || ''}`;
+      } else if (l.source_kind === 'bookmark') {
+        const b = await api(`/api/bookmarks/${l.source_id}`);
+        label = `📑 ${b.title || ''}`;
+        url = b.url || '';
+      }
+    } catch {}
+    return { ...l, label, url };
+  }));
+  $('dictLinks').innerHTML = resolved.map(l => `
+    <li class="dict-link" data-kind="${l.source_kind}" data-sid="${l.source_id}">
+      <span class="dict-link-label">${escapeHtml(l.label)}</span>
+      ${l.url ? `<a href="${escapeHtml(l.url)}" target="_blank" rel="noreferrer" class="ghost">↗</a>` : ''}
+      <button class="ghost dict-link-remove" data-kind="${l.source_kind}" data-sid="${l.source_id}">×</button>
+    </li>
+  `).join('');
+  $('dictLinks').querySelectorAll('.dict-link-label').forEach(s => {
+    s.addEventListener('click', () => {
+      const li = s.closest('.dict-link');
+      const kind = li.dataset.kind;
+      const sid = Number(li.dataset.sid);
+      navigateToDictSource(kind, sid);
+    });
+  });
+  $('dictLinks').querySelectorAll('.dict-link-remove').forEach(btn => {
+    btn.addEventListener('click', async (ev) => {
+      ev.stopPropagation();
+      await api(`/api/dictionary/${e.id}/links?source_kind=${btn.dataset.kind}&source_id=${btn.dataset.sid}`, { method: 'DELETE' });
+      await loadDictionaryEntry(e.id);
+    });
+  });
+}
+
+function navigateToDictSource(kind, sid) {
+  if (kind === 'cloud') {
+    switchTab('dig');
+    loadCloud(sid);
+  } else if (kind === 'dig') {
+    switchTab('dig');
+    loadDigSession(sid);
+  } else if (kind === 'bookmark') {
+    switchTab('bookmarks');
+    openDetail(sid);
+  }
+}
+
+async function saveDictionaryEntry() {
+  const e = state.dictDetail;
+  if (!e) return;
+  const body = {
+    term: $('dictTerm').value.trim(),
+    definition: $('dictDefinition').value,
+    notes: $('dictNotes').value,
+  };
+  if (!body.term) return alert('単語は必須です');
+  try {
+    await api(`/api/dictionary/${e.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    flashToast('保存しました');
+    await loadDictionary();
+    await loadDictionaryEntry(e.id);
+  } catch (e) {
+    alert(`保存失敗: ${e.message}`);
+  }
+}
+
+async function deleteDictionaryEntry() {
+  const e = state.dictDetail;
+  if (!e) return;
+  if (!confirm(`「${e.term}」を辞書から削除しますか？`)) return;
+  try {
+    await api(`/api/dictionary/${e.id}`, { method: 'DELETE' });
+    state.dictDetail = null;
+    $('dictDetail').classList.add('hidden');
+    await loadDictionary();
+  } catch (e) {
+    alert(`削除失敗: ${e.message}`);
+  }
+}
+
+async function createDictionaryEntry() {
+  const term = prompt('新しいエントリの単語を入力してください');
+  if (!term || !term.trim()) return;
+  try {
+    const r = await api('/api/dictionary', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ term: term.trim() }),
+    });
+    await loadDictionary();
+    await loadDictionaryEntry(r.id);
+  } catch (e) {
+    alert(`作成失敗: ${e.message}`);
   }
 }
 
@@ -1283,6 +1599,13 @@ $('digQuery').addEventListener('keydown', (e) => {
   if (e.key === 'Enter') { e.preventDefault(); startDig(); }
 });
 $('digFromBookmarks')?.addEventListener('click', startCloudFromBookmarks);
+$('dictNewBtn')?.addEventListener('click', createDictionaryEntry);
+$('dictSaveBtn')?.addEventListener('click', saveDictionaryEntry);
+$('dictDeleteBtn')?.addEventListener('click', deleteDictionaryEntry);
+$('dictSearch')?.addEventListener('input', (e) => {
+  state.dictSearch = e.target.value.trim();
+  loadDictionary();
+});
 $('ragSearchBtn').addEventListener('click', ragSearch);
 $('ragAskBtn').addEventListener('click', ragAsk);
 $('ragQuery').addEventListener('keydown', (e) => {

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -116,8 +116,13 @@
           </section>
 
           <section class="trend-card">
-            <h3>よく訪れているドメイン</h3>
+            <h3>よくアクセスしている保存ドメイン</h3>
             <div id="trendDomains" class="chart"></div>
+          </section>
+
+          <section class="trend-card">
+            <h3>よく訪れているサイト (ブクマ未保存含む)</h3>
+            <div id="trendVisitDomains" class="chart"></div>
           </section>
         </div>
       </div>
@@ -126,8 +131,10 @@
         <div class="dig-input">
           <input id="digQuery" type="text" placeholder="掘りたい単語または質問を入力 (例: WebGPU compute shader readback)" />
           <button id="digRun">ディグる</button>
+          <button id="digFromBookmarks" class="ghost" title="既存のブックマークからワードクラウドを作る">📚 ブクマから雲</button>
         </div>
         <div id="digHistory" class="dig-history"></div>
+        <div id="cloudView" class="dig-cloud"></div>
         <div id="digResult" class="dig-result"></div>
       </div>
 
@@ -180,6 +187,8 @@
       </div>
       <h3>要約</h3>
       <div id="dSummary" class="summary"></div>
+      <h3>ワードクラウド <button id="dCloudGen" class="ghost ghost-sm" title="この記事からワードクラウドを生成">生成</button></h3>
+      <div id="dCloud" class="detail-cloud"></div>
       <h3>カテゴリ</h3>
       <input id="dCategories" type="text" placeholder="カンマ区切り" />
       <h3>メモ</h3>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -50,6 +50,7 @@
         </button>
         <button class="tab" data-tab="rag">RAG</button>
         <button class="tab" data-tab="dig">ディグる</button>
+        <button class="tab" data-tab="dict">📖 辞書</button>
       </nav>
 
       <div id="bookmarksView">
@@ -159,6 +160,29 @@
         </div>
         <div id="recList" class="rec-list"></div>
         <div id="recEmpty" class="queue-empty hidden">推薦できる未訪問リンクがありません。保存記事を増やすと候補が出ます。</div>
+      </div>
+
+      <div id="dictView" class="hidden">
+        <div class="dict-bar">
+          <input id="dictSearch" type="search" placeholder="辞書を検索 (term / 説明 / メモ)" />
+          <button id="dictNewBtn">＋ 新規エントリ</button>
+        </div>
+        <div class="dict-layout">
+          <ul id="dictList" class="dict-list"></ul>
+          <div id="dictDetail" class="dict-detail hidden">
+            <div class="dict-detail-head">
+              <input id="dictTerm" type="text" placeholder="単語" />
+              <button id="dictSaveBtn">保存</button>
+              <button id="dictDeleteBtn" class="danger">削除</button>
+            </div>
+            <h4>説明</h4>
+            <textarea id="dictDefinition" rows="6" placeholder="調査内容・定義 (Markdown 可)"></textarea>
+            <h4>メモ</h4>
+            <textarea id="dictNotes" rows="4" placeholder="追加メモ"></textarea>
+            <h4>リンクされた調査記録</h4>
+            <ul id="dictLinks" class="dict-links"></ul>
+          </div>
+        </div>
       </div>
 
       <div id="queueView" class="hidden">

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -722,6 +722,101 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   margin-left: 6px;
 }
 
+.cloud-section {
+  margin-top: 14px;
+}
+.cloud-section-h {
+  margin: 0 0 8px;
+  font-size: 13px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.cloud-related {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 8px;
+}
+.cloud-related-item {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  box-shadow: var(--shadow);
+}
+.cloud-related-item .title {
+  font-weight: 600;
+  display: block;
+  text-decoration: none;
+  color: var(--accent);
+  line-height: 1.3;
+  word-break: break-all;
+}
+.cloud-related-item .title:hover { text-decoration: underline; }
+.cloud-related-item .url { font-size: 11px; color: var(--muted); word-break: break-all; }
+.cloud-related-item .snippet { font-size: 12px; color: #2c3344; line-height: 1.5; margin-top: 4px; }
+
+.cloud-graph {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px;
+  box-shadow: var(--shadow);
+}
+.cloud-graph svg { width: 100%; height: 460px; display: block; }
+.cloud-graph .cg-edge line {
+  stroke: #c5cad4;
+  stroke-width: 1.5;
+}
+.cloud-graph .cg-edge text {
+  fill: var(--muted);
+  font-size: 10px;
+  pointer-events: none;
+}
+.cloud-graph .cg-node {
+  cursor: pointer;
+  transition: filter .15s ease;
+}
+.cloud-graph .cg-node:hover { filter: brightness(1.15); }
+.cloud-graph .cg-node circle {
+  fill: var(--accent);
+  stroke: var(--panel);
+  stroke-width: 2;
+}
+.cloud-graph .cg-node.current circle {
+  fill: #1f56c0;
+  stroke: #fff;
+  stroke-width: 3;
+}
+.cloud-graph .cg-node.depth-1 circle { fill: #4a82d6; }
+.cloud-graph .cg-node.depth-2 circle { fill: #7aa3df; }
+.cloud-graph .cg-node.depth-3 circle { fill: #b0c5e8; }
+.cloud-graph .cg-label {
+  fill: var(--text);
+  font-size: 11px;
+  font-weight: 600;
+  pointer-events: none;
+}
+.cloud-graph .cg-top {
+  fill: white;
+  font-size: 9px;
+  pointer-events: none;
+}
+.cloud-graph .cg-trunc {
+  fill: var(--muted);
+  font-size: 10px;
+  font-style: italic;
+}
+.cloud-graph-hint {
+  font-size: 11px;
+  color: var(--muted);
+  text-align: center;
+  margin-top: 4px;
+}
+
 .dig-preview {
   background: var(--panel);
   border: 1px solid var(--border);

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -721,6 +721,199 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   padding: 2px 8px !important;
   margin-left: 6px;
 }
+
+.dig-preview {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px 16px;
+  margin-bottom: 12px;
+  box-shadow: var(--shadow);
+}
+.dig-preview-h {
+  margin: 0 0 8px;
+  font-size: 13px;
+  color: #1f56c0;
+}
+.dig-preview-overview {
+  background: linear-gradient(135deg, #e8f0ff 0%, #f0f5ff 100%);
+  border: 1px solid #c8d8ff;
+  border-radius: 8px;
+  padding: 10px 12px;
+  margin-bottom: 10px;
+  line-height: 1.6;
+  font-size: 13px;
+}
+.dig-preview-tag {
+  font-size: 10px;
+  text-transform: uppercase;
+  color: #1f56c0;
+  letter-spacing: 0.05em;
+  margin-bottom: 4px;
+}
+.dig-preview-list {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.dig-preview-result .title { font-weight: 500; line-height: 1.3; }
+.dig-preview-result .title a { color: var(--accent); text-decoration: none; }
+.dig-preview-result .title a:hover { text-decoration: underline; }
+.dig-preview-result .url { font-size: 11px; color: var(--muted); word-break: break-all; }
+.dig-preview-result .snippet { font-size: 12px; color: #2c3344; line-height: 1.5; }
+.dig-pending-tight { padding: 8px 12px; font-size: 12px; }
+
+.cloud-merged-list {
+  font-size: 11px;
+  color: var(--muted);
+  margin: 4px 0 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+}
+.cloud-merged-list .pill {
+  cursor: pointer;
+  background: var(--accent-bg);
+  border: 1px solid var(--border);
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+.cloud-merged-list .pill:hover { border-color: var(--accent); }
+.cloud-dict-toggle { user-select: none; cursor: pointer; }
+
+/* ── Dictionary tab ─────────────────────────────────────────── */
+.dict-bar {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+  align-items: center;
+}
+.dict-bar input { flex: 1; padding: 8px 10px; border: 1px solid var(--border); border-radius: 6px; }
+.dict-layout {
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) 1fr;
+  gap: 12px;
+  align-items: start;
+}
+.dict-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.dict-item {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  cursor: pointer;
+  box-shadow: var(--shadow);
+}
+.dict-item:hover { border-color: var(--accent); }
+.dict-item.selected { border-color: var(--accent); background: var(--accent-bg); }
+.dict-term { font-weight: 600; line-height: 1.3; }
+.dict-snippet { font-size: 11px; color: var(--muted); margin-top: 2px; line-height: 1.4; }
+.dict-meta {
+  font-size: 10px;
+  color: var(--muted);
+  display: flex;
+  justify-content: space-between;
+  margin-top: 6px;
+}
+.dict-empty {
+  font-size: 12px;
+  color: var(--muted);
+  padding: 12px;
+  text-align: center;
+}
+.dict-detail {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px;
+  box-shadow: var(--shadow);
+}
+.dict-detail-head {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 12px;
+}
+.dict-detail-head input {
+  flex: 1;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 16px;
+  font-weight: 600;
+}
+.dict-detail h4 {
+  margin: 12px 0 6px;
+  font-size: 12px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.dict-detail textarea {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 13px;
+  resize: vertical;
+}
+.dict-links {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.dict-link {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  background: var(--accent-bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 12px;
+}
+.dict-link-label {
+  flex: 1;
+  cursor: pointer;
+  color: var(--accent);
+}
+.dict-link-label:hover { text-decoration: underline; }
+.dict-link-remove { font-size: 11px !important; padding: 2px 8px !important; }
+
+.mem-toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%) translateY(20px);
+  background: #1f56c0;
+  color: white;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 13px;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.2);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity .25s ease, transform .25s ease;
+  z-index: 9999;
+}
+.mem-toast.show {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
 .visits-actions {
   display: flex;
   gap: 10px;

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -601,6 +601,126 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   width: 12px; height: 12px; border-radius: 50%; background: var(--accent);
   animation: pulse 1.4s ease-in-out infinite;
 }
+
+/* ── Word cloud ─────────────────────────────────────────────── */
+.dig-cloud {
+  margin-top: 14px;
+}
+.cloud-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.cloud-head h3 {
+  margin: 0;
+  font-size: 14px;
+}
+.cloud-breadcrumb {
+  font-size: 11px;
+  color: var(--muted);
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.cloud-breadcrumb .parent-link {
+  cursor: pointer;
+  text-decoration: underline;
+  color: var(--accent);
+}
+.cloud-breadcrumb .parent-word {
+  background: var(--accent-bg);
+  border: 1px solid var(--border);
+  padding: 1px 6px;
+  border-radius: 999px;
+}
+.cloud-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 6px 0 8px;
+  font-size: 12px;
+}
+.cloud-toolbar .grow { flex: 1; }
+.cloud-dropped-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.cloud-words {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px 18px;
+  line-height: 2.1;
+  text-align: center;
+  box-shadow: var(--shadow);
+  min-height: 80px;
+}
+.cloud-word {
+  display: inline-block;
+  margin: 0 6px;
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--accent);
+  transition: transform .12s ease, color .12s ease;
+}
+.cloud-word:hover {
+  transform: scale(1.08);
+  color: #1f56c0;
+  text-decoration: underline;
+}
+.cloud-word.dropped {
+  color: var(--muted);
+  font-weight: 400;
+  font-style: italic;
+}
+.cloud-manual {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+.cloud-manual input {
+  flex: 1;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 13px;
+}
+.dig-chain-hint {
+  font-size: 11px;
+  color: var(--muted);
+  background: var(--accent-bg);
+  border: 1px solid var(--border);
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+
+/* Per-bookmark cloud in the detail panel */
+.detail-cloud {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+  line-height: 1.9;
+  text-align: center;
+  min-height: 50px;
+}
+.detail-cloud .cloud-word {
+  margin: 0 4px;
+  font-weight: 500;
+}
+.detail-cloud-empty {
+  font-size: 11px;
+  color: var(--muted);
+  text-align: center;
+  padding: 8px;
+}
+.ghost-sm {
+  font-size: 11px !important;
+  padding: 2px 8px !important;
+  margin-left: 6px;
+}
 .visits-actions {
   display: flex;
   gap: 10px;

--- a/server/queue.js
+++ b/server/queue.js
@@ -66,3 +66,72 @@ export class FifoQueue {
 function toPlain(item) {
   return { ...item };
 }
+
+/**
+ * Concurrent task pool. Runs up to `concurrency` tasks in parallel.
+ * Same metadata + history shape as FifoQueue, but `running` reflects whether
+ * at least one slot is busy (not just the head).
+ */
+export class ConcurrentPool {
+  constructor({ concurrency = 4, historyLimit = 50 } = {}) {
+    this.concurrency = Math.max(1, Number(concurrency) || 1);
+    this.queued = [];
+    this._runningSet = new Set();
+    this.history = [];
+    this.historyLimit = historyLimit;
+    this._nextSeq = 1;
+  }
+
+  enqueue(fn, meta = {}) {
+    const item = {
+      seq: this._nextSeq++,
+      ...meta,
+      status: 'queued',
+      enqueuedAt: Date.now(),
+      startedAt: null,
+      finishedAt: null,
+      error: null,
+    };
+    this.queued.push({ item, fn });
+    this._tryStart();
+  }
+
+  _tryStart() {
+    while (this._runningSet.size < this.concurrency && this.queued.length > 0) {
+      const { item, fn } = this.queued.shift();
+      this._runningSet.add(item);
+      item.status = 'running';
+      item.startedAt = Date.now();
+      Promise.resolve()
+        .then(() => fn())
+        .then(
+          () => { item.status = 'done'; },
+          (e) => {
+            item.status = 'error';
+            item.error = e?.message ?? String(e);
+            console.error(`[pool] task ${item.kind ?? ''}#${item.seq} failed:`, item.error);
+          },
+        )
+        .finally(() => {
+          item.finishedAt = Date.now();
+          this._runningSet.delete(item);
+          this.history.unshift(item);
+          if (this.history.length > this.historyLimit) this.history.length = this.historyLimit;
+          this._tryStart();
+        });
+    }
+  }
+
+  get depth() { return this.queued.length + this._runningSet.size; }
+  get running() { return this._runningSet.size > 0; }
+
+  snapshot() {
+    return {
+      depth: this.depth,
+      running: this.running,
+      concurrency: this.concurrency,
+      items: [...this._runningSet, ...this.queued.map(q => q.item)].map(toPlain),
+      history: this.history.map(toPlain),
+    };
+  }
+}

--- a/server/recommendations.js
+++ b/server/recommendations.js
@@ -1,6 +1,8 @@
 // Site recommendations: extract outbound links from saved HTML pages, drop
 // anything already saved/visited/dismissed, score by how many of the user's
-// pages link to a given URL.
+// pages link to a given URL. The base score is then biased by:
+//   - frequently-visited site domains (page_visits log, including non-saved)
+//   - word-cloud overlap with recent bookmark word clouds
 //
 // Result is cached in memory for `CACHE_TTL_MS` to avoid re-walking 100s of
 // HTML files on every refresh. Dismissals invalidate the cache.
@@ -8,6 +10,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { parse as parseHtml } from 'node-html-parser';
+import { trendsVisitDomains, recentBookmarkWordClouds } from './db.js';
 
 const CACHE_TTL_MS = 30 * 60 * 1000;
 const MAX_SOURCE_DOCS = 250;
@@ -49,6 +52,34 @@ function compute(db, htmlDir, dismissed) {
   const savedUrls = new Set(db.prepare(`SELECT url FROM bookmarks`).all().map(r => r.url));
   const visitedUrls = new Set(db.prepare(`SELECT url FROM page_visits`).all().map(r => r.url));
 
+  // Frequently-visited domains (URL log, regardless of bookmark status). Used
+  // as a multiplicative boost on candidates that share a domain with the user's
+  // habitual sites.
+  const visitDomains = trendsVisitDomains(db, { sinceDays: 60, limit: 50 });
+  const visitDomainBoost = new Map();
+  if (visitDomains.length > 0) {
+    const max = Math.max(...visitDomains.map(d => d.visits));
+    for (const d of visitDomains) {
+      // 0..1, then mapped to 1..3 multiplier.
+      visitDomainBoost.set(d.domain, 1 + 2 * (d.visits / Math.max(max, 1)));
+    }
+  }
+
+  // Recent bookmark word clouds — kept words form a topic vocabulary; anchor
+  // text overlap with these words boosts candidates.
+  const recentClouds = recentBookmarkWordClouds(db, { limit: 30 });
+  const topicWords = new Map(); // word -> aggregated weight
+  for (const c of recentClouds) {
+    const ws = c.result?.words || [];
+    for (const w of ws) {
+      if (!w.kept) continue;
+      const key = String(w.word || '').toLowerCase();
+      if (!key) continue;
+      topicWords.set(key, (topicWords.get(key) || 0) + (w.weight || 1));
+    }
+  }
+  const topicMaxWeight = Math.max(1, ...topicWords.values());
+
   const linkStats = new Map(); // url -> { count, sources: Map<bookmarkId, {title}>, anchor }
 
   for (const b of sources) {
@@ -88,17 +119,38 @@ function compute(db, htmlDir, dismissed) {
   }
 
   return [...linkStats.entries()]
-    .map(([url, s]) => ({
-      url,
-      domain: domainOf(url),
-      count: s.count,
-      source_count: s.sources.size,
-      anchor: s.anchor,
-      sources: [...s.sources.values()].slice(0, 5),
-    }))
-    .filter(r => r.source_count >= 2 || r.count >= 3)
-    .sort((a, b) => b.source_count - a.source_count || b.count - a.count)
+    .map(([url, s]) => {
+      const domain = domainOf(url);
+      const base = s.sources.size * 10 + s.count;
+      const domainMul = visitDomainBoost.get(domain) ?? 1;
+      const topicHit = scoreTopicOverlap(s.anchor, topicWords, topicMaxWeight);
+      const score = Math.round(base * domainMul + topicHit * 6);
+      return {
+        url,
+        domain,
+        count: s.count,
+        source_count: s.sources.size,
+        anchor: s.anchor,
+        sources: [...s.sources.values()].slice(0, 5),
+        domain_boost: Number(domainMul.toFixed(2)),
+        topic_hits: Number(topicHit.toFixed(2)),
+        score,
+      };
+    })
+    .filter(r => r.source_count >= 2 || r.count >= 3 || r.domain_boost > 1.2 || r.topic_hits > 0)
+    .sort((a, b) => b.score - a.score || b.source_count - a.source_count)
     .slice(0, MAX_RESULTS);
+}
+
+function scoreTopicOverlap(anchor, topicWords, maxWeight) {
+  if (!anchor || topicWords.size === 0) return 0;
+  const text = anchor.toLowerCase();
+  let hit = 0;
+  for (const [word, weight] of topicWords) {
+    if (word.length < 2) continue;
+    if (text.includes(word)) hit += weight / maxWeight;
+  }
+  return hit;
 }
 
 function stripFragmentAndQuery(url) {

--- a/server/wordcloud.js
+++ b/server/wordcloud.js
@@ -1,0 +1,120 @@
+// Word-cloud extraction — drive the claude CLI to produce a ranked list of
+// keywords from a bundle of documents (bookmarks, dig sources, or a single
+// article). Words that appear across multiple documents get higher weights;
+// words unrelated to the bundle's summary are flagged kept=false.
+
+import { spawn } from 'node:child_process';
+
+const CLOUD_PROMPT = (label, docs) => [
+  'You are extracting a word cloud from the provided documents.',
+  '',
+  'Return STRICTLY one JSON object and nothing else (no prose, no code fences):',
+  '',
+  '{',
+  '  "summary": "1〜2 文で対象領域を要約 (日本語)",',
+  '  "words": [',
+  '    {',
+  '      "word": "...",                    // 単語または短いフレーズ',
+  '      "weight": 1〜100,                  // 出現/重要度スコア。複数の文書で繰り返し出る語は高く',
+  '      "sources": 1以上,                  // この語が出現した文書数',
+  '      "kept": true|false,               // summary と関係が薄ければ false',
+  '      "reason": ""                      // kept=false の理由 (任意)',
+  '    }',
+  '  ]',
+  '}',
+  '',
+  '- words は 25〜60 語まで返す。',
+  '- 文書間で重複する語を優先し、重複度が高いほど weight を大きくする。',
+  '- ストップワード、汎用語 (例: "the", "こと", "もの")、サイト名・著者名・年号単独は除外。',
+  '- summary に直接関係しない語は kept=false にして reason を一言。',
+  '- 言語は文書の主要言語に合わせる (日英混在なら原文の語をそのまま)。',
+  '',
+  `LABEL: ${label}`,
+  '',
+  'DOCUMENTS:',
+  docs,
+].join('\n');
+
+const VALIDATE_PROMPT = (word, context) => [
+  'Decide whether the WORD is meaningfully related to the CONTEXT.',
+  'Return STRICTLY one JSON object and nothing else: {"related": true|false, "reason": "<短い理由>"}.',
+  '',
+  `WORD: ${word}`,
+  `CONTEXT: ${context}`,
+].join('\n');
+
+export async function extractWordCloud({ label, docs, claudeBin = 'claude', timeoutMs = 300_000 }) {
+  if (!docs || !docs.trim()) throw new Error('no documents to extract from');
+  const stdout = await spawnClaude(claudeBin, CLOUD_PROMPT(label, docs), timeoutMs);
+  return parseCloud(stdout);
+}
+
+export async function validateWordRelevance({ word, context, claudeBin = 'claude', timeoutMs = 60_000 }) {
+  const stdout = await spawnClaude(claudeBin, VALIDATE_PROMPT(word, context), timeoutMs);
+  return parseValidate(stdout);
+}
+
+function spawnClaude(bin, prompt, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(bin, ['-p', prompt], { stdio: ['ignore', 'pipe', 'pipe'], shell: false });
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`claude CLI timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    child.stdout.on('data', d => { stdout += d.toString('utf8'); });
+    child.stderr.on('data', d => { stderr += d.toString('utf8'); });
+    child.on('error', err => { clearTimeout(timer); reject(err); });
+    child.on('close', code => {
+      clearTimeout(timer);
+      if (code !== 0) reject(new Error(`claude exited ${code}: ${stderr.slice(0, 400)}`));
+      else resolve(stdout);
+    });
+  });
+}
+
+function extractJsonObject(raw) {
+  let text = raw.trim();
+  const fence = text.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/);
+  if (fence) text = fence[1].trim();
+  const first = text.indexOf('{');
+  const last = text.lastIndexOf('}');
+  if (first >= 0 && last > first) text = text.slice(first, last + 1);
+  return JSON.parse(text);
+}
+
+function parseCloud(raw) {
+  let obj;
+  try { obj = extractJsonObject(raw); }
+  catch (e) { throw new Error(`Failed to parse claude output as JSON: ${e.message}\nRaw: ${raw.slice(0, 400)}`); }
+  if (!Array.isArray(obj.words)) throw new Error('claude output missing words[]');
+  const words = obj.words
+    .map(w => ({
+      word: String(w.word ?? '').trim(),
+      weight: clampWeight(Number(w.weight)),
+      sources: Math.max(1, Math.floor(Number(w.sources) || 1)),
+      kept: w.kept !== false,
+      reason: String(w.reason ?? '').trim(),
+    }))
+    .filter(w => w.word.length > 0);
+  return {
+    summary: String(obj.summary ?? '').trim(),
+    words,
+  };
+}
+
+function parseValidate(raw) {
+  let obj;
+  try { obj = extractJsonObject(raw); }
+  catch { return { related: false, reason: 'parse error' }; }
+  return {
+    related: !!obj.related,
+    reason: String(obj.reason ?? '').trim(),
+  };
+}
+
+function clampWeight(n) {
+  if (!Number.isFinite(n)) return 1;
+  return Math.max(1, Math.min(100, Math.round(n)));
+}


### PR DESCRIPTION
## Summary
- 「ディグる」タブにワードクラウド層を追加。既存ブックマーク or 完了ずみ dig セッションから claude が抽出し、語サイズ=出現頻度、要約と関係薄い語は kept=false で薄く表示。語クリックで深掘りディグ (`parent_cloud_id` / `parent_word` でチェイン)
- 各ブックマークに任意のワードクラウドを保存できる (デフォルト未生成)。詳細パネルに「生成」ボタン
- 自分でワードを投下してディグるための入力欄。claude が現在の雲の summary に対する関連性を判定
- 「傾向」タブに `page_visits` 全体集計の「よく訪れているサイト」カードを追加 (ブクマ未保存ドメイン含む)
- おすすめスコアにこの 2 軸のブースト: 頻出ドメイン (1.0〜3.0 倍) + 最近のブクマ雲のキーワード重複

## API
- `POST/GET /api/wordcloud` (origin: `bookmarks` | `dig`)
- `GET /api/wordcloud/:id`
- `POST /api/wordcloud/validate-word`
- `POST/GET /api/bookmarks/:id/wordcloud`
- `GET /api/trends/visit-domains`

## Test plan
- [ ] 既存ブクマがある状態で「📚 ブクマから雲」→ 雲が出る、語クリック → ディグが走る
- [ ] dig 完了後「🌐 このディグから雲を抽出」→ chain breadcrumb 付きで親雲に戻れる
- [ ] 詳細パネルで個別ブクマの雲を生成 → 表示、再開時に再取得される
- [ ] マニュアル入力 → 関連性 false で警告ダイアログ → 「それでも掘る」で続行
- [ ] 傾向タブで「よく訪れているサイト」が page_visits 全体から集計されている
- [ ] おすすめが頻出ドメイン / 雲ワードに引っ張られて並び替わる

🤖 Generated with [Claude Code](https://claude.com/claude-code)