### PR TITLE
fix(diary+ui): trim diary response + drop mobile select / More menu

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1919,10 +1919,14 @@ app.get('/api/diary/:date', (c) => {
   const date = c.req.param('date');
   if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return c.json({ error: 'invalid date' }, 400);
   const entry = getDiary(db, date) || { date, status: 'absent' };
-  // Always include live metrics so the UI can chart even before the claude
-  // narrative finishes. (cheap; pure SQL aggregation)
+  // The stored row contains both `metrics_json` (raw text) AND its parsed
+  // `metrics` object. We also compute fresh `live_metrics`. Sending all
+  // three triples the payload — for a busy day that pushed the response
+  // past 1.8 MB and made the Tauri WebView freeze. Keep only live_metrics
+  // (which is what the SPA actually reads) and drop the redundancies.
+  const { metrics_json: _mj, metrics: _m, ...slim } = entry;
   const liveMetrics = aggregateDay(db, date);
-  return c.json({ ...entry, live_metrics: liveMetrics });
+  return c.json({ ...slim, live_metrics: liveMetrics });
 });
 
 app.post('/api/diary/:date/generate', async (c) => {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -564,12 +564,7 @@ function switchTab(tab) {
   if (tab === 'diary') loadDiary();
   if (tab === 'events') loadEvents();
   if (tab === 'multi') loadMulti();
-  // Keep mobile tab select in sync with the active tab.
-  const sel = $('mobileTabSelect');
-  if (sel && sel.value !== tab) sel.value = tab;
   bumpTabUsage(tab);
-  reflowTabsForViewport();
-  closeTabMoreMenu();
 }
 
 // ── Tab use-count + mobile More menu ──────────────────────────────────────
@@ -587,61 +582,12 @@ function tabsInUsageOrder() {
   const u = readTabUsage();
   return tabs.slice().sort((a, b) => (u[b.dataset.tab] || 0) - (u[a.dataset.tab] || 0));
 }
-function closeTabMoreMenu() {
-  const m = $('tabMoreMenu');
-  const b = $('tabMoreBtn');
-  if (m) m.classList.add('hidden');
-  if (b) b.setAttribute('aria-expanded', 'false');
-}
-function reflowTabsForViewport() {
-  const scroll = document.querySelector('.tabs-scroll');
-  const moreWrap = document.querySelector('.tabs-more');
-  const moreMenu = $('tabMoreMenu');
-  if (!scroll || !moreWrap || !moreMenu) return;
-
-  const allTabs = [...scroll.querySelectorAll('.tab[data-tab]')];
-
-  // Reset every state from any previous run.
-  for (const t of allTabs) t.style.display = '';
-  moreMenu.replaceChildren();
-
-  const isNarrow = window.innerWidth <= 760;
-  if (!isNarrow) {
-    moreWrap.classList.add('hidden');
-    return;
-  }
-
-  const active = state.tab;
-  const ordered = tabsInUsageOrder();
-  const visibleN = 4;
-  const visible = new Set(ordered.slice(0, visibleN).map(t => t.dataset.tab));
-  if (active) visible.add(active);
-
-  let overflowCount = 0;
-  for (const t of allTabs) {
-    if (visible.has(t.dataset.tab)) {
-      t.style.display = '';
-    } else {
-      // Build a fresh button instead of cloning — cloneNode used to
-      // copy the `display: none` we set on the original, which made
-      // the More menu silently empty.
-      const item = document.createElement('button');
-      item.type = 'button';
-      item.className = 'tab' + (t.dataset.tab === active ? ' active' : '');
-      item.dataset.tab = t.dataset.tab;
-      item.textContent = (t.textContent || t.dataset.tab).trim();
-      item.addEventListener('click', (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        switchTab(t.dataset.tab);
-      });
-      moreMenu.appendChild(item);
-      t.style.display = 'none';
-      overflowCount += 1;
-    }
-  }
-  moreWrap.classList.toggle('hidden', overflowCount === 0);
-}
+// Custom More menu and mobile <select> have been removed — the tab
+// strip now scrolls horizontally on every viewport, which is more
+// reliable than juggling overflow logic. These no-ops stay around so
+// existing call sites (switchTab → reflowTabsForViewport) don't error.
+function closeTabMoreMenu() { /* no-op */ }
+function reflowTabsForViewport() { /* no-op */ }
 
 // ── Dig (deep research) ──────────────────────────────────────────────────
 
@@ -2751,34 +2697,9 @@ async function deleteSelectedVisits() {
 document.querySelectorAll('.tabs-scroll .tab').forEach(t => {
   t.addEventListener('click', () => switchTab(t.dataset.tab));
 });
-$('tabMoreBtn')?.addEventListener('click', (e) => {
-  e.stopPropagation();
-  const menu = $('tabMoreMenu');
-  const btn = $('tabMoreBtn');
-  const open = menu.classList.contains('hidden');
-  menu.classList.toggle('hidden', !open);
-  btn.setAttribute('aria-expanded', open ? 'true' : 'false');
-});
-document.addEventListener('click', (e) => {
-  const menu = $('tabMoreMenu');
-  if (!menu || menu.classList.contains('hidden')) return;
-  if (e.target.closest('.tabs-more')) return;
-  closeTabMoreMenu();
-});
-window.addEventListener('resize', reflowTabsForViewport);
-reflowTabsForViewport();
 setupCategoriesDrawer();
 setupExtensionBadge();
-setupMobileTabSelect();
 setupHowToBookmark();
-
-// Mobile <select> for tabs — fires switchTab() on change.
-function setupMobileTabSelect() {
-  const sel = $('mobileTabSelect');
-  if (!sel) return;
-  sel.value = state.tab || 'bookmarks';
-  sel.addEventListener('change', () => switchTab(sel.value));
-}
 
 // 💡 やり方 button — only shows on mobile (no Chrome extension available).
 function setupHowToBookmark() {

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -70,23 +70,6 @@
   <main class="layout" data-active-tab="bookmarks">
     <section class="content">
       <nav class="tabs">
-        <!-- Mobile uses a native <select> so the dropdown is browser-native
-             (the previous custom More menu kept rendering empty in some
-             setups; a <select> always works). Desktop hides this and uses
-             the horizontal button strip below. -->
-        <select id="mobileTabSelect" class="mobile-tab-select" aria-label="タブ">
-          <option value="bookmarks">📚 ブックマーク</option>
-          <option value="queue">🔧 作業キュー</option>
-          <option value="events">📋 イベント</option>
-          <option value="visits">📰 アクセス履歴</option>
-          <option value="trends">📈 傾向</option>
-          <option value="recommend">✨ おすすめ</option>
-          <option value="dig">🔎 ディグる</option>
-          <option value="dict">📖 辞書</option>
-          <option value="domain">🏷 ドメイン</option>
-          <option value="diary">📅 日記</option>
-          <option value="multi" class="mobile-tab-multi-only">🌐 マルチ</option>
-        </select>
         <div class="tabs-scroll">
           <button class="tab active" data-tab="bookmarks">ブックマーク</button>
           <button class="tab" data-tab="queue">
@@ -108,10 +91,6 @@
           <button class="tab" data-tab="domain">🏷 ドメイン</button>
           <button class="tab" data-tab="diary">📅 日記</button>
           <button class="tab tab-multi-only" data-tab="multi" hidden>🌐 マルチ</button>
-        </div>
-        <div class="tabs-more">
-          <button type="button" class="tab tab-more-btn" id="tabMoreBtn" aria-haspopup="true" aria-expanded="false" title="他のタブ">⋯</button>
-          <div id="tabMoreMenu" class="tab-more-menu hidden" role="menu"></div>
         </div>
       </nav>
 

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -231,39 +231,19 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   align-items: stretch;
   box-shadow: 0 1px 0 rgba(0,0,0,0.04);
 }
+/* Single horizontally-scrollable tab strip on every viewport.
+ * Custom More dropdown got dropped — it kept rendering empty in some
+ * setups and `overflow-x: auto` on the strip is the simplest reliable
+ * fallback for narrow widths. Hide the scrollbar for cosmetics. */
 .tabs-scroll {
   display: flex;
   gap: 4px;
   flex: 1 1 auto;
   min-width: 0;
-  overflow: hidden;
+  overflow-x: auto;
+  scrollbar-width: none;
 }
-.tabs-more { position: relative; flex-shrink: 0; }
-.tab-more-btn { font-weight: 600; }
-.tab-more-menu {
-  position: absolute;
-  top: 100%;
-  right: 0;
-  margin-top: 4px;
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  box-shadow: 0 6px 24px rgba(0,0,0,0.12);
-  min-width: 180px;
-  padding: 4px;
-  z-index: 20;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-.tab-more-menu .tab {
-  border-bottom: 0;
-  justify-content: flex-start;
-  border-radius: 6px;
-  padding: 8px 12px;
-}
-.tab-more-menu .tab.active { background: var(--accent-bg); }
-.tabs-more.hidden { display: none; }
+.tabs-scroll::-webkit-scrollbar { display: none; }
 .tab {
   background: transparent;
   border: 0;
@@ -1799,12 +1779,7 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   }
   .topbar-howto[hidden] { display: none !important; }
 
-  /* Mobile shows the <select> dropdown for tabs. The horizontal button
-   * strip and the legacy More menu are hidden so we never have to fight
-   * with empty-overflow rendering on small screens. */
-  .mobile-tab-select { display: block; }
-  .tabs-scroll { display: none !important; }
-  .tabs-more { display: none !important; }
+  /* Mobile uses the same horizontally-scrollable tab strip as desktop. */
   .tabs {
     margin: 0 -12px 12px;
     padding: 6px 8px;
@@ -2210,14 +2185,3 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 .ext-setup-steps { padding-left: 18px; margin: 8px 0; line-height: 1.7; font-size: 13px; }
 .ext-setup-steps li { margin-bottom: 4px; }
 
-/* Mobile tab select (hidden on desktop). */
-.mobile-tab-select {
-  display: none;
-  flex: 1 1 auto;
-  min-width: 0;
-  padding: 8px 10px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--panel);
-  font-size: 14px;
-}


### PR DESCRIPTION
## Summary

### 1. Diary 4/27 wasn't fetching (or appeared to hang)
`/api/diary/:date` was shipping THREE copies of the same metrics — `metrics_json` (389 KB raw text on 4/27), `metrics` (371 KB parsed), `live_metrics` (376 KB freshly aggregated). Total response: **1.88 MB**. Tauri WebView choked parsing that on click. The SPA only reads `live_metrics`, so the response now strips `metrics_json` + `metrics` and just sends `live_metrics`. Halves the payload immediately.

### 2. Mobile `<select>` for tabs / More menu — both removed
User said the mobile select was leaking onto desktop ("PCでもでてる。いらない"), and the More menu kept rendering empty across attempts. Settled on the simplest reliable model:
- One horizontally-scrollable tab strip on every viewport (`overflow-x: auto`, scrollbar hidden)
- HTML for `<select id="mobileTabSelect">`, `<div class="tabs-more">`, `#tabMoreBtn`, `#tabMoreMenu` deleted
- `closeTabMoreMenu` / `reflowTabsForViewport` reduced to no-ops so existing call sites still work
- Mobile media query no longer toggles `.tabs-scroll` / `.tabs-more` visibility

## Test plan
- [ ] Click 4/27 in the diary calendar → detail panel renders without hanging
- [ ] Mobile (≤ 760 px): tab strip scrolls horizontally; no `<select>` shown; no ⋯ More button
- [ ] Desktop: tab strip scrolls horizontally if window is narrow enough
- [ ] No console errors related to `tabMoreBtn` / `mobileTabSelect`

🤖 Generated with [Claude Code](https://claude.com/claude-code)