### PR TITLE
feat(diary): include the day's dig sessions

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -439,6 +439,20 @@ export function listDigSessions(db, limit = 30) {
   `).all(limit);
 }
 
+/** Dig sessions whose created_at falls on the given local date. */
+export function digSessionsForDate(db, dateStr) {
+  const rows = db.prepare(`
+    SELECT * FROM dig_sessions
+    WHERE date(created_at, 'localtime') = ?
+    ORDER BY created_at ASC
+  `).all(dateStr);
+  return rows.map(r => ({
+    ...r,
+    result: r.result_json ? safeParse(r.result_json) : null,
+    preview: r.preview_json ? safeParse(r.preview_json) : null,
+  }));
+}
+
 function safeParse(s) { try { return JSON.parse(s); } catch { return null; } }
 
 // ── app settings (key/value) ----------------------------------------------

--- a/server/diary.js
+++ b/server/diary.js
@@ -4,7 +4,7 @@
 // Hourly buckets, top domains, and active hours are computed locally;
 // claude is asked only to narrate.
 
-import { visitEventsForDate, getDiary, getDomainCatalogMap } from './db.js';
+import { visitEventsForDate, getDiary, getDomainCatalogMap, digSessionsForDate } from './db.js';
 import { runLlm } from './llm.js';
 
 // Default models per task are configured in llm.js (sonnet for diary_work,
@@ -100,6 +100,20 @@ export function aggregateDay(db, dateStr) {
   const totalEvents = hourlyVisits.reduce((s, n) => s + n, 0);
 
   const bookmarks = bookmarksForDate(db, dateStr);
+  const digs = digSessionsForDate(db, dateStr).map(d => {
+    const r = d.result || {};
+    return {
+      id: d.id,
+      query: d.query,
+      status: d.status,
+      created_at: d.created_at,
+      summary: (r.summary || '').slice(0, 600),
+      source_count: (r.sources || []).length,
+      sources: (r.sources || []).slice(0, 8).map(s => ({
+        url: s.url, title: s.title, snippet: (s.snippet || '').slice(0, 200),
+      })),
+    };
+  });
 
   return {
     date: dateStr,
@@ -111,6 +125,7 @@ export function aggregateDay(db, dateStr) {
     first_event_at: firstSeen,
     last_event_at: lastSeen,
     bookmarks,
+    digs,
     sources: {
       visit_events: events.length,
       page_visits: pageVisitsContribution,
@@ -345,9 +360,9 @@ const WORK_CONTENT_PROMPT = ({ dateStr, urlList, totalEvents, totalDomains }) =>
   urlList,
 ].join('\n');
 
-const HIGHLIGHTS_PROMPT = ({ dateStr, workContent, githubByRepo, bookmarkSummary, notes, metrics }) => [
+const HIGHLIGHTS_PROMPT = ({ dateStr, workContent, githubByRepo, bookmarkSummary, digs, notes, metrics }) => [
   `あなたは ${dateStr} の「ハイライト」セクションを書きます。`,
-  '以下の 3 種類の情報を統合し、その日の重要なポイントを箇条書きで 3〜6 個。',
+  '以下の情報を統合し、その日の重要なポイントを箇条書きで 3〜6 個。',
   '事実ベース。憶測や創作はしない。重要度の高い順。',
   '',
   '## 入力 1: 作業内容 (時系列)',
@@ -362,6 +377,14 @@ const HIGHLIGHTS_PROMPT = ({ dateStr, workContent, githubByRepo, bookmarkSummary
   '## 入力 3: GitHub commits (リポジトリごとの件数)',
   githubByRepo.repos.length
     ? githubByRepo.repos.map(r => `- ${r.repo}: ${r.count} commits`).join('\n')
+    : '(なし)',
+  '',
+  '## 入力 4: 当日のディグ調査 (検索 + 取得した情報源)',
+  (digs && digs.length > 0)
+    ? digs.map(d => {
+        const summary = d.summary ? `\n  ${d.summary.slice(0, 300)}` : '';
+        return `- 「${d.query}」 (${d.source_count} 件のソース, ${d.status})${summary}`;
+      }).join('\n')
     : '(なし)',
   '',
   '## メタ情報',
@@ -508,10 +531,10 @@ export async function generateWorkContent({ db, dateStr, metrics, timeoutMs = 18
   return await runLlm({ task: 'diary_work', prompt, timeoutMs });
 }
 
-/** Stage 3: Opus 1M (default) integrates work content + bookmark count + commits into highlights. */
-export async function generateHighlights({ dateStr, workContent, githubByRepo, bookmarkSummary, notes, metrics, timeoutMs = 240_000 }) {
+/** Stage 3: Opus 1M (default) integrates work content + bookmark count + commits + dig into highlights. */
+export async function generateHighlights({ dateStr, workContent, githubByRepo, bookmarkSummary, digs, notes, metrics, timeoutMs = 240_000 }) {
   const prompt = HIGHLIGHTS_PROMPT({
-    dateStr, workContent, githubByRepo, bookmarkSummary, notes, metrics,
+    dateStr, workContent, githubByRepo, bookmarkSummary, digs, notes, metrics,
   });
   return await runLlm({ task: 'diary_highlights', prompt, timeoutMs });
 }
@@ -537,13 +560,14 @@ export async function generateDiary({ db, dateStr, metrics, github, notes }) {
   }
 
   const workContent = await generateWorkContent({ db, dateStr, metrics });
+  const digs = metrics.digs || [];
   const highlights = await generateHighlights({
-    dateStr, workContent, githubByRepo, bookmarkSummary, notes, metrics,
+    dateStr, workContent, githubByRepo, bookmarkSummary, digs, notes, metrics,
   });
 
   // Combined summary for legacy display.
-  const summary = composeSummary({ workContent, githubByRepo, highlights });
-  return { workContent, githubByRepo, highlights, summary };
+  const summary = composeSummary({ workContent, githubByRepo, highlights, digs });
+  return { workContent, githubByRepo, highlights, summary, digs };
 }
 
 function buildBookmarkSummary(metrics) {
@@ -560,9 +584,16 @@ function buildBookmarkSummary(metrics) {
   };
 }
 
-function composeSummary({ workContent, githubByRepo, highlights }) {
+function composeSummary({ workContent, githubByRepo, highlights, digs }) {
   const parts = [];
   if (workContent) parts.push(`## 作業内容\n${workContent.trim()}`);
+  if (digs && digs.length > 0) {
+    const digLines = digs.map(d => {
+      const head = `- 「${d.query}」 (${d.source_count} 件のソース)`;
+      return d.summary ? `${head}\n  ${d.summary.slice(0, 250)}` : head;
+    }).join('\n');
+    parts.push(`## ディグ調査\n${digLines}`);
+  }
   if (githubByRepo.repos.length) {
     const repoLines = githubByRepo.repos
       .map(r => `- ${r.repo}: ${r.count} commits`)

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -1772,6 +1772,28 @@ function renderDiaryDetail() {
     });
   });
 
+  const digs = metrics.digs || [];
+  if (digs.length === 0) {
+    $('diaryDigs').innerHTML = '<li class="queue-empty">この日のディグはなし</li>';
+  } else {
+    $('diaryDigs').innerHTML = digs.map(dg => `
+      <li class="diary-dig" data-id="${dg.id}">
+        <div class="diary-dig-head">
+          <span class="diary-dig-query">${escapeHtml(dg.query)}</span>
+          <span class="diary-dig-meta">${dg.source_count} 件 · ${escapeHtml(dg.status)}</span>
+        </div>
+        ${dg.summary ? `<div class="diary-dig-summary">${escapeHtml(dg.summary)}</div>` : ''}
+      </li>
+    `).join('');
+    $('diaryDigs').querySelectorAll('.diary-dig').forEach(li => {
+      li.addEventListener('click', () => {
+        const id = Number(li.dataset.id);
+        switchTab('dig');
+        loadDigSession(id);
+      });
+    });
+  }
+
   const commits = d.github_commits?.commits || [];
   if (commits.length === 0) {
     $('diaryGithub').innerHTML = `<li class="queue-empty">${d.github_commits?.error ? escapeHtml('GitHub: ' + d.github_commits.error) : 'commit 記録なし'}</li>`;

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -263,6 +263,8 @@
             <ul id="diaryBookmarksCreated" class="diary-bookmarks"></ul>
             <h4>再訪したブックマーク</h4>
             <ul id="diaryBookmarksAccessed" class="diary-bookmarks"></ul>
+            <h4>当日のディグ調査</h4>
+            <ul id="diaryDigs" class="diary-digs"></ul>
             <h4>GitHub commits (リポ別件数)</h4>
             <ul id="diaryGithub" class="diary-github"></ul>
             <h4>メモ・補足</h4>

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -1462,3 +1462,18 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 }
 .ai-keystatus { font-size: 11px; color: var(--muted); display: block; margin-top: -4px; margin-bottom: 8px; }
 .ai-settings-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 14px; }
+
+.diary-digs { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.diary-dig {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  cursor: pointer;
+  font-size: 12px;
+}
+.diary-dig:hover { border-color: var(--accent); }
+.diary-dig-head { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; }
+.diary-dig-query { font-weight: 600; }
+.diary-dig-meta { font-size: 11px; color: var(--muted); }
+.diary-dig-summary { font-size: 11px; color: #2c3344; line-height: 1.5; margin-top: 4px; }


### PR DESCRIPTION
旧 PR #30 の再 PR (base が `feat/diary` だったため #27 マージ時に自動クローズされた)。

## Summary
当日に行ったディグ (dig_sessions) を日記に取り込みます。

- `aggregateDay` が `digSessionsForDate(db, date)` を呼んで同日の dig セッションを収集 → `metrics.digs[]` に格納
- 各 dig: `{ id, query, status, summary, source_count, sources[<=8] }`
- Opus 1M のハイライトプロンプトに 4 つ目の入力 (ディグ調査) を追加
- 詳細パネルに「当日のディグ調査」セクション。クリックでそのディグセッションへジャンプ

## Test plan
- [ ] 任意の日にディグを実行 → その日の日記を再生成 → 「当日のディグ調査」セクションが現れる
- [ ] ハイライト (Opus 1M) の出力にディグ内容が反映される
- [ ] ディグ行をクリックするとディグるタブで該当セッションが開く

🤖 Generated with [Claude Code](https://claude.com/claude-code)