### PR TITLE
feat(ui): sticky tabs + mobile More menu + categories scoped to bookmarks

### DIFF
--- a/server/public/app.js
+++ b/server/public/app.js
@@ -510,6 +510,8 @@ function switchTab(tab) {
   document.querySelectorAll('.tab').forEach(t => {
     t.classList.toggle('active', t.dataset.tab === tab);
   });
+  const layout = document.querySelector('.layout');
+  if (layout) layout.dataset.activeTab = tab;
   $('bookmarksView').classList.toggle('hidden', tab !== 'bookmarks');
   $('queueView').classList.toggle('hidden', tab !== 'queue');
   $('visitsView').classList.toggle('hidden', tab !== 'visits');
@@ -529,6 +531,68 @@ function switchTab(tab) {
   if (tab === 'domain') loadDomainCatalog();
   if (tab === 'diary') loadDiary();
   if (tab === 'events') loadEvents();
+  bumpTabUsage(tab);
+  reflowTabsForViewport();
+  closeTabMoreMenu();
+}
+
+// ── Tab use-count + mobile More menu ──────────────────────────────────────
+const TAB_USAGE_KEY = 'memoria.tabUsage.v1';
+function readTabUsage() {
+  try { return JSON.parse(localStorage.getItem(TAB_USAGE_KEY)) || {}; } catch { return {}; }
+}
+function bumpTabUsage(tab) {
+  const u = readTabUsage();
+  u[tab] = (u[tab] || 0) + 1;
+  try { localStorage.setItem(TAB_USAGE_KEY, JSON.stringify(u)); } catch {}
+}
+function tabsInUsageOrder() {
+  const tabs = [...document.querySelectorAll('.tabs-scroll .tab[data-tab]')];
+  const u = readTabUsage();
+  return tabs.slice().sort((a, b) => (u[b.dataset.tab] || 0) - (u[a.dataset.tab] || 0));
+}
+function closeTabMoreMenu() {
+  const m = $('tabMoreMenu');
+  const b = $('tabMoreBtn');
+  if (m) m.classList.add('hidden');
+  if (b) b.setAttribute('aria-expanded', 'false');
+}
+function reflowTabsForViewport() {
+  const scroll = document.querySelector('.tabs-scroll');
+  const moreWrap = document.querySelector('.tabs-more');
+  const moreMenu = $('tabMoreMenu');
+  if (!scroll || !moreWrap || !moreMenu) return;
+
+  const allTabs = [...scroll.querySelectorAll('.tab[data-tab]')];
+  for (const t of allTabs) t.style.display = '';
+  moreMenu.innerHTML = '';
+
+  const isNarrow = window.innerWidth <= 760;
+  if (!isNarrow) {
+    moreWrap.classList.add('hidden');
+    return;
+  }
+
+  const active = state.tab;
+  const ordered = tabsInUsageOrder();
+  const visibleN = 4;
+  const visible = new Set(ordered.slice(0, visibleN).map(t => t.dataset.tab));
+  if (active) visible.add(active);
+
+  let overflowCount = 0;
+  for (const t of allTabs) {
+    if (visible.has(t.dataset.tab)) {
+      t.style.display = '';
+    } else {
+      t.style.display = 'none';
+      const clone = t.cloneNode(true);
+      clone.classList.toggle('active', t.dataset.tab === active);
+      clone.addEventListener('click', () => switchTab(t.dataset.tab));
+      moreMenu.appendChild(clone);
+      overflowCount += 1;
+    }
+  }
+  moreWrap.classList.toggle('hidden', overflowCount === 0);
 }
 
 // ── Dig (deep research) ──────────────────────────────────────────────────
@@ -2335,9 +2399,25 @@ async function deleteSelectedVisits() {
   await loadVisits();
 }
 
-document.querySelectorAll('.tab').forEach(t => {
+document.querySelectorAll('.tabs-scroll .tab').forEach(t => {
   t.addEventListener('click', () => switchTab(t.dataset.tab));
 });
+$('tabMoreBtn')?.addEventListener('click', (e) => {
+  e.stopPropagation();
+  const menu = $('tabMoreMenu');
+  const btn = $('tabMoreBtn');
+  const open = menu.classList.contains('hidden');
+  menu.classList.toggle('hidden', !open);
+  btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+});
+document.addEventListener('click', (e) => {
+  const menu = $('tabMoreMenu');
+  if (!menu || menu.classList.contains('hidden')) return;
+  if (e.target.closest('.tabs-more')) return;
+  closeTabMoreMenu();
+});
+window.addEventListener('resize', reflowTabsForViewport);
+reflowTabsForViewport();
 
 $('visitsRefresh').addEventListener('click', loadVisits);
 $('visitsRange').addEventListener('change', (e) => {

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -27,7 +27,7 @@
     </div>
   </header>
 
-  <main class="layout">
+  <main class="layout" data-active-tab="bookmarks">
     <aside class="sidebar">
       <h2>カテゴリ</h2>
       <ul id="categoryList"></ul>
@@ -35,25 +35,31 @@
 
     <section class="content">
       <nav class="tabs">
-        <button class="tab active" data-tab="bookmarks">ブックマーク</button>
-        <button class="tab" data-tab="queue">
-          作業キュー
-          <span id="tabQueueCount" class="tab-count hidden">0</span>
-        </button>
-        <button class="tab" data-tab="events">📋 イベント</button>
-        <button class="tab" data-tab="visits">
-          アクセス履歴
-          <span id="tabVisitsCount" class="tab-count hidden">0</span>
-        </button>
-        <button class="tab" data-tab="trends">傾向</button>
-        <button class="tab" data-tab="recommend">
-          おすすめ
-          <span id="tabRecommendCount" class="tab-count hidden">0</span>
-        </button>
-        <button class="tab" data-tab="dig">ディグる</button>
-        <button class="tab" data-tab="dict">📖 辞書</button>
-        <button class="tab" data-tab="domain">🏷 ドメイン</button>
-        <button class="tab" data-tab="diary">📅 日記</button>
+        <div class="tabs-scroll">
+          <button class="tab active" data-tab="bookmarks">ブックマーク</button>
+          <button class="tab" data-tab="queue">
+            作業キュー
+            <span id="tabQueueCount" class="tab-count hidden">0</span>
+          </button>
+          <button class="tab" data-tab="events">📋 イベント</button>
+          <button class="tab" data-tab="visits">
+            アクセス履歴
+            <span id="tabVisitsCount" class="tab-count hidden">0</span>
+          </button>
+          <button class="tab" data-tab="trends">傾向</button>
+          <button class="tab" data-tab="recommend">
+            おすすめ
+            <span id="tabRecommendCount" class="tab-count hidden">0</span>
+          </button>
+          <button class="tab" data-tab="dig">ディグる</button>
+          <button class="tab" data-tab="dict">📖 辞書</button>
+          <button class="tab" data-tab="domain">🏷 ドメイン</button>
+          <button class="tab" data-tab="diary">📅 日記</button>
+        </div>
+        <div class="tabs-more">
+          <button type="button" class="tab tab-more-btn" id="tabMoreBtn" aria-haspopup="true" aria-expanded="false" title="他のタブ">⋯</button>
+          <div id="tabMoreMenu" class="tab-more-menu hidden" role="menu"></div>
+        </div>
       </nav>
 
       <div id="bookmarksView">

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -96,6 +96,15 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 }
 .layout:has(.detail.hidden) { grid-template-columns: 220px 1fr; }
 
+/* Categories sidebar is bookmarks-only — collapse on every other tab. */
+.layout:not([data-active-tab="bookmarks"]) > .sidebar { display: none; }
+.layout:not([data-active-tab="bookmarks"]) {
+  grid-template-columns: 1fr 360px;
+}
+.layout:not([data-active-tab="bookmarks"]):has(.detail.hidden) {
+  grid-template-columns: 1fr;
+}
+
 .sidebar {
   border-right: 1px solid var(--border);
   background: var(--panel);
@@ -116,13 +125,52 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 .sidebar li.active { background: var(--accent-bg); color: var(--accent); font-weight: 600; }
 .sidebar li .count { color: var(--muted); font-size: 12px; }
 
-.content { padding: 16px; overflow-y: auto; }
+.content { padding: 16px; overflow-y: auto; position: relative; }
 .tabs {
   display: flex;
   gap: 4px;
-  margin-bottom: 16px;
+  margin: -16px -16px 16px;
+  padding: 6px 12px 0;
   border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  position: sticky;
+  top: -16px;
+  z-index: 6;
+  align-items: stretch;
 }
+.tabs-scroll {
+  display: flex;
+  gap: 4px;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+}
+.tabs-more { position: relative; flex-shrink: 0; }
+.tab-more-btn { font-weight: 600; }
+.tab-more-menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 4px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 6px 24px rgba(0,0,0,0.12);
+  min-width: 180px;
+  padding: 4px;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.tab-more-menu .tab {
+  border-bottom: 0;
+  justify-content: flex-start;
+  border-radius: 6px;
+  padding: 8px 12px;
+}
+.tab-more-menu .tab.active { background: var(--accent-bg); }
+.tabs-more.hidden { display: none; }
 .tab {
   background: transparent;
   border: 0;
@@ -1508,3 +1556,73 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 .ev-tag { font-weight: 600; min-width: 160px; }
 .ev-time { color: var(--muted); font-family: ui-monospace, monospace; font-size: 11px; }
 .ev-det { font-size: 10px; color: var(--muted); flex-basis: 100%; word-break: break-all; }
+
+/* ──────────────────────────────────────────────────────────────────────
+ * Mobile / narrow viewport
+ * ────────────────────────────────────────────────────────────────────── */
+@media (max-width: 760px) {
+  body { font-size: 13px; }
+
+  .topbar {
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 8px 12px;
+  }
+  .topbar-controls { width: 100%; flex-wrap: wrap; margin-left: 0; }
+  .topbar-controls input[type=search] { flex: 1 1 100%; min-width: 0; }
+
+  /* Drop the categories sidebar and right-hand detail rail by default;
+     bookmark detail becomes a full-screen overlay. */
+  .layout,
+  .layout:not([data-active-tab="bookmarks"]),
+  .layout:has(.detail.hidden),
+  .layout:not([data-active-tab="bookmarks"]):has(.detail.hidden) {
+    grid-template-columns: 1fr;
+    height: auto;
+    min-height: calc(100vh - 53px);
+  }
+  .sidebar { display: none; }
+
+  .detail {
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    background: var(--panel);
+    border: 0;
+    overflow-y: auto;
+    padding: 12px;
+  }
+  .detail.hidden { display: none; }
+
+  .content { padding: 12px; }
+
+  /* Sticky tabs: keep a single horizontal scroller and reveal the More menu
+     when the row would otherwise wrap. */
+  .tabs {
+    margin: -12px -12px 12px;
+    padding: 4px 8px 0;
+    top: -12px;
+  }
+  .tabs-scroll {
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .tabs-scroll::-webkit-scrollbar { display: none; }
+
+  /* Diary collapses to a single column; calendar then detail. */
+  .diary-layout {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+  .diary-detail { padding: 12px; }
+  .diary-pie-row { flex-direction: column; }
+
+  /* Bookmark cards stack rather than tile. */
+  .cards { grid-template-columns: 1fr; }
+
+  /* Trends grid → single column. */
+  .trends-grid { grid-template-columns: 1fr; }
+
+  /* Dictionary / domain detail panes float over the list. */
+  .dict-layout { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
## Summary
- Sticky tabs row inside the content scroll area; navigation stays in reach when scrolling diary, events, or dig output.
- Categories sidebar (left rail) is now bookmarks-only — it collapses on every other tab and the layout reclaims the space.
- Mobile (<= 760px): single-column layout, off-canvas bookmark detail, sticky tab row becomes a horizontal scroller with a `⋯` **More** dropdown.
- More menu pulls items by per-tab use count (`localStorage.memoria.tabUsage.v1`); least-used tabs sink into the dropdown.
- Diary / trends / dictionary / domain catalogue reflow to a single column on narrow viewports.

## Test plan
- [ ] Desktop: open each tab; categories sidebar shows only on bookmarks tab, tabs stay sticky while scrolling diary detail
- [ ] Mobile (DevTools 360 / 414): tab row scrolls horizontally and the `⋯` button reveals overflow tabs
- [ ] Mobile: diary calendar and detail stack in one column; pie row stacks
- [ ] Mobile: bookmark detail covers the screen; closing returns to the list
- [ ] Use the same tab repeatedly, then resize to mobile — that tab stays visible while less-used ones drop into More

🤖 Generated with [Claude Code](https://claude.com/claude-code)