### PR TITLE
fix(mobile): sticky tabs + populated More menu + settings-only Export/Import

### DIFF
--- a/server/public/app.js
+++ b/server/public/app.js
@@ -593,11 +593,14 @@ function reflowTabsForViewport() {
     if (visible.has(t.dataset.tab)) {
       t.style.display = '';
     } else {
-      t.style.display = 'none';
+      // Clone BEFORE hiding the original — otherwise cloneNode(true)
+      // captures `display: none` and the More menu renders empty.
       const clone = t.cloneNode(true);
+      clone.style.display = '';
       clone.classList.toggle('active', t.dataset.tab === active);
       clone.addEventListener('click', () => switchTab(t.dataset.tab));
       moreMenu.appendChild(clone);
+      t.style.display = 'none';
       overflowCount += 1;
     }
   }

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -16,7 +16,7 @@
     <div class="brand">Memoria</div>
     <div id="queueBadge" class="queue-badge hidden" title="作業中ジョブ数">作業中 <span id="queueCount">0</span></div>
     <div class="topbar-controls">
-      <select id="sort">
+      <select id="sort" title="ブックマークの並び順">
         <option value="created_desc">追加日 (新しい順)</option>
         <option value="created_asc">追加日 (古い順)</option>
         <option value="accessed_desc">最終アクセス (新しい順)</option>
@@ -24,11 +24,7 @@
         <option value="title_asc">タイトル (A→Z)</option>
       </select>
       <input id="search" type="search" placeholder="検索 (タイトル・URL・要約)" />
-      <button id="exportBtn" class="ghost" title="選択中をエクスポート">Export</button>
-      <label class="ghost file-btn">
-        Import<input id="importInput" type="file" accept="application/json" hidden />
-      </label>
-      <button id="aiSettingsBtn" class="ghost" title="モデル/プロバイダ設定">⚙ AI</button>
+      <button id="aiSettingsBtn" class="ghost topbar-settings" title="設定 / Export / Import">⚙ 設定</button>
     </div>
   </header>
 
@@ -409,6 +405,15 @@
     <label>API Key (gpt 系を使う場合): <input id="aiOpenaiKey" type="password" placeholder="sk-..." /></label>
     <span id="aiOpenaiKeyStatus" class="ai-keystatus"></span>
     <label>デフォルトモデル: <input id="aiOpenaiModel" type="text" placeholder="gpt-4o-mini" /></label>
+    <h4>📤 エクスポート / 📥 インポート</h4>
+    <p class="ai-settings-help">ブックマークを JSON で書き出し / 取り込み (URL 重複はスキップ)。エクスポートはチェックを入れたカードのみ。</p>
+    <div class="ai-settings-actions">
+      <button id="exportBtn" class="ghost" title="選択中をエクスポート">Export</button>
+      <label class="ghost file-btn">
+        Import<input id="importInput" type="file" accept="application/json" hidden />
+      </label>
+    </div>
+
     <h4>📝 日記の常設メモ</h4>
     <p class="ai-settings-help">日記生成時に毎回プロンプトに添える「常設メモ」。プロジェクトの背景・自分の役割・生成ルール (例: <code>Memoria は LUDIARS の個人ツール。曖昧な作業は推測で断定して書く</code>) などを書いておくと、毎日の日記の作業内容 / ハイライトに反映されます。空欄なら何も追加しません。</p>
     <textarea id="aiDiaryGlobalMemo" rows="6" placeholder="例: 自分の役割は LUDIARS の AI/フルスタック開発。Memoria, Synergos, Cernere を主軸に動く。日記は事実+推測で書き、断定口調を維持。"></textarea>

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -55,7 +55,7 @@ body {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.4; }
 }
-.topbar-controls { display: flex; gap: 8px; margin-left: auto; align-items: center; }
+.topbar-controls { display: flex; gap: 8px; margin-left: auto; align-items: center; flex: 1 1 auto; justify-content: flex-end; }
 .topbar-controls select, .topbar-controls input[type=search] {
   padding: 6px 10px;
   border: 1px solid var(--border);
@@ -63,7 +63,8 @@ body {
   background: var(--panel);
   font-size: 13px;
 }
-.topbar-controls input[type=search] { min-width: 240px; }
+.topbar-controls input[type=search] { min-width: 240px; flex: 0 1 320px; }
+.topbar-settings { margin-left: auto; }
 
 button, .ghost, .file-btn {
   font-size: 13px;
@@ -1738,16 +1739,25 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
     gap: 8px;
     padding: 8px 12px;
   }
-  .topbar-controls { width: 100%; flex-wrap: wrap; margin-left: 0; }
-  .topbar-controls input[type=search] { flex: 1 1 100%; min-width: 0; }
+  .topbar-controls { width: 100%; flex-wrap: wrap; margin-left: 0; gap: 6px; }
+  .topbar-controls input[type=search] { flex: 1 1 100%; min-width: 0; order: 3; }
+  .topbar-controls select { flex: 1 1 0; min-width: 0; order: 2; }
+  .topbar-settings {
+    /* Anchor the gear to the top-right corner of the topbar even when
+     * the controls wrap onto the next row. */
+    order: 1;
+    margin-left: auto;
+  }
 
-  /* Right-hand detail rail collapses on mobile. */
+  /* Keep the layout itself viewport-bound on mobile so .content remains
+   * the scroll container — that's what makes the sticky tab nav and
+   * the categories rail behave consistently. (Falling back to body
+   * scroll caused the tabs to disappear behind the sticky topbar.) */
   .layout {
     flex-direction: column;
-    height: auto;
-    min-height: calc(100vh - 53px);
+    height: calc(100vh - 53px);
   }
-  .layout > .content { flex: 1 1 auto; }
+  .layout > .content { flex: 1 1 auto; min-height: 0; }
   /* On mobile the detail aside is positioned as a fullscreen overlay
    * (see .detail rule below) so it doesn't need a flex slot. */
   .layout > .detail { flex: 0 0 auto; }


### PR DESCRIPTION
## Summary
Three mobile-related items the user flagged.

### 1. Mobile: tabs don't float + More menu is empty
**Tabs not sticking.** Mobile media query set `.layout { height: auto; min-height: calc(100vh - 53px) }`, dropping the inner-scroll model in favour of body scroll. With no fixed-height ancestor the sticky tab nav had nothing to peg against and slid behind the sticky topbar. Restored `.layout { height: calc(100vh - 53px) }` on mobile so `.content` is the scroll container.

**More menu empty.** `reflowTabsForViewport` did `t.style.display = 'none'` *before* `t.cloneNode(true)`, so every clone in the More menu inherited `display: none` and stayed invisible. Fix: clone first, force `clone.style.display = ''`, then hide the original.

### 2. Export / Import → settings only
Moved both buttons out of the topbar into a new `📤 エクスポート / 📥 インポート` section in the AI 設定 panel. Useless on mobile (multi-select + file picker). Desktop topbar gets cleaner.

### 3. ⚙ settings always top-right
Button renamed `⚙ AI` → `⚙ 設定`, gains `.topbar-settings { margin-left: auto }`. On mobile the topbar uses `flex-wrap: wrap` with explicit `order: 1/2/3` so the gear stays in row 1 anchored right; sort dropdown is row 2; search becomes a full-width row 3.

## Test plan
- [ ] Mobile (≤ 760 px DevTools): tab nav stays pinned at top while scrolling cards
- [ ] Mobile: tap ⋯ → More menu lists every overflow tab and clicking switches
- [ ] Topbar shows ⚙ 設定 in top-right on both desktop and mobile
- [ ] Topbar no longer has Export / Import buttons; they live in ⚙ 設定 → 📤 エクスポート
- [ ] Selected bookmarks → Export still produces JSON; Import still ingests JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)