### PR TITLE
feat(ui): Pinterest tile grid for dict + domain with modal edit

### DIFF
--- a/server/public/app.js
+++ b/server/public/app.js
@@ -1268,7 +1268,7 @@ function renderDictionaryList() {
   ul.innerHTML = state.dictEntries.map(e => `
     <li class="dict-item ${state.dictDetail?.id === e.id ? 'selected' : ''}" data-id="${e.id}">
       <div class="dict-term">${escapeHtml(e.term)}</div>
-      <div class="dict-snippet">${escapeHtml((e.definition || '').slice(0, 120))}</div>
+      <div class="dict-snippet">${escapeHtml((e.definition || e.notes || '').slice(0, 320))}</div>
       <div class="dict-meta">
         <span>${e.link_count} 件リンク</span>
         <span>${fmtDate(e.updated_at)}</span>
@@ -1292,8 +1292,8 @@ async function loadDictionaryEntry(id) {
 async function renderDictionaryDetail() {
   const e = state.dictDetail;
   const panel = $('dictDetail');
-  if (!e) { panel.classList.add('hidden'); return; }
-  panel.classList.remove('hidden');
+  if (!e) { hideModal('dictDetail'); return; }
+  showModal('dictDetail');
   $('dictTerm').value = e.term || '';
   $('dictDefinition').value = e.definition || '';
   $('dictNotes').value = e.notes || '';
@@ -1390,7 +1390,7 @@ async function deleteDictionaryEntry() {
   try {
     await api(`/api/dictionary/${e.id}`, { method: 'DELETE' });
     state.dictDetail = null;
-    $('dictDetail').classList.add('hidden');
+    hideModal('dictDetail');
     await loadDictionary();
   } catch (e) {
     alert(`削除失敗: ${e.message}`);
@@ -1430,16 +1430,20 @@ function renderDomainList() {
     ul.innerHTML = '<li class="dict-empty">ドメイン辞書はまだ空です。アクセス履歴の生成によって自動で追加されます。</li>';
     return;
   }
-  ul.innerHTML = state.domainEntries.map(e => `
+  ul.innerHTML = state.domainEntries.map(e => {
+    const desc = (e.description || '').trim();
+    const can = (e.can_do || '').trim();
+    const body = desc + (desc && can ? '\n\n' : '') + (can ? `できること:\n${can}` : '');
+    return `
     <li class="dict-item ${state.domainDetail?.domain === e.domain ? 'selected' : ''}" data-domain="${escapeHtml(e.domain)}">
       <div class="dict-term">${escapeHtml(e.site_name || e.domain)}</div>
-      <div class="dict-snippet">${escapeHtml((e.description || '').slice(0, 100))}</div>
+      <div class="dict-snippet">${escapeHtml(body.slice(0, 320))}</div>
       <div class="dict-meta">
         <span>${escapeHtml(e.domain)}</span>
         <span>本日 ${e.visits_today} / 週 ${e.visits_week}</span>
       </div>
-    </li>
-  `).join('');
+    </li>`;
+  }).join('');
   ul.querySelectorAll('.dict-item').forEach(li => {
     li.addEventListener('click', () => loadDomainEntry(li.dataset.domain));
   });
@@ -1459,8 +1463,8 @@ async function loadDomainEntry(domain) {
 function renderDomainDetail() {
   const e = state.domainDetail;
   const panel = $('domainDetail');
-  if (!e) { panel.classList.add('hidden'); return; }
-  panel.classList.remove('hidden');
+  if (!e) { hideModal('domainDetail'); return; }
+  showModal('domainDetail');
   $('domainKey').value = e.domain;
   $('domainSiteName').value = e.site_name || '';
   $('domainDesc').value = e.description || '';
@@ -1516,7 +1520,7 @@ async function deleteDomainEntry() {
   if (!confirm(`「${e.domain}」をドメイン辞書から削除しますか？`)) return;
   await api(`/api/domains/${encodeURIComponent(e.domain)}`, { method: 'DELETE' });
   state.domainDetail = null;
-  $('domainDetail').classList.add('hidden');
+  hideModal('domainDetail');
   await loadDomainCatalog();
 }
 
@@ -2556,6 +2560,39 @@ $('domainDeleteBtn')?.addEventListener('click', deleteDomainEntry);
 $('domainRecatalogBtn')?.addEventListener('click', () => recatalogAllDomains({ force: false }));
 $('recatalogAllBtn')?.addEventListener('click', () => recatalogAllDomains({ force: false }));
 $('recatalogAllForceBtn')?.addEventListener('click', () => recatalogAllDomains({ force: true }));
+
+// ── modal panels (dict + domain edit) ─────────────────────────────────────
+function showModal(panelId) {
+  $(panelId).classList.remove('hidden');
+  $('modalBackdrop').hidden = false;
+}
+function hideModal(panelId) {
+  if (panelId) $(panelId).classList.add('hidden');
+  // If neither panel is open after this hide, drop the backdrop too.
+  const dictOpen = !$('dictDetail').classList.contains('hidden');
+  const domOpen  = !$('domainDetail').classList.contains('hidden');
+  $('modalBackdrop').hidden = !(dictOpen || domOpen);
+}
+function closeAllModals() {
+  state.dictDetail = null;
+  state.domainDetail = null;
+  hideModal('dictDetail');
+  hideModal('domainDetail');
+}
+$('dictDetailClose')?.addEventListener('click', () => {
+  state.dictDetail = null;
+  hideModal('dictDetail');
+});
+$('domainDetailClose')?.addEventListener('click', () => {
+  state.domainDetail = null;
+  hideModal('domainDetail');
+});
+$('modalBackdrop')?.addEventListener('click', closeAllModals);
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape' && !$('modalBackdrop').hidden) {
+    closeAllModals();
+  }
+});
 $('visitsBookmark').addEventListener('click', bookmarkSelectedVisits);
 $('visitsDelete').addEventListener('click', deleteSelectedVisits);
 $('visitsAll').addEventListener('click', (e) => {

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -177,24 +177,7 @@
           <input id="dictSearch" type="search" placeholder="辞書を検索 (term / 説明 / メモ)" />
           <button id="dictNewBtn">＋ 新規エントリ</button>
         </div>
-        <div class="dict-layout">
-          <ul id="dictList" class="dict-list"></ul>
-          <div id="dictDetail" class="dict-detail hidden">
-            <div class="dict-detail-head">
-              <input id="dictTerm" type="text" placeholder="単語" />
-              <button id="dictSaveBtn">保存</button>
-              <button id="dictShareBtn" class="ghost" title="マルチサーバに共有" hidden>📤 シェア</button>
-              <span id="dictShareStatus" class="share-status"></span>
-              <button id="dictDeleteBtn" class="danger">削除</button>
-            </div>
-            <h4>説明</h4>
-            <textarea id="dictDefinition" rows="6" placeholder="調査内容・定義 (Markdown 可)"></textarea>
-            <h4>メモ</h4>
-            <textarea id="dictNotes" rows="4" placeholder="追加メモ"></textarea>
-            <h4>リンクされた調査記録</h4>
-            <ul id="dictLinks" class="dict-links"></ul>
-          </div>
-        </div>
+        <ul id="dictList" class="dict-list pin-grid"></ul>
       </div>
 
       <div id="domainView" class="hidden">
@@ -202,28 +185,7 @@
           <input id="domainSearch" type="search" placeholder="ドメイン・サイト名・概要で検索" />
           <button id="domainRecatalogBtn" class="ghost" title="アクセス記録に出てきた全ドメインのうち、まだ辞書に無いものを fetch + 分類キューに積む">🔄 全走査</button>
         </div>
-        <div class="dict-layout">
-          <ul id="domainList" class="dict-list"></ul>
-          <div id="domainDetail" class="dict-detail hidden">
-            <div class="dict-detail-head">
-              <input id="domainKey" type="text" placeholder="ドメイン" disabled />
-              <button id="domainSaveBtn">保存</button>
-              <button id="domainRegenBtn" class="ghost" title="claude に再分類させる">再分類</button>
-              <button id="domainDeleteBtn" class="danger">削除</button>
-            </div>
-            <div id="domainStats" class="domain-stats"></div>
-            <h4>Webサイト名</h4>
-            <input id="domainSiteName" type="text" placeholder="サービス名 / プロダクト名" />
-            <h4>概要</h4>
-            <textarea id="domainDesc" rows="3" placeholder="このドメインの 1〜2 文の説明"></textarea>
-            <h4>できること</h4>
-            <textarea id="domainCanDo" rows="4" placeholder="- できること1\n- できること2"></textarea>
-            <h4>カテゴリ</h4>
-            <input id="domainKind" type="text" placeholder="例: ドキュメント / SaaS / ブログ" />
-            <h4>メモ</h4>
-            <textarea id="domainNotes" rows="3" placeholder="自分用のメモ"></textarea>
-          </div>
-        </div>
+        <ul id="domainList" class="dict-list pin-grid"></ul>
       </div>
 
       <div id="diaryView" class="hidden">
@@ -378,6 +340,48 @@
       <ul id="dAccesses" class="accesses"></ul>
     </aside>
   </main>
+
+  <!-- Modal backdrop is shared between dict and domain detail panels.
+       Click on the backdrop or Escape closes whichever modal is open. -->
+  <div id="modalBackdrop" class="modal-backdrop" hidden></div>
+
+  <div id="dictDetail" class="dict-detail modal-panel hidden">
+    <div class="dict-detail-head">
+      <input id="dictTerm" type="text" placeholder="単語" />
+      <button id="dictSaveBtn">保存</button>
+      <button id="dictShareBtn" class="ghost" title="マルチサーバに共有" hidden>📤 シェア</button>
+      <span id="dictShareStatus" class="share-status"></span>
+      <button id="dictDeleteBtn" class="danger">削除</button>
+      <button id="dictDetailClose" class="modal-close" title="閉じる">×</button>
+    </div>
+    <h4>説明</h4>
+    <textarea id="dictDefinition" rows="6" placeholder="調査内容・定義 (Markdown 可)"></textarea>
+    <h4>メモ</h4>
+    <textarea id="dictNotes" rows="4" placeholder="追加メモ"></textarea>
+    <h4>リンクされた調査記録</h4>
+    <ul id="dictLinks" class="dict-links"></ul>
+  </div>
+
+  <div id="domainDetail" class="dict-detail modal-panel hidden">
+    <div class="dict-detail-head">
+      <input id="domainKey" type="text" placeholder="ドメイン" disabled />
+      <button id="domainSaveBtn">保存</button>
+      <button id="domainRegenBtn" class="ghost" title="claude に再分類させる">再分類</button>
+      <button id="domainDeleteBtn" class="danger">削除</button>
+      <button id="domainDetailClose" class="modal-close" title="閉じる">×</button>
+    </div>
+    <div id="domainStats" class="domain-stats"></div>
+    <h4>Webサイト名</h4>
+    <input id="domainSiteName" type="text" placeholder="サービス名 / プロダクト名" />
+    <h4>概要</h4>
+    <textarea id="domainDesc" rows="3" placeholder="このドメインの 1〜2 文の説明"></textarea>
+    <h4>できること</h4>
+    <textarea id="domainCanDo" rows="4" placeholder="- できること1\n- できること2"></textarea>
+    <h4>カテゴリ</h4>
+    <input id="domainKind" type="text" placeholder="例: ドキュメント / SaaS / ブログ" />
+    <h4>メモ</h4>
+    <textarea id="domainNotes" rows="3" placeholder="自分用のメモ"></textarea>
+  </div>
 
   <div id="aiSettingsPanel" class="ai-settings hidden">
     <div class="ai-settings-head">

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -900,39 +900,86 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   align-items: center;
 }
 .dict-bar input { flex: 1; padding: 8px 10px; border: 1px solid var(--border); border-radius: 6px; }
-.dict-layout {
-  display: grid;
-  grid-template-columns: minmax(280px, 360px) 1fr;
-  gap: 12px;
-  align-items: start;
-}
-.dict-list {
+/* Dictionary + domain catalog: Pinterest-style tile grid filling the
+ * viewport. Each entry is a card; clicking opens the edit form as a
+ * modal overlay (.dict-detail.modal-panel). */
+.dict-list.pin-grid {
   list-style: none;
   padding: 0;
   margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 12px;
+  align-items: start;
 }
 .dict-item {
   background: var(--panel);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 10px 12px;
+  border-radius: 10px;
+  padding: 12px 14px;
   cursor: pointer;
   box-shadow: var(--shadow);
+  transition: border-color 80ms, transform 80ms, box-shadow 80ms;
 }
-.dict-item:hover { border-color: var(--accent); }
+.dict-item:hover {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px rgba(0,0,0,0.08);
+}
 .dict-item.selected { border-color: var(--accent); background: var(--accent-bg); }
-.dict-term { font-weight: 600; line-height: 1.3; }
-.dict-snippet { font-size: 11px; color: var(--muted); margin-top: 2px; line-height: 1.4; }
+.dict-term { font-weight: 600; line-height: 1.35; word-break: break-word; }
+.dict-snippet {
+  font-size: 12px;
+  color: var(--text);
+  margin-top: 6px;
+  line-height: 1.5;
+  /* Clamp to ~5 lines so tiles stay roughly comparable in height. */
+  display: -webkit-box;
+  -webkit-line-clamp: 5;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
 .dict-meta {
   font-size: 10px;
   color: var(--muted);
   display: flex;
   justify-content: space-between;
-  margin-top: 6px;
+  margin-top: 8px;
+  gap: 6px;
+  flex-wrap: wrap;
 }
+.dict-empty { padding: 32px; color: var(--muted); font-style: italic; text-align: center; }
+
+/* Modal overlay used for the edit panels. */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 90;
+}
+.modal-backdrop[hidden] { display: none; }
+.modal-panel {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(680px, 92vw);
+  max-height: 88vh;
+  overflow-y: auto;
+  z-index: 100;
+}
+.modal-close {
+  margin-left: auto;
+  background: transparent;
+  border: 0;
+  color: var(--muted);
+  font-size: 22px;
+  line-height: 1;
+  padding: 4px 10px;
+  cursor: pointer;
+  border-radius: 6px;
+}
+.modal-close:hover { background: #f0f2f7; color: var(--text); }
 .dict-empty {
   font-size: 12px;
   color: var(--muted);


### PR DESCRIPTION
## Summary
Dictionary and domain catalogue lists become a Pinterest-style tile grid filling the available width. Edit panels move to a shared modal overlay.

- `.dict-list.pin-grid`: `display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr))` with `gap: 12px` and `align-items: start`.
- Tiles show a longer snippet (definition + notes for dict; description + can_do for domain) clamped to ~5 lines via `-webkit-line-clamp` so card heights stay comparable.
- Both detail edit panels (dict / domain) become `.modal-panel` overlays with a shared `#modalBackdrop`. Click-outside-to-close + Escape closes whichever modal is open. Helpers `showModal(id)` / `hideModal(id)` toggle backdrop visibility based on whether any modal remains open.
- The old `.dict-layout` 2-column grid is gone; modal panels are direct children of `<body>` so they aren't constrained by the tab's scroll container.

## Test plan
- [ ] 📖 辞書 タブ: tiles fill the width in 1+ rows depending on viewport
- [ ] Click a tile → modal opens with the edit form, page behind dimmed
- [ ] Backdrop click / Escape closes the modal
- [ ] Save / Delete still work, list refreshes
- [ ] Same flow on 🏷 ドメイン tab; tile shows description + できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)