### PR TITLE
fix(visits): categories at top, domain link, URL-as-title fallback

### DIFF
--- a/server/public/app.js
+++ b/server/public/app.js
@@ -2368,13 +2368,20 @@ function renderVisits() {
     const catLine = cat?.description
       ? `<div class="visits-catalog"><span class="visits-domain-prefix">[ドメイン] </span>${cat.kind ? `<span class="visits-kind">${escapeHtml(cat.kind)}</span> ` : ''}${escapeHtml(cat.description)}</div>`
       : (cat?.status === 'pending' ? `<div class="visits-catalog pending">ドメイン分類中…</div>` : '');
+    // Title fallback chain: Sonnet-fetched page_title → recorded title →
+    // bare domain URL (so rows that never resolved a title still read as
+    // something meaningful instead of "(タイトル未取得)").
+    const titleText = pg?.page_title || v.title || (dom ? `https://${dom}/` : v.url);
     return `
       <li class="${sel ? 'selected' : ''} ${hot ? 'hot' : ''}" data-url="${escapeHtml(v.url)}">
         <input type="checkbox" class="vchk" ${sel ? 'checked' : ''} />
         <div style="min-width:0">
-          <div class="title">${escapeHtml(pg?.page_title || v.title || '(タイトル未取得)')} ${badge}</div>
+          <div class="title">${escapeHtml(titleText)} ${badge}</div>
           <div class="url">${escapeHtml(v.url)}</div>
-          <div class="visits-meta">${escapeHtml(dom)}${v.score ? ` · score ${v.score}` : ''}</div>
+          <div class="visits-meta">
+            <a class="visits-domain-link" href="#" data-domain="${escapeHtml(dom)}" title="${escapeHtml(dom)} のドメイン辞書を開く">${escapeHtml(dom)}</a>
+            ${v.score ? ` · score ${v.score}` : ''}
+          </div>
           ${pageLine}
           ${catLine}
         </div>
@@ -2389,6 +2396,9 @@ function renderVisits() {
     const url = li.dataset.url;
     const cb = li.querySelector('.vchk');
     li.addEventListener('click', (e) => {
+      // Clicks on the domain link / select / inputs shouldn't toggle the
+      // bookmark checkbox.
+      if (e.target.closest('.visits-domain-link, a, button, input')) return;
       if (e.target !== cb) {
         cb.checked = !cb.checked;
       }
@@ -2397,6 +2407,20 @@ function renderVisits() {
       li.classList.toggle('selected', cb.checked);
       $('visitsSelCount').textContent = state.visitsSelected.size;
       $('visitsAll').checked = state.visitsSelected.size === state.visits.length;
+    });
+  });
+  list.querySelectorAll('.visits-domain-link').forEach(a => {
+    a.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const domain = a.dataset.domain;
+      if (!domain) return;
+      switchTab('domain');
+      // loadDomainCatalog runs from switchTab's tab handler; await its
+      // completion before pinning the entry so the list highlights it.
+      Promise.resolve().then(async () => {
+        try { await loadDomainEntry(domain); } catch (err) { console.error(err); }
+      });
     });
   });
 }

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -70,12 +70,12 @@
           <button id="bulkClear" class="ghost">クリア</button>
         </div>
         <div class="bookmarks-main">
-          <div id="cards" class="cards"></div>
-          <div id="empty" class="empty hidden">ブックマークがありません。Chrome 拡張からページを保存してください。</div>
           <section class="bookmarks-categories">
             <h3>カテゴリ</h3>
             <ul id="categoryList"></ul>
           </section>
+          <div id="cards" class="cards"></div>
+          <div id="empty" class="empty hidden">ブックマークがありません。Chrome 拡張からページを保存してください。</div>
         </div>
       </div>
 

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -111,8 +111,8 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
  * so the sticky tab nav cannot collide with them. Other tabs never render
  * this section because it lives inside #bookmarksView. */
 .bookmarks-categories {
-  margin-top: 24px;
-  padding: 12px 14px;
+  margin: 0 0 16px;
+  padding: 10px 14px;
   background: var(--panel);
   border: 1px solid var(--border);
   border-radius: 10px;
@@ -375,6 +375,14 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 }
 .visits-list li.hot { border-left: 4px solid #d68a00; }
 .visits-meta { font-size: 11px; color: var(--muted); margin-top: 2px; }
+.visits-domain-link {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px dotted var(--accent);
+  padding-bottom: 1px;
+  cursor: pointer;
+}
+.visits-domain-link:hover { background: var(--accent-bg); border-radius: 3px; }
 
 .trends-bar {
   display: flex;


### PR DESCRIPTION
## Summary
Three fixes the user flagged after the layout rewrite.

1. **Categories vanished** because the chip strip was the last child of `#bookmarksView` — any non-trivial bookmark count pushed it past the fold. Move the section above `#cards` so it's the first thing under `#bulkBar`. Always visible without scrolling.

2. **Linkify the domain in the visits list.** Each row's domain text becomes a small dotted-underline link; clicking switches to the ドメイン tab and loads that domain's catalog entry directly. The click handler stops propagation so it doesn't also toggle the bookmark checkbox.

3. **Title fallback chain**: Sonnet `page_title` → recorded `title` → `https://<domain>/` (instead of the previous "(タイトル未取得)" placeholder). Rows now always read as something meaningful even when title fetch failed.

## Test plan
- [ ] ブックマーク tab: カテゴリ chip strip is visible at the top, above cards
- [ ] アクセス履歴 tab: each row's domain text is a dotted link; clicking it lands on ドメイン tab with that entry selected
- [ ] アクセス履歴 row with no fetched title shows `https://<domain>/` instead of `(タイトル未取得)`
- [ ] Domain link click does NOT toggle the bookmark checkbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)