### PR TITLE
feat: server uptime tracking + イベント tab + 作業キュー rename

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -107,6 +107,19 @@ export function openDb(dbPath) {
       fetched_at    TEXT
     );
 
+    CREATE TABLE IF NOT EXISTS server_events (
+      id           INTEGER PRIMARY KEY AUTOINCREMENT,
+      type         TEXT NOT NULL,
+      occurred_at  TEXT NOT NULL,
+      ended_at     TEXT,
+      duration_ms  INTEGER,
+      details_json TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_server_events_at
+      ON server_events(occurred_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_server_events_type
+      ON server_events(type);
+
     CREATE TABLE IF NOT EXISTS visit_events (
       id          INTEGER PRIMARY KEY AUTOINCREMENT,
       url         TEXT NOT NULL,
@@ -819,6 +832,44 @@ export function listDomainCatalogWithCounts(db, { limit = 500, search } = {}) {
 
 export function deleteDomainCatalog(db, domain) {
   db.prepare(`DELETE FROM domain_catalog WHERE domain = ?`).run(domain);
+}
+
+// ── server events (uptime / downtime / lifecycle) -------------------------
+
+export function insertServerEvent(db, { type, occurredAt, endedAt, durationMs, details }) {
+  return db.prepare(`
+    INSERT INTO server_events (type, occurred_at, ended_at, duration_ms, details_json)
+    VALUES (?, ?, ?, ?, ?)
+  `).run(
+    type,
+    occurredAt,
+    endedAt ?? null,
+    durationMs ?? null,
+    details ? JSON.stringify(details) : null,
+  ).lastInsertRowid;
+}
+
+export function listServerEvents(db, { limit = 200 } = {}) {
+  const rows = db.prepare(`
+    SELECT * FROM server_events
+    ORDER BY id DESC LIMIT ?
+  `).all(Number(limit) || 200);
+  return rows.map(r => ({
+    ...r,
+    details: r.details_json ? safeParse(r.details_json) : null,
+  }));
+}
+
+export function listServerEventsForDate(db, dateStr) {
+  // Any event that overlaps the local date window.
+  return db.prepare(`
+    SELECT * FROM server_events
+    WHERE date(occurred_at, 'localtime') = ?
+       OR date(COALESCE(ended_at, occurred_at), 'localtime') = ?
+    ORDER BY occurred_at ASC
+  `).all(dateStr, dateStr).map(r => ({
+    ...r, details: r.details_json ? safeParse(r.details_json) : null,
+  }));
 }
 
 // ── visit events / diary ---------------------------------------------------

--- a/server/diary.js
+++ b/server/diary.js
@@ -4,8 +4,12 @@
 // Hourly buckets, top domains, and active hours are computed locally;
 // claude is asked only to narrate.
 
-import { visitEventsForDate, getDiary, getDomainCatalogMap, digSessionsForDate } from './db.js';
+import { visitEventsForDate, getDiary, getDomainCatalogMap, digSessionsForDate, listServerEventsForDate } from './db.js';
 import { runLlm } from './llm.js';
+
+// Downtimes >5 min make it into the diary; shorter gaps are treated as
+// restarts (e.g. process kill + npm start) and silently ignored.
+const DIARY_DOWNTIME_THRESHOLD_MS = 5 * 60 * 1000;
 
 // Default models per task are configured in llm.js (sonnet for diary_work,
 // opus 1M for diary_highlights / diary_weekly). The user can override per task
@@ -115,6 +119,17 @@ export function aggregateDay(db, dateStr) {
     };
   });
 
+  // Surface significant server downtimes so claude knows the data is partial.
+  const serverEvents = listServerEventsForDate(db, dateStr);
+  const downtimes = serverEvents
+    .filter(e => e.type === 'downtime' && (e.duration_ms || 0) > DIARY_DOWNTIME_THRESHOLD_MS)
+    .map(e => ({
+      from: e.occurred_at,
+      to: e.ended_at,
+      duration_ms: e.duration_ms,
+    }));
+  const totalDowntimeMs = downtimes.reduce((s, d) => s + (d.duration_ms || 0), 0);
+
   return {
     date: dateStr,
     total_events: totalEvents,
@@ -126,6 +141,8 @@ export function aggregateDay(db, dateStr) {
     last_event_at: lastSeen,
     bookmarks,
     digs,
+    downtimes,
+    total_downtime_ms: totalDowntimeMs,
     sources: {
       visit_events: events.length,
       page_visits: pageVisitsContribution,
@@ -360,6 +377,17 @@ const WORK_CONTENT_PROMPT = ({ dateStr, urlList, totalEvents, totalDomains }) =>
   urlList,
 ].join('\n');
 
+function formatDowntimeBlock(metrics) {
+  const dts = metrics?.downtimes || [];
+  if (!dts.length) return '(なし)';
+  return dts.map(d => {
+    const from = (d.from || '').replace('T', ' ').slice(0, 19);
+    const to = (d.to || '').replace('T', ' ').slice(0, 19);
+    const mins = Math.round((d.duration_ms || 0) / 60_000);
+    return `- ${from} 〜 ${to} (${mins} 分間 Memoria サーバ停止 → アクセスログ取得なし)`;
+  }).join('\n');
+}
+
 const HIGHLIGHTS_PROMPT = ({ dateStr, workContent, githubByRepo, bookmarkSummary, digs, notes, metrics }) => [
   `あなたは ${dateStr} の「ハイライト」セクションを書きます。`,
   '以下の情報を統合し、その日の重要なポイントを箇条書きで 3〜6 個。',
@@ -389,6 +417,10 @@ const HIGHLIGHTS_PROMPT = ({ dateStr, workContent, githubByRepo, bookmarkSummary
   '',
   '## メタ情報',
   `総アクセス: ${metrics.total_events} / アクティブ時間帯: ${metrics.active_hours.join(',')}`,
+  '',
+  '## サーバ停止 (5 分超のダウンタイム)',
+  formatDowntimeBlock(metrics),
+  '上記時間帯はアクセスログが欠落しているので、その時間帯の活動についてはデータがない旨を簡潔に注記してください。',
   '',
   notes ? `## ユーザのメモ・補足 (反映してください)\n${notes}\n` : '',
   '',

--- a/server/index.js
+++ b/server/index.js
@@ -50,6 +50,8 @@ import {
 import { classifyDomain, shouldSkipDomain } from './domain-catalog.js';
 import { fetchPageMetadata } from './page-metadata.js';
 import { extractWordCloud, validateWordRelevance } from './wordcloud.js';
+import { startUptimeTracking, readHeartbeat, DOWNTIME_THRESHOLD_MS } from './uptime.js';
+import { listServerEvents, listServerEventsForDate } from './db.js';
 import {
   aggregateDay, fetchGithubActivity, fetchGithubRange,
   generateDiary, generateWeekly, summarizeGithubByRepo,
@@ -71,6 +73,8 @@ const CLAUDE_BIN = process.env.MEMORIA_CLAUDE_BIN ?? 'claude';
 mkdirSync(HTML_DIR, { recursive: true });
 const db = openDb(DB_PATH);
 loadLlmConfigFromSettings(getAppSettings(db));
+const HEARTBEAT_FILE = join(DATA_DIR, 'heartbeat.json');
+startUptimeTracking({ db, dataDir: DATA_DIR, heartbeatFile: HEARTBEAT_FILE });
 const summaryQueue = new FifoQueue();
 const cloudQueue = new FifoQueue();
 const domainCatalogQueue = new FifoQueue();
@@ -877,6 +881,21 @@ app.patch('/api/llm/config', async (c) => {
   setAppSettings(db, patch);
   loadLlmConfigFromSettings(getAppSettings(db));
   return c.json({ ok: true });
+});
+
+// ---- server events / uptime -----------------------------------------------
+
+app.get('/api/events', (c) => {
+  const limit = Number(c.req.query('limit')) || 200;
+  return c.json({ items: listServerEvents(db, { limit }) });
+});
+
+app.get('/api/uptime', (c) => {
+  const hb = readHeartbeat(HEARTBEAT_FILE);
+  return c.json({
+    heartbeat: hb,
+    downtime_threshold_ms: DOWNTIME_THRESHOLD_MS,
+  });
 });
 
 // ---- queue status ---------------------------------------------------------

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -519,6 +519,7 @@ function switchTab(tab) {
   $('dictView').classList.toggle('hidden', tab !== 'dict');
   $('domainView').classList.toggle('hidden', tab !== 'domain');
   $('diaryView').classList.toggle('hidden', tab !== 'diary');
+  $('eventsView').classList.toggle('hidden', tab !== 'events');
   if (tab === 'queue') renderQueue();
   if (tab === 'visits') loadVisits();
   if (tab === 'trends') loadTrends();
@@ -527,6 +528,7 @@ function switchTab(tab) {
   if (tab === 'dict') loadDictionary();
   if (tab === 'domain') loadDomainCatalog();
   if (tab === 'diary') loadDiary();
+  if (tab === 'events') loadEvents();
 }
 
 // ── Dig (deep research) ──────────────────────────────────────────────────
@@ -2473,3 +2475,54 @@ async function saveAiSettings() {
 document.getElementById('aiSettingsBtn')?.addEventListener('click', openAiSettings);
 document.getElementById('aiSettingsClose')?.addEventListener('click', () => $('aiSettingsPanel').classList.add('hidden'));
 document.getElementById('aiSettingsSave')?.addEventListener('click', saveAiSettings);
+
+// ── Events / uptime ────────────────────────────────────────────────────
+async function loadEvents() {
+  try {
+    const [evs, ut] = await Promise.all([
+      api('/api/events?limit=200'),
+      api('/api/uptime'),
+    ]);
+    renderUptimeStatus(ut);
+    renderEvents(evs.items || []);
+  } catch (e) { console.error(e); }
+}
+
+function renderUptimeStatus(u) {
+  const el = $('uptimeStatus');
+  if (!u?.heartbeat) { el.innerHTML = '<span style="color:var(--muted)">heartbeat 情報なし</span>'; return; }
+  const h = u.heartbeat;
+  const startedAt = h.server_started_at ? new Date(h.server_started_at) : null;
+  const lastHb = h.last_heartbeat_at ? new Date(h.last_heartbeat_at) : null;
+  const upMs = startedAt ? Date.now() - startedAt.getTime() : 0;
+  el.innerHTML = `
+    <span><b>稼働中</b> · 起動 ${startedAt ? startedAt.toLocaleString() : '?'} (${fmtElapsed(upMs)})</span>
+    <span style="margin-left:12px;color:var(--muted)">last heartbeat ${lastHb ? lastHb.toLocaleTimeString() : '?'}</span>
+  `;
+}
+
+const EVENT_LABELS = {
+  start: '🟢 起動',
+  stop: '🛑 停止 (graceful)',
+  downtime: '⚠ サーバ停止 (5 分超)',
+  restart: '🔁 再起動 (5 分以内)',
+};
+
+function renderEvents(items) {
+  const el = $('eventsList');
+  if (!items.length) { el.innerHTML = '<li class="queue-empty">イベント記録なし</li>'; return; }
+  el.innerHTML = items.map(e => {
+    const label = EVENT_LABELS[e.type] || e.type;
+    const occ = (e.occurred_at || '').replace('T', ' ').slice(0, 19);
+    const dur = e.duration_ms ? ` · ${Math.round(e.duration_ms / 1000)}秒` : '';
+    const ended = e.ended_at ? ` → ${e.ended_at.replace('T',' ').slice(0,19)}` : '';
+    const det = e.details ? `<div class="ev-det">${escapeHtml(JSON.stringify(e.details))}</div>` : '';
+    return `<li class="ev-row ev-${e.type}">
+      <span class="ev-tag">${label}</span>
+      <span class="ev-time">${escapeHtml(occ)}${ended}${dur}</span>
+      ${det}
+    </li>`;
+  }).join('');
+}
+
+document.getElementById('eventsRefresh')?.addEventListener('click', loadEvents);

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -37,9 +37,10 @@
       <nav class="tabs">
         <button class="tab active" data-tab="bookmarks">ブックマーク</button>
         <button class="tab" data-tab="queue">
-          作業リスト
+          作業キュー
           <span id="tabQueueCount" class="tab-count hidden">0</span>
         </button>
+        <button class="tab" data-tab="events">📋 イベント</button>
         <button class="tab" data-tab="visits">
           アクセス履歴
           <span id="tabVisitsCount" class="tab-count hidden">0</span>
@@ -293,6 +294,14 @@
       <div id="queueView" class="hidden">
         <p class="queue-bar-help">ブックマーク要約・ディグ・ワードクラウド・日記・週報・ドメイン分類・ページメタの作業をすべて 1 件ずつ順次処理しています。</p>
         <div id="queueGroups" class="queue-groups"></div>
+      </div>
+
+      <div id="eventsView" class="hidden">
+        <div class="events-bar">
+          <div id="uptimeStatus" class="uptime-status"></div>
+          <button id="eventsRefresh" class="ghost">更新</button>
+        </div>
+        <ul id="eventsList" class="events-list"></ul>
       </div>
     </section>
 

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -1477,3 +1477,34 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 .diary-dig-query { font-weight: 600; }
 .diary-dig-meta { font-size: 11px; color: var(--muted); }
 .diary-dig-summary { font-size: 11px; color: #2c3344; line-height: 1.5; margin-top: 4px; }
+
+.events-bar {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 12px;
+  padding: 10px 14px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.uptime-status { flex: 1; font-size: 13px; }
+.events-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+.ev-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 12px;
+  flex-wrap: wrap;
+}
+.ev-row.ev-downtime { background: #fae6e6; }
+.ev-row.ev-start { background: #e8f5e8; }
+.ev-row.ev-stop { background: #fff5e1; }
+.ev-row.ev-restart { background: var(--accent-bg); }
+.ev-tag { font-weight: 600; min-width: 160px; }
+.ev-time { color: var(--muted); font-family: ui-monospace, monospace; font-size: 11px; }
+.ev-det { font-size: 10px; color: var(--muted); flex-basis: 100%; word-break: break-all; }

--- a/server/uptime.js
+++ b/server/uptime.js
@@ -1,0 +1,134 @@
+// Server uptime tracking.
+//
+// On each tick (1s) we touch a heartbeat file with the current time. On the
+// next process boot we read that file: if its mtime is in the past, we know
+// the server was offline between (heartbeat) and (now). That gap is recorded
+// as a downtime event.
+//
+// Why a file (not just memory)? — process can crash or be SIGKILL'd, in
+// which case we never get a stop event. The heartbeat file gives us a
+// "definitely-alive at" timestamp regardless of how the process ended.
+
+import { writeFileSync, readFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { insertServerEvent } from './db.js';
+
+const TICK_MS = 1000;
+const RESTART_GRACE_MS = 5 * 60 * 1000; // 5 minutes — see DOWNTIME_THRESHOLD_MS
+
+let timer = null;
+let installedShutdownHandlers = false;
+let activeDb = null;
+let activeFile = null;
+let bootTime = null;
+let startEventId = null;
+
+export const DOWNTIME_THRESHOLD_MS = 5 * 60 * 1000;
+
+export function startUptimeTracking({ db, dataDir, heartbeatFile }) {
+  if (timer) stopUptimeTracking();
+  activeDb = db;
+  activeFile = heartbeatFile || `${dataDir}/heartbeat.json`;
+  mkdirSync(dirname(activeFile), { recursive: true });
+
+  bootTime = new Date();
+  let priorHeartbeat = null;
+  if (existsSync(activeFile)) {
+    try {
+      const raw = readFileSync(activeFile, 'utf8');
+      const parsed = JSON.parse(raw);
+      if (parsed?.last_heartbeat_at) priorHeartbeat = new Date(parsed.last_heartbeat_at);
+    } catch {}
+  }
+
+  // Record the start event.
+  startEventId = insertServerEvent(db, {
+    type: 'start',
+    occurredAt: bootTime.toISOString(),
+    details: { pid: process.pid },
+  });
+
+  // Compute the gap since last heartbeat — if any.
+  if (priorHeartbeat && Number.isFinite(priorHeartbeat.getTime())) {
+    const gapMs = bootTime.getTime() - priorHeartbeat.getTime();
+    if (gapMs > 0) {
+      const downtimeOrRestart = gapMs <= RESTART_GRACE_MS ? 'restart' : 'downtime';
+      insertServerEvent(db, {
+        type: downtimeOrRestart,
+        occurredAt: priorHeartbeat.toISOString(),
+        endedAt: bootTime.toISOString(),
+        durationMs: gapMs,
+        details: { reason: 'inferred from heartbeat gap' },
+      });
+      console.log(`[uptime] previous run ended ${priorHeartbeat.toISOString()} — `
+        + `${downtimeOrRestart} ${Math.round(gapMs / 1000)}s`);
+    }
+  }
+
+  // Heartbeat tick.
+  const tick = () => {
+    try {
+      writeFileSync(activeFile, JSON.stringify({
+        server_started_at: bootTime.toISOString(),
+        last_heartbeat_at: new Date().toISOString(),
+        pid: process.pid,
+      }), 'utf8');
+    } catch (e) {
+      console.warn(`[uptime] heartbeat write failed: ${e.message}`);
+    }
+  };
+  tick();
+  timer = setInterval(tick, TICK_MS);
+  timer.unref?.();
+
+  if (!installedShutdownHandlers) {
+    installedShutdownHandlers = true;
+    const shutdown = (signal) => {
+      try { recordCleanShutdown(signal); } catch {}
+      process.exit(0);
+    };
+    process.on('SIGINT', () => shutdown('SIGINT'));
+    process.on('SIGTERM', () => shutdown('SIGTERM'));
+    process.on('SIGHUP', () => shutdown('SIGHUP'));
+    process.on('beforeExit', () => { try { recordCleanShutdown('beforeExit'); } catch {} });
+  }
+}
+
+export function stopUptimeTracking() {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}
+
+function recordCleanShutdown(signal) {
+  if (!activeDb || !bootTime) return;
+  const now = new Date();
+  insertServerEvent(activeDb, {
+    type: 'stop',
+    occurredAt: now.toISOString(),
+    details: { signal, started_at: bootTime.toISOString() },
+  });
+  // Also bump the heartbeat to "now" so a fresh boot doesn't see a tiny gap
+  // and call it a downtime.
+  if (activeFile) {
+    try {
+      writeFileSync(activeFile, JSON.stringify({
+        server_started_at: bootTime.toISOString(),
+        last_heartbeat_at: now.toISOString(),
+        clean_shutdown: true,
+        signal,
+      }), 'utf8');
+    } catch {}
+  }
+  stopUptimeTracking();
+}
+
+export function readHeartbeat(heartbeatFile) {
+  if (!existsSync(heartbeatFile)) return null;
+  try {
+    return JSON.parse(readFileSync(heartbeatFile, 'utf8'));
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
旧 PR #32 の再 PR (base が `feat/diary` だったため #27 マージ時に自動クローズされた)。差分は同じ。

## Summary
サーバの稼働時間を 1 秒粒度で記録し、再起動 / クラッシュ / ダウンタイムをイベントログ化します。

### Heartbeat
- `data/heartbeat.json` に 1 秒ごとに `last_heartbeat_at` を書き込む
- ファイルベースなので process が SIGKILL されても次回起動時に「ここまでは生きていた」がわかる

### Downtime 推定
次回起動時に prior heartbeat と現在時刻の差を取って:
- **5 分超**: `server_events` に `downtime` として記録 → 日記の Opus 1M ハイライトプロンプトに「HH:MM〜HH:MM サーバ停止のためログ欠落」と明示される
- **5 分以下**: `restart` として記録するが日記には載せない

### イベント
- `start` (毎回起動時)
- `stop` (graceful: SIGINT/SIGTERM/SIGHUP/beforeExit)
- `downtime` / `restart` (heartbeat ギャップから推定)

### UI
- 「作業リスト」→ **「作業キュー」** リネーム
- 新タブ **📋 イベント**: heartbeat ステータスバー + 全イベントのクロノロジカル一覧 (color-coded)
- API: `GET /api/events`, `GET /api/uptime`

🤖 Generated with [Claude Code](https://claude.com/claude-code)