### PR TITLE
feat(ui): topbar multi-switch + sort/search in bookmark view + mobile categories drawer + More menu rebuild

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -71,7 +71,8 @@ import {
 } from './db.js';
 import {
   readMultiState, isConnected,
-  saveMultiUrl, saveMultiSession, clearMultiSession,
+  readMultiServers, persistServers, upsertServer, removeServer,
+  saveServerSession, clearServerSession, setActive, listConnectedActive,
   fetchMe, shareBookmark, shareDig, shareDictionary,
   multiFetch,
 } from './local/multi-client.js';
@@ -979,50 +980,101 @@ app.patch('/api/llm/config', async (c) => {
 // JWT in app_settings and forwards local resources through /api/shared/*.
 
 app.get('/api/multi/status', (c) => {
-  const state = readMultiState(db);
+  // Returns every registered server + which are active. The legacy
+  // `connected/url/user` triple is kept on the response so existing
+  // callers keep working: they reflect the FIRST active+connected one.
+  const { servers, active } = readMultiServers(db);
+  const list = servers.map(s => ({
+    label: s.label, url: s.url,
+    active: active.has(s.url),
+    connected: !!(s.jwt && s.userId),
+    user: s.userId ? { id: s.userId, name: s.userName, role: s.role } : null,
+    connected_at: s.connectedAt,
+  }));
+  const primary = readMultiState(db);
   return c.json({
-    connected: isConnected(state),
-    url: state.url,
-    user: isConnected(state)
-      ? { id: state.userId, name: state.userName, role: state.role }
-      : null,
-    connected_at: state.connectedAt,
+    servers: list,
+    connected: isConnected(primary),
+    url: primary.url,
+    user: isConnected(primary) ? { id: primary.userId, name: primary.userName, role: primary.role } : null,
+    connected_at: primary.connectedAt,
   });
 });
 
-app.post('/api/multi/connect', async (c) => {
+app.post('/api/multi/servers', async (c) => {
+  // Add or update a registered server entry (label + url). Doesn't
+  // touch JWT — that's set by the OAuth /finish handler.
   const body = await c.req.json().catch(() => null);
   if (!body?.url) return c.json({ error: 'url required' }, 400);
-  saveMultiUrl(db, body.url);
-  // The browser drives the OAuth dance — we just hand back the URL it
-  // should bounce through, plus the redirect that Cernere/Hub will use.
+  const { servers, active } = readMultiServers(db);
+  const updated = upsertServer(servers, { label: body.label || body.url, url: body.url });
+  persistServers(db, updated, active);
+  return c.json({ ok: true });
+});
+
+app.delete('/api/multi/servers', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  if (!body?.url) return c.json({ error: 'url required' }, 400);
+  const { servers, active } = readMultiServers(db);
+  active.delete(String(body.url).replace(/\/$/, ''));
+  persistServers(db, removeServer(servers, body.url), active);
+  return c.json({ ok: true });
+});
+
+app.post('/api/multi/active', async (c) => {
+  // Body: { urls: string[] } — replaces the active set.
+  const body = await c.req.json().catch(() => null);
+  if (!Array.isArray(body?.urls)) return c.json({ error: 'urls[] required' }, 400);
+  setActive(db, body.urls);
+  return c.json({ ok: true });
+});
+
+app.post('/api/multi/connect', async (c) => {
+  // Kicks off the OAuth dance for a specific server URL. The URL is
+  // registered (no-op if already there) and the SPA bounces through the
+  // returned authorize URL.
+  const body = await c.req.json().catch(() => null);
+  if (!body?.url) return c.json({ error: 'url required' }, 400);
+  const { servers, active } = readMultiServers(db);
+  const updated = upsertServer(servers, { label: body.label || body.url, url: body.url });
+  persistServers(db, updated, active);
   const redirectBack = body.redirect_uri || 'http://localhost:5180/?multi=connected';
   const start = `${body.url.replace(/\/$/, '')}/api/auth/start?redirect_uri=${encodeURIComponent(redirectBack)}`;
   return c.json({ ok: true, authorize_url: start });
 });
 
 app.post('/api/multi/finish', async (c) => {
-  // Called by the SPA after it pulls `memoria_hub_jwt` out of the URL
-  // hash/query that Cernere → Hub forwarded back. Verifies + stashes.
+  // SPA hands back the JWT after Cernere → Hub redirect. We need to know
+  // WHICH server URL it belongs to. The SPA passes `url`; if missing we
+  // fall back to the most-recently-touched registered server.
   const body = await c.req.json().catch(() => null);
   if (!body?.jwt) return c.json({ error: 'jwt required' }, 400);
-  const state = { ...readMultiState(db), jwt: body.jwt };
-  if (!state.url) return c.json({ error: 'multi url not configured' }, 400);
-  // Round-trip /api/me to validate the token and pull the user info.
+  const { servers } = readMultiServers(db);
+  const target = body.url
+    ? servers.find(s => s.url === String(body.url).replace(/\/$/, ''))
+    : servers[servers.length - 1];
+  if (!target) return c.json({ error: 'no multi server registered' }, 400);
   let me;
-  try { me = await fetchMe(state); }
+  try { me = await fetchMe({ ...target, jwt: body.jwt }); }
   catch (e) { return c.json({ error: `verify failed: ${e.message}` }, 401); }
-  saveMultiSession(db, {
+  saveServerSession(db, target.url, {
     jwt: body.jwt,
     userId: me.userId,
     userName: me.displayName,
     role: me.role,
   });
-  return c.json({ ok: true, user: me });
+  return c.json({ ok: true, url: target.url, user: me });
 });
 
-app.post('/api/multi/disconnect', (c) => {
-  clearMultiSession(db);
+app.post('/api/multi/disconnect', async (c) => {
+  // Body: { url? } — disconnect a specific server, or all if omitted.
+  const body = await c.req.json().catch(() => null);
+  if (body?.url) {
+    clearServerSession(db, body.url);
+  } else {
+    const { servers } = readMultiServers(db);
+    for (const s of servers) clearServerSession(db, s.url);
+  }
   return c.json({ ok: true });
 });
 

--- a/server/local/multi-client.js
+++ b/server/local/multi-client.js
@@ -1,20 +1,16 @@
 // @ts-check
 // Local-side client for the multi server (Memoria Hub).
 //
-// Wraps the JWT plumbing — the rest of the local server just passes the
-// resource shape. Connection state lives in app_settings (`multi_url`,
-// `multi_jwt`, `multi_user_id`, `multi_user_name`, `multi_role`,
-// `multi_connected_at`), so it survives restarts.
+// State model (multi-server era):
+//   app_settings.multi_servers      = JSON [{label, url, jwt?, userId?, userName?, role?, connectedAt?}]
+//   app_settings.multi_active_urls  = JSON string[] (subset of urls — currently active)
 //
-// @ts-check is on so the typedefs in `../types/db.d.ts` get exercised.
-// Phase 1 of the TS migration (#31): this module is the canary.
-
-/** @typedef {import('../types/db.js').Db} Db */
-/** @typedef {import('../types/db.js').MultiState} MultiState */
-
+// Backwards compatibility: if the legacy single-URL keys (multi_url + multi_jwt + …)
+// are present and multi_servers is not, they are migrated on first read into a
+// one-entry list with that URL active.
 import { getAppSettings, setAppSettings } from '../db/index.js';
 
-const SETTING_KEYS = {
+const LEGACY_KEYS = {
   url: 'multi_url',
   jwt: 'multi_jwt',
   userId: 'multi_user_id',
@@ -23,49 +19,134 @@ const SETTING_KEYS = {
   connectedAt: 'multi_connected_at',
 };
 
-/**
- * @param {Db} db
- * @returns {MultiState}
- */
-export function readMultiState(db) {
-  const s = getAppSettings(db);
+function safeJson(s, fallback) {
+  if (typeof s !== 'string' || !s) return fallback;
+  try { return JSON.parse(s); } catch { return fallback; }
+}
+
+function normalizeServer(s) {
   return {
-    url:         s[SETTING_KEYS.url] || null,
-    jwt:         s[SETTING_KEYS.jwt] || null,
-    userId:      s[SETTING_KEYS.userId] || null,
-    userName:    s[SETTING_KEYS.userName] || null,
-    role:        /** @type {MultiState['role']} */ (s[SETTING_KEYS.role] || null),
-    connectedAt: s[SETTING_KEYS.connectedAt] || null,
+    label:       (s.label || s.url || '').slice(0, 80),
+    url:         String(s.url || '').replace(/\/$/, ''),
+    jwt:         s.jwt || null,
+    userId:      s.userId || null,
+    userName:    s.userName || null,
+    role:        s.role || null,
+    connectedAt: s.connectedAt || null,
   };
 }
 
-/** @param {MultiState} state */
+/**
+ * Read all registered servers + active set. Migrates legacy single-URL keys
+ * on first call.
+ */
+export function readMultiServers(db) {
+  const s = getAppSettings(db);
+  let servers = safeJson(s.multi_servers, null);
+  if (!Array.isArray(servers)) {
+    // Migrate legacy single-URL state if any.
+    const legacyUrl = (s[LEGACY_KEYS.url] || '').trim();
+    if (legacyUrl) {
+      servers = [normalizeServer({
+        label: 'default',
+        url: legacyUrl,
+        jwt: s[LEGACY_KEYS.jwt] || null,
+        userId: s[LEGACY_KEYS.userId] || null,
+        userName: s[LEGACY_KEYS.userName] || null,
+        role: s[LEGACY_KEYS.role] || null,
+        connectedAt: s[LEGACY_KEYS.connectedAt] || null,
+      })];
+      setAppSettings(db, { multi_servers: JSON.stringify(servers) });
+    } else {
+      servers = [];
+    }
+  } else {
+    servers = servers.map(normalizeServer).filter(x => x.url);
+  }
+  let active = safeJson(s.multi_active_urls, null);
+  if (!Array.isArray(active)) {
+    // Default: every connected server is active. (On a fresh single-URL
+    // migration that means the one entry is active.)
+    active = servers.filter(x => x.jwt && x.userId).map(x => x.url);
+    setAppSettings(db, { multi_active_urls: JSON.stringify(active) });
+  }
+  return { servers, active: new Set(active) };
+}
+
+export function persistServers(db, servers, activeUrls) {
+  setAppSettings(db, {
+    multi_servers: JSON.stringify(servers.map(normalizeServer)),
+    multi_active_urls: JSON.stringify([...activeUrls]),
+  });
+}
+
+export function findServerByUrl(servers, url) {
+  const u = String(url || '').replace(/\/$/, '');
+  return servers.find(s => s.url === u) || null;
+}
+
+export function upsertServer(servers, patch) {
+  const norm = normalizeServer(patch);
+  if (!norm.url) return servers;
+  const i = servers.findIndex(s => s.url === norm.url);
+  const out = [...servers];
+  if (i >= 0) out[i] = { ...out[i], ...norm };
+  else out.push(norm);
+  return out;
+}
+
+export function removeServer(servers, url) {
+  const u = String(url || '').replace(/\/$/, '');
+  return servers.filter(s => s.url !== u);
+}
+
+/** Legacy shape — used by the share/download path; returns the FIRST active
+ *  + connected server. Multi-active dispatch is handled by the caller via
+ *  `forEachActive`. */
+export function readMultiState(db) {
+  const { servers, active } = readMultiServers(db);
+  for (const s of servers) {
+    if (active.has(s.url) && s.jwt && s.userId) return s;
+  }
+  return { url: null, jwt: null, userId: null, userName: null, role: null, connectedAt: null };
+}
+
 export function isConnected(state) {
-  return Boolean(state.url && state.jwt && state.userId);
+  return Boolean(state && state.url && state.jwt && state.userId);
 }
 
-export function saveMultiUrl(db, url) {
-  setAppSettings(db, { [SETTING_KEYS.url]: url });
+export function listConnectedActive(db) {
+  const { servers, active } = readMultiServers(db);
+  return servers.filter(s => active.has(s.url) && s.jwt && s.userId);
 }
 
-export function saveMultiSession(db, { jwt, userId, userName, role }) {
-  setAppSettings(db, {
-    [SETTING_KEYS.jwt]: jwt,
-    [SETTING_KEYS.userId]: userId,
-    [SETTING_KEYS.userName]: userName,
-    [SETTING_KEYS.role]: role || 'user',
-    [SETTING_KEYS.connectedAt]: new Date().toISOString(),
+// ── per-server session save/load ────────────────────────────────────────
+
+export function saveServerSession(db, url, { jwt, userId, userName, role }) {
+  const { servers, active } = readMultiServers(db);
+  const updated = upsertServer(servers, {
+    url, jwt, userId, userName, role: role || 'user',
+    connectedAt: new Date().toISOString(),
+    label: findServerByUrl(servers, url)?.label || url,
   });
+  active.add(url.replace(/\/$/, ''));
+  persistServers(db, updated, active);
 }
 
-export function clearMultiSession(db) {
-  setAppSettings(db, {
-    [SETTING_KEYS.jwt]: null,
-    [SETTING_KEYS.userId]: null,
-    [SETTING_KEYS.userName]: null,
-    [SETTING_KEYS.role]: null,
-    [SETTING_KEYS.connectedAt]: null,
-  });
+export function clearServerSession(db, url) {
+  const { servers, active } = readMultiServers(db);
+  const u = String(url || '').replace(/\/$/, '');
+  const updated = servers.map(s => s.url === u
+    ? { ...s, jwt: null, userId: null, userName: null, role: null, connectedAt: null }
+    : s);
+  active.delete(u);
+  persistServers(db, updated, active);
+}
+
+export function setActive(db, urls) {
+  const { servers } = readMultiServers(db);
+  const valid = new Set(servers.map(s => s.url));
+  persistServers(db, servers, [...urls].filter(u => valid.has(u)));
 }
 
 // ── HTTP helpers ─────────────────────────────────────────────────────────

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -93,8 +93,32 @@ function renderCategories() {
     li.addEventListener('click', () => {
       const cat = li.dataset.cat || null;
       state.category = cat;
+      // Mobile drawer: collapse after picking.
+      $('bookmarksView')?.classList.remove('cat-open');
       load();
     });
+  });
+}
+
+// Mobile only: ☰ カテゴリ in the bookmarks toolbar toggles a floating
+// drawer over the cards. Clicking outside the drawer (and not on the
+// toggle itself) closes it.
+function setupCategoriesDrawer() {
+  const toggle = $('categoriesToggle');
+  const view = $('bookmarksView');
+  const drawer = $('bookmarksCategories');
+  if (!toggle || !view || !drawer) return;
+  toggle.addEventListener('click', (e) => {
+    e.stopPropagation();
+    const willOpen = !view.classList.contains('cat-open');
+    view.classList.toggle('cat-open', willOpen);
+    toggle.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
+  });
+  document.addEventListener('click', (e) => {
+    if (!view.classList.contains('cat-open')) return;
+    if (e.target.closest('#bookmarksCategories, #categoriesToggle')) return;
+    view.classList.remove('cat-open');
+    toggle.setAttribute('aria-expanded', 'false');
   });
 }
 
@@ -573,8 +597,10 @@ function reflowTabsForViewport() {
   if (!scroll || !moreWrap || !moreMenu) return;
 
   const allTabs = [...scroll.querySelectorAll('.tab[data-tab]')];
+
+  // Reset every state from any previous run.
   for (const t of allTabs) t.style.display = '';
-  moreMenu.innerHTML = '';
+  moreMenu.replaceChildren();
 
   const isNarrow = window.innerWidth <= 760;
   if (!isNarrow) {
@@ -593,13 +619,20 @@ function reflowTabsForViewport() {
     if (visible.has(t.dataset.tab)) {
       t.style.display = '';
     } else {
-      // Clone BEFORE hiding the original — otherwise cloneNode(true)
-      // captures `display: none` and the More menu renders empty.
-      const clone = t.cloneNode(true);
-      clone.style.display = '';
-      clone.classList.toggle('active', t.dataset.tab === active);
-      clone.addEventListener('click', () => switchTab(t.dataset.tab));
-      moreMenu.appendChild(clone);
+      // Build a fresh button instead of cloning — cloneNode used to
+      // copy the `display: none` we set on the original, which made
+      // the More menu silently empty.
+      const item = document.createElement('button');
+      item.type = 'button';
+      item.className = 'tab' + (t.dataset.tab === active ? ' active' : '');
+      item.dataset.tab = t.dataset.tab;
+      item.textContent = (t.textContent || t.dataset.tab).trim();
+      item.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        switchTab(t.dataset.tab);
+      });
+      moreMenu.appendChild(item);
       t.style.display = 'none';
       overflowCount += 1;
     }
@@ -2731,6 +2764,7 @@ document.addEventListener('click', (e) => {
 });
 window.addEventListener('resize', reflowTabsForViewport);
 reflowTabsForViewport();
+setupCategoriesDrawer();
 
 $('visitsRefresh').addEventListener('click', loadVisits);
 $('visitsRange').addEventListener('change', (e) => {
@@ -2886,41 +2920,165 @@ async function refreshMultiStatus() {
   try {
     const s = await api('/api/multi/status');
     state.multi = s;
-    if ($('multiUrl')) $('multiUrl').value = s.url || '';
+    renderMultiSwitch(s);
+    renderMultiServersList(s);
     const status = $('multiStatus');
-    if (s.connected) {
-      status.innerHTML = `✓ <b>${escapeHtml(s.user.name)}</b> (${escapeHtml(s.user.role)}) として接続中 — ${escapeHtml(s.url)}`;
-      $('multiDisconnectBtn').hidden = false;
-      $('multiConnectBtn').textContent = '再接続';
-    } else {
-      status.textContent = s.url ? '未接続' : '(URL を入力して接続)';
-      $('multiDisconnectBtn').hidden = true;
-      $('multiConnectBtn').textContent = '接続';
+    if (status) {
+      const activeCount = (s.servers || []).filter(x => x.active && x.connected).length;
+      if (activeCount > 0) {
+        status.innerHTML = `✓ ${activeCount} サーバが接続中`;
+      } else if ((s.servers || []).length === 0) {
+        status.textContent = '(URL を追加してください)';
+      } else {
+        status.textContent = '未接続';
+      }
     }
-    // Share buttons reflect connection state.
+    // Share buttons reflect whether ANY server is active+connected.
+    const anyConnected = !!(s.servers || []).some(x => x.active && x.connected);
     document.querySelectorAll('#dShare, #dictShareBtn, #digShareBtn').forEach(b => {
-      b.hidden = !s.connected;
+      b.hidden = !anyConnected;
     });
-    if (!s.connected && $('digShareBar')) $('digShareBar').hidden = true;
+    if (!anyConnected && $('digShareBar')) $('digShareBar').hidden = true;
     if (typeof refreshMultiTabVisibility === 'function') refreshMultiTabVisibility();
   } catch (e) { console.error(e); }
 }
 
-async function multiConnect() {
-  const url = $('multiUrl').value.trim();
-  if (!url) { alert('URL を入力してください'); return; }
-  const r = await api('/api/multi/connect', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ url, redirect_uri: location.origin + '/' }),
+function renderMultiSwitch(s) {
+  const root = $('multiSwitch');
+  if (!root) return;
+  const servers = s?.servers || [];
+  if (!servers.length) {
+    root.hidden = true;
+    root.innerHTML = '';
+    return;
+  }
+  root.hidden = false;
+  // ローカル baseline pill (always-on, just visual reminder) +
+  // one toggleable pill per registered remote.
+  const items = [
+    `<span class="ms-pill ms-local active" title="ローカル DB は常に有効">🏠 ローカル</span>`,
+    ...servers.map(sv => {
+      const cls = sv.active ? 'active' : '';
+      const labelTxt = sv.label || sv.url;
+      const tip = sv.connected
+        ? `${sv.url} (${sv.user?.name || ''})`
+        : `${sv.url} — 未認証`;
+      return `<button type="button" class="ms-pill ${cls}" data-url="${escapeHtml(sv.url)}" title="${escapeHtml(tip)}">${escapeHtml(labelTxt)}</button>`;
+    }),
+  ];
+  root.innerHTML = items.join('');
+  root.querySelectorAll('.ms-pill[data-url]').forEach(btn => {
+    btn.addEventListener('click', () => toggleMultiActive(btn.dataset.url));
   });
-  // Bounce through Cernere via the Hub.
-  location.href = r.authorize_url;
 }
 
-async function multiDisconnect() {
-  if (!confirm('マルチサーバから切断しますか?')) return;
-  await api('/api/multi/disconnect', { method: 'POST' });
+async function toggleMultiActive(url) {
+  // Multi-select: clicking flips this server's membership in the active set.
+  const s = state.multi;
+  if (!s) return;
+  const active = (s.servers || []).filter(x => x.active).map(x => x.url);
+  const set = new Set(active);
+  if (set.has(url)) set.delete(url);
+  else set.add(url);
+  // If the server isn't yet authenticated, kick off OAuth instead.
+  const target = (s.servers || []).find(x => x.url === url);
+  if (target && set.has(url) && !target.connected) {
+    const r = await api('/api/multi/connect', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url, redirect_uri: location.origin + '/' }),
+    });
+    location.href = r.authorize_url;
+    return;
+  }
+  await api('/api/multi/active', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ urls: [...set] }),
+  });
+  await refreshMultiStatus();
+}
+
+function renderMultiServersList(s) {
+  const list = $('multiServersList');
+  if (!list) return;
+  const servers = s?.servers || [];
+  if (!servers.length) {
+    list.innerHTML = '<li class="multi-server-empty">登録されたマルチサーバはありません。下のフォームから追加してください。</li>';
+    return;
+  }
+  list.innerHTML = servers.map(sv => {
+    const status = sv.connected
+      ? `<span class="ms-status ok">✓ ${escapeHtml(sv.user?.name || '')} (${escapeHtml(sv.user?.role || '')})</span>`
+      : '<span class="ms-status">未認証</span>';
+    return `<li class="multi-server-row" data-url="${escapeHtml(sv.url)}">
+      <label class="ms-active-toggle">
+        <input type="checkbox" data-url="${escapeHtml(sv.url)}" ${sv.active ? 'checked' : ''} />
+        有効
+      </label>
+      <div class="ms-row-body">
+        <div class="ms-label">${escapeHtml(sv.label)}</div>
+        <div class="ms-url"><code>${escapeHtml(sv.url)}</code></div>
+        <div>${status}</div>
+      </div>
+      <div class="ms-row-actions">
+        <button class="ghost ghost-sm" data-action="connect" data-url="${escapeHtml(sv.url)}">${sv.connected ? '再接続' : '接続'}</button>
+        <button class="ghost ghost-sm" data-action="disconnect" data-url="${escapeHtml(sv.url)}" ${sv.connected ? '' : 'disabled'}>切断</button>
+        <button class="danger ghost-sm" data-action="remove" data-url="${escapeHtml(sv.url)}">削除</button>
+      </div>
+    </li>`;
+  }).join('');
+  list.querySelectorAll('input[type=checkbox][data-url]').forEach(cb => {
+    cb.addEventListener('change', () => toggleMultiActive(cb.dataset.url));
+  });
+  list.querySelectorAll('button[data-action]').forEach(btn => {
+    btn.addEventListener('click', () => multiServerAction(btn.dataset.action, btn.dataset.url));
+  });
+}
+
+async function multiServerAction(action, url) {
+  if (action === 'connect') {
+    const r = await api('/api/multi/connect', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url, redirect_uri: location.origin + '/' }),
+    });
+    location.href = r.authorize_url;
+    return;
+  }
+  if (action === 'disconnect') {
+    if (!confirm(`「${url}」から切断しますか?`)) return;
+    await api('/api/multi/disconnect', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url }),
+    });
+    await refreshMultiStatus();
+    return;
+  }
+  if (action === 'remove') {
+    if (!confirm(`「${url}」を登録解除しますか?`)) return;
+    await api('/api/multi/servers', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url }),
+    });
+    await refreshMultiStatus();
+    return;
+  }
+}
+
+async function multiAddServer() {
+  const url = ($('multiAddUrl')?.value || '').trim();
+  const label = ($('multiAddLabel')?.value || '').trim();
+  if (!url) { alert('URL を入力してください'); return; }
+  await api('/api/multi/servers', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url, label: label || url }),
+  });
+  $('multiAddUrl').value = '';
+  $('multiAddLabel').value = '';
   await refreshMultiStatus();
 }
 
@@ -2929,12 +3087,13 @@ async function multiFinishFromUrl() {
   const jwt = params.get('memoria_hub_jwt');
   if (!jwt) return;
   try {
+    // Use the most-recently-touched server as target if no explicit URL.
     const r = await api('/api/multi/finish', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ jwt }),
     });
-    showShareToast(`🌐 ${r.user.displayName} としてマルチサーバに接続しました`);
+    showShareToast(`🌐 ${r.user.displayName} (${r.url}) として接続しました`);
   } catch (e) {
     alert(`マルチ接続失敗: ${e.message}`);
   } finally {
@@ -3045,8 +3204,7 @@ async function saveAiSettings() {
 document.getElementById('aiSettingsBtn')?.addEventListener('click', openAiSettings);
 document.getElementById('aiSettingsClose')?.addEventListener('click', () => $('aiSettingsPanel').classList.add('hidden'));
 document.getElementById('aiSettingsSave')?.addEventListener('click', saveAiSettings);
-document.getElementById('multiConnectBtn')?.addEventListener('click', multiConnect);
-document.getElementById('multiDisconnectBtn')?.addEventListener('click', multiDisconnect);
+document.getElementById('multiAddBtn')?.addEventListener('click', multiAddServer);
 document.getElementById('dShare')?.addEventListener('click', shareCurrentBookmark);
 document.getElementById('dictShareBtn')?.addEventListener('click', shareCurrentDict);
 document.getElementById('digShareBtn')?.addEventListener('click', shareCurrentDig);

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -14,17 +14,10 @@
 <body>
   <header class="topbar">
     <div class="brand">Memoria</div>
+    <div id="multiSwitch" class="multi-switch" hidden></div>
     <div id="queueBadge" class="queue-badge hidden" title="作業中ジョブ数">作業中 <span id="queueCount">0</span></div>
     <div class="topbar-controls">
-      <select id="sort" title="ブックマークの並び順">
-        <option value="created_desc">追加日 (新しい順)</option>
-        <option value="created_asc">追加日 (古い順)</option>
-        <option value="accessed_desc">最終アクセス (新しい順)</option>
-        <option value="accessed_asc">最終アクセス (古い順)</option>
-        <option value="title_asc">タイトル (A→Z)</option>
-      </select>
-      <input id="search" type="search" placeholder="検索 (タイトル・URL・要約)" />
-      <button id="aiSettingsBtn" class="ghost topbar-settings" title="設定 / Export / Import">⚙ 設定</button>
+      <button id="aiSettingsBtn" class="ghost topbar-settings" title="設定">⚙ 設定</button>
     </div>
   </header>
 
@@ -60,13 +53,24 @@
       </nav>
 
       <div id="bookmarksView">
+        <div class="bookmarks-toolbar">
+          <button id="categoriesToggle" class="ghost categories-toggle" title="カテゴリを表示" aria-expanded="false">☰ カテゴリ</button>
+          <select id="sort" title="ブックマークの並び順">
+            <option value="created_desc">追加日 (新しい順)</option>
+            <option value="created_asc">追加日 (古い順)</option>
+            <option value="accessed_desc">最終アクセス (新しい順)</option>
+            <option value="accessed_asc">最終アクセス (古い順)</option>
+            <option value="title_asc">タイトル (A→Z)</option>
+          </select>
+          <input id="search" type="search" placeholder="検索 (タイトル・URL・要約)" />
+        </div>
         <div id="bulkBar" class="bulkbar hidden">
           <span id="bulkCount">0</span> 件選択中
           <button id="bulkExport">選択をエクスポート</button>
           <button id="bulkClear" class="ghost">クリア</button>
         </div>
         <div class="bookmarks-layout">
-          <aside class="bookmarks-categories">
+          <aside class="bookmarks-categories" id="bookmarksCategories">
             <h3>カテゴリ</h3>
             <ul id="categoryList"></ul>
           </aside>
@@ -452,13 +456,14 @@
       <button id="aiSettingsSave">保存</button>
     </div>
     <h4>🌐 マルチサーバ (Memoria Hub)</h4>
-    <p class="ai-settings-help">他のユーザの辞書 / ディグ / ブックマークを共有できるハブに接続します。Cernere ログインが必要です。</p>
-    <label>マルチサーバ URL <input id="multiUrl" type="text" placeholder="https://memoria-hub.example.com" /></label>
-    <div id="multiStatus" class="multi-status"></div>
-    <div class="ai-settings-actions">
-      <button id="multiConnectBtn">接続</button>
-      <button id="multiDisconnectBtn" class="danger" hidden>切断</button>
+    <p class="ai-settings-help">辞書 / ディグ / ブックマークを共有できるハブを複数登録できます。各エントリは独立した Cernere ログインを持ち、左の topbar スイッチで個別 ON/OFF (複数同時 ON 可)。</p>
+    <ul id="multiServersList" class="multi-servers"></ul>
+    <div class="multi-add-row">
+      <input id="multiAddLabel" type="text" placeholder="ラベル (例: 社内ハブ)" />
+      <input id="multiAddUrl" type="text" placeholder="https://memoria-hub.example.com" />
+      <button id="multiAddBtn">＋ 追加</button>
     </div>
+    <div id="multiStatus" class="multi-status"></div>
   </div>
   <script src="app.js"></script>
 </body>

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -55,16 +55,55 @@ body {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.4; }
 }
-.topbar-controls { display: flex; gap: 8px; margin-left: auto; align-items: center; flex: 1 1 auto; justify-content: flex-end; }
-.topbar-controls select, .topbar-controls input[type=search] {
+.topbar-controls { display: flex; gap: 8px; margin-left: auto; align-items: center; }
+.topbar-settings { margin-left: auto; }
+
+/* Multi-server switch — registered remote pills next to the brand. */
+.multi-switch {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-left: 8px;
+}
+.multi-switch[hidden] { display: none; }
+.multi-switch .ms-pill {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--muted);
+  border-radius: 999px;
+  padding: 3px 12px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  transition: background 80ms, border-color 80ms, color 80ms;
+}
+.multi-switch .ms-pill:hover { background: #f0f2f7; }
+.multi-switch .ms-pill.active {
+  background: var(--accent-bg);
+  border-color: var(--accent);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+/* Bookmark view toolbar — sort + search + categories hamburger row. */
+.bookmarks-toolbar {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+.bookmarks-toolbar select,
+.bookmarks-toolbar input[type=search] {
   padding: 6px 10px;
   border: 1px solid var(--border);
   border-radius: 6px;
   background: var(--panel);
   font-size: 13px;
 }
-.topbar-controls input[type=search] { min-width: 240px; flex: 0 1 320px; }
-.topbar-settings { margin-left: auto; }
+.bookmarks-toolbar input[type=search] { flex: 1 1 280px; min-width: 0; }
+.bookmarks-toolbar .categories-toggle { display: none; }
 
 button, .ghost, .file-btn {
   font-size: 13px;
@@ -1762,21 +1801,43 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
    * (see .detail rule below) so it doesn't need a flex slot. */
   .layout > .detail { flex: 0 0 auto; }
 
-  /* Keep the 2-pane left-right layout on mobile too (per user direction
-   * "左右ペインで"). The rail just shrinks to ~120px so the cards still
-   * have room. Sticky positioning is dropped because viewport-height
-   * sticky is awkward on small screens with the URL bar showing. */
-  .bookmarks-layout { gap: 10px; }
-  .bookmarks-categories {
-    flex: 0 0 120px;
-    padding: 8px;
-    position: static;
-    max-height: none;
+  /* Mobile: drop the rail in favour of a hamburger that opens a floating
+   * drawer. Tapping ☰ カテゴリ in the bookmarks toolbar reveals the
+   * category list as an overlay anchored under the toolbar; tapping
+   * outside or selecting a category dismisses it. */
+  #bookmarksView .bookmarks-layout { display: block !important; gap: 0; }
+  .bookmarks-toolbar .categories-toggle { display: inline-block; }
+
+  #bookmarksView .bookmarks-categories {
+    display: none;
+    position: fixed;
+    top: 110px;             /* below sticky topbar (~53px) + tabs (~45px) */
+    left: 12px;
+    right: 12px;
+    width: auto;
+    flex: 0 0 auto !important;
+    max-height: 60vh;
+    overflow-y: auto;
+    z-index: 40;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px;
+    box-shadow: 0 12px 32px rgba(0,0,0,0.18);
+  }
+  #bookmarksView.cat-open .bookmarks-categories { display: block; }
+  #bookmarksView .bookmarks-categories ul {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  #bookmarksView .bookmarks-categories li {
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 4px 12px;
     font-size: 12px;
   }
-  .bookmarks-categories h3 { font-size: 10px; margin-bottom: 4px; }
-  .bookmarks-categories li { padding: 4px 6px; font-size: 12px; }
-  .bookmarks-categories li .count { font-size: 10px; min-width: 14px; }
 
   .detail {
     position: fixed;
@@ -2038,3 +2099,47 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   box-shadow: 0 4px 14px rgba(0,0,0,0.25);
 }
 .line-chart-tip[hidden] { display: none; }
+
+/* Multi-server settings list (in AI 設定) */
+.multi-servers {
+  list-style: none;
+  padding: 0;
+  margin: 8px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.multi-server-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 12px;
+  align-items: center;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 10px;
+}
+.ms-active-toggle { display: inline-flex; align-items: center; gap: 4px; font-size: 11px; color: var(--muted); }
+.ms-row-body { min-width: 0; }
+.ms-label { font-weight: 600; }
+.ms-url { font-size: 11px; color: var(--muted); word-break: break-all; }
+.ms-status { font-size: 11px; color: var(--muted); }
+.ms-status.ok { color: #1f7a1f; }
+.ms-row-actions { display: flex; flex-direction: column; gap: 4px; align-items: flex-end; }
+.ms-row-actions .ghost-sm { padding: 3px 10px; font-size: 11px; }
+.multi-server-empty { color: var(--muted); padding: 8px; font-style: italic; font-size: 12px; }
+
+.multi-add-row {
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+  flex-wrap: wrap;
+}
+.multi-add-row input {
+  flex: 1 1 160px;
+  min-width: 0;
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 13px;
+}


### PR DESCRIPTION
## Summary
Five UI changes the user requested.

### 1. Sort + search → bookmark view
Moved out of topbar into a `.bookmarks-toolbar` row at the top of `#bookmarksView`. Topbar reduced to brand + multi-switch + queue badge + ⚙ 設定. Same element ids so JS handlers untouched.

### 2. Multi-server pill switch in topbar (next to brand)
`<div id="multiSwitch">`, hidden until ≥1 server registered. 🏠 ローカル baseline pill + one toggleable pill per remote. Click a remote pill → flips active state (multi-select). Unauthenticated server → kicks off OAuth.

### 3. Multi-URL settings + multi-active dispatch
Settings list shows each registered server (label + url + auth status) with 有効 checkbox + connect/disconnect/remove + inline ＋追加 row. State moved from per-key to:
- `app_settings.multi_servers`     = JSON `[{label, url, jwt, userId, userName, role, connectedAt}]`
- `app_settings.multi_active_urls` = JSON `string[]`

Legacy single-URL state auto-migrates on first read. New endpoints: `POST /api/multi/servers`, `DELETE /api/multi/servers`, `POST /api/multi/active`. `connect` now registers the URL implicitly. `finish` accepts an optional `url` to target the right server.

### 4. Mobile categories drawer
On ≤ 760 px the 170 px rail is replaced by `☰ カテゴリ` in the bookmarks toolbar. Click opens a floating overlay drawer (`position: fixed` under the sticky tabs, max-height 60 vh). Picking a category or clicking outside closes it. Default = collapsed.

### 5. More menu rebuilt without cloneNode
`reflowTabsForViewport` used to clone hidden tabs into the More dropdown — `cloneNode(true)` captured the inline `display: none` we set on the original right before, leaving the More menu silently empty. Now: build fresh `<button>` elements per overflow tab from source data + `replaceChildren()` to clear any stale state.

## Test plan
- [ ] Topbar shows brand + queue badge + ⚙ 設定 (no sort/search)
- [ ] Bookmark tab top row has [☰カテゴリ] [並び順 select] [検索 input]
- [ ] Add a multi server URL in 設定 → multi-switch pills appear in topbar
- [ ] Click a remote pill → OAuth flow if not authenticated, otherwise toggles active
- [ ] Multiple pills can be active simultaneously (multi-select)
- [ ] Mobile: ☰ カテゴリ opens a floating drawer with the category list
- [ ] Mobile: ⋯ More menu now actually shows the overflow tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)