### PR TITLE
feat(multi): Phase 4 — 🌐 マルチタブ + proxy (#34)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -944,6 +944,34 @@ app.post('/api/multi/disconnect', (c) => {
   return c.json({ ok: true });
 });
 
+// Read-only proxy for the multi server's GET endpoints. Forwards path +
+// query through with the saved JWT so the SPA can browse Hub content
+// without needing CORS or a second login.
+app.get('/api/multi/proxy/*', async (c) => {
+  const state = readMultiState(db);
+  if (!isConnected(state)) return c.json({ error: 'not_connected' }, 400);
+  const path = c.req.path.replace('/api/multi/proxy', '');
+  const qs = new URL(c.req.url).search;
+  const upstream = `${state.url.replace(/\/$/, '')}${path}${qs}`;
+  try {
+    const res = await fetch(upstream, {
+      headers: {
+        'Authorization': `Bearer ${state.jwt}`,
+        'Accept': 'application/json',
+      },
+    });
+    const text = await res.text();
+    return new Response(text, {
+      status: res.status,
+      headers: {
+        'Content-Type': res.headers.get('content-type') || 'application/json',
+      },
+    });
+  } catch (e) {
+    return c.json({ error: `proxy failed: ${e.message}` }, 502);
+  }
+});
+
 // Body: { kind: 'bookmark' | 'dig' | 'dict', id }
 app.post('/api/multi/share', async (c) => {
   const body = await c.req.json().catch(() => null);

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -522,6 +522,7 @@ function switchTab(tab) {
   $('domainView').classList.toggle('hidden', tab !== 'domain');
   $('diaryView').classList.toggle('hidden', tab !== 'diary');
   $('eventsView').classList.toggle('hidden', tab !== 'events');
+  $('multiView')?.classList.toggle('hidden', tab !== 'multi');
   if (tab === 'queue') renderQueue();
   if (tab === 'visits') loadVisits();
   if (tab === 'trends') loadTrends();
@@ -531,6 +532,7 @@ function switchTab(tab) {
   if (tab === 'domain') loadDomainCatalog();
   if (tab === 'diary') loadDiary();
   if (tab === 'events') loadEvents();
+  if (tab === 'multi') loadMulti();
   bumpTabUsage(tab);
   reflowTabsForViewport();
   closeTabMoreMenu();
@@ -2545,6 +2547,7 @@ async function refreshMultiStatus() {
       b.hidden = !s.connected;
     });
     if (!s.connected && $('digShareBar')) $('digShareBar').hidden = true;
+    if (typeof refreshMultiTabVisibility === 'function') refreshMultiTabVisibility();
   } catch (e) { console.error(e); }
 }
 
@@ -2745,3 +2748,116 @@ function renderEvents(items) {
 }
 
 document.getElementById('eventsRefresh')?.addEventListener('click', loadEvents);
+
+// ── 🌐 Multi (Memoria Hub) browse ─────────────────────────────────────────
+state.multiSubtab = 'bookmarks';
+
+function refreshMultiTabVisibility() {
+  const visible = !!state.multi?.connected;
+  document.querySelectorAll('.tab-multi-only').forEach(t => { t.hidden = !visible; });
+  if (!visible && state.tab === 'multi') switchTab('bookmarks');
+  if (visible) {
+    const badge = $('multiUserBadge');
+    if (badge) badge.textContent = `🌐 ${state.multi.user.name} (${state.multi.user.role})`;
+  }
+}
+
+async function loadMulti() {
+  refreshMultiTabVisibility();
+  if (!state.multi?.connected) {
+    $('multiList').innerHTML = '<div class="queue-empty">マルチサーバに接続されていません。⚙ AI から接続してください。</div>';
+    return;
+  }
+  const sub = state.multiSubtab;
+  document.querySelectorAll('.multi-subtab').forEach(b => {
+    b.classList.toggle('active', b.dataset.mtab === sub);
+  });
+  let url;
+  if (sub === 'bookmarks') url = '/api/multi/proxy/api/shared/bookmarks?limit=50';
+  else if (sub === 'digs') url = '/api/multi/proxy/api/shared/digs?limit=50';
+  else url = '/api/multi/proxy/api/shared/dictionary?limit=200';
+  let data;
+  try { data = await api(url); }
+  catch (e) {
+    $('multiList').innerHTML = `<div class="queue-empty">取得失敗: ${escapeHtml(e.message)}</div>`;
+    return;
+  }
+  const items = data.items || [];
+  if (!items.length) {
+    $('multiList').innerHTML = '<div class="queue-empty">該当エントリなし</div>';
+    return;
+  }
+  if (sub === 'bookmarks') $('multiList').innerHTML = items.map(renderMultiBookmark).join('');
+  else if (sub === 'digs') $('multiList').innerHTML = items.map(renderMultiDig).join('');
+  else $('multiList').innerHTML = items.map(renderMultiDict).join('');
+  $('multiList').querySelectorAll('[data-download]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const kind = btn.dataset.download;
+      const id = Number(btn.dataset.id);
+      btn.disabled = true;
+      btn.textContent = '取込中…';
+      try {
+        await api('/api/multi/download', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ kind, remote_id: id }),
+        });
+        btn.textContent = '✓ 取込済';
+      } catch (e) {
+        btn.textContent = `✗ ${e.message}`;
+        btn.disabled = false;
+      }
+    });
+  });
+}
+
+function renderMultiBookmark(b) {
+  return `<div class="multi-card">
+    <div class="title">${escapeHtml(b.title || b.url)}</div>
+    <div class="url"><a href="${escapeHtml(b.url)}" target="_blank" rel="noreferrer">${escapeHtml(b.url)}</a></div>
+    ${b.summary ? `<div class="summary">${escapeHtml(b.summary)}</div>` : ''}
+    <div class="cats">${(b.categories || []).map(c => `<span class="cat">${escapeHtml(c)}</span>`).join('')}</div>
+    <div class="multi-meta">
+      <span>by ${escapeHtml(b.owner_user_name || b.owner_user_id || '?')}</span>
+      <span>${fmtDate(b.shared_at)}</span>
+      <button class="ghost ghost-sm" data-download="bookmark" data-id="${b.id}">📥 ローカルへ取込</button>
+    </div>
+  </div>`;
+}
+
+function renderMultiDig(d) {
+  const r = d.result_json || d.result || {};
+  const summary = (r.summary || '').slice(0, 600);
+  return `<div class="multi-card">
+    <div class="title">⛏ ${escapeHtml(d.query)}</div>
+    ${summary ? `<div class="summary">${escapeHtml(summary)}</div>` : ''}
+    <div class="multi-meta">
+      <span>by ${escapeHtml(d.owner_user_name || d.owner_user_id || '?')}</span>
+      <span>${fmtDate(d.shared_at)}</span>
+      <button class="ghost ghost-sm" data-download="dig" data-id="${d.id}">📥 ローカルへ取込</button>
+    </div>
+  </div>`;
+}
+
+function renderMultiDict(e) {
+  return `<div class="multi-card">
+    <div class="title">📖 ${escapeHtml(e.term)}</div>
+    ${e.definition ? `<div class="summary">${escapeHtml(e.definition)}</div>` : ''}
+    <div class="multi-meta">
+      <span>by ${escapeHtml(e.owner_user_name || e.owner_user_id || '?')}</span>
+      <span>${fmtDate(e.shared_at)}</span>
+      <button class="ghost ghost-sm" data-download="dict" data-id="${e.id}">📥 ローカルへ取込</button>
+    </div>
+  </div>`;
+}
+
+document.querySelectorAll('.multi-subtab').forEach(b => {
+  b.addEventListener('click', () => {
+    state.multiSubtab = b.dataset.mtab;
+    loadMulti();
+  });
+});
+document.getElementById('multiRefresh')?.addEventListener('click', loadMulti);
+
+// First paint: surface the multi tab if we're already connected.
+refreshMultiTabVisibility();

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -55,6 +55,7 @@
           <button class="tab" data-tab="dict">📖 辞書</button>
           <button class="tab" data-tab="domain">🏷 ドメイン</button>
           <button class="tab" data-tab="diary">📅 日記</button>
+          <button class="tab tab-multi-only" data-tab="multi" hidden>🌐 マルチ</button>
         </div>
         <div class="tabs-more">
           <button type="button" class="tab tab-more-btn" id="tabMoreBtn" aria-haspopup="true" aria-expanded="false" title="他のタブ">⋯</button>
@@ -314,6 +315,21 @@
           <button id="eventsRefresh" class="ghost">更新</button>
         </div>
         <ul id="eventsList" class="events-list"></ul>
+      </div>
+
+      <div id="multiView" class="hidden">
+        <div class="multi-bar">
+          <span id="multiUserBadge" class="multi-user-badge"></span>
+          <span class="grow"></span>
+          <button id="multiRefresh" class="ghost">更新</button>
+        </div>
+        <nav class="multi-subtabs">
+          <button class="multi-subtab active" data-mtab="bookmarks">📑 ブックマーク</button>
+          <button class="multi-subtab" data-mtab="digs">⛏ ディグ</button>
+          <button class="multi-subtab" data-mtab="dictionary">📖 辞書</button>
+        </nav>
+        <div id="multiList" class="multi-list"></div>
+        <div id="multiEmpty" class="queue-empty hidden">該当エントリなし</div>
       </div>
     </section>
 

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -1656,3 +1656,71 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   max-width: 90vw;
   word-break: break-all;
 }
+
+/* ──────────────────────────────────────────────────────────────────────
+ * 🌐 Multi-server browse view
+ * ────────────────────────────────────────────────────────────────────── */
+.multi-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+  color: var(--muted);
+  font-size: 13px;
+}
+.multi-bar .grow { flex: 1; }
+.multi-user-badge {
+  background: var(--accent-bg);
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 600;
+}
+.multi-subtabs { display: flex; gap: 8px; margin-bottom: 12px; }
+.multi-subtab {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 6px;
+  padding: 6px 12px;
+  cursor: pointer;
+  font-size: 13px;
+}
+.multi-subtab.active {
+  background: var(--accent-bg);
+  border-color: var(--accent);
+  color: var(--accent);
+  font-weight: 600;
+}
+.multi-list { display: flex; flex-direction: column; gap: 8px; }
+.multi-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 14px;
+  box-shadow: var(--shadow);
+}
+.multi-card .title { font-weight: 600; line-height: 1.4; }
+.multi-card .url { font-size: 11px; color: var(--muted); word-break: break-all; }
+.multi-card .url a { color: inherit; text-decoration: none; }
+.multi-card .url a:hover { text-decoration: underline; }
+.multi-card .summary { font-size: 12px; color: var(--text); line-height: 1.5; margin-top: 6px; }
+.multi-card .cats { display: flex; gap: 4px; flex-wrap: wrap; margin-top: 4px; }
+.multi-card .cat {
+  background: var(--accent-bg);
+  color: var(--accent);
+  border-radius: 999px;
+  padding: 1px 8px;
+  font-size: 11px;
+}
+.multi-meta {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-top: 8px;
+  font-size: 11px;
+  color: var(--muted);
+}
+.multi-meta .ghost-sm { margin-left: auto; padding: 4px 10px; font-size: 11px; }


### PR DESCRIPTION
## Summary
Phase 4 of the local/multi split (#34). Local UI gains a connected-only **🌐 マルチ** tab that browses the Hub read-only.

- `GET /api/multi/proxy/*` forwards path + query to the configured Hub with the saved JWT and streams the response back. Read-only by design — writes still go through the explicit `/api/multi/share` endpoint so we can enforce local DB updates (mark shared, audit).
- New 🌐 tab in the SPA, hidden until `multi.connected`; subtabs for bookmarks / digs / dictionary; renders user / share-time + a 📥 button per row. (The 📥 handler lands in Phase 5.)
- CSS for `.multi-card`, `.multi-subtabs`, `.multi-user-badge`.

## Test plan
- [ ] Connect to a Hub (#41) — 🌐 タブ appears and renders shared bookmarks
- [ ] Hit `/api/multi/proxy/api/me` directly → returns the JWT user
- [ ] Disconnect → 🌐 タブ vanishes; if it was active, switches back to ブックマーク
- [ ] Subtab click between bookmarks/digs/dictionary refetches and renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)