### PR TITLE
feat(multi): Phase 3 — local share button + Hub connect/disconnect (#34)

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -479,6 +479,27 @@ export function digSessionsForDate(db, dateStr) {
 
 function safeParse(s) { try { return JSON.parse(s); } catch { return null; } }
 
+// ── share metadata --------------------------------------------------------
+//
+// Mark a local row as having been forwarded to a multi server. owner_user_id
+// stays NULL on the local side (NULL = "this is mine") — the multi-side row
+// is the one that carries the Cernere user id. shared_origin records the
+// remote we forwarded to so re-shares can be detected later.
+export function markBookmarkShared(db, id, { sharedAt, sharedOrigin }) {
+  db.prepare(`UPDATE bookmarks SET shared_at = ?, shared_origin = ? WHERE id = ?`)
+    .run(sharedAt, sharedOrigin, id);
+}
+
+export function markDigShared(db, id, { sharedAt, sharedOrigin }) {
+  db.prepare(`UPDATE dig_sessions SET shared_at = ?, shared_origin = ? WHERE id = ?`)
+    .run(sharedAt, sharedOrigin, id);
+}
+
+export function markDictionaryShared(db, id, { sharedAt, sharedOrigin }) {
+  db.prepare(`UPDATE dictionary_entries SET shared_at = ?, shared_origin = ? WHERE id = ?`)
+    .run(sharedAt, sharedOrigin, id);
+}
+
 // ── app settings (key/value) ----------------------------------------------
 
 export function getAppSettings(db) {

--- a/server/index.js
+++ b/server/index.js
@@ -62,6 +62,14 @@ import {
   getLlmConfig, loadLlmConfigFromSettings, settingsPatchFromConfig,
 } from './llm.js';
 import { getAppSettings, setAppSettings } from './db.js';
+import {
+  markBookmarkShared, markDigShared, markDictionaryShared,
+} from './db.js';
+import {
+  readMultiState, isConnected,
+  saveMultiUrl, saveMultiSession, clearMultiSession,
+  fetchMe, shareBookmark, shareDig, shareDictionary,
+} from './local/multi-client.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PORT = Number(process.env.MEMORIA_PORT ?? 5180);
@@ -881,6 +889,97 @@ app.patch('/api/llm/config', async (c) => {
   setAppSettings(db, patch);
   loadLlmConfigFromSettings(getAppSettings(db));
   return c.json({ ok: true });
+});
+
+// ---- multi server (Memoria Hub) integration --------------------------------
+//
+// Phase 3: 📤 share button + connection management. The local server keeps a
+// JWT in app_settings and forwards local resources through /api/shared/*.
+
+app.get('/api/multi/status', (c) => {
+  const state = readMultiState(db);
+  return c.json({
+    connected: isConnected(state),
+    url: state.url,
+    user: isConnected(state)
+      ? { id: state.userId, name: state.userName, role: state.role }
+      : null,
+    connected_at: state.connectedAt,
+  });
+});
+
+app.post('/api/multi/connect', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  if (!body?.url) return c.json({ error: 'url required' }, 400);
+  saveMultiUrl(db, body.url);
+  // The browser drives the OAuth dance — we just hand back the URL it
+  // should bounce through, plus the redirect that Cernere/Hub will use.
+  const redirectBack = body.redirect_uri || 'http://localhost:5180/?multi=connected';
+  const start = `${body.url.replace(/\/$/, '')}/api/auth/start?redirect_uri=${encodeURIComponent(redirectBack)}`;
+  return c.json({ ok: true, authorize_url: start });
+});
+
+app.post('/api/multi/finish', async (c) => {
+  // Called by the SPA after it pulls `memoria_hub_jwt` out of the URL
+  // hash/query that Cernere → Hub forwarded back. Verifies + stashes.
+  const body = await c.req.json().catch(() => null);
+  if (!body?.jwt) return c.json({ error: 'jwt required' }, 400);
+  const state = { ...readMultiState(db), jwt: body.jwt };
+  if (!state.url) return c.json({ error: 'multi url not configured' }, 400);
+  // Round-trip /api/me to validate the token and pull the user info.
+  let me;
+  try { me = await fetchMe(state); }
+  catch (e) { return c.json({ error: `verify failed: ${e.message}` }, 401); }
+  saveMultiSession(db, {
+    jwt: body.jwt,
+    userId: me.userId,
+    userName: me.displayName,
+    role: me.role,
+  });
+  return c.json({ ok: true, user: me });
+});
+
+app.post('/api/multi/disconnect', (c) => {
+  clearMultiSession(db);
+  return c.json({ ok: true });
+});
+
+// Body: { kind: 'bookmark' | 'dig' | 'dict', id }
+app.post('/api/multi/share', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  if (!body?.kind || body.id == null) return c.json({ error: 'kind+id required' }, 400);
+  const state = readMultiState(db);
+  if (!isConnected(state)) return c.json({ error: 'not_connected' }, 400);
+
+  try {
+    if (body.kind === 'bookmark') {
+      const b = getBookmark(db, body.id);
+      if (!b) return c.json({ error: 'not_found' }, 404);
+      const r = await shareBookmark(state, b);
+      markBookmarkShared(db, body.id, { sharedAt: r.shared_at, sharedOrigin: state.url });
+      return c.json({ ok: true, remote: r });
+    }
+    if (body.kind === 'dig') {
+      const d = getDigSession(db, body.id);
+      if (!d) return c.json({ error: 'not_found' }, 404);
+      const r = await shareDig(state, {
+        query: d.query, status: d.status, result: d.result,
+      });
+      markDigShared(db, body.id, { sharedAt: r.shared_at, sharedOrigin: state.url });
+      return c.json({ ok: true, remote: r });
+    }
+    if (body.kind === 'dict') {
+      const e = getDictionaryEntry(db, body.id);
+      if (!e) return c.json({ error: 'not_found' }, 404);
+      const r = await shareDictionary(state, e);
+      markDictionaryShared(db, body.id, { sharedAt: r.shared_at, sharedOrigin: state.url });
+      return c.json({ ok: true, remote: r });
+    }
+    return c.json({ error: 'unknown kind' }, 400);
+  } catch (e) {
+    console.error('[multi/share]', e);
+    return c.json({ error: e.message }, e.status || 500);
+  }
 });
 
 // ---- server events / uptime -----------------------------------------------

--- a/server/local/multi-client.js
+++ b/server/local/multi-client.js
@@ -1,0 +1,120 @@
+// Local-side client for the multi server (Memoria Hub).
+//
+// Wraps the JWT plumbing — the rest of the local server just passes the
+// resource shape. Connection state lives in app_settings (`multi_url`,
+// `multi_jwt`, `multi_user_id`, `multi_user_name`, `multi_role`,
+// `multi_connected_at`), so it survives restarts.
+import { getAppSettings, setAppSettings } from '../db/index.js';
+
+const SETTING_KEYS = {
+  url: 'multi_url',
+  jwt: 'multi_jwt',
+  userId: 'multi_user_id',
+  userName: 'multi_user_name',
+  role: 'multi_role',
+  connectedAt: 'multi_connected_at',
+};
+
+export function readMultiState(db) {
+  const s = getAppSettings(db);
+  return {
+    url:         s[SETTING_KEYS.url] || null,
+    jwt:         s[SETTING_KEYS.jwt] || null,
+    userId:      s[SETTING_KEYS.userId] || null,
+    userName:    s[SETTING_KEYS.userName] || null,
+    role:        s[SETTING_KEYS.role] || null,
+    connectedAt: s[SETTING_KEYS.connectedAt] || null,
+  };
+}
+
+export function isConnected(state) {
+  return Boolean(state.url && state.jwt && state.userId);
+}
+
+export function saveMultiUrl(db, url) {
+  setAppSettings(db, { [SETTING_KEYS.url]: url });
+}
+
+export function saveMultiSession(db, { jwt, userId, userName, role }) {
+  setAppSettings(db, {
+    [SETTING_KEYS.jwt]: jwt,
+    [SETTING_KEYS.userId]: userId,
+    [SETTING_KEYS.userName]: userName,
+    [SETTING_KEYS.role]: role || 'user',
+    [SETTING_KEYS.connectedAt]: new Date().toISOString(),
+  });
+}
+
+export function clearMultiSession(db) {
+  setAppSettings(db, {
+    [SETTING_KEYS.jwt]: null,
+    [SETTING_KEYS.userId]: null,
+    [SETTING_KEYS.userName]: null,
+    [SETTING_KEYS.role]: null,
+    [SETTING_KEYS.connectedAt]: null,
+  });
+}
+
+// ── HTTP helpers ─────────────────────────────────────────────────────────
+
+export async function multiFetch(state, path, init = {}) {
+  if (!isConnected(state)) throw new Error('not connected to a multi server');
+  const url = `${state.url.replace(/\/$/, '')}${path}`;
+  const headers = {
+    ...(init.headers || {}),
+    'Authorization': `Bearer ${state.jwt}`,
+    'X-Memoria-Origin': 'local',
+  };
+  if (init.body && !headers['Content-Type']) headers['Content-Type'] = 'application/json';
+  const res = await fetch(url, { ...init, headers });
+  const text = await res.text();
+  let body;
+  try { body = text ? JSON.parse(text) : null; } catch { body = text; }
+  if (!res.ok) {
+    const msg = (body && body.error) || `HTTP ${res.status}`;
+    const err = new Error(`multi ${path} failed: ${msg}`);
+    err.status = res.status;
+    err.body = body;
+    throw err;
+  }
+  return body;
+}
+
+export async function shareBookmark(state, b) {
+  return multiFetch(state, '/api/shared/bookmarks', {
+    method: 'POST',
+    body: JSON.stringify({
+      url: b.url,
+      title: b.title,
+      summary: b.summary || null,
+      memo: b.memo || '',
+      categories: b.categories || [],
+    }),
+  });
+}
+
+export async function shareDig(state, d) {
+  return multiFetch(state, '/api/shared/digs', {
+    method: 'POST',
+    body: JSON.stringify({
+      query: d.query,
+      status: d.status,
+      result: d.result || null,
+    }),
+  });
+}
+
+export async function shareDictionary(state, e) {
+  return multiFetch(state, '/api/shared/dictionary', {
+    method: 'POST',
+    body: JSON.stringify({
+      term: e.term,
+      definition: e.definition || null,
+      notes: e.notes || null,
+    }),
+  });
+}
+
+export async function fetchMe(state) {
+  return multiFetch(state, '/api/me');
+}

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -692,6 +692,9 @@ async function loadDigSession(id) {
 function renderDigSession() {
   const s = state.digSession;
   const el = $('digResult');
+  const shareBar = $('digShareBar');
+  if (shareBar) shareBar.hidden = !(s && s.status === 'done' && state.multi?.connected);
+  if ($('digShareStatus')) $('digShareStatus').textContent = '';
   if (!s) { el.innerHTML = ''; return; }
   if (s.status === 'pending') {
     if (s.preview) {
@@ -2518,6 +2521,133 @@ async function openAiSettings() {
     console.error(e);
     alert(`設定取得失敗: ${e.message}`);
   }
+  await refreshMultiStatus();
+}
+
+// ── Multi-server (Memoria Hub) connection ─────────────────────────────────
+async function refreshMultiStatus() {
+  try {
+    const s = await api('/api/multi/status');
+    state.multi = s;
+    if ($('multiUrl')) $('multiUrl').value = s.url || '';
+    const status = $('multiStatus');
+    if (s.connected) {
+      status.innerHTML = `✓ <b>${escapeHtml(s.user.name)}</b> (${escapeHtml(s.user.role)}) として接続中 — ${escapeHtml(s.url)}`;
+      $('multiDisconnectBtn').hidden = false;
+      $('multiConnectBtn').textContent = '再接続';
+    } else {
+      status.textContent = s.url ? '未接続' : '(URL を入力して接続)';
+      $('multiDisconnectBtn').hidden = true;
+      $('multiConnectBtn').textContent = '接続';
+    }
+    // Share buttons reflect connection state.
+    document.querySelectorAll('#dShare, #dictShareBtn, #digShareBtn').forEach(b => {
+      b.hidden = !s.connected;
+    });
+    if (!s.connected && $('digShareBar')) $('digShareBar').hidden = true;
+  } catch (e) { console.error(e); }
+}
+
+async function multiConnect() {
+  const url = $('multiUrl').value.trim();
+  if (!url) { alert('URL を入力してください'); return; }
+  const r = await api('/api/multi/connect', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url, redirect_uri: location.origin + '/' }),
+  });
+  // Bounce through Cernere via the Hub.
+  location.href = r.authorize_url;
+}
+
+async function multiDisconnect() {
+  if (!confirm('マルチサーバから切断しますか?')) return;
+  await api('/api/multi/disconnect', { method: 'POST' });
+  await refreshMultiStatus();
+}
+
+async function multiFinishFromUrl() {
+  const params = new URLSearchParams(location.search);
+  const jwt = params.get('memoria_hub_jwt');
+  if (!jwt) return;
+  try {
+    const r = await api('/api/multi/finish', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jwt }),
+    });
+    showShareToast(`🌐 ${r.user.displayName} としてマルチサーバに接続しました`);
+  } catch (e) {
+    alert(`マルチ接続失敗: ${e.message}`);
+  } finally {
+    history.replaceState({}, '', location.pathname);
+    await refreshMultiStatus();
+  }
+}
+
+function showShareToast(text) {
+  const div = document.createElement('div');
+  div.className = 'share-toast';
+  div.textContent = text;
+  document.body.appendChild(div);
+  setTimeout(() => div.remove(), 4000);
+}
+
+async function shareCurrentBookmark() {
+  if (state.detailId == null) return;
+  const btn = $('dShare');
+  btn.disabled = true;
+  $('dShareStatus').textContent = '送信中…';
+  try {
+    await api('/api/multi/share', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ kind: 'bookmark', id: state.detailId }),
+    });
+    $('dShareStatus').textContent = '✓ 共有しました';
+  } catch (e) {
+    $('dShareStatus').textContent = `✗ ${e.message}`;
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+async function shareCurrentDict() {
+  if (!state.dictDetail?.id) return;
+  const btn = $('dictShareBtn');
+  btn.disabled = true;
+  $('dictShareStatus').textContent = '送信中…';
+  try {
+    await api('/api/multi/share', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ kind: 'dict', id: state.dictDetail.id }),
+    });
+    $('dictShareStatus').textContent = '✓ 共有しました';
+  } catch (e) {
+    $('dictShareStatus').textContent = `✗ ${e.message}`;
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+async function shareCurrentDig() {
+  if (!state.digSession?.id) return;
+  const btn = $('digShareBtn');
+  btn.disabled = true;
+  $('digShareStatus').textContent = '送信中…';
+  try {
+    await api('/api/multi/share', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ kind: 'dig', id: state.digSession.id }),
+    });
+    $('digShareStatus').textContent = '✓ 共有しました';
+  } catch (e) {
+    $('digShareStatus').textContent = `✗ ${e.message}`;
+  } finally {
+    btn.disabled = false;
+  }
 }
 
 async function saveAiSettings() {
@@ -2555,6 +2685,15 @@ async function saveAiSettings() {
 document.getElementById('aiSettingsBtn')?.addEventListener('click', openAiSettings);
 document.getElementById('aiSettingsClose')?.addEventListener('click', () => $('aiSettingsPanel').classList.add('hidden'));
 document.getElementById('aiSettingsSave')?.addEventListener('click', saveAiSettings);
+document.getElementById('multiConnectBtn')?.addEventListener('click', multiConnect);
+document.getElementById('multiDisconnectBtn')?.addEventListener('click', multiDisconnect);
+document.getElementById('dShare')?.addEventListener('click', shareCurrentBookmark);
+document.getElementById('dictShareBtn')?.addEventListener('click', shareCurrentDict);
+document.getElementById('digShareBtn')?.addEventListener('click', shareCurrentDig);
+
+// Pull JWT out of OAuth redirect on first paint, then prime the share buttons.
+multiFinishFromUrl();
+refreshMultiStatus();
 
 // ── Events / uptime ────────────────────────────────────────────────────
 async function loadEvents() {

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -146,6 +146,10 @@
         </div>
         <div id="digHistory" class="dig-history"></div>
         <div id="cloudView" class="dig-cloud"></div>
+        <div id="digShareBar" class="dig-share-bar" hidden>
+          <button id="digShareBtn" class="ghost" title="マルチサーバに共有">📤 シェア</button>
+          <span id="digShareStatus" class="share-status"></span>
+        </div>
         <div id="digResult" class="dig-result"></div>
       </div>
 
@@ -170,6 +174,8 @@
             <div class="dict-detail-head">
               <input id="dictTerm" type="text" placeholder="単語" />
               <button id="dictSaveBtn">保存</button>
+              <button id="dictShareBtn" class="ghost" title="マルチサーバに共有" hidden>📤 シェア</button>
+              <span id="dictShareStatus" class="share-status"></span>
               <button id="dictDeleteBtn" class="danger">削除</button>
             </div>
             <h4>説明</h4>
@@ -335,6 +341,8 @@
         <button id="dSave">保存</button>
         <button id="dResummarize" class="ghost">再要約</button>
         <a id="dViewHtml" href="#" target="_blank" class="ghost">保存 HTML を開く</a>
+        <button id="dShare" class="ghost" title="マルチサーバに共有" hidden>📤 シェア</button>
+        <span id="dShareStatus" class="share-status"></span>
         <button id="dDelete" class="danger">削除</button>
       </div>
       <h3>アクセス履歴</h3>
@@ -359,6 +367,14 @@
     <label>デフォルトモデル: <input id="aiOpenaiModel" type="text" placeholder="gpt-4o-mini" /></label>
     <div class="ai-settings-actions">
       <button id="aiSettingsSave">保存</button>
+    </div>
+    <h4>🌐 マルチサーバ (Memoria Hub)</h4>
+    <p class="ai-settings-help">他のユーザの辞書 / ディグ / ブックマークを共有できるハブに接続します。Cernere ログインが必要です。</p>
+    <label>マルチサーバ URL <input id="multiUrl" type="text" placeholder="https://memoria-hub.example.com" /></label>
+    <div id="multiStatus" class="multi-status"></div>
+    <div class="ai-settings-actions">
+      <button id="multiConnectBtn">接続</button>
+      <button id="multiDisconnectBtn" class="danger" hidden>切断</button>
     </div>
   </div>
   <script src="app.js"></script>

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -1626,3 +1626,33 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   /* Dictionary / domain detail panes float over the list. */
   .dict-layout { grid-template-columns: 1fr; }
 }
+
+/* ──────────────────────────────────────────────────────────────────────
+ * Multi-server share UI
+ * ────────────────────────────────────────────────────────────────────── */
+.share-status { font-size: 12px; color: var(--muted); margin-left: 4px; }
+.dig-share-bar { display: flex; gap: 8px; align-items: center; margin: 8px 0; }
+.multi-status {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 12px;
+  color: var(--muted);
+  margin: 6px 0;
+}
+.share-toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--text);
+  color: #fff;
+  padding: 10px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  box-shadow: 0 6px 24px rgba(0,0,0,0.18);
+  z-index: 100;
+  max-width: 90vw;
+  word-break: break-all;
+}


### PR DESCRIPTION
## Summary
Phase 3 of the local/multi split (#34). Local server now drives the Memoria Hub share flow end-to-end.

- `local/multi-client.js` — JWT-aware fetch wrapper plus shape helpers for forwarding bookmarks / digs / dictionary entries. Connection state lives in `app_settings` (`multi_url`, `multi_jwt`, `multi_user_id`, `multi_user_name`, `multi_role`, `multi_connected_at`) so it survives restarts.
- `/api/multi/{status,connect,finish,disconnect,share}` on the local server. `connect` returns the OAuth start URL; `finish` accepts the JWT the SPA pulls out of `?memoria_hub_jwt=…`, round-trips through the Hub's `/api/me`, then stashes it.
- `markBookmarkShared / markDigShared / markDictionaryShared` SQLite helpers so re-share detection is a single NULL check.
- 📤 Share buttons on the bookmark detail panel, dictionary detail header, and dig session view (gated on connection).
- Multi-server connection panel inside the existing AI settings dialog with URL field, live status, and connect / disconnect.
- On first paint the SPA pulls `?memoria_hub_jwt=` out of the URL and finishes the handshake; toast confirms the user.

## Test plan
- [ ] Stand up the Hub from #41; in AI settings paste its URL and click 接続
- [ ] Walk through the Cernere OAuth dance and land back on the SPA → toast appears, status shows the user
- [ ] Open a bookmark detail → 📤 → confirm row in `bookmarks.shared_at` and Hub `share_log`
- [ ] Same for a dictionary entry and a completed dig session
- [ ] Disconnect → 📤 buttons disappear; share API returns `not_connected`

🤖 Generated with [Claude Code](https://claude.com/claude-code)