### PR TITLE
feat(multi): Phase 6 — moderation (admin/mod) (#34)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -946,22 +946,33 @@ app.post('/api/multi/disconnect', (c) => {
   return c.json({ ok: true });
 });
 
-// Read-only proxy for the multi server's GET endpoints. Forwards path +
-// query through with the saved JWT so the SPA can browse Hub content
-// without needing CORS or a second login.
-app.get('/api/multi/proxy/*', async (c) => {
+// Proxy for the multi server. Forwards path + query through with the saved
+// JWT so the SPA can call the Hub without dealing with CORS or a second
+// login. GET / POST are both allowed; POST is restricted to the
+// `/api/shared/moderation/*` endpoints since every other write should go
+// through `/api/multi/share` (which also updates the local row).
+async function proxyMulti(c, method) {
   const state = readMultiState(db);
   if (!isConnected(state)) return c.json({ error: 'not_connected' }, 400);
   const path = c.req.path.replace('/api/multi/proxy', '');
+  if (method === 'POST' && !path.startsWith('/api/shared/moderation/')) {
+    return c.json({ error: 'forbidden_proxy_write' }, 403);
+  }
   const qs = new URL(c.req.url).search;
   const upstream = `${state.url.replace(/\/$/, '')}${path}${qs}`;
+  const init = {
+    method,
+    headers: {
+      'Authorization': `Bearer ${state.jwt}`,
+      'Accept': 'application/json',
+    },
+  };
+  if (method === 'POST') {
+    init.headers['Content-Type'] = 'application/json';
+    init.body = await c.req.text();
+  }
   try {
-    const res = await fetch(upstream, {
-      headers: {
-        'Authorization': `Bearer ${state.jwt}`,
-        'Accept': 'application/json',
-      },
-    });
+    const res = await fetch(upstream, init);
     const text = await res.text();
     return new Response(text, {
       status: res.status,
@@ -972,7 +983,9 @@ app.get('/api/multi/proxy/*', async (c) => {
   } catch (e) {
     return c.json({ error: `proxy failed: ${e.message}` }, 502);
   }
-});
+}
+app.get('/api/multi/proxy/*', (c) => proxyMulti(c, 'GET'));
+app.post('/api/multi/proxy/*', (c) => proxyMulti(c, 'POST'));
 
 // Body: { kind: 'bookmark' | 'dig' | 'dict', id }
 app.post('/api/multi/share', async (c) => {

--- a/server/multi/db.js
+++ b/server/multi/db.js
@@ -217,7 +217,89 @@ export async function deleteSharedDictionary(id, { actingUserId, role }) {
   return { ok: true };
 }
 
-// ── moderation (Phase 6 surface, used here only for share_log writes) ──────
+// ── moderation ─────────────────────────────────────────────────────────────
+
+const TABLE_BY_KIND = {
+  bookmark: 'bookmarks',
+  dig: 'dig_sessions',
+  dict: 'dictionary_entries',
+};
+
+function tableForKind(kind) {
+  const t = TABLE_BY_KIND[kind];
+  if (!t) throw new Error(`unknown kind: ${kind}`);
+  return t;
+}
+
+// Soft-hide: row stays in the table but is filtered out of every public list.
+// Only admins/moderators can call this; the route layer enforces that.
+export async function hideShared(kind, id, { actingUserId, reason }) {
+  const t = tableForKind(kind);
+  const r = await query(
+    `UPDATE ${t}
+        SET hidden_at = now(), hidden_by = $1, hidden_reason = $2
+      WHERE id = $3 AND hidden_at IS NULL
+      RETURNING id`,
+    [actingUserId, reason || null, id],
+  );
+  if (!r.rowCount) return { ok: false, error: 'not_found_or_already_hidden' };
+  await query(
+    `INSERT INTO share_log (resource_kind, resource_id, action, acting_user_id, details_json)
+       VALUES ($1, $2, 'hide', $3, $4)`,
+    [kind, id, actingUserId, reason ? JSON.stringify({ reason }) : null],
+  );
+  return { ok: true };
+}
+
+export async function unhideShared(kind, id, { actingUserId }) {
+  const t = tableForKind(kind);
+  const r = await query(
+    `UPDATE ${t}
+        SET hidden_at = NULL, hidden_by = NULL, hidden_reason = NULL
+      WHERE id = $1 AND hidden_at IS NOT NULL
+      RETURNING id`,
+    [id],
+  );
+  if (!r.rowCount) return { ok: false, error: 'not_found_or_not_hidden' };
+  await query(
+    `INSERT INTO share_log (resource_kind, resource_id, action, acting_user_id)
+       VALUES ($1, $2, 'unhide', $3)`,
+    [kind, id, actingUserId],
+  );
+  return { ok: true };
+}
+
+export async function listHidden({ limit = 100 } = {}) {
+  const sql = (kind, t, label) => `
+    SELECT '${kind}' AS kind, id, ${label} AS label,
+           owner_user_id, owner_user_name,
+           hidden_at, hidden_by, hidden_reason
+      FROM ${t}
+     WHERE hidden_at IS NOT NULL`;
+  const r = await query(
+    `${sql('bookmark', 'bookmarks', 'title')}
+     UNION ALL
+     ${sql('dig', 'dig_sessions', 'query')}
+     UNION ALL
+     ${sql('dict', 'dictionary_entries', 'term')}
+     ORDER BY hidden_at DESC
+     LIMIT $1`,
+    [limit],
+  );
+  return r.rows;
+}
+
+export async function listShareLog({ limit = 200 } = {}) {
+  const r = await query(
+    `SELECT id, resource_kind, resource_id, action, acting_user_id,
+            occurred_at, details_json
+       FROM share_log
+       ORDER BY occurred_at DESC
+       LIMIT $1`,
+    [limit],
+  );
+  return r.rows;
+}
 
 export async function recordShareEvent({ kind, id, action, actingUserId, details }) {
   await query(

--- a/server/multi/index.js
+++ b/server/multi/index.js
@@ -32,6 +32,7 @@ import {
   listSharedDigs, insertSharedDig, deleteSharedDig,
   listSharedDictionary, insertSharedDictionary, deleteSharedDictionary,
   getSharedBookmark, getSharedDig, getSharedDictionary,
+  hideShared, unhideShared, listHidden, listShareLog,
   recordShareEvent,
 } from './db.js';
 
@@ -262,6 +263,54 @@ app.delete('/api/shared/dictionary/:id', async (c) => {
   const r = await deleteSharedDictionary(id, { actingUserId: u.userId, role: u.role });
   if (!r.ok) return c.json({ error: r.error }, r.error === 'not_found' ? 404 : 403);
   return c.json({ ok: true });
+});
+
+// ── /api/shared/moderation/* (admin / moderator only) ──────────────────────
+//
+// Hide soft-removes a row from public listings; unhide reverses it. The row
+// stays in the table either way so the audit trail is not lost.
+function isModerator(u) { return u.role === 'admin' || u.role === 'moderator'; }
+
+app.post('/api/shared/moderation/hide', async (c) => {
+  const u = await authedUser(c);
+  if (!u) return c.json({ error: 'unauthorized' }, 401);
+  if (!isModerator(u)) return c.json({ error: 'forbidden' }, 403);
+  const body = await c.req.json().catch(() => null);
+  if (!body?.kind || body.id == null) return c.json({ error: 'kind+id required' }, 400);
+  const r = await hideShared(body.kind, Number(body.id), {
+    actingUserId: u.userId, reason: body.reason,
+  });
+  if (!r.ok) return c.json({ error: r.error }, 400);
+  return c.json({ ok: true });
+});
+
+app.post('/api/shared/moderation/unhide', async (c) => {
+  const u = await authedUser(c);
+  if (!u) return c.json({ error: 'unauthorized' }, 401);
+  if (!isModerator(u)) return c.json({ error: 'forbidden' }, 403);
+  const body = await c.req.json().catch(() => null);
+  if (!body?.kind || body.id == null) return c.json({ error: 'kind+id required' }, 400);
+  const r = await unhideShared(body.kind, Number(body.id), { actingUserId: u.userId });
+  if (!r.ok) return c.json({ error: r.error }, 400);
+  return c.json({ ok: true });
+});
+
+app.get('/api/shared/moderation/hidden', async (c) => {
+  const u = await authedUser(c);
+  if (!u) return c.json({ error: 'unauthorized' }, 401);
+  if (!isModerator(u)) return c.json({ error: 'forbidden' }, 403);
+  const limit = Math.min(Number(c.req.query('limit') || 100), 500);
+  const items = await listHidden({ limit });
+  return c.json({ items });
+});
+
+app.get('/api/shared/moderation/log', async (c) => {
+  const u = await authedUser(c);
+  if (!u) return c.json({ error: 'unauthorized' }, 401);
+  if (!isModerator(u)) return c.json({ error: 'forbidden' }, 403);
+  const limit = Math.min(Number(c.req.query('limit') || 200), 1000);
+  const items = await listShareLog({ limit });
+  return c.json({ items });
 });
 
 // ── boot ───────────────────────────────────────────────────────────────────

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -2760,6 +2760,14 @@ function refreshMultiTabVisibility() {
     const badge = $('multiUserBadge');
     if (badge) badge.textContent = `🌐 ${state.multi.user.name} (${state.multi.user.role})`;
   }
+  const role = state.multi?.user?.role;
+  const isMod = role === 'admin' || role === 'moderator';
+  document.querySelectorAll('.multi-mod-only').forEach(t => { t.hidden = !(visible && isMod); });
+}
+
+function isCurrentUserModerator() {
+  const role = state.multi?.user?.role;
+  return role === 'admin' || role === 'moderator';
 }
 
 async function loadMulti() {
@@ -2772,6 +2780,9 @@ async function loadMulti() {
   document.querySelectorAll('.multi-subtab').forEach(b => {
     b.classList.toggle('active', b.dataset.mtab === sub);
   });
+  if (sub === 'moderation') {
+    return loadModeration();
+  }
   let url;
   if (sub === 'bookmarks') url = '/api/multi/proxy/api/shared/bookmarks?limit=50';
   else if (sub === 'digs') url = '/api/multi/proxy/api/shared/digs?limit=50';
@@ -2809,6 +2820,89 @@ async function loadMulti() {
       }
     });
   });
+  $('multiList').querySelectorAll('[data-hide]').forEach(btn => {
+    btn.addEventListener('click', () => moderate('hide', btn.dataset.hide, Number(btn.dataset.id)));
+  });
+}
+
+async function moderate(action, kind, id) {
+  if (action === 'hide') {
+    const reason = prompt('非表示にする理由 (任意):') ?? '';
+    if (reason === null) return;
+    try {
+      await api('/api/multi/proxy/api/shared/moderation/hide', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ kind, id, reason }),
+      });
+      showShareToast('🛡 非表示にしました');
+      loadMulti();
+    } catch (e) { alert(`失敗: ${e.message}`); }
+    return;
+  }
+  if (action === 'unhide') {
+    try {
+      await api('/api/multi/proxy/api/shared/moderation/unhide', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ kind, id }),
+      });
+      showShareToast('✓ 復元しました');
+      loadModeration();
+    } catch (e) { alert(`失敗: ${e.message}`); }
+  }
+}
+
+async function loadModeration() {
+  if (!isCurrentUserModerator()) {
+    $('multiList').innerHTML = '<div class="queue-empty">モデレーション権限がありません</div>';
+    return;
+  }
+  let hidden, log;
+  try {
+    [hidden, log] = await Promise.all([
+      api('/api/multi/proxy/api/shared/moderation/hidden?limit=100'),
+      api('/api/multi/proxy/api/shared/moderation/log?limit=100'),
+    ]);
+  } catch (e) {
+    $('multiList').innerHTML = `<div class="queue-empty">取得失敗: ${escapeHtml(e.message)}</div>`;
+    return;
+  }
+  const hiddenItems = hidden.items || [];
+  const logItems = log.items || [];
+  $('multiList').innerHTML = `
+    <h3 class="mod-h">非表示中 (${hiddenItems.length})</h3>
+    ${hiddenItems.length === 0 ? '<div class="queue-empty">非表示エントリなし</div>'
+      : hiddenItems.map(i => `<div class="multi-card mod-hidden-card">
+          <div class="title">${KIND_LABEL[i.kind] || i.kind} — ${escapeHtml(i.label || `id=${i.id}`)}</div>
+          <div class="multi-meta">
+            <span>owner: ${escapeHtml(i.owner_user_name || i.owner_user_id)}</span>
+            <span>hidden ${fmtDate(i.hidden_at)} by ${escapeHtml(i.hidden_by || '?')}</span>
+            ${i.hidden_reason ? `<span>${escapeHtml(i.hidden_reason)}</span>` : ''}
+            <button class="ghost ghost-sm" data-unhide="${i.kind}" data-id="${i.id}">↺ 復元</button>
+          </div>
+        </div>`).join('')}
+    <h3 class="mod-h">監査ログ (最新 ${logItems.length})</h3>
+    <ul class="mod-log">
+      ${logItems.map(e => `<li>
+        <span class="mono">${escapeHtml(e.occurred_at)}</span>
+        <b>${escapeHtml(e.action)}</b> ${escapeHtml(e.resource_kind)}#${e.resource_id}
+        by ${escapeHtml(e.acting_user_id)}
+        ${e.details_json ? `<span class="mod-det">${escapeHtml(JSON.stringify(e.details_json))}</span>` : ''}
+      </li>`).join('')}
+    </ul>
+  `;
+  $('multiList').querySelectorAll('[data-unhide]').forEach(btn => {
+    btn.addEventListener('click', () => moderate('unhide', btn.dataset.unhide, Number(btn.dataset.id)));
+  });
+}
+
+const KIND_LABEL = { bookmark: '📑', dig: '⛏', dict: '📖' };
+
+function modHideButton(kind, id) {
+  return isCurrentUserModerator()
+    ? `<button class="ghost ghost-sm danger" data-hide="${kind}" data-id="${id}">🛡 非表示</button>`
+    : '';
 }
 
 function renderMultiBookmark(b) {
@@ -2821,6 +2915,7 @@ function renderMultiBookmark(b) {
       <span>by ${escapeHtml(b.owner_user_name || b.owner_user_id || '?')}</span>
       <span>${fmtDate(b.shared_at)}</span>
       <button class="ghost ghost-sm" data-download="bookmark" data-id="${b.id}">📥 ローカルへ取込</button>
+      ${modHideButton('bookmark', b.id)}
     </div>
   </div>`;
 }
@@ -2835,6 +2930,7 @@ function renderMultiDig(d) {
       <span>by ${escapeHtml(d.owner_user_name || d.owner_user_id || '?')}</span>
       <span>${fmtDate(d.shared_at)}</span>
       <button class="ghost ghost-sm" data-download="dig" data-id="${d.id}">📥 ローカルへ取込</button>
+      ${modHideButton('dig', d.id)}
     </div>
   </div>`;
 }
@@ -2847,6 +2943,7 @@ function renderMultiDict(e) {
       <span>by ${escapeHtml(e.owner_user_name || e.owner_user_id || '?')}</span>
       <span>${fmtDate(e.shared_at)}</span>
       <button class="ghost ghost-sm" data-download="dict" data-id="${e.id}">📥 ローカルへ取込</button>
+      ${modHideButton('dict', e.id)}
     </div>
   </div>`;
 }

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -327,6 +327,7 @@
           <button class="multi-subtab active" data-mtab="bookmarks">📑 ブックマーク</button>
           <button class="multi-subtab" data-mtab="digs">⛏ ディグ</button>
           <button class="multi-subtab" data-mtab="dictionary">📖 辞書</button>
+          <button class="multi-subtab multi-mod-only" data-mtab="moderation" hidden>🛡 モデレーション</button>
         </nav>
         <div id="multiList" class="multi-list"></div>
         <div id="multiEmpty" class="queue-empty hidden">該当エントリなし</div>

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -1723,4 +1723,29 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   font-size: 11px;
   color: var(--muted);
 }
-.multi-meta .ghost-sm { margin-left: auto; padding: 4px 10px; font-size: 11px; }
+.multi-meta .ghost-sm { padding: 4px 10px; font-size: 11px; }
+.multi-meta .ghost-sm:first-of-type { margin-left: auto; }
+
+.mod-h {
+  font-size: 12px;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 16px 0 6px;
+}
+.mod-hidden-card { background: #fff8f8; border-color: #f0c97a; }
+.mod-log {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-size: 12px;
+  color: var(--muted);
+}
+.mod-log li {
+  padding: 4px 0;
+  border-bottom: 1px dashed var(--border);
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.mod-log .mono { font-family: ui-monospace, monospace; font-size: 11px; }
+.mod-log .mod-det { font-size: 11px; color: var(--muted); flex-basis: 100%; word-break: break-all; }


### PR DESCRIPTION
## Summary
Phase 6 of the local/multi split (#34). Adds soft-hide moderation on the Hub plus a 🛡 admin/mod-only sub-tab in the local UI.

**Hub side**
- `hideShared` / `unhideShared` flip the existing `hidden_at / hidden_by / hidden_reason` columns and write `share_log`.
- `listHidden` UNION ALLs across the three resource tables.
- `listShareLog` returns the audit trail.
- New routes (admin / moderator only): `POST /api/shared/moderation/{hide,unhide}`, `GET /api/shared/moderation/{hidden,log}`.
- Public list/get queries already filter `hidden_at IS NULL`, so a hide removes the row from every browse + download path immediately.

**Local side**
- Proxy now forwards POST, but only for `/api/shared/moderation/*` paths — non-moderation writes still have to go through `/api/multi/share` (which keeps the local DB in sync).
- 🛡 moderation sub-tab hidden unless the JWT role is admin/mod; shows the hidden list (with 復元) and the audit log.
- 🛡 非表示 button on every multi-card prompts for a reason and POSTs via the proxy.

## Test plan
- [ ] As a regular user: 🛡 buttons not visible; calling `POST /moderation/hide` directly returns 403
- [ ] As mod/admin: 🛡 タブ shows hidden + log; hiding a bookmark from the bookmarks subtab makes it disappear from list immediately
- [ ] Restore a hidden row → reappears in the public list
- [ ] Non-mod write to `/api/multi/proxy/api/shared/bookmarks` returns `forbidden_proxy_write`

🤖 Generated with [Claude Code](https://claude.com/claude-code)