### PR TITLE
feat(dig): pinned search engine selection

### DIFF
--- a/server/dig.js
+++ b/server/dig.js
@@ -1,18 +1,47 @@
 // Dig (deep research) — drive the claude CLI with WebSearch + WebFetch tools
 // allowed, ask it to return a JSON list of sources for a topic.
 //
-// We do NOT depend on a particular search engine API; the heavy lifting is
-// claude's, and the prompt asks for JSON-only output that we then parse.
+// The user can pin a specific search engine (Google / Bing / DuckDuckGo /
+// Brave). The engine is delivered as an instruction in the prompt and as a
+// preferred WebFetch URL pattern so claude actually queries the right SERP.
 
 import { spawn } from 'node:child_process';
 
-const PROMPT_TEMPLATE = (query) => [
+const SEARCH_ENGINES = {
+  default: { name: 'default', label: 'デフォルト (claude が自動選択)', serpUrl: null },
+  google: { name: 'Google', label: 'Google', serpUrl: q => `https://www.google.com/search?q=${encodeURIComponent(q)}` },
+  bing: { name: 'Bing', label: 'Bing', serpUrl: q => `https://www.bing.com/search?q=${encodeURIComponent(q)}` },
+  duckduckgo: { name: 'DuckDuckGo', label: 'DuckDuckGo', serpUrl: q => `https://duckduckgo.com/?q=${encodeURIComponent(q)}` },
+  brave: { name: 'Brave Search', label: 'Brave Search', serpUrl: q => `https://search.brave.com/search?q=${encodeURIComponent(q)}` },
+};
+
+export function listSearchEngines() {
+  return Object.entries(SEARCH_ENGINES).map(([key, v]) => ({ key, name: v.name, label: v.label }));
+}
+
+function engineFor(key) {
+  return SEARCH_ENGINES[key] || SEARCH_ENGINES.default;
+}
+
+function engineInstruction(engine, query) {
+  if (!engine.serpUrl) return '検索エンジンは claude の判断に任せます。';
+  const serp = engine.serpUrl(query);
+  return [
+    `検索エンジンは ${engine.name} を使ってください。`,
+    `WebFetch は最初に ${serp} を取り、SERP から候補を抽出してから個別ページを取得してください。`,
+    `他の検索エンジンや AI overview ジェネレータは使わないこと。`,
+  ].join('\n');
+}
+
+const PROMPT_TEMPLATE = ({ query, engine }) => [
   'You are a research agent. Use Web search and fetching to gather authoritative sources for the topic the user provides.',
+  engineInstruction(engine, query),
   'Return STRICTLY one JSON object and nothing else (no prose, no code fences):',
   '',
   '{',
   '  "query": "<the original query>",',
   '  "summary": "1〜3 段落で領域を概観 (日本語)",',
+  '  "engine": "<used search engine>",',
   '  "sources": [',
   '    {',
   '      "url": "https://...",',
@@ -31,8 +60,9 @@ const PROMPT_TEMPLATE = (query) => [
   `QUERY: ${query}`,
 ].join('\n');
 
-const PREVIEW_PROMPT_TEMPLATE = (query) => [
+const PREVIEW_PROMPT_TEMPLATE = ({ query, engine }) => [
   'You are returning a SERP-style preview as fast as possible.',
+  engineInstruction(engine, query),
   'Use ONLY web search — do NOT fetch or read result pages.',
   'If the search engine displays an AI overview / generative summary, capture it verbatim.',
   '',
@@ -40,6 +70,7 @@ const PREVIEW_PROMPT_TEMPLATE = (query) => [
   '',
   '{',
   '  "ai_overview": "search engine の AI overview があればその文章 (なければ空文字)",',
+  '  "engine": "<used search engine>",',
   '  "results": [',
   '    {',
   '      "title": "...",',
@@ -57,14 +88,16 @@ const PREVIEW_PROMPT_TEMPLATE = (query) => [
   `QUERY: ${query}`,
 ].join('\n');
 
-export async function runDigPreview({ query, claudeBin = 'claude', timeoutMs = 90_000 }) {
-  const prompt = PREVIEW_PROMPT_TEMPLATE(query);
-  const stdout = await spawnClaudeWithTools(claudeBin, prompt, ['WebSearch'], timeoutMs);
+export async function runDigPreview({ query, searchEngine = 'default', claudeBin = 'claude', timeoutMs = 90_000 }) {
+  const engine = engineFor(searchEngine);
+  const prompt = PREVIEW_PROMPT_TEMPLATE({ query, engine });
+  const stdout = await spawnClaudeWithTools(claudeBin, prompt, ['WebSearch', 'WebFetch'], timeoutMs);
   return parsePreview(stdout);
 }
 
-export async function runDig({ query, claudeBin = 'claude', timeoutMs = 600_000 }) {
-  const prompt = PROMPT_TEMPLATE(query);
+export async function runDig({ query, searchEngine = 'default', claudeBin = 'claude', timeoutMs = 600_000 }) {
+  const engine = engineFor(searchEngine);
+  const prompt = PROMPT_TEMPLATE({ query, engine });
   const stdout = await spawnClaude(claudeBin, prompt, timeoutMs);
   return parseJsonStrict(stdout);
 }

--- a/server/index.js
+++ b/server/index.js
@@ -30,7 +30,7 @@ import {
 import { summarizeWithClaude, htmlToText } from './claude.js';
 import { FifoQueue, ConcurrentPool } from './queue.js';
 import { recommendationsFor, dismissRecommendation, clearDismissals } from './recommendations.js';
-import { runDig, runDigPreview } from './dig.js';
+import { runDig, runDigPreview, listSearchEngines } from './dig.js';
 import {
   insertDigSession, setDigResult, setDigPreview, getDigSession, listDigSessions,
   insertWordCloud, setWordCloudResult, getWordCloud, listWordClouds,
@@ -373,31 +373,36 @@ app.delete('/api/recommendations/dismissals', (c) => {
 // strictly one job at a time so the user can watch progress in 作業リスト.
 const digQueue = new FifoQueue();
 
-function enqueueDig(id, query) {
+function enqueueDig(id, query, searchEngine = 'default') {
   digQueue.enqueue(async () => {
     // Phase 1: SERP preview (fast — no page fetches). Persisted as soon as
     // it lands so the FE can render before the deep claude pass finishes.
-    runDigPreview({ query, claudeBin: CLAUDE_BIN })
+    runDigPreview({ query, searchEngine, claudeBin: CLAUDE_BIN })
       .then(preview => setDigPreview(db, id, preview))
       .catch(err => console.warn(`[dig#${id}] preview failed: ${err.message}`));
     // Phase 2: full deep analysis with WebFetch (existing behavior).
     try {
-      const result = await runDig({ query, claudeBin: CLAUDE_BIN });
+      const result = await runDig({ query, searchEngine, claudeBin: CLAUDE_BIN });
       setDigResult(db, id, { status: 'done', result });
     } catch (e) {
       setDigResult(db, id, { status: 'error', error: e.message.slice(0, 500) });
       throw e;
     }
-  }, { kind: 'dig', sessionId: id, title: query });
+  }, { kind: 'dig', sessionId: id, title: query, search_engine: searchEngine });
 }
 
 app.post('/api/dig', async (c) => {
   const body = await c.req.json().catch(() => null);
   const query = body?.query;
   if (!query || typeof query !== 'string') return c.json({ error: 'query required' }, 400);
+  const searchEngine = typeof body.search_engine === 'string' ? body.search_engine : 'default';
   const id = insertDigSession(db, query);
-  enqueueDig(id, query);
-  return c.json({ id, queued: true });
+  enqueueDig(id, query, searchEngine);
+  return c.json({ id, queued: true, search_engine: searchEngine });
+});
+
+app.get('/api/dig/engines', (c) => {
+  return c.json({ items: listSearchEngines() });
 });
 
 app.get('/api/dig', (c) => {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -536,6 +536,17 @@ async function loadDigHistory() {
     const { items } = await api('/api/dig');
     state.digHistory = items;
     renderDigHistory();
+    if (!state.digEnginesLoaded) loadDigEngines();
+  } catch (e) { console.error(e); }
+}
+
+async function loadDigEngines() {
+  try {
+    const { items } = await api('/api/dig/engines');
+    const sel = $('digEngine');
+    if (!sel) return;
+    sel.innerHTML = items.map(e => `<option value="${e.key}">${escapeHtml(e.label)}</option>`).join('');
+    state.digEnginesLoaded = true;
   } catch (e) { console.error(e); }
 }
 
@@ -561,10 +572,12 @@ async function startDig({ chainCloudId, chainParentWord } = {}) {
   $('digRun').disabled = true;
   $('digRun').textContent = '掘削中…';
   try {
+    const engineSel = $('digEngine');
+    const search_engine = engineSel ? engineSel.value : 'default';
     const r = await api('/api/dig', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ query: q }),
+      body: JSON.stringify({ query: q, search_engine }),
     });
     state.digChain = {
       cloudId: chainCloudId ?? null,

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -132,6 +132,7 @@
       <div id="digView" class="hidden">
         <div class="dig-input">
           <input id="digQuery" type="text" placeholder="掘りたい単語または質問を入力 (例: WebGPU compute shader readback)" />
+          <select id="digEngine" title="検索エンジン" class="dig-engine"></select>
           <button id="digRun">ディグる</button>
           <button id="digFromBookmarks" class="ghost" title="既存のブックマークからワードクラウドを作る">📚 ブクマから雲</button>
         </div>

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -1408,3 +1408,10 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   color: var(--muted);
   margin-left: 4px;
 }
+.dig-engine {
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: white;
+  font-size: 13px;
+}


### PR DESCRIPTION
## Summary
ディグの検索エンジンを Google / Bing / DuckDuckGo / Brave / デフォルト (claude 自動) から選べるようにします。

- `dig.js` は `searchEngine` オプションを受け取り、プロンプトに「この検索エンジンを使え」「最初に SERP URL (例: https://www.google.com/search?q=...) を WebFetch せよ」を埋め込みます
- 検索結果が指定エンジンのものに固定されるので provenance が一貫します
- `POST /api/dig` に `search_engine` フィールド追加、`GET /api/dig/engines` でエンジン一覧を返します
- ディグるタブのクエリ入力の隣にドロップダウンを追加

## Test plan
- [ ] 「Google」を選択してディグ → preview/full の両方で Google SERP が利用される
- [ ] 「DuckDuckGo」を選択するとそちらの SERP が使われる
- [ ] デフォルトは従来通り claude 任せ

🤖 Generated with [Claude Code](https://claude.com/claude-code)