### PR TITLE
feat(extension+mobile): status badge + mobile tab <select> + 💡 やり方 + settings top-right

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1302,6 +1302,33 @@ app.get('/api/categories', (c) => {
 
 // ---- access ping (from extension) -----------------------------------------
 
+// Lightweight status used by the SPA to badge whether the Chrome extension
+// is actually feeding us /api/access pings. "Recent" = something landed in
+// the last 24h; "active" = within the last 5 min (extension is running
+// right now). The desktop app uses this to nudge first-run users to
+// install the extension; a regular browser tab hides the badge entirely.
+app.get('/api/extension/status', (c) => {
+  const row = db.prepare(`
+    SELECT visited_at FROM visit_events
+    ORDER BY visited_at DESC
+    LIMIT 1
+  `).get();
+  if (!row) {
+    return c.json({ configured: false, last_seen: null, active: false });
+  }
+  const lastUtcMs = new Date(String(row.visited_at).replace(' ', 'T') + 'Z').getTime();
+  if (!Number.isFinite(lastUtcMs)) {
+    return c.json({ configured: false, last_seen: null, active: false });
+  }
+  const ageMs = Date.now() - lastUtcMs;
+  return c.json({
+    configured: ageMs < 24 * 60 * 60_000,
+    active: ageMs < 5 * 60_000,
+    last_seen: new Date(lastUtcMs).toISOString(),
+    age_ms: ageMs,
+  });
+});
+
 app.post('/api/access', async (c) => {
   const body = await c.req.json().catch(() => null);
   if (!body || typeof body.url !== 'string') return c.json({ error: 'url required' }, 400);

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -564,6 +564,9 @@ function switchTab(tab) {
   if (tab === 'diary') loadDiary();
   if (tab === 'events') loadEvents();
   if (tab === 'multi') loadMulti();
+  // Keep mobile tab select in sync with the active tab.
+  const sel = $('mobileTabSelect');
+  if (sel && sel.value !== tab) sel.value = tab;
   bumpTabUsage(tab);
   reflowTabsForViewport();
   closeTabMoreMenu();
@@ -2765,6 +2768,92 @@ document.addEventListener('click', (e) => {
 window.addEventListener('resize', reflowTabsForViewport);
 reflowTabsForViewport();
 setupCategoriesDrawer();
+setupExtensionBadge();
+setupMobileTabSelect();
+setupHowToBookmark();
+
+// Mobile <select> for tabs — fires switchTab() on change.
+function setupMobileTabSelect() {
+  const sel = $('mobileTabSelect');
+  if (!sel) return;
+  sel.value = state.tab || 'bookmarks';
+  sel.addEventListener('change', () => switchTab(sel.value));
+}
+
+// 💡 やり方 button — only shows on mobile (no Chrome extension available).
+function setupHowToBookmark() {
+  const btn = $('howToBookmarkBtn');
+  const overlay = $('howToBookmarkOverlay');
+  const close = $('howToBookmarkClose');
+  if (!btn || !overlay) return;
+  // Show only when viewport is mobile-ish — desktop uses the Chrome
+  // extension, so this prompt isn't relevant.
+  function syncVisibility() {
+    btn.hidden = window.innerWidth > 760;
+  }
+  syncVisibility();
+  window.addEventListener('resize', syncVisibility);
+  btn.addEventListener('click', () => { overlay.hidden = false; });
+  close?.addEventListener('click', () => { overlay.hidden = true; });
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) overlay.hidden = true;
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && !overlay.hidden) overlay.hidden = true;
+  });
+}
+
+// Extension status badge — only meaningful when running inside the Tauri
+// desktop wrapper (a regular browser tab doesn't need the prompt). Polls
+// /api/extension/status every 30 s and updates the topbar pill.
+function isTauri() {
+  return !!(window.__TAURI_INTERNALS__ || window.__TAURI__ || window.__TAURI_METADATA__);
+}
+async function refreshExtensionBadge() {
+  const badge = $('extensionBadge');
+  if (!badge) return;
+  if (!isTauri()) {
+    badge.hidden = true;
+    return;
+  }
+  try {
+    const s = await api('/api/extension/status');
+    badge.hidden = false;
+    if (s.configured) {
+      badge.className = 'ext-badge ext-ok';
+      badge.textContent = s.active ? '✓ 拡張 OK' : '✓ 拡張接続済';
+      badge.title = s.last_seen ? `最終 ping: ${new Date(s.last_seen).toLocaleString()}` : '';
+    } else {
+      badge.className = 'ext-badge ext-warn';
+      badge.textContent = '⚠ 拡張未設定 (クリック)';
+      badge.title = 'クリックしてセットアップ手順を表示';
+    }
+  } catch (e) {
+    console.error('extension status failed', e);
+  }
+}
+function setupExtensionBadge() {
+  const badge = $('extensionBadge');
+  const overlay = $('extensionSetupOverlay');
+  const close = $('extensionSetupClose');
+  if (!badge || !overlay) return;
+  badge.addEventListener('click', () => {
+    if (badge.classList.contains('ext-warn')) {
+      const urlEl = $('extensionSetupUrl');
+      if (urlEl) urlEl.textContent = location.origin || 'http://localhost:5180';
+      overlay.hidden = false;
+    }
+  });
+  close?.addEventListener('click', () => { overlay.hidden = true; });
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) overlay.hidden = true;
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && !overlay.hidden) overlay.hidden = true;
+  });
+  refreshExtensionBadge();
+  setInterval(refreshExtensionBadge, 30_000);
+}
 
 $('visitsRefresh').addEventListener('click', loadVisits);
 $('visitsRange').addEventListener('change', (e) => {

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -15,15 +15,78 @@
   <header class="topbar">
     <div class="brand">Memoria</div>
     <div id="multiSwitch" class="multi-switch" hidden></div>
+    <button id="extensionBadge" type="button" class="ext-badge" hidden></button>
     <div id="queueBadge" class="queue-badge hidden" title="作業中ジョブ数">作業中 <span id="queueCount">0</span></div>
     <div class="topbar-controls">
+      <button id="howToBookmarkBtn" class="ghost topbar-howto" title="ブックマークの追加方法" hidden>💡 やり方</button>
       <button id="aiSettingsBtn" class="ghost topbar-settings" title="設定">⚙ 設定</button>
     </div>
   </header>
 
+  <!-- Mobile-only: how to bookmark when the Chrome extension isn't an
+       option (Android Chrome, iOS Safari, etc.). Re-uses the PWA share-
+       target instructions. -->
+  <div id="howToBookmarkOverlay" class="modal-backdrop" hidden>
+    <div class="modal-panel ext-setup">
+      <div class="ext-setup-head">
+        <h3>📌 スマホでブックマークする方法</h3>
+        <button id="howToBookmarkClose" class="modal-close" title="閉じる">×</button>
+      </div>
+      <p class="ext-setup-help">スマホには Chrome 拡張が無いので、Memoria を <b>PWA</b> としてインストールしてから OS の共有メニューで送ります。</p>
+      <ol class="ext-setup-steps">
+        <li>Memoria の URL を開いた状態で、ブラウザのメニュー →
+          <b>「ホーム画面に追加」</b> または <b>「アプリをインストール」</b></li>
+        <li>シェアしたいページで <b>共有</b> ボタンを押す</li>
+        <li>共有先のリストから <b>Memoria</b> を選ぶと自動で保存キューに入ります</li>
+      </ol>
+      <p class="ext-setup-help">iOS Safari は Web Share Target に対応しないので、<a href="https://github.com/LUDIARS/Memoria/blob/main/docs/mobile-share.md" target="_blank" rel="noreferrer">iOS Shortcut テンプレート</a> を使ってください。</p>
+    </div>
+  </div>
+
+  <!-- Setup overlay: how to install + configure the Chrome extension.
+       Shown when the user clicks the "拡張未設定" badge. -->
+  <div id="extensionSetupOverlay" class="modal-backdrop" hidden>
+    <div class="modal-panel ext-setup">
+      <div class="ext-setup-head">
+        <h3>🧩 Chrome 拡張をセットアップ</h3>
+        <button id="extensionSetupClose" class="modal-close" title="閉じる">×</button>
+      </div>
+      <p class="ext-setup-help">Memoria はブラウザで開いているページを Chrome 拡張から受け取ります。
+        この PC で拡張がまだ動いていないようです。下の手順で 1 度だけ設定してください。</p>
+      <ol class="ext-setup-steps">
+        <li>Chrome で <code>chrome://extensions</code> を開く</li>
+        <li>右上の <b>「デベロッパーモード」</b> を <b>ON</b></li>
+        <li><b>「パッケージ化されていない拡張機能を読み込む」</b> をクリックし、
+          このリポジトリの <code>extension/</code> フォルダを選ぶ</li>
+        <li>拡張のオプションを開き、<b>サーバ URL</b> に
+          <code id="extensionSetupUrl">http://localhost:5180</code> が入っていることを確認</li>
+        <li>適当なページを開いてみてください。数秒後ここの表示が <b>✓ 拡張 OK</b> に変わります</li>
+      </ol>
+      <p class="ext-setup-help">うまく動かないときは <code>chrome://extensions</code> の Memoria Bookmarker を
+        🔄 リロード → 確認したいページで F5 で再読込。</p>
+    </div>
+  </div>
+
   <main class="layout" data-active-tab="bookmarks">
     <section class="content">
       <nav class="tabs">
+        <!-- Mobile uses a native <select> so the dropdown is browser-native
+             (the previous custom More menu kept rendering empty in some
+             setups; a <select> always works). Desktop hides this and uses
+             the horizontal button strip below. -->
+        <select id="mobileTabSelect" class="mobile-tab-select" aria-label="タブ">
+          <option value="bookmarks">📚 ブックマーク</option>
+          <option value="queue">🔧 作業キュー</option>
+          <option value="events">📋 イベント</option>
+          <option value="visits">📰 アクセス履歴</option>
+          <option value="trends">📈 傾向</option>
+          <option value="recommend">✨ おすすめ</option>
+          <option value="dig">🔎 ディグる</option>
+          <option value="dict">📖 辞書</option>
+          <option value="domain">🏷 ドメイン</option>
+          <option value="diary">📅 日記</option>
+          <option value="multi" class="mobile-tab-multi-only">🌐 マルチ</option>
+        </select>
         <div class="tabs-scroll">
           <button class="tab active" data-tab="bookmarks">ブックマーク</button>
           <button class="tab" data-tab="queue">

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -1773,19 +1773,41 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 @media (max-width: 760px) {
   body { font-size: 13px; }
 
+  /* Mobile topbar: pin .topbar-controls to the top-right via absolute
+   * positioning so the ⚙ 設定 + 💡 やり方 buttons always sit in the
+   * top-right corner regardless of how brand / multi-switch /
+   * extension badge / queue badge wrap. */
   .topbar {
     flex-wrap: wrap;
     gap: 8px;
-    padding: 8px 12px;
+    padding: 8px 56px 8px 12px;        /* leave room on the right */
+    position: sticky;
+    top: 0;
+    z-index: 10;
   }
-  .topbar-controls { width: 100%; flex-wrap: wrap; margin-left: 0; gap: 6px; }
-  .topbar-controls input[type=search] { flex: 1 1 100%; min-width: 0; order: 3; }
-  .topbar-controls select { flex: 1 1 0; min-width: 0; order: 2; }
-  .topbar-settings {
-    /* Anchor the gear to the top-right corner of the topbar even when
-     * the controls wrap onto the next row. */
-    order: 1;
-    margin-left: auto;
+  .topbar-controls {
+    position: absolute;
+    top: 6px;
+    right: 8px;
+    width: auto;
+    margin-left: 0;
+    gap: 4px;
+  }
+  .topbar-controls .ghost {
+    padding: 5px 10px;
+    font-size: 12px;
+  }
+  .topbar-howto[hidden] { display: none !important; }
+
+  /* Mobile shows the <select> dropdown for tabs. The horizontal button
+   * strip and the legacy More menu are hidden so we never have to fight
+   * with empty-overflow rendering on small screens. */
+  .mobile-tab-select { display: block; }
+  .tabs-scroll { display: none !important; }
+  .tabs-more { display: none !important; }
+  .tabs {
+    margin: 0 -12px 12px;
+    padding: 6px 8px;
   }
 
   /* Keep the layout itself viewport-bound on mobile so .content remains
@@ -2157,4 +2179,45 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   border: 1px solid var(--border);
   border-radius: 6px;
   font-size: 13px;
+}
+
+/* Extension status badge (Tauri only) */
+.ext-badge {
+  border: 1px solid var(--border);
+  background: var(--panel);
+  color: var(--text);
+  border-radius: 999px;
+  padding: 3px 12px;
+  font-size: 12px;
+  cursor: default;
+  margin-left: 4px;
+}
+.ext-badge[hidden] { display: none; }
+.ext-badge.ext-ok { border-color: #1f7a1f; color: #1f7a1f; background: #eafbe9; cursor: default; }
+.ext-badge.ext-warn { border-color: #c0392b; color: #c0392b; background: #fae6e6; cursor: pointer; }
+.ext-badge.ext-warn:hover { background: #f5d0d0; }
+
+.ext-setup .ext-setup-head { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; }
+.ext-setup .ext-setup-head h3 { margin: 0; flex: 1; }
+.ext-setup-help { font-size: 13px; line-height: 1.6; color: var(--text); margin: 6px 0; }
+.ext-setup-help code {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 0 4px;
+  font-size: 12px;
+}
+.ext-setup-steps { padding-left: 18px; margin: 8px 0; line-height: 1.7; font-size: 13px; }
+.ext-setup-steps li { margin-bottom: 4px; }
+
+/* Mobile tab select (hidden on desktop). */
+.mobile-tab-select {
+  display: none;
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel);
+  font-size: 14px;
 }


### PR DESCRIPTION
## Summary
User-flagged batch.

### 1. Chrome extension status badge (Tauri only)
New `GET /api/extension/status` returns `{ configured, active, last_seen }` based on the most recent `visit_events.visited_at`. SPA polls every 30 s and shows a topbar pill:
- ✓ 拡張 OK / ✓ 拡張接続済 (green)
- ⚠ 拡張未設定 (クリック) — red, opens an overlay with step-by-step setup instructions

Visible only inside Tauri (detected via `window.__TAURI_INTERNALS__`). Regular browser tabs hide it.

### 2. Mobile tab nav → native `<select>`
The custom More menu kept rendering empty in some setups. Mobile path replaced with a `<select id="mobileTabSelect">`; mobile media query hides `.tabs-scroll` + `.tabs-more`. Desktop unchanged.

### 3. Settings always top-right on mobile + 💡 やり方 button
`.topbar-controls` becomes `position: absolute; top: 6px; right: 8px` on mobile so ⚙ 設定 + 💡 やり方 always sit in the top-right corner regardless of how the brand / multi-switch / extension badge / queue badge wrap. Topbar gets `padding-right: 56px` for the slot.

💡 やり方 button (mobile only) opens an overlay describing the PWA share-target install flow + iOS Shortcut fallback. Chrome extension isn't an option on mobile, so this is the canonical "how to bookmark from a phone" guide.

## Test plan
- [ ] Tauri desktop app: badge appears, says ⚠ 拡張未設定 if no recent pings, clicking opens setup overlay
- [ ] Browser tab: badge hidden
- [ ] Mobile (≤ 760px): tabs are a `<select>`; ⚙ 設定 + 💡 やり方 anchored top-right; 💡 やり方 opens PWA setup overlay
- [ ] Desktop: tabs still horizontal button strip + ⋯ More

🤖 Generated with [Claude Code](https://claude.com/claude-code)