### PR TITLE
feat: Tauri desktop wrapper (scaffold)

### DIFF
--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -1,0 +1,3 @@
+src-tauri/target/
+src-tauri/Cargo.lock
+src-tauri/gen/

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,0 +1,55 @@
+# Memoria Desktop (Tauri)
+
+Tauri 2.x ラッパー。既存の Memoria Node サーバを子プロセスとして起動し、ローカルの `http://localhost:5180/` を WebView で表示します。
+
+## 必要なもの
+
+- Rust toolchain (`rustup default stable`)
+- Tauri CLI: `cargo install tauri-cli --version "^2.0"`
+- Node 22 LTS+ (Memoria サーバ実行用)
+- Windows: Microsoft Edge WebView2 (Win10/11 にプリインストール済)
+- macOS: Xcode CLI tools
+- Linux: `webkit2gtk-4.1` + `libssl-dev`
+
+## 開発実行
+
+```bash
+# ターミナル A: Memoria サーバを起動
+cd ../server
+npm install
+npm start
+
+# ターミナル B: Tauri 開発ビルド (内部で WebView が localhost:5180 を読みにいく)
+cd ../desktop
+cargo tauri dev
+```
+
+`cargo tauri dev` はサーバが立ち上がっていることを前提にします。サーバが落ちている場合は WebView が「接続できません」を表示します。
+
+## サーバ自動起動 (production build)
+
+`cargo tauri build` で生成されるバイナリは、起動時に `node ./server/index.js` を子プロセスとして起動します:
+
+- `MEMORIA_SERVER_DIR`: server ディレクトリの絶対パス (デフォルト: 実行バイナリの隣の `server/`)
+- `MEMORIA_NODE_BIN`: Node 実行ファイル (デフォルト: `node`)
+- `MEMORIA_PORT`: サーバポート (デフォルト: 5180)
+
+production 配布時は server/ ディレクトリ + node_modules/ を同梱する必要があります。詳細は `desktop/src-tauri/tauri.conf.json` の `bundle.resources` を編集してください (本 PR の時点では未設定 — Node 同梱方針が決まり次第対応)。
+
+## ビルド
+
+```bash
+cd desktop
+cargo tauri build
+```
+
+成果物:
+- Windows: `src-tauri/target/release/bundle/msi/` または `nsis/`
+- macOS: `src-tauri/target/release/bundle/dmg/`
+- Linux: `src-tauri/target/release/bundle/deb/` 等
+
+## 既知の制約
+
+- 現状サーバ自動起動は production build のみ。dev ビルドは server を別ターミナルで起動する必要あり
+- Node 本体は同梱しない (ユーザの PATH に入っている前提)。これは将来 [pkg](https://github.com/vercel/pkg) や [Bun --compile](https://bun.sh/docs/bundler/executables) で単一バイナリ化することで解消予定
+- アイコン: `desktop/src-tauri/icons/` に空のプレースホルダしか入っていません。本番リリースまでにブランド画像を差し替えてください

--- a/desktop/dist-stub/index.html
+++ b/desktop/dist-stub/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <title>Memoria — 起動中</title>
+    <style>
+      body { font-family: system-ui, sans-serif; padding: 32px; color: #444; }
+      .pulse { width: 12px; height: 12px; border-radius: 50%; background: #1f56c0;
+               animation: pulse 1.4s ease-in-out infinite; display: inline-block; }
+      @keyframes pulse {
+        0%, 100% { opacity: 0.4; transform: scale(0.85); }
+        50%      { opacity: 1.0; transform: scale(1.1); }
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Memoria</h1>
+    <p><span class="pulse"></span> サーバを起動しています…</p>
+    <p>本番ビルドではこの画面は出ず、直接 http://localhost:5180/ が読み込まれます。dev で表示されているなら server/ が起動しているか確認してください。</p>
+  </body>
+</html>

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "memoria-desktop"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.77"
+
+[lib]
+name = "memoria_desktop_lib"
+crate-type = ["lib", "cdylib", "staticlib"]
+
+[build-dependencies]
+tauri-build = { version = "2", features = [] }
+
+[dependencies]
+tauri = { version = "2", features = [] }
+tauri-plugin-shell = "2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[features]
+default = ["custom-protocol"]
+custom-protocol = ["tauri/custom-protocol"]

--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tauri_build::build()
+}

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://schema.tauri.app/config/2/capability",
+  "identifier": "default",
+  "description": "Default capabilities for the Memoria desktop wrapper.",
+  "windows": ["main"],
+  "permissions": [
+    "core:default",
+    "shell:allow-open"
+  ]
+}

--- a/desktop/src-tauri/icons/README.md
+++ b/desktop/src-tauri/icons/README.md
@@ -1,0 +1,5 @@
+# Icon assets
+
+Tauri が要求するアイコンセット (32x32.png, 128x128.png, icon.ico, icon.icns) を本番ビルド前にここに置いてください。
+
+最低限の用意は `cargo install tauri-cli && cargo tauri icon path/to/source.png` でまとめて生成できます。

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1,0 +1,93 @@
+// Memoria desktop entry point.
+//
+// On startup we (try to) spawn the Node-based Memoria server as a child
+// process and aim the WebView at http://localhost:<MEMORIA_PORT>/. When the
+// app window is closed we kill the child so the port is freed.
+//
+// Spawn behaviour is controlled by env vars / build mode:
+//   MEMORIA_SERVER_DIR  — absolute path to the server/ directory
+//                          (default: <exe_dir>/server)
+//   MEMORIA_NODE_BIN    — Node executable (default: "node")
+//   MEMORIA_PORT        — port the server listens on (default: 5180)
+//
+// In `cargo tauri dev` the user is expected to run the server themselves;
+// the spawn errors are tolerated so the dev workflow stays clean.
+
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::sync::Mutex;
+
+use tauri::Manager;
+
+struct ServerHandle(Mutex<Option<Child>>);
+
+fn spawn_server() -> Option<Child> {
+    let server_dir = std::env::var("MEMORIA_SERVER_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            let mut p = std::env::current_exe().unwrap_or_default();
+            p.pop();
+            p.push("server");
+            p
+        });
+    let node_bin = std::env::var("MEMORIA_NODE_BIN").unwrap_or_else(|_| "node".to_string());
+    let port = std::env::var("MEMORIA_PORT").unwrap_or_else(|_| "5180".to_string());
+
+    if !server_dir.exists() {
+        eprintln!(
+            "[memoria-desktop] server dir not found at {:?} — assuming it's already running",
+            server_dir
+        );
+        return None;
+    }
+
+    match Command::new(&node_bin)
+        .current_dir(&server_dir)
+        .arg("index.js")
+        .env("MEMORIA_PORT", &port)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(child) => {
+            eprintln!(
+                "[memoria-desktop] spawned {} (pid {}) in {:?} (port {})",
+                node_bin,
+                child.id(),
+                server_dir,
+                port
+            );
+            Some(child)
+        }
+        Err(e) => {
+            eprintln!(
+                "[memoria-desktop] failed to spawn server ({} index.js in {:?}): {}",
+                node_bin, server_dir, e
+            );
+            None
+        }
+    }
+}
+
+fn main() {
+    tauri::Builder::default()
+        .plugin(tauri_plugin_shell::init())
+        .manage(ServerHandle(Mutex::new(None)))
+        .setup(|app| {
+            let handle: tauri::State<ServerHandle> = app.state();
+            *handle.0.lock().unwrap() = spawn_server();
+            Ok(())
+        })
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::CloseRequested { .. } = event {
+                let handle: tauri::State<ServerHandle> = window.app_handle().state();
+                if let Some(mut child) = handle.0.lock().unwrap().take() {
+                    let _ = child.kill();
+                }
+            }
+        })
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "Memoria",
+  "version": "0.1.0",
+  "identifier": "com.ludiars.memoria",
+  "build": {
+    "beforeDevCommand": "",
+    "beforeBuildCommand": "",
+    "devUrl": "http://localhost:5180",
+    "frontendDist": "../dist-stub"
+  },
+  "app": {
+    "windows": [
+      {
+        "title": "Memoria",
+        "width": 1440,
+        "height": 900,
+        "minWidth": 980,
+        "minHeight": 600,
+        "url": "http://localhost:5180/"
+      }
+    ],
+    "security": {
+      "csp": null
+    }
+  },
+  "bundle": {
+    "active": true,
+    "targets": "all",
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/icon.icns",
+      "icons/icon.ico"
+    ],
+    "category": "Productivity",
+    "shortDescription": "Web bookmarking + research + diary",
+    "longDescription": "Memoria desktop wrapper. Runs the Memoria Node server as a child process and shows its UI in a WebView."
+  }
+}


### PR DESCRIPTION
## Summary
既存の Memoria サーバを **Tauri 2.x** ネイティブアプリでラップします。

## レイアウト
\`\`\`
desktop/
├── README.md                    # ビルド手順 / 既知の制約
├── dist-stub/index.html         # WebView がサーバに繋がらないときのフォールバック
└── src-tauri/
    ├── Cargo.toml               # Tauri 2 + tauri-plugin-shell
    ├── tauri.conf.json          # window=http://localhost:5180
    ├── build.rs
    ├── capabilities/default.json # Tauri 2 ACL
    ├── icons/README.md          # 画像差し替え方針
    └── src/main.rs              # 子プロセス管理
\`\`\`

## 動作
- `setup` フックで \`node server/index.js\` を spawn (env: \`MEMORIA_SERVER_DIR\` / \`MEMORIA_NODE_BIN\` / \`MEMORIA_PORT\`)
- WebView は \`http://localhost:5180/\` を直接読む (= 既存 web UI と完全互換)
- ウィンドウ close で子プロセスを kill

## 開発
\`\`\`bash
# Term A
cd server && npm start
# Term B
cd desktop && cargo tauri dev
\`\`\`

## 残作業 (別 Issue / 別 PR)
- アイコン (`desktop/src-tauri/icons/`)
- production build に Node ランタイム + server/ を同梱 (\`bundle.resources\`) — Node 単体バイナリ化 (pkg / bun --compile) を検討
- TS 化 (#31)

## Test plan
- [ ] `cargo tauri dev` で起動し、ローカルサーバの UI がネイティブウィンドウで開く
- [ ] ウィンドウを閉じると子プロセスが停止 (port 5180 が free になる)
- [ ] `MEMORIA_PORT=5181` 等で port を変更してもサーバ + WebView ともに追従

🤖 Generated with [Claude Code](https://claude.com/claude-code)