### PR TITLE
feat(multi): Phase 7 — Docker compose deploy + Cernere runbook (#34)

### DIFF
--- a/server/multi/.dockerignore
+++ b/server/multi/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+.env
+.env.local
+*.log
+.DS_Store

--- a/server/multi/.env.example
+++ b/server/multi/.env.example
@@ -24,3 +24,13 @@ MEMORIA_JWT_SECRET=replace-with-a-long-random-string
 # Browsers that may call /api/shared/*  (comma-separated; no value = no
 # cross-origin access at all).
 MEMORIA_HUB_ALLOWED_ORIGINS=http://localhost:5180,https://memoria.example.com
+
+# ── docker-compose only ───────────────────────────────────────────────
+# Postgres credentials; the compose stack provisions a fresh DB on first
+# boot and the hub container connects via the in-network DNS name.
+POSTGRES_USER=memoria
+POSTGRES_PASSWORD=memoria
+POSTGRES_DB=memoria_hub
+
+# Host port the hub binds to (container always listens on 5280).
+MEMORIA_HUB_HOST_PORT=5280

--- a/server/multi/Dockerfile
+++ b/server/multi/Dockerfile
@@ -1,0 +1,29 @@
+# Memoria Hub — Phase 7 production image.
+#
+# Build context is `server/multi/`. The image is intentionally minimal:
+# only the multi-server code and its deps (pg, jose, hono, …). Local
+# server modules at `../*.js` are never imported.
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json ./
+# `npm install` instead of `npm ci` — lockfile lives one level up in the
+# monorepo install layout. Phase 7 follow-up will add a dedicated
+# `multi/package-lock.json` once the dep set settles.
+RUN npm install --omit=dev
+
+FROM node:20-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+ENV MEMORIA_HUB_PORT=5280
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+EXPOSE 5280
+
+# Tiny health check via /healthz so docker-compose's healthcheck has
+# something cheap to hit.
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 \
+  CMD wget -qO- http://localhost:${MEMORIA_HUB_PORT}/healthz || exit 1
+
+# `npm start` runs migrations on container start, then boots Hono.
+CMD ["sh", "-c", "node migrate.js && node index.js"]

--- a/server/multi/README.md
+++ b/server/multi/README.md
@@ -72,13 +72,74 @@ JWT は HS256 / 30 日 / `iss=memoria-hub`。リフレッシュは無し (再ロ
 `/api/*` は cross-origin から呼べない。同一オリジン (Hub の Web UI) からは
 当然動く。
 
+## デプロイ (Phase 7)
+
+`docker-compose.yml` で Postgres + Hub を 1 コマンド起動。
+
+```bash
+cd server/multi
+cp .env.example .env
+# 編集 — MEMORIA_CERNERE_*, MEMORIA_JWT_SECRET, MEMORIA_HUB_BASE,
+#         POSTGRES_PASSWORD は最低限変更すること。
+
+docker compose up -d --build
+docker compose logs -f hub          # マイグレーション + 起動ログ
+curl -fsS http://localhost:5280/healthz
+```
+
+ストレージは名前付きボリューム `memoria-hub-pg` に永続化。バックアップは
+通常の `pg_dump`:
+
+```bash
+docker compose exec postgres pg_dump -U memoria memoria_hub > backup.sql
+```
+
+### Cernere OAuth クライアント登録ランブック
+
+本番の Cernere 側で OAuth クライアントを登録する手順。
+
+1. Cernere admin UI で **新規 OAuth client** を作成。
+   - `client_id`: `memoria-hub-prod` 等
+   - `redirect_uris`: `https://<HUB_BASE>/api/auth/callback` (本番) と
+     `http://localhost:5280/api/auth/callback` (開発)
+   - `scopes`: `profile`
+   - `pkce_required`: ✅ (S256)
+   - `client_secret`: 自動生成された値を控える
+2. Cernere admin UI で対象ユーザに `memoria-hub` クライアントへの権限を
+   付与 (各ユーザは自分のリソースのみ書ける。`role=moderator` /
+   `role=admin` を付けると非表示操作が可能)。
+3. 上記値を `server/multi/.env` に書き込む:
+   - `MEMORIA_CERNERE_BASE`
+   - `MEMORIA_CERNERE_CLIENT_ID`
+   - `MEMORIA_CERNERE_CLIENT_SECRET`
+   - `MEMORIA_HUB_BASE` (Cernere に登録した redirect_uri のホスト部と
+     一致させる)
+   - `MEMORIA_JWT_SECRET` (`openssl rand -base64 48` 程度)
+4. `docker compose up -d --build` で適用、ローカル Memoria の AI 設定から
+   接続テスト → トークン取得 → `/api/shared/*` 動作確認。
+
+### TLS / リバースプロキシ
+
+Hub は HTTPS を実装しない。本番では Caddy / nginx / Cloudflare Tunnel 等
+で TLS 終端し、127.0.0.1:5280 にプロキシする。
+
+```caddy
+hub.memoria.example.com {
+  reverse_proxy 127.0.0.1:5280
+  encode zstd gzip
+}
+```
+
+`MEMORIA_HUB_ALLOWED_ORIGINS` に Memoria ローカルの公開オリジンを列挙する
+こと (例 `https://memoria.example.com`)。
+
 ## 進捗
 
 - **Phase 0**: ✅ db façade + core/local/multi seam (PR #40)
 - **Phase 1**: ✅ ローカル SQLite に共有メタカラム追加 + Postgres 初期スキーマ (PR #35)
-- **Phase 2**: ✅ MVP (Cernere SSO + /api/shared/*) — このディレクトリ
-- **Phase 3**: 📤 ローカル UI からの share button (#34)
-- **Phase 4**: 🌐 ローカル UI からの multi タブ + proxy (#34)
-- **Phase 5**: 📥 multi → ローカル ダウンロード (#34)
-- **Phase 6**: モデレーション (admin/mod) (#34)
-- **Phase 7**: Cernere OAuth クライアント本番登録 + docker-compose 一式 (#34)
+- **Phase 2**: ✅ MVP (Cernere SSO + /api/shared/*) — PR #41
+- **Phase 3**: ✅ 📤 ローカル UI からの share button — PR #42
+- **Phase 4**: ✅ 🌐 ローカル UI からの multi タブ + proxy — PR #43
+- **Phase 5**: ✅ 📥 multi → ローカル ダウンロード — PR #44
+- **Phase 6**: ✅ モデレーション (admin/mod) — PR #46
+- **Phase 7**: ✅ docker-compose stack + Cernere 登録ランブック — このディレクトリ

--- a/server/multi/docker-compose.yml
+++ b/server/multi/docker-compose.yml
@@ -1,0 +1,53 @@
+# Memoria Hub deploy stack — Phase 7.
+#
+# Brings up Postgres + the Hub container. Reads secrets from `./.env`
+# (copied from `.env.example`). Postgres data is persisted in a named
+# volume.
+#
+# Usage:
+#   cd server/multi
+#   cp .env.example .env  # then edit
+#   docker compose up -d
+#
+# Once healthy, point the local server's "マルチサーバ URL" at this Hub
+# (defaults to http://localhost:5280) and walk through the Cernere OAuth
+# flow.
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-memoria}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-memoria}
+      POSTGRES_DB: ${POSTGRES_DB:-memoria_hub}
+    volumes:
+      - memoria-hub-pg:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-memoria} -d ${POSTGRES_DB:-memoria_hub}"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    # No host port mapping by default — only the hub container needs it.
+
+  hub:
+    build:
+      context: .
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      MEMORIA_HUB_PORT: 5280
+      MEMORIA_HUB_BASE: ${MEMORIA_HUB_BASE}
+      MEMORIA_PG_URL: postgres://${POSTGRES_USER:-memoria}:${POSTGRES_PASSWORD:-memoria}@postgres:5432/${POSTGRES_DB:-memoria_hub}
+      MEMORIA_PG_POOL: 10
+      MEMORIA_CERNERE_BASE: ${MEMORIA_CERNERE_BASE}
+      MEMORIA_CERNERE_CLIENT_ID: ${MEMORIA_CERNERE_CLIENT_ID}
+      MEMORIA_CERNERE_CLIENT_SECRET: ${MEMORIA_CERNERE_CLIENT_SECRET}
+      MEMORIA_JWT_SECRET: ${MEMORIA_JWT_SECRET}
+      MEMORIA_HUB_ALLOWED_ORIGINS: ${MEMORIA_HUB_ALLOWED_ORIGINS}
+    ports:
+      - "${MEMORIA_HUB_HOST_PORT:-5280}:5280"
+
+volumes:
+  memoria-hub-pg:


### PR DESCRIPTION
## Summary
Phase 7 of the local/multi split (#34). Wraps up the multi-server work.

- `multi/Dockerfile` — node:20-alpine, runs migrations then `node index.js`, ships `/healthz` for compose's healthcheck.
- `multi/docker-compose.yml` — Postgres 16 + Hub container. Postgres data on a named volume `memoria-hub-pg`; Hub waits for `pg_isready` before booting. Host port configurable via `MEMORIA_HUB_HOST_PORT`.
- `.env.example` extended with the compose-only `POSTGRES_*` vars and `MEMORIA_HUB_HOST_PORT`.
- README adds: deploy walkthrough, Cernere admin-UI runbook (client registration, scopes, PKCE, redirect URIs), backup commands, TLS reverse-proxy guidance.
- `.dockerignore` keeps node_modules and .env out of the build context.

Cernere production OAuth client registration is a manual admin step in Cernere itself, so it lives as a runbook rather than code.

## Test plan
- [ ] `docker compose up -d --build` succeeds against a populated `.env`
- [ ] `curl /healthz` returns 200 and `docker compose logs hub` shows the migration applying
- [ ] Walk through the Cernere runbook on a Cernere staging instance
- [ ] Local Memoria 接続テスト → JWT 取得 → `/api/shared/bookmarks` POST が 201

🤖 Generated with [Claude Code](https://claude.com/claude-code)