### PR TITLE
fix(layout): bookmarks (and other tabs) get full content width

### DIFF
--- a/server/public/style.css
+++ b/server/public/style.css
@@ -91,10 +91,15 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 
 .layout {
   display: grid;
-  grid-template-columns: 1fr 360px;
+  /* `minmax(0, 1fr)` instead of plain `1fr`: the latter has implicit
+   * min-width: auto, which shrinks the column when a child overflows
+   * its track (the sticky tab nav with negative margin used to squeeze
+   * the bookmarks view down to ~170px). minmax(0,…) lets the column
+   * fill the remaining space regardless of content min-size. */
+  grid-template-columns: minmax(0, 1fr) 360px;
   height: calc(100vh - 53px);
 }
-.layout:has(.detail.hidden) { grid-template-columns: 1fr; }
+.layout:has(.detail.hidden) { grid-template-columns: minmax(0, 1fr); }
 
 /* Categories live INSIDE the bookmarks page, below the cards. They sit in
  * normal document flow — no sticky positioning, no layout-level sidebar —


### PR DESCRIPTION
## Summary
The bookmarks view was rendering at ~170 px because `.layout` used `grid-template-columns: 1fr 360px`. CSS Grid resolves plain `1fr` as `minmax(auto, 1fr)`, where `auto` is the column's implicit min-width — driven by its content's intrinsic min-size.

The sticky tab nav uses negative `margin: -16px -16px 16px` to break out of `.content`'s padding, which gives the column a wider implicit min-content; the grid then squeezes the rest of the column down to fit, leaving any tab whose direct content isn't already wide (notably bookmarks) clamped down.

Switching the column to `minmax(0, 1fr)` lets the track fill the remaining space irrespective of child min-size. The right-hand detail aside still gets its 360 px when present, otherwise the column takes the full row.

## Test plan
- [ ] Bookmarks tab fills the available width, cards tile in multiple columns again
- [ ] Open bookmark detail → main column shrinks gracefully to leave room for the 360 px aside
- [ ] Other tabs (queue / events / trends / etc.) still render correctly
- [ ] No horizontal scrollbar on the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)