### PR TITLE
feat: per-task LLM provider selection (Claude/Gemini/Codex/OpenAI)

### DIFF
--- a/server/claude.js
+++ b/server/claude.js
@@ -1,5 +1,5 @@
-import { spawn } from 'node:child_process';
 import { parse as parseHtml } from 'node-html-parser';
+import { runLlm } from './llm.js';
 
 const MAX_TEXT = 30000; // chars passed to claude
 
@@ -20,7 +20,7 @@ export function htmlToText(html) {
  * Ask Claude Code (CLI, non-interactive) to produce a summary + 3-5 categories.
  * Returns { summary: string, categories: string[] }.
  */
-export async function summarizeWithClaude({ url, title, html, claudeBin = 'claude', timeoutMs = 180_000 }) {
+export async function summarizeWithClaude({ url, title, html, timeoutMs = 180_000 }) {
   const text = htmlToText(html).slice(0, MAX_TEXT);
 
   const prompt = [
@@ -40,40 +40,8 @@ export async function summarizeWithClaude({ url, title, html, claudeBin = 'claud
     text,
   ].join('\n');
 
-  const stdout = await runClaude(claudeBin, prompt, timeoutMs);
+  const stdout = await runLlm({ task: 'summarize', prompt, timeoutMs });
   return parseClaudeJson(stdout);
-}
-
-function runClaude(bin, prompt, timeoutMs) {
-  // Pass the prompt via stdin instead of as an argv entry — Windows command
-  // lines top out around 8 KB and long prompts hit ENAMETOOLONG otherwise.
-  return new Promise((resolve, reject) => {
-    const child = spawn(bin, ['-p'], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      shell: false,
-    });
-    let stdout = '';
-    let stderr = '';
-    const timer = setTimeout(() => {
-      child.kill('SIGKILL');
-      reject(new Error(`claude CLI timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-    child.stdout.on('data', d => { stdout += d.toString('utf8'); });
-    child.stderr.on('data', d => { stderr += d.toString('utf8'); });
-    child.on('error', err => {
-      clearTimeout(timer);
-      reject(err);
-    });
-    child.on('close', code => {
-      clearTimeout(timer);
-      if (code !== 0) {
-        reject(new Error(`claude CLI exited with ${code}: ${stderr.slice(0, 400)}`));
-        return;
-      }
-      resolve(stdout);
-    });
-    child.stdin.end(prompt, 'utf8');
-  });
 }
 
 function parseClaudeJson(raw) {

--- a/server/db.js
+++ b/server/db.js
@@ -153,6 +153,11 @@ export function openDb(dbPath) {
       value  TEXT
     );
 
+    CREATE TABLE IF NOT EXISTS app_settings (
+      key   TEXT PRIMARY KEY,
+      value TEXT
+    );
+
     CREATE TABLE IF NOT EXISTS dictionary_entries (
       id           INTEGER PRIMARY KEY AUTOINCREMENT,
       term         TEXT NOT NULL UNIQUE,
@@ -435,6 +440,31 @@ export function listDigSessions(db, limit = 30) {
 }
 
 function safeParse(s) { try { return JSON.parse(s); } catch { return null; } }
+
+// ── app settings (key/value) ----------------------------------------------
+
+export function getAppSettings(db) {
+  const rows = db.prepare(`SELECT key, value FROM app_settings`).all();
+  const out = {};
+  for (const r of rows) out[r.key] = r.value;
+  return out;
+}
+
+export function setAppSettings(db, patch) {
+  const tx = db.transaction(() => {
+    for (const [k, v] of Object.entries(patch)) {
+      if (v == null || v === '') {
+        db.prepare(`DELETE FROM app_settings WHERE key = ?`).run(k);
+      } else {
+        db.prepare(`
+          INSERT INTO app_settings (key, value) VALUES (?, ?)
+          ON CONFLICT(key) DO UPDATE SET value = excluded.value
+        `).run(k, String(v));
+      }
+    }
+  });
+  tx();
+}
 
 // ── word clouds ------------------------------------------------------------
 

--- a/server/diary.js
+++ b/server/diary.js
@@ -4,14 +4,12 @@
 // Hourly buckets, top domains, and active hours are computed locally;
 // claude is asked only to narrate.
 
-import { spawn } from 'node:child_process';
 import { visitEventsForDate, getDiary, getDomainCatalogMap } from './db.js';
+import { runLlm } from './llm.js';
 
-// Model selection. The `claude` CLI accepts `--model sonnet` and `--model opus`.
-// We use Sonnet for the per-URL narrative (cheap, repetitive) and Opus 1M for
-// the integrative highlight/weekly narrative.
-const MODEL_SONNET = 'sonnet';
-const MODEL_OPUS_1M = 'claude-opus-4-7[1m]';
+// Default models per task are configured in llm.js (sonnet for diary_work,
+// opus 1M for diary_highlights / diary_weekly). The user can override per task
+// from the AI settings panel.
 
 const MIN_VISITS_FOR_REPORT = 1;
 
@@ -497,8 +495,8 @@ function formatUrlLine(ts, url) {
   return `${m ? m[1] : '??:??'} ${url}`;
 }
 
-/** Stage 1: Sonnet writes 作業内容 from the URL timeline. */
-export async function generateWorkContent({ db, dateStr, metrics, claudeBin = 'claude', timeoutMs = 180_000 }) {
+/** Stage 1: Sonnet (default) writes 作業内容 from the URL timeline. */
+export async function generateWorkContent({ db, dateStr, metrics, timeoutMs = 180_000 }) {
   const urlList = buildUrlList(db, dateStr);
   if (!urlList.trim()) return '';
   const prompt = WORK_CONTENT_PROMPT({
@@ -507,22 +505,22 @@ export async function generateWorkContent({ db, dateStr, metrics, claudeBin = 'c
     totalEvents: metrics.total_events,
     totalDomains: metrics.unique_domains,
   });
-  return await spawnClaude(claudeBin, prompt, MODEL_SONNET, timeoutMs);
+  return await runLlm({ task: 'diary_work', prompt, timeoutMs });
 }
 
-/** Stage 3: Opus 1M integrates work content + bookmark count + commits into highlights. */
-export async function generateHighlights({ dateStr, workContent, githubByRepo, bookmarkSummary, notes, metrics, claudeBin = 'claude', timeoutMs = 240_000 }) {
+/** Stage 3: Opus 1M (default) integrates work content + bookmark count + commits into highlights. */
+export async function generateHighlights({ dateStr, workContent, githubByRepo, bookmarkSummary, notes, metrics, timeoutMs = 240_000 }) {
   const prompt = HIGHLIGHTS_PROMPT({
     dateStr, workContent, githubByRepo, bookmarkSummary, notes, metrics,
   });
-  return await spawnClaude(claudeBin, prompt, MODEL_OPUS_1M, timeoutMs);
+  return await runLlm({ task: 'diary_highlights', prompt, timeoutMs });
 }
 
 /**
  * Top-level diary generator orchestrating the three stages. Returns the
  * structured pieces; the caller persists them.
  */
-export async function generateDiary({ db, dateStr, metrics, github, notes, claudeBin = 'claude' }) {
+export async function generateDiary({ db, dateStr, metrics, github, notes }) {
   const githubByRepo = summarizeGithubByRepo(github);
   const bookmarkSummary = buildBookmarkSummary(metrics);
 
@@ -538,9 +536,9 @@ export async function generateDiary({ db, dateStr, metrics, github, notes, claud
     };
   }
 
-  const workContent = await generateWorkContent({ db, dateStr, metrics, claudeBin });
+  const workContent = await generateWorkContent({ db, dateStr, metrics });
   const highlights = await generateHighlights({
-    dateStr, workContent, githubByRepo, bookmarkSummary, notes, metrics, claudeBin,
+    dateStr, workContent, githubByRepo, bookmarkSummary, notes, metrics,
   });
 
   // Combined summary for legacy display.
@@ -575,26 +573,6 @@ function composeSummary({ workContent, githubByRepo, highlights }) {
   return parts.join('\n\n');
 }
 
-function spawnClaude(bin, prompt, model, timeoutMs) {
-  return new Promise((resolve, reject) => {
-    const args = ['-p'];
-    if (model) args.push('--model', model);
-    const child = spawn(bin, args, { stdio: ['pipe', 'pipe', 'pipe'], shell: false });
-    let stdout = '';
-    let stderr = '';
-    const timer = setTimeout(() => { child.kill('SIGKILL'); reject(new Error(`claude CLI (${model || 'default'}) timed out after ${timeoutMs}ms`)); }, timeoutMs);
-    child.stdout.on('data', d => { stdout += d.toString('utf8'); });
-    child.stderr.on('data', d => { stderr += d.toString('utf8'); });
-    child.on('error', err => { clearTimeout(timer); reject(err); });
-    child.on('close', code => {
-      clearTimeout(timer);
-      if (code !== 0) reject(new Error(`claude (${model || 'default'}) exited ${code}: ${stderr.slice(0, 400)}`));
-      else resolve(stdout.trim());
-    });
-    child.stdin.end(prompt, 'utf8');
-  });
-}
-
 // ── weekly --------------------------------------------------------------
 
 const WEEKLY_PROMPT = ({ weekStart, weekEnd, dailyBlock, githubBlock }) => [
@@ -627,7 +605,7 @@ const WEEKLY_PROMPT = ({ weekStart, weekEnd, dailyBlock, githubBlock }) => [
  * Generate a weekly narrative from 7 daily diaries + commits.
  * The caller pre-fetches both via the GitHub API (per-repo commits API).
  */
-export async function generateWeekly({ weekStart, weekEnd, dailyDiaries, githubByRepo, claudeBin = 'claude', timeoutMs = 360_000 }) {
+export async function generateWeekly({ weekStart, weekEnd, dailyDiaries, githubByRepo, timeoutMs = 360_000 }) {
   const dailyBlock = dailyDiaries.map(d => {
     const head = d.summary || d.work_content || '(日報なし)';
     return `### ${d.date}\n${(head || '').slice(0, 1500)}`;
@@ -639,7 +617,7 @@ export async function generateWeekly({ weekStart, weekEnd, dailyDiaries, githubB
     }).join('\n\n')
     : '(commit なし)';
   const prompt = WEEKLY_PROMPT({ weekStart, weekEnd, dailyBlock, githubBlock });
-  return await spawnClaude(claudeBin, prompt, MODEL_OPUS_1M, timeoutMs);
+  return await runLlm({ task: 'diary_weekly', prompt, timeoutMs });
 }
 
 /** Fetch a user's commits across `repos` in a date range, grouped by repo. */

--- a/server/dig.js
+++ b/server/dig.js
@@ -5,7 +5,7 @@
 // Brave). The engine is delivered as an instruction in the prompt and as a
 // preferred WebFetch URL pattern so claude actually queries the right SERP.
 
-import { spawn } from 'node:child_process';
+import { runLlm } from './llm.js';
 
 const SEARCH_ENGINES = {
   default: { name: 'default', label: 'デフォルト (claude が自動選択)', serpUrl: null },
@@ -88,39 +88,22 @@ const PREVIEW_PROMPT_TEMPLATE = ({ query, engine }) => [
   `QUERY: ${query}`,
 ].join('\n');
 
-export async function runDigPreview({ query, searchEngine = 'default', claudeBin = 'claude', timeoutMs = 90_000 }) {
+export async function runDigPreview({ query, searchEngine = 'default', timeoutMs = 90_000 }) {
   const engine = engineFor(searchEngine);
   const prompt = PREVIEW_PROMPT_TEMPLATE({ query, engine });
-  const stdout = await spawnClaudeWithTools(claudeBin, prompt, ['WebSearch', 'WebFetch'], timeoutMs);
+  const stdout = await runLlm({
+    task: 'dig_preview', prompt, tools: ['WebSearch', 'WebFetch'], timeoutMs,
+  });
   return parsePreview(stdout);
 }
 
-export async function runDig({ query, searchEngine = 'default', claudeBin = 'claude', timeoutMs = 600_000 }) {
+export async function runDig({ query, searchEngine = 'default', timeoutMs = 600_000 }) {
   const engine = engineFor(searchEngine);
   const prompt = PROMPT_TEMPLATE({ query, engine });
-  const stdout = await spawnClaude(claudeBin, prompt, timeoutMs);
-  return parseJsonStrict(stdout);
-}
-
-function spawnClaudeWithTools(bin, prompt, tools, timeoutMs) {
-  return new Promise((resolve, reject) => {
-    const args = ['-p', '--allowedTools', tools.join(',')];
-    const child = spawn(bin, args, { stdio: ['pipe', 'pipe', 'pipe'], shell: false });
-    let stdout = '', stderr = '';
-    const timer = setTimeout(() => {
-      child.kill('SIGKILL');
-      reject(new Error(`claude CLI timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-    child.stdout.on('data', d => { stdout += d.toString('utf8'); });
-    child.stderr.on('data', d => { stderr += d.toString('utf8'); });
-    child.on('error', err => { clearTimeout(timer); reject(err); });
-    child.on('close', code => {
-      clearTimeout(timer);
-      if (code !== 0) reject(new Error(`claude exited ${code}: ${stderr.slice(0, 400)}`));
-      else resolve(stdout);
-    });
-    child.stdin.end(prompt, 'utf8');
+  const stdout = await runLlm({
+    task: 'dig', prompt, tools: ['WebSearch', 'WebFetch'], timeoutMs,
   });
+  return parseJsonStrict(stdout);
 }
 
 function parsePreview(raw) {
@@ -146,31 +129,6 @@ function parsePreview(raw) {
 
 function extractDomain(url) {
   try { return new URL(String(url)).hostname.toLowerCase(); } catch { return ''; }
-}
-
-function spawnClaude(bin, prompt, timeoutMs) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(
-      bin,
-      ['-p', '--allowedTools', 'WebSearch,WebFetch'],
-      { stdio: ['pipe', 'pipe', 'pipe'], shell: false },
-    );
-    let stdout = '';
-    let stderr = '';
-    const timer = setTimeout(() => {
-      child.kill('SIGKILL');
-      reject(new Error(`claude CLI timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-    child.stdout.on('data', d => { stdout += d.toString('utf8'); });
-    child.stderr.on('data', d => { stderr += d.toString('utf8'); });
-    child.on('error', err => { clearTimeout(timer); reject(err); });
-    child.on('close', code => {
-      clearTimeout(timer);
-      if (code !== 0) reject(new Error(`claude exited ${code}: ${stderr.slice(0, 400)}`));
-      else resolve(stdout);
-    });
-    child.stdin.end(prompt, 'utf8');
-  });
 }
 
 function parseJsonStrict(raw) {

--- a/server/domain-catalog.js
+++ b/server/domain-catalog.js
@@ -3,8 +3,8 @@
 // result in the domain_catalog table. Re-checks are skipped while the row
 // exists, so this runs lazily on /api/access pings.
 
-import { spawn } from 'node:child_process';
 import { parse as parseHtml } from 'node-html-parser';
+import { runLlm } from './llm.js';
 
 const SKIP_HOST = /^(localhost|127\.0\.0\.1|0\.0\.0\.0|::1|\[::1\])$/i;
 
@@ -43,7 +43,7 @@ const CLASSIFY_PROMPT = ({ domain, title, metaDescription, bodySample }) => [
  *   { ok: true, ...fields }   — classification succeeded
  *   { ok: false, error }      — claude or HTML parse failed (keep row, mark error)
  */
-export async function classifyDomain({ domain, claudeBin = 'claude', timeoutMs = 60_000 }) {
+export async function classifyDomain({ domain, timeoutMs = 60_000 }) {
   if (shouldSkipDomain(domain)) return { skip: true };
 
   let res;
@@ -91,7 +91,7 @@ export async function classifyDomain({ domain, claudeBin = 'claude', timeoutMs =
   const prompt = CLASSIFY_PROMPT({ domain, title, metaDescription, bodySample });
   let parsed;
   try {
-    const stdout = await spawnClaude(claudeBin, prompt, 'sonnet', timeoutMs);
+    const stdout = await runLlm({ task: 'domain_classify', prompt, timeoutMs });
     parsed = parseClassifyJson(stdout);
   } catch (e) {
     return { ok: false, error: `claude: ${e.message}`, title, metaDescription };
@@ -125,24 +125,3 @@ function parseClassifyJson(raw) {
   };
 }
 
-function spawnClaude(bin, prompt, model, timeoutMs) {
-  return new Promise((resolve, reject) => {
-    const args = ['-p'];
-    if (model) args.push('--model', model);
-    const child = spawn(bin, args, { stdio: ['pipe', 'pipe', 'pipe'], shell: false });
-    let stdout = '', stderr = '';
-    const timer = setTimeout(() => {
-      child.kill('SIGKILL');
-      reject(new Error(`timeout after ${timeoutMs}ms`));
-    }, timeoutMs);
-    child.stdout.on('data', d => { stdout += d.toString('utf8'); });
-    child.stderr.on('data', d => { stderr += d.toString('utf8'); });
-    child.on('error', err => { clearTimeout(timer); reject(err); });
-    child.on('close', code => {
-      clearTimeout(timer);
-      if (code !== 0) reject(new Error(`exit ${code}: ${stderr.slice(0, 300)}`));
-      else resolve(stdout);
-    });
-    child.stdin.end(prompt, 'utf8');
-  });
-}

--- a/server/index.js
+++ b/server/index.js
@@ -55,6 +55,11 @@ import {
   generateDiary, generateWeekly, summarizeGithubByRepo,
   formatLocalDate, yesterdayLocal, weekRangeFor, weekOfMonth, pingGithub,
 } from './diary.js';
+import {
+  TASKS as LLM_TASKS, PROVIDERS as LLM_PROVIDERS,
+  getLlmConfig, loadLlmConfigFromSettings, settingsPatchFromConfig,
+} from './llm.js';
+import { getAppSettings, setAppSettings } from './db.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PORT = Number(process.env.MEMORIA_PORT ?? 5180);
@@ -65,6 +70,7 @@ const CLAUDE_BIN = process.env.MEMORIA_CLAUDE_BIN ?? 'claude';
 
 mkdirSync(HTML_DIR, { recursive: true });
 const db = openDb(DB_PATH);
+loadLlmConfigFromSettings(getAppSettings(db));
 const summaryQueue = new FifoQueue();
 const cloudQueue = new FifoQueue();
 const domainCatalogQueue = new FifoQueue();
@@ -177,7 +183,7 @@ function enqueueSummary(id) {
     try {
       const html = readFileSync(htmlAbs, 'utf8');
       const { summary, categories } = await summarizeWithClaude({
-        url: cur.url, title: cur.title, html, claudeBin: CLAUDE_BIN,
+        url: cur.url, title: cur.title, html,
       });
       setSummary(db, id, { summary, categories, status: 'done' });
     } catch (e) {
@@ -377,12 +383,12 @@ function enqueueDig(id, query, searchEngine = 'default') {
   digQueue.enqueue(async () => {
     // Phase 1: SERP preview (fast — no page fetches). Persisted as soon as
     // it lands so the FE can render before the deep claude pass finishes.
-    runDigPreview({ query, searchEngine, claudeBin: CLAUDE_BIN })
+    runDigPreview({ query, searchEngine })
       .then(preview => setDigPreview(db, id, preview))
       .catch(err => console.warn(`[dig#${id}] preview failed: ${err.message}`));
     // Phase 2: full deep analysis with WebFetch (existing behavior).
     try {
-      const result = await runDig({ query, searchEngine, claudeBin: CLAUDE_BIN });
+      const result = await runDig({ query, searchEngine });
       setDigResult(db, id, { status: 'done', result });
     } catch (e) {
       setDigResult(db, id, { status: 'error', error: e.message.slice(0, 500) });
@@ -461,7 +467,7 @@ function buildBookmarkDoc(b) {
 function enqueueCloud(id, { docs, label }) {
   cloudQueue.enqueue(async () => {
     try {
-      const result = await extractWordCloud({ label, docs, claudeBin: CLAUDE_BIN });
+      const result = await extractWordCloud({ label, docs });
       setWordCloudResult(db, id, { status: 'done', result });
     } catch (e) {
       setWordCloudResult(db, id, { status: 'error', error: e.message.slice(0, 500) });
@@ -703,7 +709,7 @@ app.post('/api/wordcloud/validate-word', async (c) => {
   const context = body?.context;
   if (!word || !context) return c.json({ error: 'word and context required' }, 400);
   try {
-    const r = await validateWordRelevance({ word, context, claudeBin: CLAUDE_BIN });
+    const r = await validateWordRelevance({ word, context });
     return c.json(r);
   } catch (e) {
     return c.json({ error: e.message }, 500);
@@ -840,6 +846,37 @@ app.post('/api/dictionary/upsert-from-source', async (c) => {
   }
   addDictionaryLink(db, { entryId, sourceKind, sourceId });
   return c.json({ id: entryId, existed });
+});
+
+// ---- llm config -----------------------------------------------------------
+
+app.get('/api/llm/config', (c) => {
+  const cfg = getLlmConfig();
+  return c.json({
+    config: {
+      ...cfg,
+      // Mask the API key when returning to FE.
+      openai_api_key: cfg.openai_api_key ? '***' : '',
+      openai_api_key_set: !!cfg.openai_api_key,
+    },
+    tasks: LLM_TASKS,
+    providers: Object.entries(LLM_PROVIDERS).map(([key, v]) => ({
+      key,
+      label: v.label,
+      kind: v.kind,
+      supportsTools: v.supportsTools,
+    })),
+  });
+});
+
+app.patch('/api/llm/config', async (c) => {
+  const body = await c.req.json().catch(() => ({}));
+  const patch = settingsPatchFromConfig(body);
+  // Don't blow away the API key with the masked '***' value.
+  if (patch['llm.openai.api_key'] === '***') delete patch['llm.openai.api_key'];
+  setAppSettings(db, patch);
+  loadLlmConfigFromSettings(getAppSettings(db));
+  return c.json({ ok: true });
 });
 
 // ---- queue status ---------------------------------------------------------

--- a/server/index.js
+++ b/server/index.js
@@ -84,7 +84,7 @@ function maybeQueuePageMetadata(url) {
   if (getPageMetadata(db, url)) return;
   insertPageMetadataPending(db, url);
   pageMetadataQueue.enqueue(async () => {
-    const result = await fetchPageMetadata({ url, claudeBin: CLAUDE_BIN });
+    const result = await fetchPageMetadata({ url });
     if (result.skip) {
       deletePageMetadata(db, url);
       return;
@@ -138,7 +138,7 @@ function maybeQueueDomain(url) {
   if (getDomainCatalog(db, domain)) return;
   insertDomainPending(db, domain);
   domainCatalogQueue.enqueue(async () => {
-    const result = await classifyDomain({ domain, claudeBin: CLAUDE_BIN });
+    const result = await classifyDomain({ domain });
     if (result.skip) {
       deleteDomainCatalog(db, domain);
       return;
@@ -1004,7 +1004,7 @@ app.post('/api/domains/:domain/regenerate', (c) => {
   // protects manual fields.
   insertDomainPending(db, d);
   domainCatalogQueue.enqueue(async () => {
-    const result = await classifyDomain({ domain: d, claudeBin: CLAUDE_BIN });
+    const result = await classifyDomain({ domain: d });
     if (result.skip || result.dropRow) {
       deleteDomainCatalog(db, d);
       return;
@@ -1218,7 +1218,7 @@ async function runDiaryGeneration(dateStr) {
   let result;
   try {
     result = await generateDiary({
-      db, dateStr, metrics, github, notes, claudeBin: CLAUDE_BIN,
+      db, dateStr, metrics, github, notes,
     });
   } catch (e) {
     upsertDiary(db, {
@@ -1373,7 +1373,7 @@ async function runWeeklyGeneration(weekStart) {
   try {
     summary = await generateWeekly({
       weekStart: range.start, weekEnd: range.end,
-      dailyDiaries, githubByRepo, claudeBin: CLAUDE_BIN,
+      dailyDiaries, githubByRepo,
     });
   } catch (e) {
     upsertWeekly(db, {

--- a/server/llm.js
+++ b/server/llm.js
@@ -1,0 +1,179 @@
+// LLM dispatch — every place that used to call `spawn('claude', ...)` should
+// route through runLlm({ task, prompt, ... }) so the user can pick a provider
+// per task: Claude CLI, Gemini CLI, Codex CLI, or the OpenAI Chat API.
+//
+// Per-task config is loaded once at startup (and re-loaded on PATCH) from
+// app_settings. Tasks recognised at the moment:
+//   summarize / dig / dig_preview / cloud_extract / cloud_validate
+
+import { spawn } from 'node:child_process';
+
+export const TASKS = ['summarize', 'dig', 'dig_preview', 'cloud_extract', 'cloud_validate'];
+
+export const PROVIDERS = {
+  claude: {
+    label: 'Claude CLI',
+    kind: 'cli',
+    defaultBin: 'claude',
+    supportsTools: true,
+    supportsModel: true,
+  },
+  gemini: {
+    label: 'Gemini CLI',
+    kind: 'cli',
+    defaultBin: 'gemini',
+    supportsTools: false,
+    supportsModel: true,
+  },
+  codex: {
+    label: 'Codex CLI',
+    kind: 'cli',
+    defaultBin: 'codex',
+    supportsTools: false,
+    supportsModel: true,
+  },
+  openai: {
+    label: 'OpenAI API',
+    kind: 'api',
+    supportsTools: false,
+    supportsModel: true,
+  },
+};
+
+let cfg = {
+  tasks: Object.fromEntries(TASKS.map(t => [t, { provider: 'claude' }])),
+  bins: { claude: 'claude', gemini: 'gemini', codex: 'codex' },
+  openai_api_key: '',
+  openai_model: 'gpt-4o-mini',
+};
+
+export function getLlmConfig() {
+  return JSON.parse(JSON.stringify(cfg));
+}
+
+export function loadLlmConfigFromSettings(settings) {
+  // settings is the { key: value } map from app_settings.
+  const tasks = {};
+  for (const t of TASKS) {
+    tasks[t] = {
+      provider: settings[`llm.${t}.provider`] || 'claude',
+      model: settings[`llm.${t}.model`] || '',
+    };
+  }
+  cfg = {
+    tasks,
+    bins: {
+      claude: settings['llm.bin.claude'] || 'claude',
+      gemini: settings['llm.bin.gemini'] || 'gemini',
+      codex:  settings['llm.bin.codex']  || 'codex',
+    },
+    openai_api_key: settings['llm.openai.api_key'] || '',
+    openai_model:   settings['llm.openai.model']   || 'gpt-4o-mini',
+  };
+}
+
+export function settingsPatchFromConfig(patch) {
+  // Convert a partial { tasks, bins, openai_api_key, openai_model } back into
+  // app_settings flat keys.
+  const out = {};
+  if (patch.tasks) {
+    for (const [t, v] of Object.entries(patch.tasks)) {
+      if (v?.provider !== undefined) out[`llm.${t}.provider`] = v.provider;
+      if (v?.model !== undefined)    out[`llm.${t}.model`] = v.model;
+    }
+  }
+  if (patch.bins) {
+    for (const [k, v] of Object.entries(patch.bins)) out[`llm.bin.${k}`] = v;
+  }
+  if (patch.openai_api_key !== undefined) out['llm.openai.api_key'] = patch.openai_api_key;
+  if (patch.openai_model !== undefined)   out['llm.openai.model']   = patch.openai_model;
+  return out;
+}
+
+/**
+ * Run an LLM call for a named task. Falls back to Claude CLI if the configured
+ * provider isn't usable (e.g. OpenAI selected but no API key set).
+ *
+ * Args:
+ *   task        — one of TASKS
+ *   prompt      — the full prompt text (sent over stdin for CLIs)
+ *   tools       — optional array (e.g. ['WebSearch', 'WebFetch']) only honoured
+ *                 by providers that support it (claude)
+ *   timeoutMs
+ */
+export async function runLlm({ task, prompt, tools, timeoutMs = 180_000 }) {
+  const taskCfg = cfg.tasks[task] || { provider: 'claude' };
+  let provider = taskCfg.provider || 'claude';
+  // Fallback: OpenAI without a key drops back to claude.
+  if (provider === 'openai' && !cfg.openai_api_key) provider = 'claude';
+  const p = PROVIDERS[provider];
+  if (!p) throw new Error(`unknown provider: ${provider}`);
+  if (p.kind === 'api') {
+    return runOpenAi({
+      apiKey: cfg.openai_api_key,
+      model: taskCfg.model || cfg.openai_model || 'gpt-4o-mini',
+      prompt, timeoutMs,
+    });
+  }
+  // CLI providers
+  const bin = cfg.bins[provider] || p.defaultBin;
+  const args = ['-p'];
+  if (taskCfg.model && p.supportsModel) args.push('--model', taskCfg.model);
+  if (tools && p.supportsTools) args.push('--allowedTools', tools.join(','));
+  return runCli({ bin, args, prompt, timeoutMs, label: provider });
+}
+
+function runCli({ bin, args, prompt, timeoutMs, label }) {
+  return new Promise((resolve, reject) => {
+    let child;
+    try {
+      child = spawn(bin, args, { stdio: ['pipe', 'pipe', 'pipe'], shell: false });
+    } catch (e) {
+      reject(new Error(`spawn ${bin}: ${e.message}`));
+      return;
+    }
+    let stdout = '', stderr = '';
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`${label} CLI timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    child.stdout.on('data', d => { stdout += d.toString('utf8'); });
+    child.stderr.on('data', d => { stderr += d.toString('utf8'); });
+    child.on('error', err => { clearTimeout(timer); reject(new Error(`${label} CLI: ${err.message}`)); });
+    child.on('close', code => {
+      clearTimeout(timer);
+      if (code !== 0) reject(new Error(`${label} CLI exited ${code}: ${stderr.slice(0, 400)}`));
+      else resolve(stdout);
+    });
+    child.stdin.end(prompt, 'utf8');
+  });
+}
+
+async function runOpenAi({ apiKey, model, prompt, timeoutMs }) {
+  if (!apiKey) throw new Error('OpenAI API key is not configured');
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: 'user', content: prompt }],
+        temperature: 0.4,
+      }),
+      signal: ac.signal,
+    });
+    if (!res.ok) {
+      const body = (await res.text()).slice(0, 400);
+      throw new Error(`OpenAI ${res.status}: ${body}`);
+    }
+    const data = await res.json();
+    return data.choices?.[0]?.message?.content || '';
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/server/llm.js
+++ b/server/llm.js
@@ -4,11 +4,27 @@
 //
 // Per-task config is loaded once at startup (and re-loaded on PATCH) from
 // app_settings. Tasks recognised at the moment:
-//   summarize / dig / dig_preview / cloud_extract / cloud_validate
+//   summarize, dig, dig_preview, cloud_extract, cloud_validate,
+//   domain_classify, page_summary,
+//   diary_work, diary_highlights, diary_weekly
 
 import { spawn } from 'node:child_process';
 
-export const TASKS = ['summarize', 'dig', 'dig_preview', 'cloud_extract', 'cloud_validate'];
+export const TASKS = [
+  'summarize', 'dig', 'dig_preview', 'cloud_extract', 'cloud_validate',
+  'domain_classify', 'page_summary',
+  'diary_work', 'diary_highlights', 'diary_weekly',
+];
+
+// When the user hasn't explicitly chosen a model for a task, fall back to these.
+// Sonnet for cheap repeated work; Opus 1M for the integrative narratives.
+const TASK_DEFAULT_MODELS = {
+  domain_classify: 'sonnet',
+  page_summary: 'sonnet',
+  diary_work: 'sonnet',
+  diary_highlights: 'claude-opus-4-7[1m]',
+  diary_weekly: 'claude-opus-4-7[1m]',
+};
 
 export const PROVIDERS = {
   claude: {
@@ -118,7 +134,8 @@ export async function runLlm({ task, prompt, tools, timeoutMs = 180_000 }) {
   // CLI providers
   const bin = cfg.bins[provider] || p.defaultBin;
   const args = ['-p'];
-  if (taskCfg.model && p.supportsModel) args.push('--model', taskCfg.model);
+  const modelToUse = taskCfg.model || TASK_DEFAULT_MODELS[task] || '';
+  if (modelToUse && p.supportsModel) args.push('--model', modelToUse);
   if (tools && p.supportsTools) args.push('--allowedTools', tools.join(','));
   return runCli({ bin, args, prompt, timeoutMs, label: provider });
 }

--- a/server/page-metadata.js
+++ b/server/page-metadata.js
@@ -3,9 +3,9 @@
 // specific page is". Cached forever in page_metadata; 404 / DNS errors
 // drop the row so it can be retried later.
 
-import { spawn } from 'node:child_process';
 import { parse as parseHtml } from 'node-html-parser';
 import { shouldSkipDomain } from './domain-catalog.js';
+import { runLlm } from './llm.js';
 
 const SUMMARY_PROMPT = ({ url, title, metaDescription, ogTitle, ogDescription, ogType, headers, bodySample }) => [
   'あなたは Web ページのメタ情報をもとに、「このページは何か」を 1〜2 文の日本語で説明する係です。',
@@ -29,7 +29,7 @@ const SUMMARY_PROMPT = ({ url, title, metaDescription, ogTitle, ogDescription, o
   bodySample,
 ].join('\n');
 
-export async function fetchPageMetadata({ url, claudeBin = 'claude', timeoutMs = 60_000 }) {
+export async function fetchPageMetadata({ url, timeoutMs = 60_000 }) {
   let host;
   try { host = new URL(url).hostname.toLowerCase(); }
   catch { return { dropRow: true, error: 'invalid url' }; }
@@ -101,7 +101,7 @@ export async function fetchPageMetadata({ url, claudeBin = 'claude', timeoutMs =
   });
   let parsed;
   try {
-    const stdout = await spawnClaude(claudeBin, promptText, 'sonnet', timeoutMs);
+    const stdout = await runLlm({ task: 'page_summary', prompt: promptText, timeoutMs });
     parsed = parseSummaryJson(stdout);
   } catch (e) {
     return {
@@ -151,21 +151,3 @@ function parseSummaryJson(raw) {
   };
 }
 
-function spawnClaude(bin, prompt, model, timeoutMs) {
-  return new Promise((resolve, reject) => {
-    const args = ['-p'];
-    if (model) args.push('--model', model);
-    const child = spawn(bin, args, { stdio: ['pipe', 'pipe', 'pipe'], shell: false });
-    let stdout = '', stderr = '';
-    const timer = setTimeout(() => { child.kill('SIGKILL'); reject(new Error(`timeout after ${timeoutMs}ms`)); }, timeoutMs);
-    child.stdout.on('data', d => { stdout += d.toString('utf8'); });
-    child.stderr.on('data', d => { stderr += d.toString('utf8'); });
-    child.on('error', err => { clearTimeout(timer); reject(err); });
-    child.on('close', code => {
-      clearTimeout(timer);
-      if (code !== 0) reject(new Error(`exit ${code}: ${stderr.slice(0, 300)}`));
-      else resolve(stdout);
-    });
-    child.stdin.end(prompt, 'utf8');
-  });
-}

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -2382,3 +2382,72 @@ setInterval(async () => {
 }, 2000);
 refreshQueue();
 refreshVisitsBadge();
+
+// ── AI / LLM settings panel ───────────────────────────────────────────
+async function openAiSettings() {
+  $('aiSettingsPanel').classList.remove('hidden');
+  try {
+    const r = await api('/api/llm/config');
+    const cfg = r.config;
+    const tasks = r.tasks;
+    const providers = r.providers;
+    const optionsHtml = providers.map(p => `<option value="${p.key}">${escapeHtml(p.label)}</option>`).join('');
+    $('aiTaskRows').innerHTML = tasks.map(t => `
+      <div class="ai-task-row">
+        <label>${escapeHtml(t)}</label>
+        <select data-task="${t}" class="ai-task-provider">${optionsHtml}</select>
+        <input data-task="${t}" class="ai-task-model" type="text" placeholder="モデル名 (任意)" />
+      </div>
+    `).join('');
+    for (const t of tasks) {
+      const tCfg = cfg.tasks?.[t] || {};
+      $('aiTaskRows').querySelector(`select[data-task="${t}"]`).value = tCfg.provider || 'claude';
+      $('aiTaskRows').querySelector(`input[data-task="${t}"]`).value = tCfg.model || '';
+    }
+    $('aiBinClaude').value = cfg.bins?.claude || '';
+    $('aiBinGemini').value = cfg.bins?.gemini || '';
+    $('aiBinCodex').value  = cfg.bins?.codex  || '';
+    $('aiOpenaiKey').value = '';
+    $('aiOpenaiModel').value = cfg.openai_model || '';
+    $('aiOpenaiKeyStatus').textContent = cfg.openai_api_key_set ? '✓ API key 設定済み (再入力で上書き)' : '(未設定)';
+  } catch (e) {
+    console.error(e);
+    alert(`設定取得失敗: ${e.message}`);
+  }
+}
+
+async function saveAiSettings() {
+  const tasks = {};
+  document.querySelectorAll('.ai-task-row').forEach(row => {
+    const sel = row.querySelector('.ai-task-provider');
+    const inp = row.querySelector('.ai-task-model');
+    const t = sel.dataset.task;
+    tasks[t] = { provider: sel.value, model: inp.value.trim() };
+  });
+  const body = {
+    tasks,
+    bins: {
+      claude: $('aiBinClaude').value.trim() || 'claude',
+      gemini: $('aiBinGemini').value.trim() || 'gemini',
+      codex:  $('aiBinCodex').value.trim()  || 'codex',
+    },
+    openai_model: $('aiOpenaiModel').value.trim() || 'gpt-4o-mini',
+  };
+  const k = $('aiOpenaiKey').value;
+  if (k && k !== '***') body.openai_api_key = k;
+  try {
+    await api('/api/llm/config', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    alert('保存しました。次回のジョブから反映されます。');
+    $('aiSettingsPanel').classList.add('hidden');
+  } catch (e) {
+    alert(`保存失敗: ${e.message}`);
+  }
+}
+
+document.getElementById('aiSettingsBtn')?.addEventListener('click', openAiSettings);
+document.getElementById('aiSettingsClose')?.addEventListener('click', () => $('aiSettingsPanel').classList.add('hidden'));
+document.getElementById('aiSettingsSave')?.addEventListener('click', saveAiSettings);

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -23,6 +23,7 @@
       <label class="ghost file-btn">
         Import<input id="importInput" type="file" accept="application/json" hidden />
       </label>
+      <button id="aiSettingsBtn" class="ghost" title="モデル/プロバイダ設定">⚙ AI</button>
     </div>
   </header>
 
@@ -324,6 +325,25 @@
     </aside>
   </main>
 
+  <div id="aiSettingsPanel" class="ai-settings hidden">
+    <div class="ai-settings-head">
+      <h3>AI モデル / プロバイダ設定</h3>
+      <button id="aiSettingsClose" class="ghost">×</button>
+    </div>
+    <p class="ai-settings-help">タスクごとに使う LLM プロバイダを選びます。Claude CLI / Gemini CLI / Codex CLI / OpenAI API を切り替え可能。Tools (WebSearch 等) が必要なタスクで非対応プロバイダを選ぶと、そのタスクは Tools なしで動きます。</p>
+    <div id="aiTaskRows"></div>
+    <h4>CLI バイナリパス (PATH に通っていない場合のみ指定)</h4>
+    <label>claude: <input id="aiBinClaude" type="text" placeholder="claude" /></label>
+    <label>gemini: <input id="aiBinGemini" type="text" placeholder="gemini" /></label>
+    <label>codex:  <input id="aiBinCodex"  type="text" placeholder="codex" /></label>
+    <h4>OpenAI API</h4>
+    <label>API Key (gpt 系を使う場合): <input id="aiOpenaiKey" type="password" placeholder="sk-..." /></label>
+    <span id="aiOpenaiKeyStatus" class="ai-keystatus"></span>
+    <label>デフォルトモデル: <input id="aiOpenaiModel" type="text" placeholder="gpt-4o-mini" /></label>
+    <div class="ai-settings-actions">
+      <button id="aiSettingsSave">保存</button>
+    </div>
+  </div>
   <script src="app.js"></script>
 </body>
 </html>

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -1207,6 +1207,51 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   font-size: 13px;
   font-family: inherit;
 }
+
+.ai-settings {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 18px 22px;
+  box-shadow: 0 12px 48px rgba(0,0,0,0.2);
+  width: 560px;
+  max-height: 80vh;
+  overflow-y: auto;
+  z-index: 100;
+}
+.ai-settings-head { display: flex; justify-content: space-between; align-items: center; }
+.ai-settings-head h3 { margin: 0; }
+.ai-settings-help { font-size: 11px; color: var(--muted); margin: 8px 0 16px; line-height: 1.5; }
+.ai-settings h4 { margin: 14px 0 6px; font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; }
+.ai-task-row {
+  display: grid;
+  grid-template-columns: 130px 160px 1fr;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 6px;
+  font-size: 12px;
+}
+.ai-task-row label { color: var(--text); font-family: ui-monospace, monospace; }
+.ai-task-row select, .ai-task-row input { padding: 4px 8px; border: 1px solid var(--border); border-radius: 4px; font-size: 12px; }
+.ai-settings label {
+  display: block;
+  font-size: 12px;
+  color: var(--muted);
+  margin-bottom: 8px;
+}
+.ai-settings label input {
+  display: block;
+  width: 100%;
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  margin-top: 4px;
+  font-size: 13px;
+}
 .diary-settings-help { font-size: 11px; color: var(--muted); margin-bottom: 12px; }
 .diary-settings-tokenstatus { font-size: 11px; color: var(--muted); display: block; margin-top: -6px; margin-bottom: 8px; }
 .diary-settings-actions { display: flex; gap: 8px; justify-content: flex-end; }
@@ -1415,3 +1460,5 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   background: white;
   font-size: 13px;
 }
+.ai-keystatus { font-size: 11px; color: var(--muted); display: block; margin-top: -4px; margin-bottom: 8px; }
+.ai-settings-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 14px; }

--- a/server/wordcloud.js
+++ b/server/wordcloud.js
@@ -3,7 +3,7 @@
 // article). Words that appear across multiple documents get higher weights;
 // words unrelated to the bundle's summary are flagged kept=false.
 
-import { spawn } from 'node:child_process';
+import { runLlm } from './llm.js';
 
 const CLOUD_PROMPT = (label, docs) => [
   'You are extracting a word cloud from the provided documents.',
@@ -43,36 +43,15 @@ const VALIDATE_PROMPT = (word, context) => [
   `CONTEXT: ${context}`,
 ].join('\n');
 
-export async function extractWordCloud({ label, docs, claudeBin = 'claude', timeoutMs = 300_000 }) {
+export async function extractWordCloud({ label, docs, timeoutMs = 300_000 }) {
   if (!docs || !docs.trim()) throw new Error('no documents to extract from');
-  const stdout = await spawnClaude(claudeBin, CLOUD_PROMPT(label, docs), timeoutMs);
+  const stdout = await runLlm({ task: 'cloud_extract', prompt: CLOUD_PROMPT(label, docs), timeoutMs });
   return parseCloud(stdout);
 }
 
-export async function validateWordRelevance({ word, context, claudeBin = 'claude', timeoutMs = 60_000 }) {
-  const stdout = await spawnClaude(claudeBin, VALIDATE_PROMPT(word, context), timeoutMs);
+export async function validateWordRelevance({ word, context, timeoutMs = 60_000 }) {
+  const stdout = await runLlm({ task: 'cloud_validate', prompt: VALIDATE_PROMPT(word, context), timeoutMs });
   return parseValidate(stdout);
-}
-
-function spawnClaude(bin, prompt, timeoutMs) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(bin, ['-p'], { stdio: ['pipe', 'pipe', 'pipe'], shell: false });
-    let stdout = '';
-    let stderr = '';
-    const timer = setTimeout(() => {
-      child.kill('SIGKILL');
-      reject(new Error(`claude CLI timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-    child.stdout.on('data', d => { stdout += d.toString('utf8'); });
-    child.stderr.on('data', d => { stderr += d.toString('utf8'); });
-    child.on('error', err => { clearTimeout(timer); reject(err); });
-    child.on('close', code => {
-      clearTimeout(timer);
-      if (code !== 0) reject(new Error(`claude exited ${code}: ${stderr.slice(0, 400)}`));
-      else resolve(stdout);
-    });
-    child.stdin.end(prompt, 'utf8');
-  });
 }
 
 function extractJsonObject(raw) {


### PR DESCRIPTION
## Summary
タスク (要約 / dig / dig preview / 雲抽出 / 雲関連性チェック) ごとに LLM プロバイダを切り替えられるようにします。

- 新モジュール **server/llm.js** に `runLlm({ task, prompt, tools, timeoutMs })` を実装
- プロバイダ: **Claude CLI** / **Gemini CLI** / **Codex CLI** / **OpenAI API** (gpt-4o-mini デフォルト)
- 4 つの spawn 呼び出し (claude.js / dig.js × 2 / wordcloud.js × 2) を runLlm に統一
- CLI には常に stdin でプロンプトを渡す (ENAMETOOLONG 対策)
- 設定は `app_settings` テーブル (key/value) に永続化。プロセス起動時にロード
- API: `GET /api/llm/config` (API key はマスク) / `PATCH /api/llm/config`
- ヘッダに **⚙ AI** ボタン追加 → タスクごとにプロバイダ + 任意のモデル名 + CLI バイナリパス + OpenAI API key を編集できるパネル

OpenAI を選んだのに API key 未設定の場合は自動で Claude CLI にフォールバックするので落ちません。

## Test plan
- [ ] ⚙ AI から各タスクのプロバイダを変更 → 保存 → そのタスクが選ばれたプロバイダで動く
- [ ] OpenAI を選んで API key 入れて bookmark を保存 → gpt-4o-mini で要約される
- [ ] Gemini CLI を `gemini` で PATH に通して dig を Gemini に切り替え → エラーなく動く (Tools 非対応なので WebSearch は使わない)
- [ ] API key を一度設定 → GET で `'***'` に masked

🤖 Generated with [Claude Code](https://claude.com/claude-code)