### PR TITLE
fix(ui): categories live inside bookmarks page, no tab interference

### DIFF
--- a/server/public/index.html
+++ b/server/public/index.html
@@ -69,16 +69,12 @@
           <button id="bulkExport">選択をエクスポート</button>
           <button id="bulkClear" class="ghost">クリア</button>
         </div>
-        <div class="bookmarks-layout">
-          <aside class="bookmarks-categories">
-            <h3>カテゴリ</h3>
-            <ul id="categoryList"></ul>
-          </aside>
-          <div class="bookmarks-main">
-            <div id="cards" class="cards"></div>
-            <div id="empty" class="empty hidden">ブックマークがありません。Chrome 拡張からページを保存してください。</div>
-          </div>
-        </div>
+        <div id="cards" class="cards"></div>
+        <div id="empty" class="empty hidden">ブックマークがありません。Chrome 拡張からページを保存してください。</div>
+        <section class="bookmarks-categories">
+          <h3>カテゴリ</h3>
+          <ul id="categoryList"></ul>
+        </section>
       </div>
 
       <div id="visitsView" class="hidden">

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -96,41 +96,68 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 }
 .layout:has(.detail.hidden) { grid-template-columns: 1fr; }
 
-/* Categories rail lives inside the bookmarks tab now (not the layout). */
-.bookmarks-layout {
-  display: grid;
-  grid-template-columns: 220px 1fr;
-  gap: 16px;
-  align-items: start;
-}
+/* Categories live INSIDE the bookmarks page, below the cards. They sit in
+ * normal document flow — no sticky positioning, no layout-level sidebar —
+ * so the sticky tab nav cannot collide with them. Other tabs never render
+ * this section because it lives inside #bookmarksView. */
 .bookmarks-categories {
+  margin-top: 24px;
+  padding: 12px 14px;
   background: var(--panel);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 12px;
-  position: sticky;
-  top: 0;
-  max-height: calc(100vh - 120px);
-  overflow-y: auto;
+  border-radius: 10px;
+  box-shadow: var(--shadow);
 }
 .bookmarks-categories h3 {
   font-size: 12px;
   text-transform: uppercase;
   color: var(--muted);
-  margin: 4px 0 8px;
+  margin: 0 0 8px;
+  letter-spacing: 0.04em;
 }
-.bookmarks-categories ul { list-style: none; padding: 0; margin: 0; }
-.bookmarks-categories li {
-  padding: 6px 8px;
-  border-radius: 6px;
-  cursor: pointer;
+.bookmarks-categories ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
   display: flex;
-  justify-content: space-between;
-  font-size: 13px;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.bookmarks-categories li {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 999px;
+  padding: 4px 12px;
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1.4;
 }
 .bookmarks-categories li:hover { background: #f0f2f7; }
-.bookmarks-categories li.active { background: var(--accent-bg); color: var(--accent); font-weight: 600; }
-.bookmarks-categories li .count { color: var(--muted); font-size: 12px; }
+.bookmarks-categories li.active {
+  background: var(--accent-bg);
+  border-color: var(--accent);
+  color: var(--accent);
+  font-weight: 600;
+}
+.bookmarks-categories li .count {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  color: var(--muted);
+  border-radius: 999px;
+  padding: 0 6px;
+  font-size: 11px;
+  min-width: 18px;
+  text-align: center;
+}
+.bookmarks-categories li.active .count {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
 
 .content { padding: 16px; overflow-y: auto; position: relative; }
 .tabs {
@@ -1640,17 +1667,12 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   .topbar-controls { width: 100%; flex-wrap: wrap; margin-left: 0; }
   .topbar-controls input[type=search] { flex: 1 1 100%; min-width: 0; }
 
-  /* Right-hand detail rail and categories rail collapse on mobile. */
+  /* Right-hand detail rail collapses on mobile. */
   .layout,
   .layout:has(.detail.hidden) {
     grid-template-columns: 1fr;
     height: auto;
     min-height: calc(100vh - 53px);
-  }
-  .bookmarks-layout { grid-template-columns: 1fr; }
-  .bookmarks-categories {
-    position: static;
-    max-height: none;
   }
 
   .detail {


### PR DESCRIPTION
## Summary
Previous attempt tried to put categories in a 220px side rail (`.bookmarks-layout` grid) with `position: sticky; top: 0`. That collided with the sticky tab nav (top: -16px) and felt like a parallel rail rather than a child of the bookmarks page.

Restructured so the DOM matches the mental model:

- `<section class="bookmarks-categories">` is now the **last child of `#bookmarksView`**, after `#cards`.
- Renders as a horizontal **chip strip** (rounded pills, flex-wrap) in normal document flow — no sticky, no grid sidebar, no fixed rail.
- The sticky tab nav sits cleanly above its own scroll container and cannot interfere with the categories pane.
- Other tabs never render the section because it lives inside `#bookmarksView`.

Drops the now-unused `.bookmarks-layout` / `.bookmarks-main` markup and the matching mobile media-query rules.

## Test plan
- [ ] Open ブックマーク tab → cards on top, カテゴリ chip strip at the bottom
- [ ] Scroll content → tabs stay sticky, no overlap or visual collision with chip strip
- [ ] Switch to other tabs → categories pane is gone (lives inside #bookmarksView)
- [ ] Click a category chip → cards filter as before
- [ ] Mobile width → chips wrap naturally, no horizontal scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)