### PR TITLE
feat(multi-server): Phase 0–1 設計書 + share metadata columns + skeleton

### DIFF
--- a/docs/multi-server-architecture.md
+++ b/docs/multi-server-architecture.md
@@ -1,0 +1,204 @@
+# Memoria 二層アーキテクチャ — Local Server / Multi Server
+
+## 目的
+
+これまでの `MEMORIA_MODE=local|online` を「ローカル機能のフルセット」と「共有用のシェアハブ」という 2 つの**別モード**として明確に分離し、両者を 1 リポジトリで管理する。
+
+| | ローカルサーバ (Local) | マルチサーバ (Multi) |
+|---|---|---|
+| 主目的 | 個人の知識ベース | 全員で共有する辞書・ディグ・ブクマのハブ |
+| DB | SQLite (single file) | **Postgres** |
+| デスクトップアプリ | あり (Tauri) | なし |
+| 認証 | なし (シングルユーザ) | **Cernere SSO** |
+| アクセス履歴 / 日記 / 週報 / ドメイン辞書 / 作業キュー | あり | **なし** |
+| 共有可能なリソース | — | **辞書 / ディグる / ブックマーク** の 3 つ |
+| サーバ自動起動 | 0:00 cron | 不要 |
+| デプロイ形態 | 個人 PC | 共有インフラ (Cernere の隣) |
+
+---
+
+## ユースケース
+
+1. **個人利用**: ローカルサーバ単体で完結。今までと同じ。
+2. **シェア**: ローカルから「シェア」ボタンを押すと、選択した辞書エントリ / ディグセッション / ブックマークがマルチサーバへ送信され、誰でも閲覧可能になる。
+3. **ダウンロード**: マルチサーバの誰かのリソースを自分のローカル DB に「ダウンロード」して取り込む。
+4. **接続**: 「マルチサーバに接続」ボタンで Cernere 認証 → マルチサーバの API に対してローカル UI から検索・閲覧できる。
+
+ユーザ情報を持たない (= ローカル単独利用) 場合のオーナーは「自分」とみなす。
+
+---
+
+## 認証フロー
+
+### 1. ローカル → マルチへの接続初期化
+
+1. ユーザがローカル UI で「マルチサーバ URL」を設定
+2. ローカルが `GET <multi>/api/auth/cernere` を叩く → Cernere の OAuth フロー (PKCE) を開始
+3. Cernere のコールバック URL で **マルチサーバ** が JWT (HS256, 有効期限 30 日) を発行し、ローカルへリダイレクト
+4. ローカルは JWT を `app_settings.multi_jwt` / `app_settings.multi_user_id` / `app_settings.multi_user_name` に保存
+5. 以後ローカル → マルチの通信はすべて `Authorization: Bearer <JWT>` で行う
+
+### 2. マルチサーバ側の権限
+
+- `cernere.user_id` の値をオーナーキーとして使う
+- Cernere のロール: `user` / `moderator` / `admin`
+  - user: 自分の投稿の CRUD のみ
+  - moderator: 他ユーザの投稿を非表示にできる
+  - admin: 全削除 + マルチサーバの DB メンテ
+
+ロール情報は JWT のクレームに乗せ、マルチサーバが API ゲートで判定する。
+
+---
+
+## 共有可能リソースのスキーマ統合
+
+ローカル DB のスキーマを **正本** として扱い、マルチ DB はその上位互換 (= ローカルの全カラム + ユーザ情報) として持つ。
+
+### 共有テーブル → ユーザ情報追加カラム
+
+すべての共有可能テーブルに以下を追加:
+
+```sql
+ALTER TABLE bookmarks         ADD COLUMN owner_user_id TEXT;
+ALTER TABLE bookmarks         ADD COLUMN owner_user_name TEXT;
+ALTER TABLE bookmarks         ADD COLUMN shared_at TEXT;     -- 共有元から見た送信時刻
+ALTER TABLE bookmarks         ADD COLUMN shared_origin TEXT; -- 'local' or '<multi-server-id>'
+-- 同様に dictionary_entries, dig_sessions にも追加
+```
+
+ローカル DB でも同じカラムを持つ (NULL 許可)。NULL = 自分のもの。
+
+### マルチでのみ存在するメタ
+
+```sql
+CREATE TABLE share_log (
+  id            BIGSERIAL PRIMARY KEY,
+  resource_kind TEXT NOT NULL,           -- 'bookmark' | 'dig' | 'dict'
+  resource_id   BIGINT NOT NULL,
+  shared_by     TEXT NOT NULL,
+  shared_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  source_origin TEXT
+);
+```
+
+---
+
+## API 仕様
+
+### マルチサーバ API (Cernere JWT 必須)
+
+| Method | Path | 内容 |
+|---|---|---|
+| POST | `/api/auth/cernere` | OAuth コールバック; JWT 発行 |
+| GET | `/api/me` | JWT を検証して user_id / role / display_name を返す |
+| **bookmarks** |
+| GET | `/api/shared/bookmarks` | 全公開ブクマ (簡易ページネーション) |
+| POST | `/api/shared/bookmarks` | シェア (= ローカルからの import) |
+| DELETE | `/api/shared/bookmarks/:id` | 自分のシェアの取り下げ (admin/mod は他人も) |
+| **dig sessions** |
+| GET | `/api/shared/digs` | |
+| POST | `/api/shared/digs` | |
+| DELETE | `/api/shared/digs/:id` | |
+| **dictionary** |
+| GET | `/api/shared/dictionary` | |
+| POST | `/api/shared/dictionary` | |
+| DELETE | `/api/shared/dictionary/:id` | |
+| **moderation (admin/mod)** |
+| GET | `/api/shared/moderation/log` | |
+| POST | `/api/shared/moderation/hide` | |
+
+### ローカルサーバ API (新規)
+
+| Method | Path | 内容 |
+|---|---|---|
+| POST | `/api/multi/connect` | マルチサーバ URL を保存 → OAuth リダイレクトを返す |
+| POST | `/api/multi/disconnect` | JWT を破棄 |
+| GET | `/api/multi/status` | 接続中か / user / role / token 残期限 |
+| POST | `/api/multi/share` | `{kind, id}` を選択して JWT 経由でマルチに POST |
+| POST | `/api/multi/download` | `{kind, remote_id}` をローカルにインポート |
+| GET | `/api/multi/proxy/...` | マルチの GET をプロキシ (CORS 回避 + 認証付与) |
+
+---
+
+## UI 計画
+
+### ローカル UI に追加するもの
+
+- **AI 設定パネル**にマルチ接続セクション (URL + 接続状態 + Cernere 名 + ロール + 切断)
+- **ブックマーク / 辞書 / ディグ** タブの各エントリに「📤 シェア」ボタン
+- 接続中なら**ヘッダ**に新タブ「🌐 マルチ」が出現
+  - マルチ → ローカルへの「📥 ダウンロード」ボタン
+  - 検索 / フィルタ
+  - ユーザ別フィード
+
+### マルチサーバ UI
+
+- ローカル UI と同じソースをそのまま使う (機能タブを動的に隠す)
+  - `mode=multi` のときは: ブクマ / ディグ / 辞書 / ⚙ AI のみ表示
+  - access history / 日記 / 週報 / ドメイン / イベント / 作業キュー は非表示
+- ヘッダに Cernere ログインバッジ
+
+---
+
+## 実装フェーズ
+
+### Phase 0: 基盤分離 (この PR の前提)
+- `server/index.js` を `core/`、`local/`、`multi/` の薄い 3 層に分離
+- `core/`: 共有可能なリソース (bookmark / dig / dict) のロジック
+- `local/`: それ以外 (visits / diary / domain / events / page-meta / cloud / queue / uptime / GH 連携)
+- `multi/`: Cernere 認証 + share API
+- DB レイヤ: SQLite と Postgres の両方を抽象 (drizzle / raw / minimal mapper のいずれか)
+
+### Phase 1: スキーマ拡張
+- ローカル SQLite に owner_user_id / owner_user_name / shared_at / shared_origin を ALTER 追加
+- Postgres マイグレーション (`migrations/multi/001_init.sql`)
+- ローカル side のクエリは「NULL = 自分」を前提に動く
+
+### Phase 2: マルチサーバ MVP
+- Postgres + Cernere SSO
+- /api/me, /api/shared/bookmarks (CRUD), /api/shared/digs, /api/shared/dictionary
+- 公開時タイムスタンプ + シェア元 origin を記録
+- ロール検証 (user/mod/admin)
+
+### Phase 3: ローカル → マルチ「シェア」
+- ローカル UI に 📤 シェアボタン
+- POST /api/multi/share → JWT 付きでマルチに POST
+- 成功時、ローカル側にも shared_at と shared_origin を立てる (重複シェア検出)
+
+### Phase 4: マルチ閲覧 (ローカルから)
+- 「🌐 マルチ」タブを実装
+- /api/multi/proxy/* で GET をマルチに転送
+- 共通 UI コンポーネント (BookmarkCard / DictEntry / DigSession) を再利用
+
+### Phase 5: マルチ → ローカル「ダウンロード」
+- 📥 ダウンロードボタン
+- POST /api/multi/download → local DB に upsert (owner_user_id 含む)
+
+### Phase 6: モデレーション
+- admin/mod 用の hide / restore / 全削除エンドポイント
+- マルチ UI に hidden 表示の切り替え
+
+### Phase 7: デプロイ + Cernere 連携の実機検証
+- マルチサーバの Docker compose (Postgres + Hono)
+- Cernere の OAuth クライアント登録
+- ローカル → マルチの E2E 通し
+
+---
+
+## 設計上の注意点
+
+- **DB 抽象化**: 既存コードは `db.js` (better-sqlite3) を直接使っている。Phase 0 で薄いラッパー (`db()` が `query()` / `prepare()` / `transaction()` を返す) を作り、SQLite / Postgres どちらも実装する
+- **JWT は HS256 で短命**: 30 日にし、refresh は再ログイン (Cernere の SSO に倣う)
+- **CORS**: マルチサーバは `*` ではなく許可リスト方式に絞る
+- **個人データ非保管ルール**: 個人プロフィールは Cernere 単一情報源。マルチ DB は user_id + display_name のスナップショットのみ保持 (rotate 可能)
+- **既存 PR の整合**:
+  - feat/multi-model (#29 マージ済) の AI 設定パネルにマルチ接続セクションを追記する (Phase 4 と同時)
+  - feat/uptime-event-log (作業キュー) はローカル専用機能
+- **共通 UI**: モード判定は `index.html` 配信時に `<meta name="memoria-mode" content="local|multi">` を埋めて FE で読む
+
+---
+
+## 通しコード対応
+
+- ローカルサーバ: `Mm` (= 既存)
+- マルチサーバ: `MmH` (Memoria Hub) 提案 — `LUDIARS/PROJECT-CODES.md` に追記予定

--- a/server/db.js
+++ b/server/db.js
@@ -219,6 +219,17 @@ export function openDb(dbPath) {
   if (!dcCols.includes('notes'))       db.exec(`ALTER TABLE domain_catalog ADD COLUMN notes TEXT`);
   if (!dcCols.includes('user_edited')) db.exec(`ALTER TABLE domain_catalog ADD COLUMN user_edited INTEGER NOT NULL DEFAULT 0`);
 
+  // Phase 1 (multi-server): ownership / share metadata on the three shareable
+  // resources. NULL owner_user_id = "this is mine" on a local server.
+  // Same columns exist on the multi-server schema (Postgres) — see docs/.
+  const shareCols = ['owner_user_id', 'owner_user_name', 'shared_at', 'shared_origin'];
+  for (const tbl of ['bookmarks', 'dictionary_entries', 'dig_sessions']) {
+    const existing = db.prepare(`PRAGMA table_info(${tbl})`).all().map(c => c.name);
+    for (const col of shareCols) {
+      if (!existing.includes(col)) db.exec(`ALTER TABLE ${tbl} ADD COLUMN ${col} TEXT`);
+    }
+  }
+
   // Forward-compat: ensure newer columns exist on older DBs.
   const cols = db.prepare(`PRAGMA table_info(bookmarks)`).all().map(c => c.name);
   if (!cols.includes('last_accessed_at')) {

--- a/server/multi/README.md
+++ b/server/multi/README.md
@@ -1,0 +1,30 @@
+# Memoria Multi-Server (Memoria Hub)
+
+[設計書](../../docs/multi-server-architecture.md)
+
+`server/multi/` 配下はマルチサーバ専用のコード。ローカルサーバ (`server/index.js`) と共有テーブル定義は core 層を経由する。
+
+## 構成 (予定)
+```
+server/multi/
+├── index.js            # Hono app entry — Cernere SSO + /api/shared/*
+├── db.js               # Postgres 抽象 (better-sqlite3 と同じ shape を返す)
+├── auth.js             # Cernere OAuth フロー + JWT (HS256, 30 日)
+├── shared.js           # /api/shared/bookmarks /digs /dictionary
+├── moderation.js       # admin / mod 専用エンドポイント
+└── migrations/
+    └── 001_init.sql    # Postgres スキーマ初期化
+```
+
+## 起動 (予定)
+```
+MEMORIA_MULTI=1
+MEMORIA_PG_URL=postgres://...
+MEMORIA_CERNERE_OAUTH_CLIENT=<id>
+MEMORIA_CERNERE_OAUTH_SECRET=<secret>
+MEMORIA_JWT_SECRET=<long-random>
+node multi/index.js
+```
+
+## 進捗
+Phase 0 (server を core/local/multi に分離) と Phase 2 (MVP) は別 PR で実装する。

--- a/server/multi/migrations/001_init.sql
+++ b/server/multi/migrations/001_init.sql
@@ -1,0 +1,92 @@
+-- Memoria Hub (multi-server) Postgres schema — initial cut.
+--
+-- Mirror of the local SQLite schema for the three shareable resources only.
+-- Local-only tables (page_visits, visit_events, diary_entries, weekly_reports,
+-- domain_catalog, page_metadata, accesses, server_events, app_settings,
+-- bookmark_categories, recommendation_dismissals, dictionary_links,
+-- word_clouds, dig_sessions.preview_json — anything not for sharing) are
+-- intentionally absent.
+--
+-- All shared rows carry owner_user_id (Cernere user id) and a snapshot of
+-- owner_user_name. shared_origin is informational ("which local server
+-- forwarded this row").
+
+CREATE TABLE bookmarks (
+  id                BIGSERIAL PRIMARY KEY,
+  url               TEXT NOT NULL,
+  title             TEXT NOT NULL,
+  summary           TEXT,
+  memo              TEXT NOT NULL DEFAULT '',
+  -- HTML body is *not* stored here; only the metadata.
+
+  owner_user_id     TEXT NOT NULL,
+  owner_user_name   TEXT NOT NULL,
+  shared_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  shared_origin     TEXT,
+
+  hidden_at         TIMESTAMPTZ,
+  hidden_by         TEXT,
+  hidden_reason     TEXT
+);
+CREATE INDEX idx_bookmarks_owner    ON bookmarks(owner_user_id);
+CREATE INDEX idx_bookmarks_shared   ON bookmarks(shared_at DESC);
+
+CREATE TABLE bookmark_categories (
+  bookmark_id  BIGINT NOT NULL REFERENCES bookmarks(id) ON DELETE CASCADE,
+  category     TEXT NOT NULL,
+  PRIMARY KEY (bookmark_id, category)
+);
+
+CREATE TABLE dictionary_entries (
+  id            BIGSERIAL PRIMARY KEY,
+  term          TEXT NOT NULL,
+  definition    TEXT,
+  notes         TEXT,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  owner_user_id     TEXT NOT NULL,
+  owner_user_name   TEXT NOT NULL,
+  shared_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  shared_origin     TEXT,
+
+  hidden_at         TIMESTAMPTZ,
+  hidden_by         TEXT,
+  hidden_reason     TEXT,
+
+  -- Same term can exist for multiple users on the multi-server.
+  UNIQUE (owner_user_id, term)
+);
+CREATE INDEX idx_dictionary_owner   ON dictionary_entries(owner_user_id);
+
+CREATE TABLE dig_sessions (
+  id            BIGSERIAL PRIMARY KEY,
+  query         TEXT NOT NULL,
+  status        TEXT NOT NULL,
+  result_json   JSONB,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  owner_user_id     TEXT NOT NULL,
+  owner_user_name   TEXT NOT NULL,
+  shared_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  shared_origin     TEXT,
+
+  hidden_at         TIMESTAMPTZ,
+  hidden_by         TEXT,
+  hidden_reason     TEXT
+);
+CREATE INDEX idx_dig_owner    ON dig_sessions(owner_user_id);
+CREATE INDEX idx_dig_shared   ON dig_sessions(shared_at DESC);
+
+-- Audit log for moderation actions and shares.
+CREATE TABLE share_log (
+  id              BIGSERIAL PRIMARY KEY,
+  resource_kind   TEXT NOT NULL,             -- 'bookmark' | 'dig' | 'dict'
+  resource_id     BIGINT NOT NULL,
+  action          TEXT NOT NULL,             -- 'share' | 'hide' | 'unhide' | 'delete'
+  acting_user_id  TEXT NOT NULL,
+  occurred_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  details_json    JSONB
+);
+CREATE INDEX idx_share_log_at      ON share_log(occurred_at DESC);
+CREATE INDEX idx_share_log_target  ON share_log(resource_kind, resource_id);


### PR DESCRIPTION
Issue: #34

## このPRに含まれるもの (Phase 1 / 設計のみ)

### 設計書
- [`docs/multi-server-architecture.md`](https://github.com/LUDIARS/Memoria/blob/feat/multi-server-mode/docs/multi-server-architecture.md) — Memoria を Local Server / Multi Server (Memoria Hub) に分離する全体計画 (Phase 0–7)

### Phase 1: スキーマ拡張
- bookmarks / dictionary_entries / dig_sessions に `owner_user_id` / `owner_user_name` / `shared_at` / `shared_origin` を追加
- 既存ローカル DB は openDb() の forward-compat 区画で自動 ALTER
- NULL = 「自分のもの」(ローカル単独運用と互換)

### Multi server skeleton
- `server/multi/README.md` — ディレクトリレイアウト案
- `server/multi/migrations/001_init.sql` — Postgres 初期スキーマ (3 つの共有可能リソース + bookmark_categories + share_log)。ローカル限定テーブル (page_visits / diary_entries / weekly_reports / domain_catalog / page_metadata / accesses / server_events / app_settings / recommendation_dismissals / dictionary_links / word_clouds) は意図的に除外

## このPRに含まれないもの (後続 Issue/PR)

- **Phase 0**: server を core/local/multi に分離 + DB 抽象 (SQLite/Postgres)
- **Phase 2**: マルチサーバ MVP (Cernere SSO + /api/shared/*)
- **Phase 3**: ローカル → マルチ「シェア」(📤)
- **Phase 4**: 「🌐 マルチ」タブ実装 (proxy)
- **Phase 5**: マルチ → ローカル「ダウンロード」(📥)
- **Phase 6**: モデレーション
- **Phase 7**: デプロイ + Cernere 連携 E2E

各 Phase は本 PR がマージされたあと別 PR で順次積み上げる予定 (Issue #34 のチェックリスト参照)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)