### PR TITLE
feat(diary): one-shot improve UI + global memo (settings)

### DIFF
--- a/server/diary.js
+++ b/server/diary.js
@@ -573,24 +573,37 @@ function formatUrlLine(ts, url) {
   return `${m ? m[1] : '??:??'} ${url}`;
 }
 
+function appendMemoAndImprove(prompt, { globalMemo, improve } = {}) {
+  const tail = [];
+  if (globalMemo && globalMemo.trim()) {
+    tail.push('', '## ユーザの常設メモ (毎回参照)', globalMemo.trim());
+  }
+  if (improve && improve.trim()) {
+    tail.push('', '## このターンだけの改善指示 (最優先)', improve.trim());
+  }
+  return tail.length > 0 ? `${prompt}\n${tail.join('\n')}` : prompt;
+}
+
 /** Stage 1: Sonnet (default) writes 作業内容 from the URL timeline. */
-export async function generateWorkContent({ db, dateStr, metrics, timeoutMs = 180_000 }) {
+export async function generateWorkContent({ db, dateStr, metrics, globalMemo, improve, timeoutMs = 180_000 }) {
   const urlList = buildUrlList(db, dateStr);
   if (!urlList.trim()) return '';
-  const prompt = WORK_CONTENT_PROMPT({
+  const base = WORK_CONTENT_PROMPT({
     dateStr,
     urlList,
     totalEvents: metrics.total_events,
     totalDomains: metrics.unique_domains,
   });
+  const prompt = appendMemoAndImprove(base, { globalMemo, improve });
   return await runLlm({ task: 'diary_work', prompt, timeoutMs });
 }
 
 /** Stage 3: Opus 1M (default) integrates work content + bookmark count + commits + dig into highlights. */
-export async function generateHighlights({ dateStr, workContent, githubByRepo, bookmarkSummary, digs, notes, metrics, timeoutMs = 240_000 }) {
-  const prompt = HIGHLIGHTS_PROMPT({
+export async function generateHighlights({ dateStr, workContent, githubByRepo, bookmarkSummary, digs, notes, metrics, globalMemo, improve, timeoutMs = 240_000 }) {
+  const base = HIGHLIGHTS_PROMPT({
     dateStr, workContent, githubByRepo, bookmarkSummary, digs, notes, metrics,
   });
+  const prompt = appendMemoAndImprove(base, { globalMemo, improve });
   return await runLlm({ task: 'diary_highlights', prompt, timeoutMs });
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -867,12 +867,15 @@ app.post('/api/dictionary/upsert-from-source', async (c) => {
 
 app.get('/api/llm/config', (c) => {
   const cfg = getLlmConfig();
+  const settings = getAppSettings(db);
   return c.json({
     config: {
       ...cfg,
       // Mask the API key when returning to FE.
       openai_api_key: cfg.openai_api_key ? '***' : '',
       openai_api_key_set: !!cfg.openai_api_key,
+      // Standing memo passed to every diary generation.
+      diary_global_memo: settings['diary.global_memo'] || '',
     },
     tasks: LLM_TASKS,
     providers: Object.entries(LLM_PROVIDERS).map(([key, v]) => ({
@@ -897,6 +900,10 @@ app.patch('/api/llm/config', async (c) => {
   const patch = settingsPatchFromConfig(body);
   // Don't blow away the API key with the masked '***' value.
   if (patch['llm.openai.api_key'] === '***') delete patch['llm.openai.api_key'];
+  // Diary-specific standing memo lives outside the LLM config object.
+  if (typeof body.diary_global_memo === 'string') {
+    patch['diary.global_memo'] = body.diary_global_memo;
+  }
   setAppSettings(db, patch);
   loadLlmConfigFromSettings(getAppSettings(db));
   return c.json({ ok: true });
@@ -1551,7 +1558,7 @@ function settingsAsObject() {
 // Stages share a context object that is closed over by every queued task,
 // so later stages can read what earlier stages produced. Failure in any
 // stage marks the diary row as `error` and stops the chain.
-function enqueueDiaryStages(dateStr) {
+function enqueueDiaryStages(dateStr, opts = {}) {
   const ctx = {
     metrics: null,
     github: null,
@@ -1560,6 +1567,10 @@ function enqueueDiaryStages(dateStr) {
     githubByRepo: null,
     highlights: '',
     bookmarkSummary: null,
+    // One-shot improvement instruction from the UI (not persisted).
+    improve: typeof opts.improve === 'string' ? opts.improve.trim() : '',
+    // Standing memo from app_settings — passed to every prompt.
+    globalMemo: '',
     failed: false,
   };
 
@@ -1579,6 +1590,7 @@ function enqueueDiaryStages(dateStr) {
     ctx.metrics = aggregateDay(db, dateStr);
     const prior = getDiary(db, dateStr);
     ctx.notes = prior?.notes || '';
+    ctx.globalMemo = (getAppSettings(db)['diary.global_memo'] || '').trim();
     upsertDiary(db, { date: dateStr, status: 'pending', metrics: ctx.metrics, error: null });
   }, { kind: 'diary_prepare', date: dateStr, title: `📅 ${dateStr} 集計` });
 
@@ -1604,7 +1616,11 @@ function enqueueDiaryStages(dateStr) {
   diaryQueue.enqueue(async () => {
     if (ctx.failed) return;
     try {
-      ctx.workContent = await generateWorkContent({ db, dateStr, metrics: ctx.metrics });
+      ctx.workContent = await generateWorkContent({
+        db, dateStr, metrics: ctx.metrics,
+        globalMemo: ctx.globalMemo,
+        improve: ctx.improve,
+      });
       upsertDiary(db, {
         date: dateStr,
         workContent: ctx.workContent,
@@ -1642,6 +1658,8 @@ function enqueueDiaryStages(dateStr) {
         githubByRepo: ctx.githubByRepo,
         bookmarkSummary: ctx.bookmarkSummary,
         digs, notes: ctx.notes, metrics: ctx.metrics,
+        globalMemo: ctx.globalMemo,
+        improve: ctx.improve,
       });
       const summary = composeDiarySummary({
         workContent: ctx.workContent,
@@ -1731,11 +1749,12 @@ async function runDiaryGeneration(dateStr) {
   });
 }
 
-function enqueueDiary(dateStr) {
+function enqueueDiary(dateStr, opts = {}) {
   // User-facing diary regenerate. Splits into prepare → github → work →
   // highlights so each LLM/IO step is its own queue entry. The legacy
   // single-task path (runDiaryGeneration) is kept for the weekly cron.
-  enqueueDiaryStages(dateStr);
+  // `opts.improve` carries one-shot UI feedback for this run only.
+  enqueueDiaryStages(dateStr, opts);
 }
 
 app.get('/api/diary', (c) => {
@@ -1763,10 +1782,13 @@ app.get('/api/diary/:date', (c) => {
   return c.json({ ...entry, live_metrics: liveMetrics });
 });
 
-app.post('/api/diary/:date/generate', (c) => {
+app.post('/api/diary/:date/generate', async (c) => {
   const date = c.req.param('date');
   if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return c.json({ error: 'invalid date' }, 400);
-  enqueueDiary(date);
+  // Body is optional. When present, `improve` is a one-shot instruction
+  // appended to the prompt for this run only (not persisted).
+  const body = await c.req.json().catch(() => null);
+  enqueueDiary(date, { improve: body?.improve });
   return c.json({ queued: true, queue_depth: diaryQueue.depth });
 });
 

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -1997,22 +1997,44 @@ function renderHourlyChart(hours) {
   return `<svg viewBox="0 0 ${w} ${h}" preserveAspectRatio="xMidYMid meet">${bars}</svg>`;
 }
 
-async function generateDiary() {
+async function generateDiary({ improve = '' } = {}) {
   const date = state.diaryDetailDate;
   if (!date) return;
-  const btn = $('diaryGenerate');
+  const btn = improve ? $('diaryImproveBtn') : $('diaryGenerate');
+  const baseLabel = btn.textContent;
   btn.disabled = true;
   btn.textContent = '投入中…';
+  const status = $('diaryImproveStatus');
+  if (improve && status) { status.textContent = ''; }
   try {
-    await api(`/api/diary/${date}/generate`, { method: 'POST' });
-    flashToast(`${date} の日記を生成キューに投入しました`);
+    await api(`/api/diary/${date}/generate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ improve }),
+    });
+    flashToast(`${date} の日記を生成キューに投入しました${improve ? ' (改善指示込み)' : ''}`);
+    if (improve) {
+      // One-shot — clear the textarea so the next click is a fresh prompt.
+      $('diaryImproveInput').value = '';
+      if (status) status.textContent = '✓ 投入しました';
+    }
     await loadDiaryDetail(date);
   } catch (e) {
-    alert(`失敗: ${e.message}`);
+    if (improve && status) status.textContent = `✗ ${e.message}`;
+    else alert(`失敗: ${e.message}`);
   } finally {
     btn.disabled = false;
-    btn.textContent = '再生成';
+    btn.textContent = baseLabel;
   }
+}
+
+async function improveDiary() {
+  const text = ($('diaryImproveInput')?.value || '').trim();
+  if (!text) {
+    alert('改善したい内容を書いてから押してください。');
+    return;
+  }
+  await generateDiary({ improve: text });
 }
 
 async function deleteDiaryEntry() {
@@ -2541,7 +2563,8 @@ $('diaryToday')?.addEventListener('click', () => {
   refreshDiaryMonth();
   loadDiaryDetail(todayLocalDate());
 });
-$('diaryGenerate')?.addEventListener('click', generateDiary);
+$('diaryGenerate')?.addEventListener('click', () => generateDiary());
+$('diaryImproveBtn')?.addEventListener('click', improveDiary);
 $('diaryDelete')?.addEventListener('click', deleteDiaryEntry);
 $('diaryNotesSave')?.addEventListener('click', saveDiaryNotes);
 $('diarySettingsBtn')?.addEventListener('click', openDiarySettings);
@@ -2638,6 +2661,7 @@ async function openAiSettings() {
     $('aiOpenaiKey').value = '';
     $('aiOpenaiModel').value = cfg.openai_model || '';
     $('aiOpenaiKeyStatus').textContent = cfg.openai_api_key_set ? '✓ API key 設定済み (再入力で上書き)' : '(未設定)';
+    if ($('aiDiaryGlobalMemo')) $('aiDiaryGlobalMemo').value = cfg.diary_global_memo || '';
     if (r.runtime) {
       const rt = r.runtime;
       $('aiRuntimeInfo').innerHTML = `
@@ -2797,6 +2821,7 @@ async function saveAiSettings() {
     },
     openai_model: $('aiOpenaiModel').value.trim() || 'gpt-4o-mini',
     git_bash_path: $('aiGitBashPath').value.trim(),
+    diary_global_memo: $('aiDiaryGlobalMemo')?.value || '',
   };
   const k = $('aiOpenaiKey').value;
   if (k && k !== '***') body.openai_api_key = k;

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -257,6 +257,14 @@
             <div class="diary-detail-actions">
               <button id="diaryNotesSave">メモを保存</button>
             </div>
+
+            <h4>🔧 この日記を改善</h4>
+            <p class="diary-improve-help">出力に対するフィードバック (例: <code>もっと簡潔に</code> / <code>○○の話題を強調</code> / <code>時間帯を詳しく</code>) を書いて改善ボタンを押すと、その指示を上乗せして当日分だけ再生成します。指示は永続化されません。</p>
+            <textarea id="diaryImproveInput" rows="3" placeholder="例: 12〜15時のブロックを2行に分けて、Memoria の作業を主役に書き直して"></textarea>
+            <div class="diary-detail-actions">
+              <button id="diaryImproveBtn">改善して再生成</button>
+              <span id="diaryImproveStatus" class="share-status"></span>
+            </div>
           </div>
         </div>
         <div id="diarySettingsPanel" class="diary-settings hidden">
@@ -401,6 +409,10 @@
     <label>API Key (gpt 系を使う場合): <input id="aiOpenaiKey" type="password" placeholder="sk-..." /></label>
     <span id="aiOpenaiKeyStatus" class="ai-keystatus"></span>
     <label>デフォルトモデル: <input id="aiOpenaiModel" type="text" placeholder="gpt-4o-mini" /></label>
+    <h4>📝 日記の常設メモ</h4>
+    <p class="ai-settings-help">日記生成時に毎回プロンプトに添える「常設メモ」。プロジェクトの背景・自分の役割・生成ルール (例: <code>Memoria は LUDIARS の個人ツール。曖昧な作業は推測で断定して書く</code>) などを書いておくと、毎日の日記の作業内容 / ハイライトに反映されます。空欄なら何も追加しません。</p>
+    <textarea id="aiDiaryGlobalMemo" rows="6" placeholder="例: 自分の役割は LUDIARS の AI/フルスタック開発。Memoria, Synergos, Cernere を主軸に動く。日記は事実+推測で書き、断定口調を維持。"></textarea>
+
     <h4>🧹 メンテナンス</h4>
     <p class="ai-settings-help">過去のアクセス記録に出てきたドメインのうち、まだドメイン辞書に登録されていないものを fetch + 分類キューに積みます。 force にすると既存行も再分類します (user_edited 列は保護)。</p>
     <div class="ai-settings-actions">

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -1934,3 +1934,27 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 }
 .mod-log .mono { font-family: ui-monospace, monospace; font-size: 11px; }
 .mod-log .mod-det { font-size: 11px; color: var(--muted); flex-basis: 100%; word-break: break-all; }
+
+.diary-improve-help {
+  font-size: 11px;
+  color: var(--muted);
+  margin: 2px 0 6px;
+  line-height: 1.5;
+}
+.diary-improve-help code {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 0 4px;
+  font-size: 11px;
+}
+#diaryImproveInput,
+#aiDiaryGlobalMemo {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 13px;
+  resize: vertical;
+}


### PR DESCRIPTION
## Summary
Two related additions to the diary tab.

### 1. Per-day improvement instruction (one-shot)
A new **🔧 この日記を改善** textarea + button on the diary detail panel. The user writes feedback ("もっと簡潔に", "12〜15時を細かく", etc.) and clicks 改善して再生成 — the instruction is sent in the POST body of `/api/diary/:date/generate` as `{ improve }` and appended to both the `diary_work` and `diary_highlights` prompts under "## このターンだけの改善指示 (最優先)". The instruction is **not persisted** — it lives only for this regenerate run, then the textarea clears.

### 2. Global standing memo (persisted in app_settings)
A new **📝 日記の常設メモ** textarea in the AI 設定 panel writes to `app_settings['diary.global_memo']`. Every diary generation reads it at the prepare stage and appends it to both stage prompts as "## ユーザの常設メモ (毎回参照)". Use it for project context, role description, durable rules.

### Plumbing
- `enqueueDiaryStages(dateStr, opts)` carries `opts.improve` through the closure ctx; stage 0 also reads the global memo from settings.
- `generateWorkContent` / `generateHighlights` accept `globalMemo` + `improve` and pipe them to `appendMemoAndImprove(prompt, …)` — a single helper that appends the two sections in a fixed order (memo first, improve last so it overrides).
- `/api/llm/config` GET returns `config.diary_global_memo`. PATCH writes back via `app_settings['diary.global_memo']`.

## Test plan
- [ ] AI 設定 → 📝 日記の常設メモ に文章を書いて保存 → 再ロード後も値が残る
- [ ] 日記の詳細 → 🔧 改善 textarea に「12〜15時を 2 ブロックに分けて」と書いて改善して再生成 → 作業キューに `📝 作業内容` + `✨ ハイライト` が積まれる
- [ ] 出力に常設メモの方向性が反映される + 改善指示の通りに変わる
- [ ] 改善 textarea が一度送ったら空になる (one-shot)
- [ ] 通常の 再生成 ボタンも引き続き動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)