### PR TITLE
fix(layout+diary): force 2-pane on PC, sticky tabs reads as header, UTC bug in diary aggregator

### DIFF
--- a/server/diary.js
+++ b/server/diary.js
@@ -21,6 +21,19 @@ function extractDomain(url) {
   try { return new URL(String(url)).hostname.toLowerCase(); } catch { return null; }
 }
 
+// SQLite stores datetime() values as UTC strings without a timezone marker
+// ("2026-04-27 02:00:00"). new Date() on that string parses it as local
+// time — wrong by the local TZ offset. Append `Z` so JS parses it as UTC,
+// then standard accessors (getHours(), toLocaleString(), etc.) return the
+// correct LOCAL values.
+function parseSqliteUtc(s) {
+  if (!s) return null;
+  const iso = String(s).replace(' ', 'T');
+  // Already has TZ info — leave it alone.
+  if (/[zZ]|[+-]\d{2}:?\d{2}$/.test(iso)) return new Date(iso);
+  return new Date(iso + 'Z');
+}
+
 /**
  * Aggregate the day from BOTH sources together (no URL-level dedup).
  * - visit_events: per-event log. 1 row = 1 hit at its precise hour.
@@ -39,7 +52,7 @@ export function aggregateDay(db, dateStr) {
   // 1) Per-event log
   const events = visitEventsForDate(db, dateStr);
   for (const e of events) {
-    const localHour = new Date(e.visited_at.replace(' ', 'T')).getHours();
+    const localHour = parseSqliteUtc(e.visited_at)?.getHours();
     const hour = Number.isFinite(localHour) ? localHour : 0;
     hourlyVisits[hour] += 1;
     if (!firstSeen || e.visited_at < firstSeen) firstSeen = e.visited_at;
@@ -63,7 +76,7 @@ export function aggregateDay(db, dateStr) {
     if (!domain) continue;
     let hour = 0;
     try {
-      hour = new Date(v.last_seen_at.replace(' ', 'T')).getHours();
+      hour = parseSqliteUtc(v.last_seen_at)?.getHours();
       if (!Number.isFinite(hour)) hour = 0;
     } catch {}
     hourlyVisits[hour] += 1;
@@ -557,7 +570,7 @@ function buildUrlList(db, dateStr) {
   let lastUrl = '';
   let lastTs = 0;
   for (const e of events) {
-    const ts = new Date(e.visited_at.replace(' ', 'T')).getTime();
+    const ts = parseSqliteUtc(e.visited_at)?.getTime() || 0;
     if (e.url === lastUrl && Math.abs(ts - lastTs) < 120_000) continue; // collapse <2min
     lines.push(formatUrlLine(e.visited_at, e.url));
     lastUrl = e.url;
@@ -568,9 +581,14 @@ function buildUrlList(db, dateStr) {
 }
 
 function formatUrlLine(ts, url) {
-  // ts may be 'YYYY-MM-DD HH:MM:SS' (sqlite) — pull HH:MM
-  const m = String(ts).match(/(\d{2}:\d{2})/);
-  return `${m ? m[1] : '??:??'} ${url}`;
+  // ts is a SQLite UTC datetime ('YYYY-MM-DD HH:MM:SS'). Parse as UTC then
+  // emit the local HH:MM so claude sees the user's wall-clock time, not
+  // UTC offset by the local timezone.
+  const d = parseSqliteUtc(ts);
+  if (!d || isNaN(d.getTime())) return `??:?? ${url}`;
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  return `${hh}:${mm} ${url}`;
 }
 
 function appendMemoAndImprove(prompt, { globalMemo, improve } = {}) {

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -107,38 +107,36 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 .layout > .content { flex: 1 1 auto; min-width: 0; }
 .layout > .detail  { flex: 0 0 360px; }
 
-/* Bookmarks tab gets a 2-pane flex inside #bookmarksView: a fixed-width
- * left rail with the category list and a flexible cards pane on the
- * right. This is scoped to the bookmarks tab — other tabs don't render
- * the rail because the markup lives inside #bookmarksView.
- * `min-width: 0` on the cards pane lets it shrink as needed when the
- * detail aside is open. */
-.bookmarks-layout {
-  display: flex;
+/* Bookmarks tab: 2-pane left/right.
+ *   .bookmarks-categories — fixed-width rail on the left
+ *   .bookmarks-main       — flexible cards pane on the right
+ * Scoped to #bookmarksView so other tabs don't render this. */
+#bookmarksView .bookmarks-layout {
+  display: flex !important;
+  flex-direction: row !important;
   gap: 16px;
-  align-items: stretch;
+  align-items: flex-start;
+  width: 100%;
 }
-.bookmarks-categories {
-  flex: 0 0 170px;
+#bookmarksView .bookmarks-categories {
+  flex: 0 0 170px !important;
+  width: 170px;
   background: var(--panel);
   border: 1px solid var(--border);
   border-radius: 10px;
   padding: 12px;
   box-shadow: var(--shadow);
-  align-self: flex-start;
-  position: sticky;
-  top: 0;
-  max-height: calc(100vh - 140px);
-  overflow-y: auto;
+  /* No sticky — keeps layout simple and avoids interactions with the
+   * sticky tab nav above. The rail just scrolls with the cards. */
 }
-.bookmarks-categories h3 {
+#bookmarksView .bookmarks-categories h3 {
   font-size: 12px;
   text-transform: uppercase;
   color: var(--muted);
   margin: 0 0 8px;
   letter-spacing: 0.04em;
 }
-.bookmarks-categories ul {
+#bookmarksView .bookmarks-categories ul {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -146,7 +144,7 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   flex-direction: column;
   gap: 2px;
 }
-.bookmarks-categories li {
+#bookmarksView .bookmarks-categories li {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -159,24 +157,25 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   font-size: 13px;
   line-height: 1.4;
 }
-.bookmarks-categories li:hover { background: #f0f2f7; }
-.bookmarks-categories li.active {
+#bookmarksView .bookmarks-categories li:hover { background: #f0f2f7; }
+#bookmarksView .bookmarks-categories li.active {
   background: var(--accent-bg);
   color: var(--accent);
   font-weight: 600;
 }
-.bookmarks-categories li .count {
+#bookmarksView .bookmarks-categories li .count {
   color: var(--muted);
   font-size: 11px;
   min-width: 18px;
   text-align: right;
 }
-.bookmarks-categories li.active .count {
+#bookmarksView .bookmarks-categories li.active .count {
   color: var(--accent);
 }
-.bookmarks-main {
-  flex: 1 1 auto;
+#bookmarksView .bookmarks-main {
+  flex: 1 1 auto !important;
   min-width: 0;
+  width: 100%;
 }
 
 .content { padding: 16px; overflow-y: auto; position: relative; }
@@ -184,13 +183,14 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   display: flex;
   gap: 4px;
   margin: -16px -16px 16px;
-  padding: 6px 12px 0;
+  padding: 8px 12px 0;
   border-bottom: 1px solid var(--border);
-  background: var(--bg);
+  background: var(--panel);
   position: sticky;
   top: -16px;
   z-index: 6;
   align-items: stretch;
+  box-shadow: 0 1px 0 rgba(0,0,0,0.04);
 }
 .tabs-scroll {
   display: flex;


### PR DESCRIPTION
## Summary
User reported: on PC the bookmarks layout still wasn't 2-pane, the tab nav still wasn't sticky, and bookmarks made 9–11 JST on 4/27 were grouped under the wrong day in the diary's hourly chart.

### 1. Force 2-pane left/right (PC + mobile)
Scoped every bookmarks-layout rule to `#bookmarksView` and added `!important` on `display: flex; flex-direction: row` and on the rail width (`flex: 0 0 170px`). Drops the `position: sticky` on the rail — it was interacting with the sticky tabs above and produced layouts where the rail collapsed.

### 2. Tabs sticky reads as a fixed header
Background changed from `var(--bg)` → `var(--panel)` + a thin shadow so the bar is visually distinct from the cards behind it as it sticks.

### 3. Diary UTC parsing bug
SQLite stores `datetime('now')` as a UTC string without a TZ marker. `new Date('2026-04-27 02:00:00'.replace(' ', 'T'))` was being parsed as **local** time, then `.getHours()` returned 2 — when the actual local hour was 11 JST (UTC+9). Result: every bookmark/visit landed in the wrong hour bucket of the diary, off by the local TZ offset (the 9–11 JST range showed as 0–2 UTC).

Added `parseSqliteUtc(s)` helper that appends `Z` before constructing the Date. Used in:
- `aggregateDay` (visit_events + page_visits → hourly bucket)
- `buildUrlList` (dedup window + display time)
- `formatUrlLine` (HH:MM passed to claude)

The frontend's `fmtDate` already had this fix; this PR brings the diary backend in line.

## Test plan
- [ ] PC: ブックマーク tab shows 170px categories rail on the left, cards on the right
- [ ] Scroll cards → tabs nav stays pinned at top with a clear background
- [ ] Mobile: same 2-pane (120px rail) — categories never stack on top
- [ ] Regenerate the 4/27 diary → 9〜11 時帯のブクマが 9–11 ブロックに反映される (UTC 0–2 ではない)
- [ ] 作業内容 prompt の URL リストの HH:MM が JST 表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)