### PR TITLE
feat(diary): include the day's dig sessions

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -434,6 +434,20 @@ export function listDigSessions(db, limit = 30) {
   `).all(limit);
 }
 
+/** Dig sessions whose created_at falls on the given local date. */
+export function digSessionsForDate(db, dateStr) {
+  const rows = db.prepare(`
+    SELECT * FROM dig_sessions
+    WHERE date(created_at, 'localtime') = ?
+    ORDER BY created_at ASC
+  `).all(dateStr);
+  return rows.map(r => ({
+    ...r,
+    result: r.result_json ? safeParse(r.result_json) : null,
+    preview: r.preview_json ? safeParse(r.preview_json) : null,
+  }));
+}
+
 function safeParse(s) { try { return JSON.parse(s); } catch { return null; } }
 
 // ── word clouds ------------------------------------------------------------

--- a/server/diary.js
+++ b/server/diary.js
@@ -5,7 +5,7 @@
 // claude is asked only to narrate.
 
 import { spawn } from 'node:child_process';
-import { visitEventsForDate, getDiary, getDomainCatalogMap } from './db.js';
+import { visitEventsForDate, getDiary, getDomainCatalogMap, digSessionsForDate } from './db.js';
 
 // Model selection. The `claude` CLI accepts `--model sonnet` and `--model opus`.
 // We use Sonnet for the per-URL narrative (cheap, repetitive) and Opus 1M for
@@ -102,6 +102,20 @@ export function aggregateDay(db, dateStr) {
   const totalEvents = hourlyVisits.reduce((s, n) => s + n, 0);
 
   const bookmarks = bookmarksForDate(db, dateStr);
+  const digs = digSessionsForDate(db, dateStr).map(d => {
+    const r = d.result || {};
+    return {
+      id: d.id,
+      query: d.query,
+      status: d.status,
+      created_at: d.created_at,
+      summary: (r.summary || '').slice(0, 600),
+      source_count: (r.sources || []).length,
+      sources: (r.sources || []).slice(0, 8).map(s => ({
+        url: s.url, title: s.title, snippet: (s.snippet || '').slice(0, 200),
+      })),
+    };
+  });
 
   return {
     date: dateStr,
@@ -113,6 +127,7 @@ export function aggregateDay(db, dateStr) {
     first_event_at: firstSeen,
     last_event_at: lastSeen,
     bookmarks,
+    digs,
     sources: {
       visit_events: events.length,
       page_visits: pageVisitsContribution,
@@ -347,9 +362,9 @@ const WORK_CONTENT_PROMPT = ({ dateStr, urlList, totalEvents, totalDomains }) =>
   urlList,
 ].join('\n');
 
-const HIGHLIGHTS_PROMPT = ({ dateStr, workContent, githubByRepo, bookmarkSummary, notes, metrics }) => [
+const HIGHLIGHTS_PROMPT = ({ dateStr, workContent, githubByRepo, bookmarkSummary, digs, notes, metrics }) => [
   `あなたは ${dateStr} の「ハイライト」セクションを書きます。`,
-  '以下の 3 種類の情報を統合し、その日の重要なポイントを箇条書きで 3〜6 個。',
+  '以下の情報を統合し、その日の重要なポイントを箇条書きで 3〜6 個。',
   '事実ベース。憶測や創作はしない。重要度の高い順。',
   '',
   '## 入力 1: 作業内容 (時系列)',
@@ -364,6 +379,14 @@ const HIGHLIGHTS_PROMPT = ({ dateStr, workContent, githubByRepo, bookmarkSummary
   '## 入力 3: GitHub commits (リポジトリごとの件数)',
   githubByRepo.repos.length
     ? githubByRepo.repos.map(r => `- ${r.repo}: ${r.count} commits`).join('\n')
+    : '(なし)',
+  '',
+  '## 入力 4: 当日のディグ調査 (検索 + 取得した情報源)',
+  (digs && digs.length > 0)
+    ? digs.map(d => {
+        const summary = d.summary ? `\n  ${d.summary.slice(0, 300)}` : '';
+        return `- 「${d.query}」 (${d.source_count} 件のソース, ${d.status})${summary}`;
+      }).join('\n')
     : '(なし)',
   '',
   '## メタ情報',
@@ -510,10 +533,10 @@ export async function generateWorkContent({ db, dateStr, metrics, claudeBin = 'c
   return await spawnClaude(claudeBin, prompt, MODEL_SONNET, timeoutMs);
 }
 
-/** Stage 3: Opus 1M integrates work content + bookmark count + commits into highlights. */
-export async function generateHighlights({ dateStr, workContent, githubByRepo, bookmarkSummary, notes, metrics, claudeBin = 'claude', timeoutMs = 240_000 }) {
+/** Stage 3: Opus 1M integrates work content + bookmark count + commits + dig into highlights. */
+export async function generateHighlights({ dateStr, workContent, githubByRepo, bookmarkSummary, digs, notes, metrics, claudeBin = 'claude', timeoutMs = 240_000 }) {
   const prompt = HIGHLIGHTS_PROMPT({
-    dateStr, workContent, githubByRepo, bookmarkSummary, notes, metrics,
+    dateStr, workContent, githubByRepo, bookmarkSummary, digs, notes, metrics,
   });
   return await spawnClaude(claudeBin, prompt, MODEL_OPUS_1M, timeoutMs);
 }
@@ -539,13 +562,14 @@ export async function generateDiary({ db, dateStr, metrics, github, notes, claud
   }
 
   const workContent = await generateWorkContent({ db, dateStr, metrics, claudeBin });
+  const digs = metrics.digs || [];
   const highlights = await generateHighlights({
-    dateStr, workContent, githubByRepo, bookmarkSummary, notes, metrics, claudeBin,
+    dateStr, workContent, githubByRepo, bookmarkSummary, digs, notes, metrics, claudeBin,
   });
 
   // Combined summary for legacy display.
-  const summary = composeSummary({ workContent, githubByRepo, highlights });
-  return { workContent, githubByRepo, highlights, summary };
+  const summary = composeSummary({ workContent, githubByRepo, highlights, digs });
+  return { workContent, githubByRepo, highlights, summary, digs };
 }
 
 function buildBookmarkSummary(metrics) {
@@ -562,9 +586,16 @@ function buildBookmarkSummary(metrics) {
   };
 }
 
-function composeSummary({ workContent, githubByRepo, highlights }) {
+function composeSummary({ workContent, githubByRepo, highlights, digs }) {
   const parts = [];
   if (workContent) parts.push(`## 作業内容\n${workContent.trim()}`);
+  if (digs && digs.length > 0) {
+    const digLines = digs.map(d => {
+      const head = `- 「${d.query}」 (${d.source_count} 件のソース)`;
+      return d.summary ? `${head}\n  ${d.summary.slice(0, 250)}` : head;
+    }).join('\n');
+    parts.push(`## ディグ調査\n${digLines}`);
+  }
   if (githubByRepo.repos.length) {
     const repoLines = githubByRepo.repos
       .map(r => `- ${r.repo}: ${r.count} commits`)

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -1759,6 +1759,28 @@ function renderDiaryDetail() {
     });
   });
 
+  const digs = metrics.digs || [];
+  if (digs.length === 0) {
+    $('diaryDigs').innerHTML = '<li class="queue-empty">この日のディグはなし</li>';
+  } else {
+    $('diaryDigs').innerHTML = digs.map(dg => `
+      <li class="diary-dig" data-id="${dg.id}">
+        <div class="diary-dig-head">
+          <span class="diary-dig-query">${escapeHtml(dg.query)}</span>
+          <span class="diary-dig-meta">${dg.source_count} 件 · ${escapeHtml(dg.status)}</span>
+        </div>
+        ${dg.summary ? `<div class="diary-dig-summary">${escapeHtml(dg.summary)}</div>` : ''}
+      </li>
+    `).join('');
+    $('diaryDigs').querySelectorAll('.diary-dig').forEach(li => {
+      li.addEventListener('click', () => {
+        const id = Number(li.dataset.id);
+        switchTab('dig');
+        loadDigSession(id);
+      });
+    });
+  }
+
   const commits = d.github_commits?.commits || [];
   if (commits.length === 0) {
     $('diaryGithub').innerHTML = `<li class="queue-empty">${d.github_commits?.error ? escapeHtml('GitHub: ' + d.github_commits.error) : 'commit 記録なし'}</li>`;

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -261,6 +261,8 @@
             <ul id="diaryBookmarksCreated" class="diary-bookmarks"></ul>
             <h4>再訪したブックマーク</h4>
             <ul id="diaryBookmarksAccessed" class="diary-bookmarks"></ul>
+            <h4>当日のディグ調査</h4>
+            <ul id="diaryDigs" class="diary-digs"></ul>
             <h4>GitHub commits (リポ別件数)</h4>
             <ul id="diaryGithub" class="diary-github"></ul>
             <h4>メモ・補足</h4>

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -1408,3 +1408,18 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   color: var(--muted);
   margin-left: 4px;
 }
+
+.diary-digs { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.diary-dig {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  cursor: pointer;
+  font-size: 12px;
+}
+.diary-dig:hover { border-color: var(--accent); }
+.diary-dig-head { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; }
+.diary-dig-query { font-weight: 600; }
+.diary-dig-meta { font-size: 11px; color: var(--muted); }
+.diary-dig-summary { font-size: 11px; color: #2c3344; line-height: 1.5; margin-top: 4px; }


### PR DESCRIPTION
## Summary
当日に行ったディグ (dig_sessions) を日記に取り込みます。

- `aggregateDay` が `digSessionsForDate(db, date)` を呼んで同日の dig セッションを収集 → `metrics.digs[]` に格納
- 各 dig: `{ id, query, status, summary, source_count, sources[<=8] }`
- Opus 1M のハイライトプロンプトに 4 つ目の入力 (ディグ調査) を追加
- 詳細パネルに「当日のディグ調査」セクション。クリックでそのディグセッションへジャンプ

## Branch policy
PR の base は `feat/diary` です。日記の集約モジュール + 多段生成パイプラインが PR #27 (feat/diary) で初めて入るため、そちらに依存しています。`main` には適用できません。`feat/diary` がマージされたら、このブランチも main に向けて rebase 可能です。

## Test plan
- [ ] 任意の日にディグを実行 → その日の日記を再生成 → 「当日のディグ調査」セクションが現れる
- [ ] ハイライト (Opus 1M) の出力にディグ内容が反映される
- [ ] ディグ行をクリックするとディグるタブで該当セッションが開く

🤖 Generated with [Claude Code](https://claude.com/claude-code)