### PR TITLE
feat(trends): work hours + keywords + GitHub + clickable rows + tooltips; fix memo + visit titles

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -528,10 +528,23 @@ export function getAppSettings(db) {
   return out;
 }
 
+// Keys whose stored row should be DELETED when the user clears them
+// (credentials / one-shot session info — empty string == cleared and we
+// don't want stale rows lying around). Everything else preserves an
+// empty string as an empty string so plain text fields like
+// `diary.global_memo` don't get auto-wiped when the user happens to
+// save the panel with the textarea empty for a moment.
+const DELETE_ON_EMPTY_KEYS = new Set([
+  'multi_jwt', 'multi_user_id', 'multi_user_name', 'multi_role',
+  'multi_connected_at', 'multi_url',
+  'llm.openai.api_key',
+  'github_token',
+]);
+
 export function setAppSettings(db, patch) {
   const tx = db.transaction(() => {
     for (const [k, v] of Object.entries(patch)) {
-      if (v == null || v === '') {
+      if (v == null || (v === '' && DELETE_ON_EMPTY_KEYS.has(k))) {
         db.prepare(`DELETE FROM app_settings WHERE key = ?`).run(k);
       } else {
         db.prepare(`
@@ -1224,6 +1237,133 @@ export function trendsDomains(db, { sinceDays = 30, limit = 12 } = {}) {
     .map(([domain, hits]) => ({ domain, hits }))
     .sort((a, b) => b.hits - a.hits)
     .slice(0, Number(limit) || 12);
+}
+
+/**
+ * Per-day estimated work minutes derived from visit_events. Cuts each visitor
+ * timeline at gaps > GAP_MS (idle); the remaining intra-session deltas are
+ * summed and capped per session at SESSION_CAP_MS (long single visits would
+ * otherwise inflate the metric).
+ */
+export function trendsWorkHours(db, { sinceDays = 30 } = {}) {
+  const days = Number(sinceDays) || 30;
+  const GAP_MS = 30 * 60_000;          // 30 min idle = session boundary
+  const SESSION_CAP_MS = 4 * 60 * 60_000; // single session capped at 4h
+  const rows = db.prepare(`
+    SELECT visited_at FROM visit_events
+    WHERE visited_at >= datetime('now', ?)
+    ORDER BY visited_at ASC
+  `).all(`-${days} days`);
+  // Bucket per local-date.
+  const perDay = new Map();
+  function dateKeyLocal(d) {
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  }
+  function parseUtc(s) {
+    return new Date(String(s).replace(' ', 'T') + 'Z');
+  }
+  let prevTs = null;
+  let sessionStart = null;
+  let prevDateKey = null;
+  function flush(endTs) {
+    if (sessionStart != null) {
+      const dur = Math.min(endTs - sessionStart, SESSION_CAP_MS);
+      perDay.set(prevDateKey, (perDay.get(prevDateKey) || 0) + dur);
+    }
+    sessionStart = null;
+    prevTs = null;
+    prevDateKey = null;
+  }
+  for (const r of rows) {
+    const d = parseUtc(r.visited_at);
+    const ts = d.getTime();
+    if (!Number.isFinite(ts)) continue;
+    const key = dateKeyLocal(d);
+    if (prevTs == null) {
+      sessionStart = ts;
+      prevTs = ts;
+      prevDateKey = key;
+      continue;
+    }
+    const gap = ts - prevTs;
+    if (gap > GAP_MS || key !== prevDateKey) {
+      flush(prevTs);
+      sessionStart = ts;
+      prevTs = ts;
+      prevDateKey = key;
+    } else {
+      prevTs = ts;
+    }
+  }
+  if (prevTs != null) flush(prevTs);
+
+  // Zero-fill so the chart shows all days in the window.
+  const out = [];
+  const today = new Date();
+  for (let i = days - 1; i >= 0; i--) {
+    const dt = new Date(today);
+    dt.setDate(today.getDate() - i);
+    const k = dateKeyLocal(dt);
+    out.push({
+      date: k,
+      minutes: Math.round((perDay.get(k) || 0) / 60_000),
+    });
+  }
+  return out;
+}
+
+const KEYWORD_STOPWORDS = new Set([
+  'the','and','for','with','from','that','this','your','you','our','have','has','was','were','will','what','when','where','which','who','about','into','than','then','also','but','not','are','can','use','using','how','why','etc',
+  'について','として','による','によって','などの','する','して','です','ます','ない','ある','こと','もの','よう','これ','それ','ため','など','とは','では','での','さん','さま','様','記事','ページ','こちら','そして','しかし','ただし','ここ','以下','以上',
+]);
+
+function tokenize(text) {
+  const t = String(text || '').toLowerCase();
+  const out = [];
+  // ASCII / Latin words ≥ 3 chars.
+  for (const m of t.matchAll(/[a-z][a-z0-9_+#.-]{2,}/g)) out.push(m[0]);
+  // Japanese-ish runs ≥ 2 chars (CJK + katakana/hiragana lump).
+  for (const m of t.matchAll(/[぀-ヿ一-鿿]{2,}/g)) out.push(m[0]);
+  return out.filter(w => !KEYWORD_STOPWORDS.has(w));
+}
+
+/**
+ * Keyword frequency across recent page titles + bookmark titles + dig
+ * queries. Crude tokeniser: ASCII words ≥3 chars + JP runs ≥2 chars,
+ * minus stopwords.
+ */
+export function trendsKeywords(db, { sinceDays = 30, limit = 25 } = {}) {
+  const days = Number(sinceDays) || 30;
+  const ago = `-${days} days`;
+  const sources = [];
+  for (const r of db.prepare(`
+    SELECT title FROM page_visits WHERE last_seen_at >= datetime('now', ?)
+  `).all(ago)) sources.push(r.title);
+  for (const r of db.prepare(`
+    SELECT title FROM bookmarks WHERE created_at >= datetime('now', ?)
+  `).all(ago)) sources.push(r.title);
+  for (const r of db.prepare(`
+    SELECT query FROM dig_sessions WHERE created_at >= datetime('now', ?)
+  `).all(ago)) sources.push(r.query);
+  // Dictionary terms also reflect what the user is studying.
+  for (const r of db.prepare(`
+    SELECT term FROM dictionary_entries WHERE updated_at >= datetime('now', ?)
+  `).all(ago)) sources.push(r.term);
+
+  const tally = new Map();
+  for (const text of sources) {
+    if (!text) continue;
+    const seen = new Set();  // count each source once per word
+    for (const w of tokenize(text)) {
+      if (seen.has(w)) continue;
+      seen.add(w);
+      tally.set(w, (tally.get(w) || 0) + 1);
+    }
+  }
+  return [...tally.entries()]
+    .map(([word, count]) => ({ word, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, Number(limit) || 25);
 }
 
 function extractDomain(url) {

--- a/server/index.js
+++ b/server/index.js
@@ -26,6 +26,8 @@ import {
   trendsCategoryDiff,
   trendsTimeline,
   trendsDomains,
+  trendsWorkHours,
+  trendsKeywords,
 } from './db.js';
 import { summarizeWithClaude, htmlToText } from './claude.js';
 import { FifoQueue, ConcurrentPool } from './queue.js';
@@ -368,6 +370,68 @@ app.get('/api/trends/domains', (c) => {
 app.get('/api/trends/visit-domains', (c) => {
   const days = Number(c.req.query('days')) || 30;
   return c.json({ items: trendsVisitDomains(db, { sinceDays: days }) });
+});
+
+app.get('/api/trends/work-hours', (c) => {
+  const days = Number(c.req.query('days')) || 30;
+  return c.json({ items: trendsWorkHours(db, { sinceDays: days }) });
+});
+
+app.get('/api/trends/keywords', (c) => {
+  const days = Number(c.req.query('days')) || 30;
+  return c.json({ items: trendsKeywords(db, { sinceDays: days, limit: 30 }) });
+});
+
+// GitHub commit trend (only meaningful when a token + user + repos are
+// configured under diary settings). Cached in memory for 5 min so the user
+// can flip the trends-range select without hammering the API.
+const githubTrendCache = new Map(); // key = `${days}` → { at, payload }
+app.get('/api/trends/github', async (c) => {
+  const days = Number(c.req.query('days')) || 30;
+  const key = `${days}`;
+  const cached = githubTrendCache.get(key);
+  if (cached && Date.now() - cached.at < 5 * 60_000) {
+    return c.json(cached.payload);
+  }
+  const settings = settingsAsObject();
+  if (!settings.github_user || !settings.github_repos?.length) {
+    return c.json({ enabled: false, reason: 'github_not_configured' });
+  }
+  const since = new Date(Date.now() - days * 86400_000).toISOString();
+  const until = new Date().toISOString();
+  try {
+    const r = await fetchGithubRange({
+      token: settings.github_token,
+      user: settings.github_user,
+      repos: settings.github_repos,
+      since, until,
+    });
+    // Per-day commit count for the line chart.
+    const perDay = new Map();
+    for (const c of (r.commits || [])) {
+      const d = String(c.created_at || '').slice(0, 10);
+      if (!d) continue;
+      perDay.set(d, (perDay.get(d) || 0) + 1);
+    }
+    const today = new Date();
+    const series = [];
+    for (let i = days - 1; i >= 0; i--) {
+      const dt = new Date(today);
+      dt.setDate(today.getDate() - i);
+      const k = dt.toISOString().slice(0, 10);
+      series.push({ date: k, count: perDay.get(k) || 0 });
+    }
+    const payload = {
+      enabled: true,
+      total: (r.commits || []).length,
+      repos: r.repos || [],
+      series,
+    };
+    githubTrendCache.set(key, { at: Date.now(), payload });
+    return c.json(payload);
+  } catch (e) {
+    return c.json({ enabled: true, error: e.message, total: 0, repos: [], series: [] });
+  }
 });
 
 // ---- recommendations ------------------------------------------------------

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -2210,36 +2210,141 @@ function renderRecommendations() {
 async function loadTrends() {
   const days = state.trendsRange;
   try {
-    const [cats, diff, timeline, domains, visitDomains] = await Promise.all([
+    const [cats, diff, timeline, domains, visitDomains, workHours, keywords, github] = await Promise.all([
       api(`/api/trends/categories?days=${encodeURIComponent(days)}`),
       api(`/api/trends/category-diff?days=7`),
       api(`/api/trends/timeline?days=${encodeURIComponent(days)}`),
       api(`/api/trends/domains?days=${encodeURIComponent(days)}`),
       api(`/api/trends/visit-domains?days=${encodeURIComponent(days)}`),
+      api(`/api/trends/work-hours?days=${encodeURIComponent(days)}`),
+      api(`/api/trends/keywords?days=${encodeURIComponent(days)}`),
+      api(`/api/trends/github?days=${encodeURIComponent(days)}`).catch(() => ({ enabled: false })),
     ]);
     renderTrendCategories(cats.items);
     renderTrendDiff(diff.items);
     renderTrendTimeline(timeline.items);
     renderTrendDomains(domains.items);
     renderTrendVisitDomains(visitDomains.items);
+    renderTrendWorkHours(workHours.items);
+    renderTrendKeywords(keywords.items);
+    renderTrendGithub(github);
   } catch (e) {
     console.error('trends load failed', e);
   }
 }
 
 function renderTrendCategories(items) {
-  $('trendCategories').innerHTML = svgHorizontalBar(items, c => c.category, c => c.count);
+  // Clickable horizontal bars: each row gets a `data-category` so the
+  // event listener below can route to the bookmarks tab filtered by it.
+  $('trendCategories').innerHTML = svgHorizontalBar(items, c => c.category, c => c.count, '', {
+    rowAttr: c => `data-category="${escapeHtml(c.category)}"`,
+    rowClass: 'clickable',
+  });
+  $('trendCategories').querySelectorAll('[data-category]').forEach(el => {
+    el.addEventListener('click', () => {
+      const cat = el.dataset.category;
+      if (!cat) return;
+      state.category = cat;
+      switchTab('bookmarks');
+      load();
+    });
+    el.style.cursor = 'pointer';
+  });
 }
 
 function renderTrendDomains(items) {
-  $('trendDomains').innerHTML = svgHorizontalBar(items, c => c.domain, c => c.hits, 'alt');
+  $('trendDomains').innerHTML = svgHorizontalBar(items, c => c.domain, c => c.hits, 'alt', {
+    rowAttr: c => `data-domain="${escapeHtml(c.domain)}"`,
+    rowClass: 'clickable',
+  });
+  attachDomainClick($('trendDomains'));
 }
 
 function renderTrendVisitDomains(items) {
-  $('trendVisitDomains').innerHTML = svgHorizontalBar(items, c => c.domain, c => c.visits, 'alt');
+  $('trendVisitDomains').innerHTML = svgHorizontalBar(items, c => c.domain, c => c.visits, 'alt', {
+    rowAttr: c => `data-domain="${escapeHtml(c.domain)}"`,
+    rowClass: 'clickable',
+  });
+  attachDomainClick($('trendVisitDomains'));
 }
 
-function svgHorizontalBar(items, labelFn, valueFn, klass = '') {
+function attachDomainClick(root) {
+  if (!root) return;
+  root.querySelectorAll('[data-domain]').forEach(el => {
+    el.style.cursor = 'pointer';
+    el.addEventListener('click', async () => {
+      const domain = el.dataset.domain;
+      if (!domain) return;
+      switchTab('domain');
+      await new Promise(r => setTimeout(r, 0));
+      try { await loadDomainEntry(domain); }
+      catch (err) {
+        try {
+          await api(`/api/domains/${encodeURIComponent(domain)}/regenerate`, { method: 'POST' });
+          flashToast(`「${domain}」を分類キューに追加しました`);
+          await loadDomainCatalog();
+        } catch (e2) { console.error(e2); }
+      }
+    });
+  });
+}
+
+function renderTrendKeywords(items) {
+  const el = $('trendKeywords');
+  if (!el) return;
+  if (!items.length) { el.innerHTML = '<div class="queue-empty">データなし</div>'; return; }
+  const max = Math.max(...items.map(i => i.count), 1);
+  el.innerHTML = items.map(i => {
+    const weight = 0.7 + (i.count / max) * 0.5;          // 0.7–1.2
+    const fontSz = 11 + (i.count / max) * 7;             // 11–18 px
+    return `<span class="trend-kw" style="font-size:${fontSz.toFixed(1)}px;font-weight:${Math.round(weight * 600)}" title="${i.count} 回">${escapeHtml(i.word)} <span class="trend-kw-n">${i.count}</span></span>`;
+  }).join('');
+}
+
+function renderTrendWorkHours(items) {
+  const el = $('trendWorkHours');
+  if (!el) return;
+  if (!items?.length) { el.innerHTML = '<div class="queue-empty">データなし</div>'; return; }
+  // items: [{date: 'YYYY-MM-DD', minutes}]
+  const data = items.map(d => ({ date: d.date, value: d.minutes / 60, raw: d.minutes }));
+  el.innerHTML = renderLineChartSvg(data, {
+    yLabel: (v) => `${v.toFixed(1)}h`,
+    pointLabel: (d) => `${d.date} : ${(d.value).toFixed(1)} 時間 (${d.raw} 分)`,
+  });
+  attachLineChartTooltip(el);
+}
+
+function renderTrendGithub(payload) {
+  const card = $('trendGithubCard');
+  if (!card) return;
+  if (!payload?.enabled) {
+    card.hidden = true;
+    return;
+  }
+  card.hidden = false;
+  if (payload.error) {
+    $('trendGithubSummary').textContent = `取得失敗: ${payload.error}`;
+    $('trendGithubChart').innerHTML = '';
+    $('trendGithubRepos').innerHTML = '';
+    return;
+  }
+  $('trendGithubSummary').textContent = `期間内 ${payload.total} commits / ${payload.repos.length} リポジトリ`;
+  const series = (payload.series || []).map(d => ({ date: d.date, value: d.count, raw: d.count }));
+  $('trendGithubChart').innerHTML = renderLineChartSvg(series, {
+    yLabel: (v) => `${Math.round(v)}`,
+    pointLabel: (d) => `${d.date} : ${d.value} commits`,
+    klass: 'gh',
+  });
+  attachLineChartTooltip($('trendGithubChart'));
+  $('trendGithubRepos').innerHTML = (payload.repos || []).map(r => `
+    <li>
+      <span class="repo">${escapeHtml(r.repo)}</span>
+      <span class="count">${r.count} commits</span>
+    </li>
+  `).join('');
+}
+
+function svgHorizontalBar(items, labelFn, valueFn, klass = '', opts = {}) {
   if (!items.length) return '<div class="queue-empty">データなし</div>';
   const max = Math.max(...items.map(valueFn), 1);
   const rowH = 22, padTop = 4, padLeft = 130, padRight = 40, w = 460;
@@ -2249,36 +2354,120 @@ function svgHorizontalBar(items, labelFn, valueFn, klass = '') {
     const len = Math.round((v / max) * (w - padLeft - padRight));
     const y = padTop + i * rowH;
     const label = String(labelFn(it)).slice(0, 18);
+    const attr = opts.rowAttr ? opts.rowAttr(it) : '';
+    const rowClass = opts.rowClass || '';
     return `
-      <text class="label" x="${padLeft - 8}" y="${y + 14}" text-anchor="end">${escapeHtml(label)}</text>
-      <rect class="bar ${klass}" x="${padLeft}" y="${y + 4}" width="${len}" height="14" rx="2" />
-      <text class="label" x="${padLeft + len + 6}" y="${y + 14}">${v}</text>
+      <g class="bar-row ${rowClass}" ${attr}>
+        <rect class="bar-hit" x="0" y="${y}" width="${w}" height="${rowH}" fill="transparent" />
+        <text class="label" x="${padLeft - 8}" y="${y + 14}" text-anchor="end">${escapeHtml(label)}</text>
+        <rect class="bar ${klass}" x="${padLeft}" y="${y + 4}" width="${len}" height="14" rx="2" />
+        <text class="label" x="${padLeft + len + 6}" y="${y + 14}">${v}</text>
+      </g>
     `;
   }).join('');
   return `<svg viewBox="0 0 ${w} ${h}" preserveAspectRatio="xMinYMin meet">${rows}</svg>`;
 }
 
+// Generic line chart returning an SVG string. `data` = [{date, value, raw}].
+// Hover tooltips are wired up by attachLineChartTooltip(container).
+function renderLineChartSvg(data, { yLabel, pointLabel, klass = '' } = {}) {
+  if (!data?.length) return '<div class="queue-empty">データなし</div>';
+  const w = 600, h = 200, padL = 40, padR = 12, padT = 12, padB = 24;
+  const innerW = w - padL - padR, innerH = h - padT - padB;
+  const max = Math.max(1, ...data.map(d => d.value || 0));
+  const xStep = innerW / Math.max(1, data.length - 1);
+  const points = data.map((d, i) => {
+    const x = padL + i * xStep;
+    const y = padT + innerH - ((d.value || 0) / max) * innerH;
+    return { x, y, d, i };
+  });
+  const polyline = points.map(p => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ');
+  const yLabelFn = yLabel || (v => String(Math.round(v * 10) / 10));
+  const yLabels = [0, max / 2, max].map(v => {
+    const y = padT + innerH - (v / max) * innerH;
+    return `<text class="label" x="${padL - 6}" y="${y + 3}" text-anchor="end">${yLabelFn(v)}</text>
+            <line class="grid" x1="${padL}" y1="${y}" x2="${padL + innerW}" y2="${y}" />`;
+  }).join('');
+  const xLabelStep = Math.max(1, Math.floor(data.length / 6));
+  const xLabels = data.map((d, i) => {
+    if (i % xLabelStep !== 0 && i !== data.length - 1) return '';
+    const x = padL + i * xStep;
+    const md = (d.date || '').slice(5);
+    return `<text class="label" x="${x.toFixed(1)}" y="${h - 6}" text-anchor="middle">${md}</text>`;
+  }).join('');
+  const dots = points.map(p => `<circle class="dot ${klass}" cx="${p.x.toFixed(1)}" cy="${p.y.toFixed(1)}" r="3" />`).join('');
+  const hits = points.map(p => `
+    <circle class="hit" cx="${p.x.toFixed(1)}" cy="${p.y.toFixed(1)}" r="14"
+      data-x="${p.x.toFixed(1)}" data-y="${p.y.toFixed(1)}"
+      data-label="${escapeHtml(pointLabel ? pointLabel(p.d) : `${p.d.date}: ${p.d.value}`)}"
+      fill="transparent" />
+  `).join('');
+  return `
+    <div class="line-chart">
+      <svg viewBox="0 0 ${w} ${h}" preserveAspectRatio="xMinYMin meet">
+        ${yLabels}
+        <polyline class="line ${klass}" points="${polyline}" />
+        ${dots}
+        ${hits}
+        ${xLabels}
+      </svg>
+      <div class="line-chart-tip" hidden></div>
+    </div>
+  `;
+}
+
+function attachLineChartTooltip(container) {
+  if (!container) return;
+  const wrap = container.querySelector('.line-chart');
+  const svg = wrap?.querySelector('svg');
+  const tip = wrap?.querySelector('.line-chart-tip');
+  if (!wrap || !svg || !tip) return;
+  function show(target) {
+    tip.textContent = target.dataset.label || '';
+    tip.hidden = false;
+    const cx = parseFloat(target.dataset.x);
+    const cy = parseFloat(target.dataset.y);
+    const rect = svg.getBoundingClientRect();
+    const vb = svg.viewBox.baseVal;
+    const px = (cx / vb.width) * rect.width;
+    const py = (cy / vb.height) * rect.height;
+    tip.style.left = `${px + 8}px`;
+    tip.style.top = `${py - 24}px`;
+  }
+  function hide() { tip.hidden = true; }
+  for (const hit of svg.querySelectorAll('.hit')) {
+    hit.addEventListener('mouseenter', () => show(hit));
+    hit.addEventListener('mouseleave', hide);
+    hit.addEventListener('focus', () => show(hit));
+    hit.addEventListener('blur', hide);
+    hit.setAttribute('tabindex', '0');
+  }
+}
+
 function renderTrendTimeline(items) {
-  if (!items.length) { $('trendTimeline').innerHTML = '<div class="queue-empty">データなし</div>'; return; }
-  const w = 600, h = 200, padL = 32, padR = 12, padT = 12, padB = 24;
+  const el = $('trendTimeline');
+  if (!items.length) { el.innerHTML = '<div class="queue-empty">データなし</div>'; return; }
+  const w = 600, h = 200, padL = 40, padR = 12, padT = 12, padB = 24;
   const innerW = w - padL - padR, innerH = h - padT - padB;
   const max = Math.max(1, ...items.flatMap(d => [d.saves, d.accesses]));
   const xStep = innerW / Math.max(1, items.length - 1);
-  function pts(key) {
-    return items.map((d, i) => {
-      const x = padL + i * xStep;
-      const y = padT + innerH - (d[key] / max) * innerH;
-      return `${x.toFixed(1)},${y.toFixed(1)}`;
-    }).join(' ');
+  function ptsFor(key) {
+    return items.map((d, i) => ({
+      x: padL + i * xStep,
+      y: padT + innerH - (d[key] / max) * innerH,
+      d, key,
+    }));
   }
-  function dots(key, klass) {
-    return items.map((d, i) => {
-      const x = padL + i * xStep;
-      const y = padT + innerH - (d[key] / max) * innerH;
-      return `<circle class="${klass}" cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="2.5" />`;
-    }).join('');
-  }
-  // Y axis labels (0, max/2, max)
+  const savesPts = ptsFor('saves');
+  const accPts = ptsFor('accesses');
+  const polyline = (pts) => pts.map(p => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ');
+  const dotsFor = (pts, klass) => pts.map(p => `<circle class="${klass}" cx="${p.x.toFixed(1)}" cy="${p.y.toFixed(1)}" r="3" />`).join('');
+  const hitsFor = (pts, key) => pts.map(p => `
+    <circle class="hit" cx="${p.x.toFixed(1)}" cy="${p.y.toFixed(1)}" r="12"
+      data-x="${p.x.toFixed(1)}" data-y="${p.y.toFixed(1)}"
+      data-label="${escapeHtml(`${p.d.date} : ${key === 'saves' ? '保存' : 'アクセス'} ${p.d[key]}`)}"
+      fill="transparent" />
+  `).join('');
   const yLabels = [0, Math.round(max / 2), max].map(v => {
     const y = padT + innerH - (v / max) * innerH;
     return `<text class="label" x="${padL - 6}" y="${y + 3}" text-anchor="end">${v}</text>
@@ -2288,23 +2477,28 @@ function renderTrendTimeline(items) {
   const xLabels = items.map((d, i) => {
     if (i % xLabelStep !== 0 && i !== items.length - 1) return '';
     const x = padL + i * xStep;
-    const md = d.date.slice(5);
-    return `<text class="label" x="${x.toFixed(1)}" y="${h - 6}" text-anchor="middle">${md}</text>`;
+    return `<text class="label" x="${x.toFixed(1)}" y="${h - 6}" text-anchor="middle">${d.date.slice(5)}</text>`;
   }).join('');
-  $('trendTimeline').innerHTML = `
-    <svg viewBox="0 0 ${w} ${h}" preserveAspectRatio="xMinYMin meet">
-      ${yLabels}
-      <polyline class="line-saves" points="${pts('saves')}" />
-      <polyline class="line-accesses" points="${pts('accesses')}" />
-      ${dots('saves', 'dot')}
-      ${dots('accesses', 'dot-alt')}
-      ${xLabels}
-    </svg>
+  el.innerHTML = `
+    <div class="line-chart">
+      <svg viewBox="0 0 ${w} ${h}" preserveAspectRatio="xMinYMin meet">
+        ${yLabels}
+        <polyline class="line-saves" points="${polyline(savesPts)}" />
+        <polyline class="line-accesses" points="${polyline(accPts)}" />
+        ${dotsFor(savesPts, 'dot')}
+        ${dotsFor(accPts, 'dot-alt')}
+        ${hitsFor(savesPts, 'saves')}
+        ${hitsFor(accPts, 'accesses')}
+        ${xLabels}
+      </svg>
+      <div class="line-chart-tip" hidden></div>
+    </div>
     <div class="chart-legend">
       <span><span class="dot saves"></span>新規保存</span>
       <span><span class="dot accesses"></span>アクセス</span>
     </div>
   `;
+  attachLineChartTooltip(el);
 }
 
 function renderTrendDiff(items) {
@@ -2397,10 +2591,17 @@ function renderVisits() {
     const catLine = cat?.description
       ? `<div class="visits-catalog"><span class="visits-domain-prefix">[ドメイン] </span>${cat.kind ? `<span class="visits-kind">${escapeHtml(cat.kind)}</span> ` : ''}${escapeHtml(cat.description)}</div>`
       : (cat?.status === 'pending' ? `<div class="visits-catalog pending">ドメイン分類中…</div>` : '');
-    // Title fallback chain: Sonnet-fetched page_title → recorded title →
-    // bare domain URL (so rows that never resolved a title still read as
-    // something meaningful instead of "(タイトル未取得)").
-    const titleText = pg?.page_title || v.title || (dom ? `https://${dom}/` : v.url);
+    // Title fallback chain: Sonnet page_title → recorded title (only if
+    // it isn't itself a URL) → domain catalog site_name → bare domain.
+    // The URL fallback was leaking through whenever the page never
+    // resolved a title — we now prefer the human-readable domain info.
+    const titleLooksLikeUrl = (s) => typeof s === 'string' && /^\s*https?:\/\//i.test(s);
+    const realTitle = pg?.page_title
+      || (titleLooksLikeUrl(v.title) ? null : v.title)
+      || cat?.site_name
+      || dom
+      || v.url;
+    const titleText = realTitle;
     return `
       <li class="${sel ? 'selected' : ''} ${hot ? 'hot' : ''}" data-url="${escapeHtml(v.url)}">
         <input type="checkbox" class="vchk" ${sel ? 'checked' : ''} />

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -121,13 +121,25 @@
           </section>
 
           <section class="trend-card">
-            <h3>カテゴリ別 保存数</h3>
-            <div id="trendCategories" class="chart"></div>
+            <h3>1 日の作業時間 (推定)</h3>
+            <p class="trend-help">アクセス記録から 30 分以上空くまでを 1 セッションとして合計した分数 (1 セッションは最大 4 時間でクリップ)。</p>
+            <div id="trendWorkHours" class="chart"></div>
+          </section>
+
+          <section class="trend-card">
+            <h3>カテゴリ別 保存数 (クリックでブクマに絞り込み)</h3>
+            <div id="trendCategories" class="chart trend-categories-chart"></div>
           </section>
 
           <section class="trend-card">
             <h3>増えた・減ったカテゴリ (7 日比較)</h3>
             <ul id="trendDiff" class="trend-diff"></ul>
+          </section>
+
+          <section class="trend-card">
+            <h3>最近よく見ているキーワード</h3>
+            <p class="trend-help">直近のアクセス履歴・ブクマ・ディグ・辞書から抽出した語の頻度。</p>
+            <div id="trendKeywords" class="trend-keywords"></div>
           </section>
 
           <section class="trend-card">
@@ -138,6 +150,13 @@
           <section class="trend-card">
             <h3>よく訪れているサイト (ブクマ未保存含む)</h3>
             <div id="trendVisitDomains" class="chart"></div>
+          </section>
+
+          <section id="trendGithubCard" class="trend-card" hidden>
+            <h3>GitHub commits</h3>
+            <div id="trendGithubSummary" class="trend-help"></div>
+            <div id="trendGithubChart" class="chart"></div>
+            <ul id="trendGithubRepos" class="trend-github-repos"></ul>
           </section>
         </div>
       </div>

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -1973,3 +1973,68 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   font-size: 13px;
   resize: vertical;
 }
+
+/* ──────────────────────────────────────────────────────────────────────
+ * Trends — extra cards + line chart tooltips
+ * ────────────────────────────────────────────────────────────────────── */
+.trend-help { font-size: 11px; color: var(--muted); margin: 0 0 8px; line-height: 1.5; }
+
+.trend-categories-chart .bar-row.clickable:hover .bar { fill: var(--accent); }
+.trend-categories-chart .bar-row.clickable:hover .label { fill: var(--accent); font-weight: 600; }
+.bar-row.clickable { cursor: pointer; }
+
+.trend-keywords {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  align-items: baseline;
+  line-height: 1.6;
+}
+.trend-kw {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 2px 10px;
+  color: var(--text);
+}
+.trend-kw .trend-kw-n {
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 400;
+  margin-left: 4px;
+}
+
+.trend-github-repos {
+  list-style: none;
+  padding: 0;
+  margin: 8px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.trend-github-repos li {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  padding: 3px 0;
+  border-bottom: 1px dashed var(--border);
+}
+.trend-github-repos .repo { color: var(--text); }
+.trend-github-repos .count { color: var(--muted); }
+
+.line-chart { position: relative; }
+.line-chart .hit { cursor: pointer; }
+.line-chart .hit:hover, .line-chart .hit:focus { outline: none; }
+.line-chart-tip {
+  position: absolute;
+  background: var(--text);
+  color: #fff;
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 11px;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 5;
+  box-shadow: 0 4px 14px rgba(0,0,0,0.25);
+}
+.line-chart-tip[hidden] { display: none; }


### PR DESCRIPTION
## Summary
Expansion of the 傾向 tab plus two inline fixes that surfaced while doing it.

### New trend cards
- **1 日の作業時間 (推定)** — per-day minutes derived from `visit_events`, cutting at >30 min idle (session boundary), each session capped at 4h. Line chart.
- **最近よく見ているキーワード** — frequency tag cloud from recent page-visit titles + bookmark titles + dig queries + dictionary terms. ASCII ≥3 chars + JP runs ≥2 chars, minus stopwords. Heavier weight = more frequent.
- **GitHub commits** — hidden when no token + user + repos configured. Otherwise: total + per-day commit count line + per-repo list. 5-minute in-memory cache so flipping the period select doesn't hammer GitHub.

### Existing cards: clickable + tooltips
- Categories bar → click → ブックマーク tab filtered by that category.
- Domain bars (saved + visited) → click → ドメイン tab opens that entry (queues classification if uncatalogued).
- Line charts: invisible hit circles per point trigger a floating tooltip on `mouseenter` / `focus`. Keyboard accessible.

### Inline fixes
- **Visit title fallback**: previously fell back to `https://<domain>/` literally. Now: `pg.page_title → recorded title (skipped if URL-like) → catalog.site_name → domain`.
- **Diary memo persistence**: `setAppSettings` was deleting any row whose value was an empty string — that clobbered `diary.global_memo` whenever the user saved the AI settings panel with the textarea empty. Empty-on-save now only deletes credential-style keys (`multi_jwt`, `openai_api_key`, `github_token`, etc.). Plain text fields preserve `""` as `""`.

## Test plan
- [ ] 傾向: 7 cards visible (8 if GitHub configured)
- [ ] Click a category bar → ブックマーク tab opens with that filter
- [ ] Click a domain bar → ドメイン tab opens with that entry
- [ ] Hover line chart points → tooltip with date + value
- [ ] Recent keywords show as a tag cloud
- [ ] Configure GitHub token in 日記 → GitHub commits card appears in 傾向
- [ ] アクセス履歴: rows with no fetched title show site_name (or domain) instead of `https://...`
- [ ] Save a memo in 設定 → close → reopen → memo still there

🤖 Generated with [Claude Code](https://claude.com/claude-code)