### PR TITLE
feat(arch): Phase 0 — db façade + core/local/multi seams (#34)

### DIFF
--- a/server/core/README.md
+++ b/server/core/README.md
@@ -1,0 +1,31 @@
+# `server/core/` — Shareable resources
+
+The three resource types that can be shared between the local server and the
+multi server (Memoria Hub) live here:
+
+- **bookmarks** — fetched HTML, summary, categories, word cloud
+- **dig sessions** — deep-research queries with their results
+- **dictionary entries** — user-curated terms and definitions
+
+The Multi server only ever serves these three kinds. Anything else (diary,
+visit history, domain catalogue, page metadata, uptime tracking, work queue)
+belongs in [`server/local/`](../local/README.md).
+
+## Phase 0 placement
+
+The implementation files are still living at `server/*.js` so the smoke test
+keeps working. As of Phase 0 this directory is the **target** for the move
+in a follow-up cleanup PR — see the import map in
+[`docs/multi-server-architecture.md`](../../docs/multi-server-architecture.md).
+
+When the move happens these files migrate here:
+
+| current path | future path |
+| --- | --- |
+| `server/claude.js` | `server/core/claude.js` |
+| `server/dig.js` | `server/core/dig.js` |
+| `server/wordcloud.js` | `server/core/wordcloud.js` |
+| `server/llm.js` | `server/core/llm.js` |
+
+DB access goes through [`../db/`](../db/README.md) so the Postgres adapter
+slots in cleanly under either local or multi mode.

--- a/server/db/README.md
+++ b/server/db/README.md
@@ -1,0 +1,38 @@
+# `server/db/` — Database abstraction seam
+
+Phase 0 introduces this folder as the seam where the **SQLite** local-server
+backend and the future **Postgres** multi-server backend will live side by
+side. Until Phase 2 lands a Postgres adapter, only `sqlite.js` is real.
+
+```
+db/
+├── index.js   ← façade: picks an adapter (SQLite default), re-exports the
+│                same surface that the old monolithic `server/db.js` did.
+├── sqlite.js  ← thin wrapper around `../db.js` (the current 1000+ line
+│                better-sqlite3 module). Phase 0 keeps the implementation
+│                in place to keep the smoke test green.
+└── postgres.js (Phase 2) ← Cernere-fronted multi-server adapter.
+```
+
+## Why a façade rather than a hard move
+
+The legacy `server/db.js` has hundreds of named exports consumed by
+`index.js`, `diary.js`, `dig.js`, etc. Renaming every import in one PR risks
+silent breakage (CI smoke does a `node --check`, not a full run of every
+endpoint). The façade lets us:
+
+1. Move call sites to `from './db/index.js'` incrementally per module.
+2. Plug a Postgres adapter for the multi server without touching local code.
+3. Keep the legacy `server/db.js` import path working until every caller has
+   migrated.
+
+## Selecting an adapter
+
+`openDb(dbPath, { kind } = {})` accepts:
+
+- `kind: 'sqlite'` (default) — the current implementation.
+- `kind: 'postgres'` (Phase 2) — opens a connection pool against the URL in
+  `MEMORIA_PG_URL`. `dbPath` is ignored.
+
+The Multi server boots with `MEMORIA_MODE=multi` (Phase 7) and sets the
+adapter at startup; everything else stays adapter-agnostic.

--- a/server/db/index.js
+++ b/server/db/index.js
@@ -1,0 +1,30 @@
+// Database façade.
+//
+// Picks an adapter at runtime so the rest of the server can stay agnostic.
+// Default is SQLite (local server). Phase 2 will register a Postgres
+// adapter for the multi server (Memoria Hub).
+//
+// Today the SQLite adapter just re-exports `../db.js`; this seam exists so
+// callers can migrate `from '../db.js'` → `from '../db/index.js'` without
+// disrupting behaviour. New modules should target this façade.
+import * as sqlite from './sqlite.js';
+
+const ADAPTER = (process.env.MEMORIA_DB_KIND || 'sqlite').toLowerCase();
+
+function pickAdapter(kind) {
+  switch (kind) {
+    case 'sqlite':
+      return sqlite;
+    case 'postgres':
+      throw new Error('postgres adapter is not yet implemented (Phase 2)');
+    default:
+      throw new Error(`unknown MEMORIA_DB_KIND: ${kind}`);
+  }
+}
+
+const adapter = pickAdapter(ADAPTER);
+
+// Re-export the adapter's full surface so importers can `import { … } from
+// 'server/db/index.js'` without caring which backend is active.
+export const openDb = adapter.openDb;
+export * from './sqlite.js';

--- a/server/db/sqlite.js
+++ b/server/db/sqlite.js
@@ -1,0 +1,7 @@
+// SQLite adapter for the local server.
+//
+// Phase 0 implementation: re-export the legacy monolithic `server/db.js`
+// so call sites can migrate one at a time. When Phase 2 adds a Postgres
+// adapter, both will sit behind `./index.js`.
+export * from '../db.js';
+export { openDb as default } from '../db.js';

--- a/server/index.js
+++ b/server/index.js
@@ -50,7 +50,7 @@ import {
 import { classifyDomain, shouldSkipDomain } from './domain-catalog.js';
 import { fetchPageMetadata } from './page-metadata.js';
 import { extractWordCloud, validateWordRelevance } from './wordcloud.js';
-import { startUptimeTracking, readHeartbeat, DOWNTIME_THRESHOLD_MS } from './uptime.js';
+import { startUptimeTracking, readHeartbeat, DOWNTIME_THRESHOLD_MS } from './local/uptime.js';
 import { listServerEvents, listServerEventsForDate } from './db.js';
 import {
   aggregateDay, fetchGithubActivity, fetchGithubRange,

--- a/server/local/README.md
+++ b/server/local/README.md
@@ -1,0 +1,27 @@
+# `server/local/` — Local-only features
+
+Everything that the multi server (Memoria Hub) does **not** ship lives here.
+These features assume a single user and a single SQLite database file —
+i.e. they do not need to think about `owner_user_id`.
+
+| feature | module |
+| --- | --- |
+| Visit history (`page_visits` / `visit_events`) | `local/visits.js` |
+| Daily diary + weekly report | `local/diary.js` |
+| Domain catalogue | `local/domain-catalog.js` |
+| Per-page metadata (og:* + Sonnet kind) | `local/page-metadata.js` |
+| Uptime + downtime tracking | `local/uptime.js` |
+| Work queue + queue history | `local/queue.js` (TODO) |
+| GitHub commits → diary | `local/github.js` (TODO) |
+| Recommendations (未訪問リンク) | `local/recommendations.js` |
+
+## Phase 0 placement
+
+As with [`../core/`](../core/README.md), the actual implementations are
+still at `server/*.js` to keep the CI smoke test green. They migrate here
+in a follow-up cleanup PR. Until then this directory holds READMEs and
+new modules.
+
+The DB layer is shared with `core/` via [`../db/`](../db/README.md). All
+local-only tables (`page_visits`, `domain_catalog`, `diary_entries`,
+`server_events`, etc.) live in the SQLite adapter.

--- a/server/local/uptime.js
+++ b/server/local/uptime.js
@@ -11,7 +11,7 @@
 
 import { writeFileSync, readFileSync, existsSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
-import { insertServerEvent } from './db.js';
+import { insertServerEvent } from '../db/index.js';
 
 const TICK_MS = 1000;
 const RESTART_GRACE_MS = 5 * 60 * 1000; // 5 minutes — see DOWNTIME_THRESHOLD_MS


### PR DESCRIPTION
## Summary
Issue #34 Phase 0. Establishes the structural boundary the multi-server work needs to plug into, without yet pulling every legacy module out of `server/*.js` (those follow as cleanup PRs to keep the CI smoke green).

- **`server/db/` façade.** `db/index.js` selects an adapter by `MEMORIA_DB_KIND` (`sqlite` by default). `db/sqlite.js` re-exports the legacy `server/db.js` so existing call sites stay valid. Phase 2 will land `db/postgres.js` for the multi server.
- **`server/core/` and `server/local/` directories** with READMEs that map every legacy module (`claude.js`, `dig.js`, `wordcloud.js`, `llm.js` → core; visits/diary/domain/page-meta/uptime/recommendations → local) to its future home.
- One concrete migration exercises the seam: `server/uptime.js` → `server/local/uptime.js`, now importing through the db façade.

Phase 1 schema work landed in #35; Phases 2–7 (Cernere SSO + share/download flows) build on this seam.

## Test plan
- [x] `node --check` on every relocated and new file
- [ ] CI lint + smoke boots, saves a bookmark, drains the queue
- [ ] Verify the only consumer of `./uptime.js` was `index.js` (updated to `./local/uptime.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)