### PR TITLE
feat(domain): batch recatalog all domains seen in access records

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1297,6 +1297,82 @@ app.delete('/api/domains/:domain', (c) => {
   return c.json({ ok: true });
 });
 
+/**
+ * page_visits + visit_events に蓄積されたアクセス記録の全ドメインを走査し、
+ * domain_catalog にまだ無いものを fetch + 分類キューに積む。
+ *
+ * - 既存 catalog 行 (status=done/pending/error) は skip
+ * - localhost / 127.0.0.1 等の skip 対象も skip
+ * - body の `force=true` で既存行も強制的に再キュー (regenerate と同じ挙動を一括適用)
+ *
+ * 既存の lazy `maybeQueueDomain` (アクセス時に 1 件ずつ enqueue) を補完する
+ * メンテナンス用 batch。「過去のアクセスのうち未分類のドメインを今すぐ全部分類」
+ * という用途。
+ */
+app.post('/api/domains/recatalog-all', async (c) => {
+  const body = await c.req.json().catch(() => ({}));
+  const force = body && body.force === true;
+
+  // 2 ソースから unique URL を集める
+  const visitedUrls = new Set();
+  for (const r of db.prepare(`SELECT DISTINCT url FROM page_visits`).all()) {
+    if (r.url) visitedUrls.add(r.url);
+  }
+  for (const r of db.prepare(`SELECT DISTINCT url FROM visit_events`).all()) {
+    if (r.url) visitedUrls.add(r.url);
+  }
+
+  // URL → unique domain
+  const seenDomains = new Map(); // domain -> sample url
+  for (const url of visitedUrls) {
+    const domain = extractDomainFromUrl(url);
+    if (!domain) continue;
+    if (!seenDomains.has(domain)) seenDomains.set(domain, url);
+  }
+
+  let queued = 0;
+  let skippedExisting = 0;
+  let skippedHost = 0;
+  for (const [domain, sampleUrl] of seenDomains) {
+    if (shouldSkipDomain(domain)) { skippedHost++; continue; }
+    if (!force && getDomainCatalog(db, domain)) { skippedExisting++; continue; }
+    if (force) {
+      // regenerate と同じ流れ: pending 行を立てて、queue に積む
+      insertDomainPending(db, domain);
+      domainCatalogQueue.enqueue(async () => {
+        const result = await classifyDomain({ domain });
+        if (result.skip || result.dropRow) {
+          deleteDomainCatalog(db, domain);
+          return;
+        }
+        if (!result.ok) {
+          setDomainCatalog(db, domain, { status: 'error', error: result.error });
+          return;
+        }
+        setDomainCatalog(db, domain, {
+          title: result.title, site_name: result.site_name,
+          description: result.description, can_do: result.can_do,
+          kind: result.kind, status: 'done', error: null,
+        });
+      }, { kind: 'domain', domain, title: domain });
+    } else {
+      // dedup 任せ (新ドメインだけが pending 行として入る)
+      maybeQueueDomain(sampleUrl);
+    }
+    queued++;
+  }
+
+  return c.json({
+    scanned_urls: visitedUrls.size,
+    unique_domains: seenDomains.size,
+    queued,
+    skipped_existing: skippedExisting,
+    skipped_host: skippedHost,
+    queue_depth: domainCatalogQueue.depth,
+    force,
+  });
+});
+
 app.get('/api/visits/suggested', (c) => {
   const days = Number(c.req.query('days')) || 30;
   return c.json({ items: listSuggestedVisits(db, { sinceDays: days }) });

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -1520,6 +1520,41 @@ async function deleteDomainEntry() {
   await loadDomainCatalog();
 }
 
+async function recatalogAllDomains({ force = false } = {}) {
+  const note = force
+    ? 'force 再分類: 既存ドメインも含めて全部再分類します (user_edited 列は保護)。LLM コストが高くつく可能性があります。実行しますか？'
+    : 'アクセス記録に出てきたドメインのうち、まだ辞書に無いものを分類キューに積みます。実行しますか？';
+  if (!confirm(note)) return;
+  const status = $('recatalogAllStatus');
+  if (status) {
+    status.textContent = '走査中...';
+    status.classList.remove('error');
+  }
+  try {
+    const r = await api('/api/domains/recatalog-all', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ force }),
+    });
+    const msg = `走査 URL ${r.scanned_urls}、ユニークドメイン ${r.unique_domains}、`
+              + `キュー追加 ${r.queued}、既存スキップ ${r.skipped_existing}、`
+              + `host スキップ ${r.skipped_host}、キュー深さ ${r.queue_depth}`;
+    flashToast(msg);
+    if (status) {
+      status.textContent = msg;
+      status.classList.remove('error');
+    }
+    await loadDomainCatalog();
+  } catch (e) {
+    const msg = `失敗: ${e.message}`;
+    alert(msg);
+    if (status) {
+      status.textContent = msg;
+      status.classList.add('error');
+    }
+  }
+}
+
 // ── Diary ──────────────────────────────────────────────────────────────
 
 function todayLocalDate() {
@@ -2482,6 +2517,9 @@ $('domainSearch')?.addEventListener('input', (e) => {
 $('domainSaveBtn')?.addEventListener('click', saveDomainEntry);
 $('domainRegenBtn')?.addEventListener('click', regenerateDomainEntry);
 $('domainDeleteBtn')?.addEventListener('click', deleteDomainEntry);
+$('domainRecatalogBtn')?.addEventListener('click', () => recatalogAllDomains({ force: false }));
+$('recatalogAllBtn')?.addEventListener('click', () => recatalogAllDomains({ force: false }));
+$('recatalogAllForceBtn')?.addEventListener('click', () => recatalogAllDomains({ force: true }));
 $('visitsBookmark').addEventListener('click', bookmarkSelectedVisits);
 $('visitsDelete').addEventListener('click', deleteSelectedVisits);
 $('visitsAll').addEventListener('click', (e) => {

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -198,6 +198,7 @@
       <div id="domainView" class="hidden">
         <div class="dict-bar">
           <input id="domainSearch" type="search" placeholder="ドメイン・サイト名・概要で検索" />
+          <button id="domainRecatalogBtn" class="ghost" title="アクセス記録に出てきた全ドメインのうち、まだ辞書に無いものを fetch + 分類キューに積む">🔄 全走査</button>
         </div>
         <div class="dict-layout">
           <ul id="domainList" class="dict-list"></ul>
@@ -394,6 +395,14 @@
     <label>API Key (gpt 系を使う場合): <input id="aiOpenaiKey" type="password" placeholder="sk-..." /></label>
     <span id="aiOpenaiKeyStatus" class="ai-keystatus"></span>
     <label>デフォルトモデル: <input id="aiOpenaiModel" type="text" placeholder="gpt-4o-mini" /></label>
+    <h4>🧹 メンテナンス</h4>
+    <p class="ai-settings-help">過去のアクセス記録に出てきたドメインのうち、まだドメイン辞書に登録されていないものを fetch + 分類キューに積みます。 force にすると既存行も再分類します (user_edited 列は保護)。</p>
+    <div class="ai-settings-actions">
+      <button id="recatalogAllBtn">アクセス記録から全ドメインを走査</button>
+      <button id="recatalogAllForceBtn" class="ghost" title="既存の辞書行も含めて全部再分類する">force 再分類</button>
+    </div>
+    <div id="recatalogAllStatus" class="multi-status"></div>
+
     <h4>🛠 ランタイム情報 (読み取り専用)</h4>
     <p class="ai-settings-help">これらは起動時に決まる値で、変更には再起動が必要です。デスクトップアプリから自動で渡されます。</p>
     <div id="aiRuntimeInfo" class="ai-runtime-info"></div>


### PR DESCRIPTION
## Summary
別セッションで仕込まれていたメンテナンス用の全ドメイン走査をマージ可能な形に整える。

過去の `page_visits` + `visit_events` に出てきたドメインを集約し、`domain_catalog` にまだ無いものを fetch + 分類キューに乗せる。既存の lazy `maybeQueueDomain` (アクセス時 1 件ずつ enqueue) を補完する batch。

### Endpoint
```
POST /api/domains/recatalog-all
body: { force?: boolean }
```
- デフォルト: catalog 行が無いドメインだけ enqueue。既存 (done / pending / error) は skip。
- `force: true`: すべてのドメインを regenerate と同じ流れで再分類 (`user_edited` 行は `setDomainCatalog` の guard で保護)。
- localhost / loopback は `shouldSkipDomain` で skip。
- レスポンス: `scanned_urls / unique_domains / queued / skipped_existing / skipped_host / queue_depth`。

### UI
- 🏷 ドメインタブの検索バー右に **🔄 全走査** ボタン
- ⚙ AI 設定 → **🧹 メンテナンス** セクション
  - `アクセス記録から全ドメインを走査` (default)
  - `force 再分類` (ghost、警告強め)
  - 結果カウンタを表示する status 行

## Test plan
- [ ] 🔄 全走査をクリック → 確認ダイアログ → 結果トースト
- [ ] 結果の `queued` 件数が作業キュー (`📋 ドメイン分類`) で順次処理される
- [ ] 既存 catalog がある状態でもう一度走査 → `skipped_existing` がほぼ全件
- [ ] force 再分類 → 既存行も `pending` に戻ってキューに積まれる、`user_edited=1` 行は値が保護される

🤖 Generated with [Claude Code](https://claude.com/claude-code)