### PR TITLE
chore(ts): TypeScript foundation + canary module (#31)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,14 @@ jobs:
           set -e
           while IFS= read -r f; do
             node --check "$f"
-          done < <(find server -type f -name '*.js' -not -path 'server/node_modules/*')
+          done < <(find server -type f -name '*.js' -not -path 'server/node_modules/*' -not -path 'server/multi/node_modules/*')
+
+      - name: Typecheck (server)
+        working-directory: server
+        run: |
+          # devDeps may not be in the lockfile yet — install on demand.
+          npx --yes -p typescript@5.6 -p @types/node@20 -p @types/better-sqlite3@7 \
+            tsc --noEmit -p tsconfig.json
 
       - name: Syntax check (mcp-server)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,12 @@ jobs:
       - name: Typecheck (server)
         working-directory: server
         run: |
-          # devDeps may not be in the lockfile yet — install on demand.
-          npx --yes -p typescript@5.6 -p @types/node@20 -p @types/better-sqlite3@7 \
-            tsc --noEmit -p tsconfig.json
+          # devDeps aren't in the lockfile (lean prod install). Install into
+          # node_modules without touching package-lock.json so tsc can
+          # resolve @types/* via the standard typeRoots path.
+          npm install --no-save --no-package-lock --no-audit --no-fund \
+            typescript@5.6 @types/node@20 @types/better-sqlite3@7
+          npx tsc --noEmit -p tsconfig.json
 
       - name: Syntax check (mcp-server)
         run: |

--- a/server/local/multi-client.js
+++ b/server/local/multi-client.js
@@ -1,9 +1,17 @@
+// @ts-check
 // Local-side client for the multi server (Memoria Hub).
 //
 // Wraps the JWT plumbing — the rest of the local server just passes the
 // resource shape. Connection state lives in app_settings (`multi_url`,
 // `multi_jwt`, `multi_user_id`, `multi_user_name`, `multi_role`,
 // `multi_connected_at`), so it survives restarts.
+//
+// @ts-check is on so the typedefs in `../types/db.d.ts` get exercised.
+// Phase 1 of the TS migration (#31): this module is the canary.
+
+/** @typedef {import('../types/db.js').Db} Db */
+/** @typedef {import('../types/db.js').MultiState} MultiState */
+
 import { getAppSettings, setAppSettings } from '../db/index.js';
 
 const SETTING_KEYS = {
@@ -15,6 +23,10 @@ const SETTING_KEYS = {
   connectedAt: 'multi_connected_at',
 };
 
+/**
+ * @param {Db} db
+ * @returns {MultiState}
+ */
 export function readMultiState(db) {
   const s = getAppSettings(db);
   return {
@@ -22,11 +34,12 @@ export function readMultiState(db) {
     jwt:         s[SETTING_KEYS.jwt] || null,
     userId:      s[SETTING_KEYS.userId] || null,
     userName:    s[SETTING_KEYS.userName] || null,
-    role:        s[SETTING_KEYS.role] || null,
+    role:        /** @type {MultiState['role']} */ (s[SETTING_KEYS.role] || null),
     connectedAt: s[SETTING_KEYS.connectedAt] || null,
   };
 }
 
+/** @param {MultiState} state */
 export function isConnected(state) {
   return Boolean(state.url && state.jwt && state.userId);
 }

--- a/server/local/multi-client.js
+++ b/server/local/multi-client.js
@@ -85,7 +85,9 @@ export async function multiFetch(state, path, init = {}) {
   try { body = text ? JSON.parse(text) : null; } catch { body = text; }
   if (!res.ok) {
     const msg = (body && body.error) || `HTTP ${res.status}`;
-    const err = new Error(`multi ${path} failed: ${msg}`);
+    const err = /** @type {Error & {status?: number, body?: unknown}} */ (
+      new Error(`multi ${path} failed: ${msg}`)
+    );
     err.status = res.status;
     err.body = body;
     throw err;

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node --env-file-if-exists=.env --env-file-if-exists=../.env index.js",
     "dev": "node --watch --env-file-if-exists=.env --env-file-if-exists=../.env index.js",
-    "typecheck": "npx --yes -p typescript@5.6 -p @types/node@20 -p @types/better-sqlite3@7 tsc --noEmit -p tsconfig.json"
+    "typecheck": "npm install --no-save --no-package-lock --no-audit --no-fund typescript@5.6 @types/node@20 @types/better-sqlite3@7 && npx tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@hono/node-server": "^1.13.7",

--- a/server/package.json
+++ b/server/package.json
@@ -6,17 +6,12 @@
   "scripts": {
     "start": "node --env-file-if-exists=.env --env-file-if-exists=../.env index.js",
     "dev": "node --watch --env-file-if-exists=.env --env-file-if-exists=../.env index.js",
-    "typecheck": "tsc --noEmit -p tsconfig.json"
+    "typecheck": "npx --yes -p typescript@5.6 -p @types/node@20 -p @types/better-sqlite3@7 tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@hono/node-server": "^1.13.7",
     "better-sqlite3": "^11.3.0",
     "hono": "^4.6.10",
     "node-html-parser": "^6.1.13"
-  },
-  "devDependencies": {
-    "@types/better-sqlite3": "^7.6.11",
-    "@types/node": "^20.16.0",
-    "typescript": "^5.6.0"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -5,12 +5,18 @@
   "type": "module",
   "scripts": {
     "start": "node --env-file-if-exists=.env --env-file-if-exists=../.env index.js",
-    "dev": "node --watch --env-file-if-exists=.env --env-file-if-exists=../.env index.js"
+    "dev": "node --watch --env-file-if-exists=.env --env-file-if-exists=../.env index.js",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@hono/node-server": "^1.13.7",
     "better-sqlite3": "^11.3.0",
     "hono": "^4.6.10",
     "node-html-parser": "^6.1.13"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.11",
+    "@types/node": "^20.16.0",
+    "typescript": "^5.6.0"
   }
 }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "strict": true,
+    "noImplicitAny": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": [
+    "**/*.js",
+    "**/*.ts",
+    "**/*.mjs"
+  ],
+  "exclude": [
+    "node_modules",
+    "multi/node_modules",
+    "public/**/*",
+    "data/**/*"
+  ]
+}

--- a/server/types/db.d.ts
+++ b/server/types/db.d.ts
@@ -1,0 +1,74 @@
+// Shared types for the local server's SQLite layer.
+//
+// Phase 1 of the TS migration (#31) lays the groundwork. As individual
+// modules grow `// @ts-check` directives (or migrate to `.ts`), they import
+// these shapes via `import('./types/db.js')` JSDoc annotations.
+import type Database from 'better-sqlite3';
+
+export type Db = Database.Database;
+
+export interface BookmarkRow {
+  id: number;
+  url: string;
+  title: string;
+  html_path: string;
+  summary: string | null;
+  memo: string;
+  status: 'pending' | 'done' | 'error';
+  error: string | null;
+  created_at: string;
+  updated_at: string;
+  last_accessed_at: string | null;
+  access_count: number;
+  // Phase 1 share-metadata columns (NULL = "this is mine" on a local DB).
+  owner_user_id: string | null;
+  owner_user_name: string | null;
+  shared_at: string | null;
+  shared_origin: string | null;
+}
+
+export interface DigSessionRow {
+  id: number;
+  query: string;
+  created_at: string;
+  status: 'pending' | 'done' | 'error';
+  error: string | null;
+  result_json: string | null;
+  preview_json: string | null;
+  owner_user_id: string | null;
+  owner_user_name: string | null;
+  shared_at: string | null;
+  shared_origin: string | null;
+}
+
+export interface DictionaryEntryRow {
+  id: number;
+  term: string;
+  definition: string | null;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+  owner_user_id: string | null;
+  owner_user_name: string | null;
+  shared_at: string | null;
+  shared_origin: string | null;
+}
+
+export interface ServerEventRow {
+  id: number;
+  type: 'start' | 'stop' | 'downtime' | 'restart';
+  occurred_at: string;
+  ended_at: string | null;
+  duration_ms: number | null;
+  details_json: string | null;
+}
+
+// Multi-server connection state stored under app_settings keys.
+export interface MultiState {
+  url: string | null;
+  jwt: string | null;
+  userId: string | null;
+  userName: string | null;
+  role: 'user' | 'moderator' | 'admin' | null;
+  connectedAt: string | null;
+}


### PR DESCRIPTION
## Summary
Phase 1 of the TS migration (#31). Sets up a tsc-based typecheck pipeline without disrupting the existing JS module layout, then converts one small module as the canary so the seam is exercised end-to-end.

- `server/tsconfig.json`: `allowJs` + `checkJs:false` + `noEmit`. Files only get type-checked when they opt in with `// @ts-check`. Migration is module-by-module as files are converted.
- `server/types/db.d.ts`: shared shapes (`Db`, `BookmarkRow`, `DigSessionRow`, `DictionaryEntryRow`, `ServerEventRow`, `MultiState`). Imported from JSDoc via `@typedef`.
- `server/local/multi-client.js`: gains `// @ts-check` and JSDoc annotations for the public API. This module is the canary that proves the import-from-d.ts path.
- `package.json`: new `npm run typecheck` script. devDeps list typescript + @types/node + @types/better-sqlite3 (lockfile isn't regenerated yet — CI installs them on demand via `npx -p`).
- CI: new `Typecheck (server)` step runs after the syntax check; uses `npx -p typescript -p @types/node -p @types/better-sqlite3` so it works whether or not the lockfile is up-to-date.

Subsequent PRs migrate one module at a time by adding `// @ts-check` and JSDoc, then eventually renaming `.js` → `.ts`.

## Test plan
- [ ] CI typecheck step passes
- [ ] `cd server && npm install && npm run typecheck` works locally
- [ ] Add a deliberate type error in `local/multi-client.js` (e.g. pass a number where `string` is expected) and verify CI catches it

🤖 Generated with [Claude Code](https://claude.com/claude-code)