### PR TITLE
feat(multi): Phase 5 — 📥 download (multi → local) (#34)

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -485,6 +485,25 @@ function safeParse(s) { try { return JSON.parse(s); } catch { return null; } }
 // stays NULL on the local side (NULL = "this is mine") — the multi-side row
 // is the one that carries the Cernere user id. shared_origin records the
 // remote we forwarded to so re-shares can be detected later.
+//
+// Downloaded rows go the other way: they came from a multi server, so we set
+// owner_user_id / owner_user_name to the remote owner so the UI can render
+// "by <user>" without confusing them with rows the user authored locally.
+export function setBookmarkOwner(db, id, { ownerUserId, ownerUserName, sharedAt, sharedOrigin }) {
+  db.prepare(`UPDATE bookmarks SET owner_user_id = ?, owner_user_name = ?, shared_at = ?, shared_origin = ? WHERE id = ?`)
+    .run(ownerUserId, ownerUserName, sharedAt, sharedOrigin, id);
+}
+
+export function setDigOwner(db, id, { ownerUserId, ownerUserName, sharedAt, sharedOrigin }) {
+  db.prepare(`UPDATE dig_sessions SET owner_user_id = ?, owner_user_name = ?, shared_at = ?, shared_origin = ? WHERE id = ?`)
+    .run(ownerUserId, ownerUserName, sharedAt, sharedOrigin, id);
+}
+
+export function setDictionaryOwner(db, id, { ownerUserId, ownerUserName, sharedAt, sharedOrigin }) {
+  db.prepare(`UPDATE dictionary_entries SET owner_user_id = ?, owner_user_name = ?, shared_at = ?, shared_origin = ? WHERE id = ?`)
+    .run(ownerUserId, ownerUserName, sharedAt, sharedOrigin, id);
+}
+
 export function markBookmarkShared(db, id, { sharedAt, sharedOrigin }) {
   db.prepare(`UPDATE bookmarks SET shared_at = ?, shared_origin = ? WHERE id = ?`)
     .run(sharedAt, sharedOrigin, id);

--- a/server/index.js
+++ b/server/index.js
@@ -64,11 +64,13 @@ import {
 import { getAppSettings, setAppSettings } from './db.js';
 import {
   markBookmarkShared, markDigShared, markDictionaryShared,
+  setBookmarkOwner, setDigOwner, setDictionaryOwner,
 } from './db.js';
 import {
   readMultiState, isConnected,
   saveMultiUrl, saveMultiSession, clearMultiSession,
   fetchMe, shareBookmark, shareDig, shareDictionary,
+  multiFetch,
 } from './local/multi-client.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -1006,6 +1008,105 @@ app.post('/api/multi/share', async (c) => {
     return c.json({ error: 'unknown kind' }, 400);
   } catch (e) {
     console.error('[multi/share]', e);
+    return c.json({ error: e.message }, e.status || 500);
+  }
+});
+
+// Body: { kind: 'bookmark' | 'dig' | 'dict', remote_id }
+//
+// Pulls a single resource from the connected Hub and writes it into the
+// local SQLite. owner_user_id / owner_user_name are populated from the
+// Hub row so the UI can render "by <user>" when the local owner is
+// somebody else. shared_origin is set to the Hub URL.
+app.post('/api/multi/download', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  if (!body?.kind || body.remote_id == null) return c.json({ error: 'kind+remote_id required' }, 400);
+  const state = readMultiState(db);
+  if (!isConnected(state)) return c.json({ error: 'not_connected' }, 400);
+
+  try {
+    if (body.kind === 'bookmark') {
+      const remote = await multiFetch(state,`/api/shared/bookmarks/${body.remote_id}`);
+      // Bookmarks need an HTML body locally — fetch the URL ourselves.
+      // Fall back to a placeholder if the page is unreachable; the user
+      // can re-fetch via the existing 再要約 button.
+      const escapeHtml = (s = '') => String(s).replace(/[&<>"']/g, ch => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+      }[ch]));
+      let htmlBody;
+      try { htmlBody = (await fetchPageHtml(remote.url)).html; }
+      catch (e) {
+        htmlBody = `<!-- downloaded from ${state.url}; original fetch failed: ${e.message} -->\n<html><head><title>${escapeHtml(remote.title || '')}</title></head><body></body></html>`;
+      }
+      const ts = new Date().toISOString().replace(/[:.]/g, '-');
+      const safe = ts + '_' + Math.random().toString(36).slice(2, 8) + '.html';
+      writeFileSync(join(HTML_DIR, safe), htmlBody, 'utf8');
+      const ins = insertImportedBookmark(db, {
+        url: remote.url,
+        title: remote.title,
+        html_path: safe,
+        summary: remote.summary,
+        memo: remote.memo,
+        categories: remote.categories || [],
+      });
+      if (ins.skipped) return c.json({ ok: true, duplicate: true, id: ins.id });
+      setBookmarkOwner(db, ins.id, {
+        ownerUserId: remote.owner_user_id,
+        ownerUserName: remote.owner_user_name,
+        sharedAt: remote.shared_at,
+        sharedOrigin: state.url,
+      });
+      return c.json({ ok: true, id: ins.id });
+    }
+    if (body.kind === 'dig') {
+      const remote = await multiFetch(state,`/api/shared/digs/${body.remote_id}`);
+      const id = insertDigSession(db, remote.query);
+      setDigResult(db, id, {
+        status: remote.status || 'done',
+        result: remote.result_json || remote.result || null,
+        error: null,
+      });
+      setDigOwner(db, id, {
+        ownerUserId: remote.owner_user_id,
+        ownerUserName: remote.owner_user_name,
+        sharedAt: remote.shared_at,
+        sharedOrigin: state.url,
+      });
+      return c.json({ ok: true, id });
+    }
+    if (body.kind === 'dict') {
+      const remote = await multiFetch(state,`/api/shared/dictionary/${body.remote_id}`);
+      // Dictionary terms are unique locally — namespace remote-owned terms
+      // with the owner so a download doesn't clobber a local entry.
+      const namespacedTerm = remote.owner_user_id
+        ? `${remote.term} (@${remote.owner_user_name || remote.owner_user_id})`
+        : remote.term;
+      const existing = findDictionaryEntryByTerm(db, namespacedTerm);
+      let id;
+      if (existing) {
+        updateDictionaryEntry(db, existing.id, {
+          definition: remote.definition,
+          notes: remote.notes,
+        });
+        id = existing.id;
+      } else {
+        id = insertDictionaryEntry(db, {
+          term: namespacedTerm,
+          definition: remote.definition,
+          notes: remote.notes,
+        });
+      }
+      setDictionaryOwner(db, id, {
+        ownerUserId: remote.owner_user_id,
+        ownerUserName: remote.owner_user_name,
+        sharedAt: remote.shared_at,
+        sharedOrigin: state.url,
+      });
+      return c.json({ ok: true, id });
+    }
+    return c.json({ error: 'unknown kind' }, 400);
+  } catch (e) {
+    console.error('[multi/download]', e);
     return c.json({ error: e.message }, e.status || 500);
   }
 });

--- a/server/multi/db.js
+++ b/server/multi/db.js
@@ -50,6 +50,44 @@ export async function listSharedBookmarks({ limit = 50, before = null } = {}) {
   return r.rows;
 }
 
+export async function getSharedBookmark(id) {
+  const r = await query(
+    `SELECT b.id, b.url, b.title, b.summary, b.memo,
+            b.owner_user_id, b.owner_user_name,
+            b.shared_at, b.shared_origin,
+            COALESCE(
+              (SELECT json_agg(category ORDER BY category)
+                 FROM bookmark_categories WHERE bookmark_id = b.id), '[]'::json
+            ) AS categories
+       FROM bookmarks b
+       WHERE id = $1 AND hidden_at IS NULL`,
+    [id],
+  );
+  return r.rows[0] || null;
+}
+
+export async function getSharedDig(id) {
+  const r = await query(
+    `SELECT id, query, status, result_json, owner_user_id, owner_user_name,
+            shared_at, shared_origin
+       FROM dig_sessions
+       WHERE id = $1 AND hidden_at IS NULL`,
+    [id],
+  );
+  return r.rows[0] || null;
+}
+
+export async function getSharedDictionary(id) {
+  const r = await query(
+    `SELECT id, term, definition, notes, owner_user_id, owner_user_name,
+            shared_at, shared_origin
+       FROM dictionary_entries
+       WHERE id = $1 AND hidden_at IS NULL`,
+    [id],
+  );
+  return r.rows[0] || null;
+}
+
 export async function insertSharedBookmark({ url, title, summary, memo, categories, ownerUserId, ownerUserName, sharedOrigin }) {
   const r = await query(
     `INSERT INTO bookmarks (url, title, summary, memo, owner_user_id, owner_user_name, shared_origin)

--- a/server/multi/index.js
+++ b/server/multi/index.js
@@ -31,6 +31,7 @@ import {
   listSharedBookmarks, insertSharedBookmark, deleteSharedBookmark,
   listSharedDigs, insertSharedDig, deleteSharedDig,
   listSharedDictionary, insertSharedDictionary, deleteSharedDictionary,
+  getSharedBookmark, getSharedDig, getSharedDictionary,
   recordShareEvent,
 } from './db.js';
 
@@ -160,6 +161,12 @@ app.post('/api/shared/bookmarks', async (c) => {
   return c.json(r, 201);
 });
 
+app.get('/api/shared/bookmarks/:id', async (c) => {
+  const r = await getSharedBookmark(Number(c.req.param('id')));
+  if (!r) return c.json({ error: 'not_found' }, 404);
+  return c.json(r);
+});
+
 app.delete('/api/shared/bookmarks/:id', async (c) => {
   const u = await authedUser(c);
   if (!u) return c.json({ error: 'unauthorized' }, 401);
@@ -198,6 +205,12 @@ app.post('/api/shared/digs', async (c) => {
   return c.json(r, 201);
 });
 
+app.get('/api/shared/digs/:id', async (c) => {
+  const r = await getSharedDig(Number(c.req.param('id')));
+  if (!r) return c.json({ error: 'not_found' }, 404);
+  return c.json(r);
+});
+
 app.delete('/api/shared/digs/:id', async (c) => {
   const u = await authedUser(c);
   if (!u) return c.json({ error: 'unauthorized' }, 401);
@@ -234,6 +247,12 @@ app.post('/api/shared/dictionary', async (c) => {
     actingUserId: u.userId, details: { term: body.term },
   });
   return c.json(r, 201);
+});
+
+app.get('/api/shared/dictionary/:id', async (c) => {
+  const r = await getSharedDictionary(Number(c.req.param('id')));
+  if (!r) return c.json({ error: 'not_found' }, 404);
+  return c.json(r);
 });
 
 app.delete('/api/shared/dictionary/:id', async (c) => {


### PR DESCRIPTION
## Summary
Phase 5 of the local/multi split (#34). Pulls a single shared resource off the Hub and imports it into SQLite. Fills in the 📥 button from #43.

**Hub side**
- `getSharedBookmark(id)` / `getSharedDig(id)` / `getSharedDictionary(id)` in `multi/db.js`
- `GET /api/shared/<kind>/:id` routes. Hidden rows excluded.

**Local side**
- `POST /api/multi/download {kind, remote_id}` resolves the row through `multiFetch`, then writes to SQLite:
  - **bookmark**: server-side fetch the URL HTML (placeholder if unreachable), `insertImportedBookmark` + `setBookmarkOwner` so the row carries the remote owner and `shared_origin = <hub-url>`.
  - **dig**: `insertDigSession` + `setDigResult(status='done')` + `setDigOwner`.
  - **dict**: term namespaced as `<term> (@<owner>)` so it does not clobber a local entry, then `insert/update` + `setDictionaryOwner`.
- New SQLite helpers `setBookmarkOwner` / `setDigOwner` / `setDictionaryOwner`.

## Test plan
- [ ] 📥 on a remote bookmark → local bookmarks row appears with owner_user_id set
- [ ] 📥 on a remote dig → dig_sessions row inserted with status=done
- [ ] 📥 on a remote dictionary entry → namespaced term (no clobber)
- [ ] Second 📥 on the same bookmark → `{duplicate: true}` response

🤖 Generated with [Claude Code](https://claude.com/claude-code)