### PR TITLE
feat(pwa): web share target + iOS Shortcut template

### DIFF
--- a/docs/mobile-share.md
+++ b/docs/mobile-share.md
@@ -1,0 +1,64 @@
+# Mobile share → Memoria
+
+Memoria registers itself as a Web Share Target so the OS share sheet can hand a
+URL straight to the server, which queues the page just like a Chrome-extension
+save.
+
+The plumbing:
+
+1. `server/public/manifest.webmanifest` declares `share_target.action = /share`.
+2. The browser sends `GET /share?url=…&title=…&text=…` once the user installs
+   Memoria as a PWA.
+3. `app.get('/share')` in `server/index.js` extracts the first http(s) URL it
+   can find (preferring `url`, falling back to a regex over `text` / `title`),
+   calls `bulkSaveUrls([url])`, and 303-redirects to `/?share=ok&u=…`.
+4. The SPA shows a one-shot toast confirming the save.
+
+## Android (Chrome / Edge / Brave)
+
+1. Open `https://<your-memoria-host>/` in Chrome.
+2. Menu → **Add to Home screen** (or **Install app**).
+3. Once installed, **Memoria** appears in the share sheet of any app.
+4. Sharing a page hands the URL to `/share`. Memoria fetches the HTML on the
+   server, summarises, and adds it to the bookmark queue.
+
+## iOS (Safari)
+
+iOS Safari does **not** implement Web Share Target — there is no way for a PWA
+to register in the iOS share sheet. The workaround is an iOS Shortcut:
+
+1. Open the **Shortcuts** app.
+2. Tap **+** → **New Shortcut**.
+3. Add the **Get URLs from Input** action.
+4. Add **URL** (`https://<your-memoria-host>/share?url=`).
+5. Add **Combine Text** to concatenate the URL above with the URL from step 3
+   (URL-encoded). The simplest way: use the **URL Encode** action between
+   them, then **Get Contents of URL** with method `GET`.
+6. Toggle **Show in Share Sheet** in shortcut settings.
+7. Set **Share Sheet Types** to **URLs**.
+
+A starter `.shortcut` JSON-equivalent (paste into the Shortcut text editor):
+
+```text
+Action 1: Get Contents of URL
+  URL: https://YOUR-HOST/share?url=[URL Encoded Shortcut Input]
+  Method: GET
+  Headers: (none)
+```
+
+Once saved, sharing any URL from Safari → Memoria runs the shortcut, the
+server saves the page, and the response (the redirect to `/?share=ok…`) is
+discarded.
+
+## Local-only / private deployments
+
+If Memoria is reachable only on localhost, the PWA install path still works on
+desktop (Chrome → Install app). Mobile share targets require a publicly
+addressable HTTPS host — typical patterns:
+
+- Tailscale + custom DNS for personal use.
+- Reverse-proxy (Caddy / Cloudflare Tunnel) in front of `npm start`.
+
+The `/share` handler trusts whoever can reach it, so do not expose the server
+to the open internet without authentication. Multi-server mode (issue #34)
+will add Cernere SSO in front of `/share` and the rest of the API.

--- a/server/index.js
+++ b/server/index.js
@@ -1716,6 +1716,40 @@ function scheduleSundayEvening() {
 }
 scheduleSundayEvening();
 
+// ---- PWA Web Share Target -------------------------------------------------
+//
+// PWA share_target (manifest.webmanifest) routes the OS share sheet here on
+// Android. iOS has no PWA share_target — the iOS Shortcut template in
+// docs/mobile-share.md drives this same endpoint instead.
+//
+// Inputs (all optional, supplied by the share sheet):
+//   ?title=…  ?text=…  ?url=…
+// We extract the first http(s) URL we can find, kick off a server-side fetch
+// + summarize via the existing bulk-save path, then redirect back to the SPA.
+function extractShareUrl(q) {
+  const direct = (q.get('url') || '').trim();
+  if (/^https?:\/\//i.test(direct)) return direct;
+  for (const key of ['text', 'title']) {
+    const v = (q.get(key) || '').trim();
+    const m = v.match(/https?:\/\/\S+/i);
+    if (m) return m[0].replace(/[.,;:!?)\]]+$/g, '');
+  }
+  return null;
+}
+
+app.get('/share', async (c) => {
+  const q = new URL(c.req.url).searchParams;
+  const target = extractShareUrl(q);
+  if (!target) {
+    return c.redirect('/?share=invalid', 303);
+  }
+  // Fire-and-forget — bulkSaveUrls handles dedup and queues the summary.
+  bulkSaveUrls([target]).catch(err => {
+    console.error('[share] bulkSaveUrls failed:', err.message);
+  });
+  return c.redirect('/?share=ok&u=' + encodeURIComponent(target), 303);
+});
+
 // ---- static UI ------------------------------------------------------------
 
 app.use('/*', serveStatic({ root: './public' }));

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -2958,3 +2958,22 @@ document.getElementById('multiRefresh')?.addEventListener('click', loadMulti);
 
 // First paint: surface the multi tab if we're already connected.
 refreshMultiTabVisibility();
+
+// ── PWA share_target landing ───────────────────────────────────────────────
+// /share redirects back here with ?share=ok&u=<url> after queueing the save.
+(function pwaShareToast() {
+  const params = new URLSearchParams(location.search);
+  const flag = params.get('share');
+  if (!flag) return;
+  const u = params.get('u') || '';
+  const div = document.createElement('div');
+  div.className = 'share-toast';
+  div.textContent = flag === 'ok'
+    ? `📌 「${u}」を保存しました`
+    : '⚠ 共有された URL を解釈できませんでした';
+  document.body.appendChild(div);
+  setTimeout(() => div.remove(), 4000);
+  // Strip the query so reload doesn't re-show the toast.
+  history.replaceState({}, '', location.pathname);
+})();
+

--- a/server/public/icon-192.svg
+++ b/server/public/icon-192.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" width="192" height="192">
+  <rect width="192" height="192" rx="32" fill="#2a6df4"/>
+  <path d="M48 56h12l16 28 16-28h12v80h-12V80l-12 22h-8L60 80v56H48z" fill="#fff"/>
+  <circle cx="148" cy="56" r="12" fill="#ffd166"/>
+</svg>

--- a/server/public/icon-512.svg
+++ b/server/public/icon-512.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" rx="96" fill="#2a6df4"/>
+  <path d="M128 152h32l44 76 44-76h32v208h-32V216l-32 56h-24l-32-56v144h-32z" fill="#fff"/>
+  <circle cx="392" cy="148" r="32" fill="#ffd166"/>
+</svg>

--- a/server/public/icon-maskable.svg
+++ b/server/public/icon-maskable.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" fill="#2a6df4"/>
+  <g transform="translate(0 24)">
+    <path d="M168 192h28l40 64 40-64h28v160h-28V244l-30 48h-20l-30-48v108h-28z" fill="#fff"/>
+    <circle cx="356" cy="188" r="22" fill="#ffd166"/>
+  </g>
+</svg>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -3,7 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#2a6df4" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-title" content="Memoria" />
   <title>Memoria</title>
+  <link rel="manifest" href="manifest.webmanifest" />
+  <link rel="apple-touch-icon" href="icon-192.svg" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/server/public/manifest.webmanifest
+++ b/server/public/manifest.webmanifest
@@ -1,0 +1,24 @@
+{
+  "name": "Memoria",
+  "short_name": "Memoria",
+  "description": "Personal bookmark + dig + diary workspace",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#f6f7f9",
+  "theme_color": "#2a6df4",
+  "icons": [
+    { "src": "icon-192.svg", "sizes": "192x192", "type": "image/svg+xml", "purpose": "any" },
+    { "src": "icon-512.svg", "sizes": "512x512", "type": "image/svg+xml", "purpose": "any" },
+    { "src": "icon-maskable.svg", "sizes": "512x512", "type": "image/svg+xml", "purpose": "maskable" }
+  ],
+  "share_target": {
+    "action": "/share",
+    "method": "GET",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Memoria is now a PWA with a `share_target` so Android share sheets can hand a URL directly to the server.
- New endpoint `GET /share` parses `url`/`text`/`title`, fires `bulkSaveUrls([url])`, and redirects to `/?share=ok&u=…`.
- One-shot toast on landing for visible feedback.
- Manifest icons are 3 inline SVGs (192/512 + maskable), keeping CI free of binary asset generation.
- `docs/mobile-share.md` documents Android install + the iOS Shortcut workaround (iOS Safari does not implement Web Share Target).

## Test plan
- [ ] Install Memoria as a PWA on Android Chrome and confirm it appears in the share sheet
- [ ] Share a URL → Memoria; verify the bookmark appears in the queue and the toast renders
- [ ] On iOS, follow `docs/mobile-share.md` to set up the Shortcut and confirm it round-trips through `/share`
- [ ] Hit `/share?text=hello%20https://example.com` directly to confirm regex extraction
- [ ] Hit `/share?title=no%20url` and confirm the redirect uses `share=invalid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)