### PR TITLE
feat(diary): paginate bookmark / dig lists with more ▽

### DIFF
--- a/server/diary.js
+++ b/server/diary.js
@@ -42,7 +42,11 @@ function parseSqliteUtc(s) {
  * that signals "heavy activity on that URL" (touched many times today, plus
  * still present in the per-URL touch table).
  */
-export function aggregateDay(db, dateStr) {
+// Initial page size for the bookmark / dig lists in the diary view.
+// Anything beyond this is loaded on-demand via the per-list endpoints.
+const DIARY_LIST_INITIAL = 10;
+
+export function aggregateDay(db, dateStr, { listLimit = DIARY_LIST_INITIAL } = {}) {
   const hourlyVisits = new Array(24).fill(0);
   const domainTally = new Map();
   const domainHours = new Map(); // domain -> Set of hour buckets seen
@@ -116,8 +120,15 @@ export function aggregateDay(db, dateStr) {
 
   const totalEvents = hourlyVisits.reduce((s, n) => s + n, 0);
 
-  const bookmarks = bookmarksForDate(db, dateStr);
-  const digs = digSessionsForDate(db, dateStr).map(d => {
+  // Bookmark + dig lists are paginated for the live response. The
+  // highlights prompt builder calls aggregateDay() with `listLimit: null`
+  // so claude still sees the full picture.
+  const bookmarks = bookmarksForDate(db, dateStr,
+    listLimit == null ? {} : { limit: listLimit, offset: 0 });
+  const allDigs = digSessionsForDate(db, dateStr);
+  const digsTotal = allDigs.length;
+  const digSlice = listLimit == null ? allDigs : allDigs.slice(0, listLimit);
+  const digs = digSlice.map(d => {
     const r = d.result || {};
     return {
       id: d.id,
@@ -154,6 +165,7 @@ export function aggregateDay(db, dateStr) {
     last_event_at: lastSeen,
     bookmarks,
     digs,
+    digs_total: digsTotal,
     downtimes,
     total_downtime_ms: totalDowntimeMs,
     sources: {
@@ -331,14 +343,30 @@ function inferAuthHint({ probes, fmt }) {
 }
 
 /** Bookmarks created or accessed on `dateStr`. */
-export function bookmarksForDate(db, dateStr) {
+// Per-day bookmark lists used by the diary view. `limit/offset` paginate;
+// `null` limit returns everything (used by the highlights prompt builder
+// inside aggregateDay so claude still sees the full picture).
+export function bookmarksForDate(db, dateStr, { limit = null, offset = 0 } = {}) {
+  const limitClause = limit == null ? '' : ' LIMIT ? OFFSET ?';
+  const args = limit == null ? [dateStr] : [dateStr, Number(limit) || 0, Number(offset) || 0];
+
+  const createdTotal = db.prepare(`
+    SELECT COUNT(*) AS n FROM bookmarks WHERE date(created_at, 'localtime') = ?
+  `).get(dateStr).n;
   const created = db.prepare(`
     SELECT id, url, title, summary, created_at
     FROM bookmarks
     WHERE date(created_at, 'localtime') = ?
     ORDER BY created_at ASC
-  `).all(dateStr);
+    ${limitClause}
+  `).all(...args);
 
+  const accessedTotal = db.prepare(`
+    SELECT COUNT(DISTINCT b.id) AS n
+    FROM accesses a
+    JOIN bookmarks b ON b.id = a.bookmark_id
+    WHERE date(a.accessed_at, 'localtime') = ?
+  `).get(dateStr).n;
   const accessedRows = db.prepare(`
     SELECT b.id, b.url, b.title,
            MIN(a.accessed_at) AS first_accessed_at,
@@ -349,9 +377,14 @@ export function bookmarksForDate(db, dateStr) {
     WHERE date(a.accessed_at, 'localtime') = ?
     GROUP BY b.id
     ORDER BY access_count DESC, last_accessed_at DESC
-  `).all(dateStr);
+    ${limitClause}
+  `).all(...args);
 
-  return { created, accessed: accessedRows };
+  return {
+    created, accessed: accessedRows,
+    created_total: createdTotal,
+    accessed_total: accessedTotal,
+  };
 }
 
 /** GitHub commits grouped by repository: { byRepo: {repo: count}, total, repos: [...] }. */

--- a/server/index.js
+++ b/server/index.js
@@ -35,6 +35,7 @@ import { recommendationsFor, dismissRecommendation, clearDismissals } from './re
 import { runDig, runDigPreview, listSearchEngines } from './dig.js';
 import {
   insertDigSession, setDigResult, setDigPreview, getDigSession, listDigSessions,
+  digSessionsForDate,
   insertWordCloud, setWordCloudResult, getWordCloud, listWordClouds,
   getBookmarkWordCloud, recentBookmarkWordClouds, trendsVisitDomains,
   listDictionaryEntries, getDictionaryEntry, findDictionaryEntryByTerm,
@@ -58,6 +59,7 @@ import {
   aggregateDay, fetchGithubActivity, fetchGithubRange,
   generateDiary, generateWorkContent, generateHighlights,
   generateWeekly, summarizeGithubByRepo,
+  bookmarksForDate,
   formatLocalDate, yesterdayLocal, weekRangeFor, weekOfMonth, pingGithub,
 } from './diary.js';
 import {
@@ -1730,7 +1732,10 @@ function enqueueDiaryStages(dateStr, opts = {}) {
   // diary entering the pipeline immediately.
   diaryQueue.enqueue(async () => {
     if (ctx.failed) return;
-    ctx.metrics = aggregateDay(db, dateStr);
+    // Highlights/summary need the full bookmark+dig lists for accurate
+    // counts and topDomains; the API response uses the default 10-per-list
+    // limit so the SPA isn't asked to render hundreds of <li>s up front.
+    ctx.metrics = aggregateDay(db, dateStr, { listLimit: null });
     const prior = getDiary(db, dateStr);
     ctx.notes = prior?.notes || '';
     ctx.globalMemo = (getAppSettings(db)['diary.global_memo'] || '').trim();
@@ -1925,8 +1930,48 @@ app.get('/api/diary/:date', (c) => {
   // past 1.8 MB and made the Tauri WebView freeze. Keep only live_metrics
   // (which is what the SPA actually reads) and drop the redundancies.
   const { metrics_json: _mj, metrics: _m, ...slim } = entry;
+  // listLimit defaults to 10 — keeps the response small enough for the
+  // Tauri WebView even on days with hundreds of bookmarks. Full lists
+  // come from /api/diary/:date/bookmarks and /api/diary/:date/digs.
   const liveMetrics = aggregateDay(db, date);
   return c.json({ ...slim, live_metrics: liveMetrics });
+});
+
+// Paginated bookmark list for the diary panel's "more ▽" button.
+//   ?kind=created|accessed&limit=20&offset=10
+app.get('/api/diary/:date/bookmarks', (c) => {
+  const date = c.req.param('date');
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return c.json({ error: 'invalid date' }, 400);
+  const kind = c.req.query('kind') === 'accessed' ? 'accessed' : 'created';
+  const limit = Math.min(Number(c.req.query('limit')) || 20, 200);
+  const offset = Math.max(Number(c.req.query('offset')) || 0, 0);
+  const r = bookmarksForDate(db, date, { limit, offset });
+  return c.json({
+    items: r[kind],
+    total: kind === 'accessed' ? r.accessed_total : r.created_total,
+    offset, limit,
+  });
+});
+
+// Paginated dig list for the diary panel.
+app.get('/api/diary/:date/digs', (c) => {
+  const date = c.req.param('date');
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return c.json({ error: 'invalid date' }, 400);
+  const limit = Math.min(Number(c.req.query('limit')) || 20, 200);
+  const offset = Math.max(Number(c.req.query('offset')) || 0, 0);
+  const all = digSessionsForDate(db, date);
+  const slice = all.slice(offset, offset + limit).map(d => {
+    const r = d.result || {};
+    return {
+      id: d.id, query: d.query, status: d.status, created_at: d.created_at,
+      summary: (r.summary || '').slice(0, 600),
+      source_count: (r.sources || []).length,
+      sources: (r.sources || []).slice(0, 8).map(s => ({
+        url: s.url, title: s.title, snippet: (s.snippet || '').slice(0, 200),
+      })),
+    };
+  });
+  return c.json({ items: slice, total: all.length, offset, limit });
 });
 
 app.post('/api/diary/:date/generate', async (c) => {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -1847,54 +1847,16 @@ function renderDiaryDetail() {
     }).join('');
 
   const created = metrics.bookmarks?.created || [];
-  $('diaryBookmarksCreated').innerHTML = created.length === 0
-    ? '<li class="queue-empty">新規ブックマークなし</li>'
-    : created.map(b =>
-      `<li class="diary-bookmark" data-id="${b.id}">
-        <a href="${escapeHtml(b.url)}" target="_blank" rel="noreferrer" class="title">${escapeHtml(b.title)}</a>
-        <div class="url">${escapeHtml(b.url)}</div>
-        ${b.summary ? `<div class="summary">${escapeHtml(b.summary.slice(0, 200))}</div>` : ''}
-      </li>`
-    ).join('');
+  const createdTotal = metrics.bookmarks?.created_total ?? created.length;
+  renderDiaryBookmarkList('diaryBookmarksCreated', created, createdTotal, 'created', '新規ブックマークなし');
+
   const accessed = metrics.bookmarks?.accessed || [];
-  $('diaryBookmarksAccessed').innerHTML = accessed.length === 0
-    ? '<li class="queue-empty">再訪なし</li>'
-    : accessed.map(b =>
-      `<li class="diary-bookmark" data-id="${b.id}">
-        <a href="${escapeHtml(b.url)}" target="_blank" rel="noreferrer" class="title">${escapeHtml(b.title)}</a>
-        <div class="url">${escapeHtml(b.url)} <span class="access-count">×${b.access_count}</span></div>
-      </li>`
-    ).join('');
-  document.querySelectorAll('.diary-bookmark').forEach(li => {
-    li.addEventListener('click', (ev) => {
-      if (ev.target.tagName === 'A') return;
-      const id = Number(li.dataset.id);
-      switchTab('bookmarks');
-      openDetail(id);
-    });
-  });
+  const accessedTotal = metrics.bookmarks?.accessed_total ?? accessed.length;
+  renderDiaryBookmarkList('diaryBookmarksAccessed', accessed, accessedTotal, 'accessed', '再訪なし');
 
   const digs = metrics.digs || [];
-  if (digs.length === 0) {
-    $('diaryDigs').innerHTML = '<li class="queue-empty">この日のディグはなし</li>';
-  } else {
-    $('diaryDigs').innerHTML = digs.map(dg => `
-      <li class="diary-dig" data-id="${dg.id}">
-        <div class="diary-dig-head">
-          <span class="diary-dig-query">${escapeHtml(dg.query)}</span>
-          <span class="diary-dig-meta">${dg.source_count} 件 · ${escapeHtml(dg.status)}</span>
-        </div>
-        ${dg.summary ? `<div class="diary-dig-summary">${escapeHtml(dg.summary)}</div>` : ''}
-      </li>
-    `).join('');
-    $('diaryDigs').querySelectorAll('.diary-dig').forEach(li => {
-      li.addEventListener('click', () => {
-        const id = Number(li.dataset.id);
-        switchTab('dig');
-        loadDigSession(id);
-      });
-    });
-  }
+  const digsTotal = metrics.digs_total ?? digs.length;
+  renderDiaryDigList(digs, digsTotal);
 
   const commits = d.github_commits?.commits || [];
   if (commits.length === 0) {
@@ -1961,6 +1923,124 @@ function renderDomainPie(domains) {
     startAngle = endAngle;
   });
   return `<svg viewBox="0 0 220 220" preserveAspectRatio="xMidYMid meet">${paths}</svg>`;
+}
+
+// ── Diary list paging helpers ─────────────────────────────────────────────
+
+function bookmarkLi(b, withAccessCount = false) {
+  const accessCount = withAccessCount && b.access_count
+    ? `<span class="access-count">×${b.access_count}</span>`
+    : '';
+  const summary = b.summary ? `<div class="summary">${escapeHtml(String(b.summary).slice(0, 200))}</div>` : '';
+  return `<li class="diary-bookmark" data-id="${b.id}">
+    <a href="${escapeHtml(b.url)}" target="_blank" rel="noreferrer" class="title">${escapeHtml(b.title || b.url)}</a>
+    <div class="url">${escapeHtml(b.url)} ${accessCount}</div>
+    ${summary}
+  </li>`;
+}
+function attachBookmarkClicks(scope) {
+  scope.querySelectorAll('.diary-bookmark').forEach(li => {
+    if (li.dataset.bound === '1') return;
+    li.dataset.bound = '1';
+    li.addEventListener('click', (ev) => {
+      if (ev.target.tagName === 'A') return;
+      const id = Number(li.dataset.id);
+      switchTab('bookmarks');
+      openDetail(id);
+    });
+  });
+}
+
+function renderDiaryBookmarkList(elId, items, total, kind, emptyMsg) {
+  const ul = $(elId);
+  if (!items.length) {
+    ul.innerHTML = `<li class="queue-empty">${emptyMsg}</li>`;
+    return;
+  }
+  const withAccess = kind === 'accessed';
+  ul.innerHTML = items.map(b => bookmarkLi(b, withAccess)).join('');
+  attachBookmarkClicks(ul);
+  if (total > items.length) {
+    appendDiaryMoreButton(ul, items.length, total, async (offset) => {
+      const date = state.diaryDetailDate;
+      const r = await api(`/api/diary/${date}/bookmarks?kind=${kind}&offset=${offset}&limit=20`);
+      return { items: (r.items || []).map(b => bookmarkLi(b, withAccess)), total: r.total };
+    });
+  }
+}
+
+function renderDiaryDigList(items, total) {
+  const ul = $('diaryDigs');
+  if (!items.length) {
+    ul.innerHTML = '<li class="queue-empty">この日のディグはなし</li>';
+    return;
+  }
+  ul.innerHTML = items.map(digLi).join('');
+  attachDigClicks(ul);
+  if (total > items.length) {
+    appendDiaryMoreButton(ul, items.length, total, async (offset) => {
+      const date = state.diaryDetailDate;
+      const r = await api(`/api/diary/${date}/digs?offset=${offset}&limit=20`);
+      return { items: (r.items || []).map(digLi), total: r.total };
+    });
+  }
+}
+function digLi(dg) {
+  return `<li class="diary-dig" data-id="${dg.id}">
+    <div class="diary-dig-head">
+      <span class="diary-dig-query">${escapeHtml(dg.query)}</span>
+      <span class="diary-dig-meta">${dg.source_count} 件 · ${escapeHtml(dg.status)}</span>
+    </div>
+    ${dg.summary ? `<div class="diary-dig-summary">${escapeHtml(dg.summary)}</div>` : ''}
+  </li>`;
+}
+function attachDigClicks(scope) {
+  scope.querySelectorAll('.diary-dig').forEach(li => {
+    if (li.dataset.bound === '1') return;
+    li.dataset.bound = '1';
+    li.addEventListener('click', () => {
+      const id = Number(li.dataset.id);
+      switchTab('dig');
+      loadDigSession(id);
+    });
+  });
+}
+
+// Inserts a "more ▽" button at the end of the list. Each click fetches the
+// next page and appends it; when the list is exhausted the button removes
+// itself. `fetchPage(offset) → { items: htmlString[], total }`.
+function appendDiaryMoreButton(ul, currentLen, total, fetchPage) {
+  const li = document.createElement('li');
+  li.className = 'diary-more';
+  let offset = currentLen;
+  const remaining = () => Math.max(0, total - offset);
+  function syncLabel(loading) {
+    li.innerHTML = loading
+      ? '読込中…'
+      : `more ▽ <span class="diary-more-count">残り ${remaining()} 件</span>`;
+  }
+  syncLabel(false);
+  li.addEventListener('click', async () => {
+    if (li.dataset.busy === '1') return;
+    li.dataset.busy = '1';
+    syncLabel(true);
+    try {
+      const { items, total: newTotal } = await fetchPage(offset);
+      const frag = document.createElement('div');
+      frag.innerHTML = items.join('');
+      while (frag.firstChild) ul.insertBefore(frag.firstChild, li);
+      attachBookmarkClicks(ul);
+      attachDigClicks(ul);
+      offset += items.length;
+      if (typeof newTotal === 'number') total = newTotal;
+      if (offset >= total) li.remove();
+      else { syncLabel(false); li.dataset.busy = ''; }
+    } catch (e) {
+      li.innerHTML = `<span class="error">取得失敗: ${escapeHtml(e.message)}</span>`;
+      li.dataset.busy = '';
+    }
+  });
+  ul.appendChild(li);
 }
 
 function renderHourlyChart(hours) {

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -2185,3 +2185,21 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 .ext-setup-steps { padding-left: 18px; margin: 8px 0; line-height: 1.7; font-size: 13px; }
 .ext-setup-steps li { margin-bottom: 4px; }
 
+
+.diary-more {
+  list-style: none;
+  text-align: center;
+  padding: 8px 12px;
+  background: var(--bg);
+  border: 1px dashed var(--border);
+  border-radius: 6px;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 12px;
+  margin-top: 6px;
+  user-select: none;
+  transition: background 80ms;
+}
+.diary-more:hover { background: var(--accent-bg); }
+.diary-more-count { color: var(--muted); margin-left: 6px; font-size: 11px; }
+.diary-more .error { color: var(--danger); }


### PR DESCRIPTION
## Summary
4/27 + 4/28 diaries weren't loading: even after PR #68 trimmed the response, the panel still tried to render ~460 created + ~460 accessed bookmarks + all digs in a single innerHTML — Tauri's WebView still choked.

### Backend
- `bookmarksForDate(db, date, { limit, offset })` — paginated, returns `{ created, accessed, created_total, accessed_total }`.
- `aggregateDay(db, date, { listLimit })` — default 10 per list. Live API path uses default; highlights pipeline calls with `listLimit: null` so claude still sees the whole day.
- `digs_total` included alongside the trimmed `digs[]`.
- New: `GET /api/diary/:date/bookmarks?kind=created|accessed&offset=&limit=` and `GET /api/diary/:date/digs?offset=&limit=`. Both return `{ items, total, offset, limit }`.

### Frontend
- Render helpers extracted (`renderDiaryBookmarkList`, `renderDiaryDigList`, `bookmarkLi`, `digLi`).
- After the initial 10, an inline `more ▽ 残り N 件` button is appended. Clicking fetches the next 20 and inserts above the button. Button removes itself when exhausted.

Net: opening 4/27 now ships ~30 items instead of 920+, the WebView stays responsive, and the user drills through the rest only on demand.

## Test plan
- [ ] Open 4/27 → renders within a second
- [ ] 新規ブックマーク / 再訪 / ディグ each show up to 10 items + a "more ▽ 残り N 件" button when total > 10
- [ ] Click more → next 20 appear above the button, count updates
- [ ] When offset reaches total, the button disappears
- [ ] Days with < 10 items don't show a more button

🤖 Generated with [Claude Code](https://claude.com/claude-code)