### PR TITLE
feat: GPS tracks integration — OwnTracks → Memoria + Google Maps overlay + 日記参照

### DIFF
--- a/config/mosquitto/acl
+++ b/config/mosquitto/acl
@@ -1,0 +1,10 @@
+# Memoria mosquitto ACL (allow_anonymous 有効時は参照されない)
+#
+# 例: alice が OwnTracks 端末から自分の prefix だけ publish できる構成
+#
+# user alice
+# topic readwrite owntracks/alice/#
+#
+# user memoria-sub
+# topic read owntracks/+/+
+# topic read owntracks/+/+/+

--- a/config/mosquitto/mosquitto.conf
+++ b/config/mosquitto/mosquitto.conf
@@ -1,0 +1,27 @@
+# Memoria 個人用 Mosquitto config
+#
+# OwnTracks (iOS/Android) → owntracks/<user>/<device> に publish。
+# memoria-owntracks-server (別 process) が wildcard で subscribe する。
+#
+# 既定は anonymous 許可 (個人 LAN 限定運用前提)。
+# WAN 公開する場合は `allow_anonymous false` + passwd / acl の有効化、
+# 加えて 8883 (TLS) listener を追加すること。
+
+listener 1883
+listener 9001
+protocol websockets
+
+allow_anonymous true
+# 認証を有効化する場合は以下のコメントを外す:
+# allow_anonymous false
+# password_file /mosquitto/config/passwd
+# acl_file /mosquitto/config/acl
+
+persistence true
+persistence_location /mosquitto/data/
+
+log_dest stdout
+log_type error
+log_type warning
+log_type notice
+log_type information

--- a/config/mosquitto/mosquitto.conf
+++ b/config/mosquitto/mosquitto.conf
@@ -1,21 +1,25 @@
 # Memoria 個人用 Mosquitto config
 #
 # OwnTracks (iOS/Android) → owntracks/<user>/<device> に publish。
-# memoria-owntracks-server (別 process) が wildcard で subscribe する。
+# Memoria の in-process subscriber (server/index.js) もしくは別 process
+# (server/owntracks-server.js) が wildcard で subscribe する。
 #
-# 既定は anonymous 許可 (個人 LAN 限定運用前提)。
-# WAN 公開する場合は `allow_anonymous false` + passwd / acl の有効化、
-# 加えて 8883 (TLS) listener を追加すること。
+# WAN (Cloudflare Tunnel + MQTT-over-WSS) で公開する場合は port 9001 (WS)
+# を使い、 必ず認証必須にする。 LAN-only ならどちらでも可。
+#
+# 既定は **認証必須**。 anonymous で開発したい場合は下のコメントを切替えて。
 
 listener 1883
 listener 9001
 protocol websockets
 
-allow_anonymous true
-# 認証を有効化する場合は以下のコメントを外す:
-# allow_anonymous false
-# password_file /mosquitto/config/passwd
-# acl_file /mosquitto/config/acl
+# === 認証 (既定: 必須) ====================================================
+allow_anonymous false
+password_file /mosquitto/config/passwd
+acl_file /mosquitto/config/acl
+
+# === 認証なしで開発したい場合 (上 3 行をコメントアウトして下を有効化) ====
+# allow_anonymous true
 
 persistence true
 persistence_location /mosquitto/data/

--- a/config/mosquitto/passwd
+++ b/config/mosquitto/passwd
@@ -1,0 +1,6 @@
+# この file は anonymous 許可時はコンテナで参照されない (mosquitto.conf の
+# password_file コメントを外したときのみ有効)。
+#
+# 認証を有効化する場合は mosquitto_passwd で生成する:
+#   docker run --rm -v $(pwd):/work eclipse-mosquitto:2.0 \
+#     mosquitto_passwd -c -b /work/passwd alice <PASSWORD>

--- a/config/mosquitto/setup-passwd.sh
+++ b/config/mosquitto/setup-passwd.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Memoria mosquitto: passwd + acl を初期生成する。
+#
+# 用途:
+#   1. OwnTracks (publisher) 用ユーザを 1 つ作る (既定 'me')
+#   2. Memoria subscriber 用ユーザを 1 つ作る (既定 'memoria-sub')
+#
+# 使い方:
+#   ./setup-passwd.sh                      # 対話式で password を聞く
+#   ./setup-passwd.sh me PASS1 sub PASS2   # 直接渡す (CI 等)
+#
+# 既存の passwd / acl を上書きする (バックアップは取らない)。
+#
+# Cygwin / Git Bash でも動く想定。 docker 経由で mosquitto_passwd を呼ぶので
+# ホストに mosquitto をインストールしていなくても動く。
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+PUB_USER="${1:-me}"
+PUB_PASS="${2:-}"
+SUB_USER="${3:-memoria-sub}"
+SUB_PASS="${4:-}"
+
+if [ -z "$PUB_PASS" ]; then
+  read -srp "Publisher (${PUB_USER}) のパスワード: " PUB_PASS; echo
+fi
+if [ -z "$SUB_PASS" ]; then
+  read -srp "Subscriber (${SUB_USER}) のパスワード: " SUB_PASS; echo
+fi
+
+# mosquitto_passwd 内蔵のため eclipse-mosquitto コンテナを使う
+docker run --rm -i --entrypoint sh \
+  -v "$PWD:/work" \
+  eclipse-mosquitto:2.0 -c "
+    : > /work/passwd
+    mosquitto_passwd -b /work/passwd '${PUB_USER}' '${PUB_PASS}'
+    mosquitto_passwd -b /work/passwd '${SUB_USER}' '${SUB_PASS}'
+  "
+
+cat > acl <<EOF
+# Memoria mosquitto ACL
+# Publisher (端末): 自分の topic prefix に publish のみ
+user ${PUB_USER}
+topic readwrite owntracks/${PUB_USER}/#
+
+# Subscriber (Memoria server): 全 owntracks 配下 read
+user ${SUB_USER}
+topic read owntracks/+/+
+topic read owntracks/+/+/+
+EOF
+
+echo "✅ passwd / acl を生成しました。"
+echo "   - publisher:  ${PUB_USER}"
+echo "   - subscriber: ${SUB_USER}"
+echo "   docker compose restart mosquitto で反映してください。"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+# Memoria 個人用インフラ
+#
+# OwnTracks (iOS/Android) → mosquitto → memoria-owntracks-server (別 process)
+# → SQLite (data/memoria.db)
+#
+# Iv (Imperativus) の mosquitto と衝突しないように既定 host port を 1884 (TCP)
+# / 9002 (WS) にしている。LAN 内で他 broker と共存しない場合は
+# `MEMORIA_MQTT_PORT=1883` で上書き可能。
+#
+# 起動: `docker compose up -d mosquitto`
+# 停止: `docker compose down`
+#
+# 認証 (任意):
+#   1. mosquitto-passwd で passwd を生成
+#      docker compose run --rm --entrypoint mosquitto_passwd mosquitto -b /tmp/passwd alice <PASSWORD>
+#      cat tmp/passwd >> config/mosquitto/passwd  (起動コンテナにコピーする経路はホスト側で)
+#   2. config/mosquitto/acl を編集
+#   3. mosquitto.conf の `allow_anonymous` を false に切り替え
+#
+# 個人用途では LAN 限定 + anonymous 許可 (default) のままでも実用できる。
+# ただし WAN 公開する場合は必ず認証 + TLS を有効化すること。
+
+services:
+  mosquitto:
+    image: eclipse-mosquitto:2.0
+    container_name: memoria-mosquitto
+    restart: unless-stopped
+    ports:
+      - "${MEMORIA_MQTT_PORT:-1884}:1883"
+      - "${MEMORIA_MQTT_WS_PORT:-9002}:9001"
+    volumes:
+      - ./config/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
+      - ./config/mosquitto/passwd:/mosquitto/config/passwd:ro
+      - ./config/mosquitto/acl:/mosquitto/config/acl:ro
+      - memoria-mosquitto-data:/mosquitto/data
+      - memoria-mosquitto-log:/mosquitto/log
+
+volumes:
+  memoria-mosquitto-data:
+  memoria-mosquitto-log:

--- a/server/db.js
+++ b/server/db.js
@@ -208,6 +208,29 @@ export function openDb(dbPath) {
       ON word_clouds(created_at DESC);
     CREATE INDEX IF NOT EXISTS idx_word_clouds_bookmark
       ON word_clouds(origin_bookmark_id);
+
+    CREATE TABLE IF NOT EXISTS gps_locations (
+      id            INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id       TEXT NOT NULL DEFAULT 'me',
+      device_id     TEXT,
+      recorded_at   TEXT NOT NULL,
+      lat           REAL NOT NULL,
+      lon           REAL NOT NULL,
+      accuracy_m    REAL,
+      altitude_m    REAL,
+      velocity_kmh  REAL,
+      course_deg    REAL,
+      battery_pct   INTEGER,
+      conn          TEXT,
+      raw_json      TEXT,
+      received_at   TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_gps_locations_at
+      ON gps_locations(recorded_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_gps_locations_user_at
+      ON gps_locations(user_id, recorded_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_gps_locations_dedup
+      ON gps_locations(user_id, device_id, recorded_at);
   `);
 
   // Forward-compat: ensure newer columns exist on older word_clouds tables.
@@ -1429,3 +1452,126 @@ export function insertImportedBookmark(db, b) {
   }
   return { skipped: false, id };
 }
+
+// ---------------------------------------------------------------------------
+// gps_locations — OwnTracks 由来の位置情報
+// ---------------------------------------------------------------------------
+
+const GPS_INSERT_STMT_KEY = Symbol('gpsInsertStmt');
+
+/**
+ * 1 点の GPS 位置を挿入する。同一 (user_id, device_id, recorded_at) は無視 (重複防止)。
+ * `loc.recordedAt` は ISO 8601、`loc.tst` (OwnTracks の epoch 秒) どちらか必須。
+ */
+export function insertGpsLocation(db, loc) {
+  const userId = loc.userId || 'me';
+  const recordedAt = loc.recordedAt
+    ? loc.recordedAt
+    : (typeof loc.tst === 'number'
+        ? new Date(loc.tst * 1000).toISOString()
+        : new Date().toISOString());
+  // CONFLICT 回避: 同一 (user, device, time) の点は dedup
+  const dupCheck = db.prepare(`
+    SELECT id FROM gps_locations
+    WHERE user_id = ? AND IFNULL(device_id, '') = IFNULL(?, '') AND recorded_at = ?
+    LIMIT 1
+  `).get(userId, loc.deviceId ?? null, recordedAt);
+  if (dupCheck) return { skipped: true, id: dupCheck.id };
+
+  const info = db.prepare(`
+    INSERT INTO gps_locations
+      (user_id, device_id, recorded_at, lat, lon,
+       accuracy_m, altitude_m, velocity_kmh, course_deg, battery_pct, conn, raw_json)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    userId,
+    loc.deviceId ?? null,
+    recordedAt,
+    loc.lat,
+    loc.lon,
+    loc.accuracy ?? null,
+    loc.altitude ?? null,
+    loc.velocity ?? null,
+    loc.course ?? null,
+    loc.battery ?? null,
+    loc.conn ?? null,
+    loc.rawJson ?? null,
+  );
+  return { skipped: false, id: info.lastInsertRowid };
+}
+
+/**
+ * 期間内の位置点を時系列順で返す。`from` / `to` は ISO 8601。
+ * device_id を絞り込みたい場合は `deviceId` を渡す。
+ */
+export function listGpsLocationsInRange(db, { from, to, userId = 'me', deviceId } = {}) {
+  const where = ['user_id = ?'];
+  const params = [userId];
+  if (from) { where.push('recorded_at >= ?'); params.push(from); }
+  if (to)   { where.push('recorded_at <= ?'); params.push(to); }
+  if (deviceId) { where.push('device_id = ?'); params.push(deviceId); }
+  return db.prepare(`
+    SELECT id, user_id, device_id, recorded_at, lat, lon,
+           accuracy_m, altitude_m, velocity_kmh, course_deg, battery_pct, conn
+    FROM gps_locations
+    WHERE ${where.join(' AND ')}
+    ORDER BY recorded_at ASC
+  `).all(...params);
+}
+
+/**
+ * 位置情報を持っている日付 (YYYY-MM-DD, local TZ) と件数を新しい順で返す。
+ * UI の date picker / カレンダー表示用。
+ */
+export function listGpsLocationDays(db, { userId = 'me', limit = 365 } = {}) {
+  return db.prepare(`
+    SELECT date(recorded_at, 'localtime') AS day,
+           COUNT(*)                       AS points,
+           MIN(recorded_at)               AS first_at,
+           MAX(recorded_at)               AS last_at
+    FROM gps_locations
+    WHERE user_id = ?
+    GROUP BY day
+    ORDER BY day DESC
+    LIMIT ?
+  `).all(userId, limit);
+}
+
+/**
+ * 当日 (local TZ) の点件数。日記 / metrics 用の安価な取得。
+ */
+export function gpsLocationCountForDate(db, dateStr, { userId = 'me' } = {}) {
+  const row = db.prepare(`
+    SELECT COUNT(*) AS n
+    FROM gps_locations
+    WHERE user_id = ? AND date(recorded_at, 'localtime') = ?
+  `).get(userId, dateStr);
+  return row ? row.n : 0;
+}
+
+/**
+ * 指定日 (local TZ) の点を時系列で返す。日記の metrics + Maps overlay 共用。
+ */
+export function listGpsLocationsForDate(db, dateStr, { userId = 'me' } = {}) {
+  return db.prepare(`
+    SELECT id, device_id, recorded_at, lat, lon,
+           accuracy_m, altitude_m, velocity_kmh, course_deg
+    FROM gps_locations
+    WHERE user_id = ? AND date(recorded_at, 'localtime') = ?
+    ORDER BY recorded_at ASC
+  `).all(userId, dateStr);
+}
+
+/**
+ * 古い点を削除する (retention)。`olderThan` は ISO 8601。
+ */
+export function deleteGpsLocationsOlderThan(db, olderThan, { userId = 'me' } = {}) {
+  const info = db.prepare(`
+    DELETE FROM gps_locations
+    WHERE user_id = ? AND recorded_at < ?
+  `).run(userId, olderThan);
+  return info.changes;
+}
+
+void GPS_INSERT_STMT_KEY; // reserved for prepared-stmt cache
+

--- a/server/diary.js
+++ b/server/diary.js
@@ -4,7 +4,7 @@
 // Hourly buckets, top domains, and active hours are computed locally;
 // claude is asked only to narrate.
 
-import { visitEventsForDate, getDiary, getDomainCatalogMap, digSessionsForDate, listServerEventsForDate } from './db.js';
+import { visitEventsForDate, getDiary, getDomainCatalogMap, digSessionsForDate, listServerEventsForDate, listGpsLocationsForDate } from './db.js';
 import { runLlm } from './llm.js';
 
 // Downtimes >5 min make it into the diary; shorter gaps are treated as
@@ -154,6 +154,13 @@ export function aggregateDay(db, dateStr, { listLimit = DIARY_LIST_INITIAL } = {
     }));
   const totalDowntimeMs = downtimes.reduce((s, d) => s + (d.duration_ms || 0), 0);
 
+  // GPS — OwnTracks 由来の歩いた軌跡を当日分集計する。
+  // ポイント数と概算距離 + bbox + アクティブ時間帯を出す。
+  // クラスタリング (場所推定) はやらない (静止判定が難しく、誤推定すると
+  // 日記の根拠が壊れるため)。代わりに raw 距離 + 中央付近の代表点で示す。
+  const gpsPoints = listGpsLocationsForDate(db, dateStr);
+  const gps = summarizeGpsForDate(gpsPoints);
+
   return {
     date: dateStr,
     total_events: totalEvents,
@@ -168,10 +175,90 @@ export function aggregateDay(db, dateStr, { listLimit = DIARY_LIST_INITIAL } = {
     digs_total: digsTotal,
     downtimes,
     total_downtime_ms: totalDowntimeMs,
+    gps,
     sources: {
       visit_events: events.length,
       page_visits: pageVisitsContribution,
     },
+  };
+}
+
+// Haversine 距離 (m)。地球半径 6371008 m (mean)。短距離では誤差は数 cm 以下。
+function haversineMeters(a, b) {
+  const R = 6_371_008;
+  const toRad = (d) => (d * Math.PI) / 180;
+  const dLat = toRad(b.lat - a.lat);
+  const dLon = toRad(b.lon - a.lon);
+  const sa = Math.sin(dLat / 2);
+  const so = Math.sin(dLon / 2);
+  const h = sa * sa + Math.cos(toRad(a.lat)) * Math.cos(toRad(b.lat)) * so * so;
+  return 2 * R * Math.asin(Math.min(1, Math.sqrt(h)));
+}
+
+/**
+ * 当日の GPS 点列から日記用 metrics を組み立てる。
+ *
+ * 出力:
+ *   { points, devices, distance_meters, bbox, midpoint, hours, first_at, last_at }
+ *
+ * `bbox` / `midpoint` は Opus 1M プロンプトで「どのあたりに居たか」を
+ * narrate させるのに最低限必要な情報。`midpoint` は `bbox` の中心。
+ *
+ * 静止判定 (e.g., 同一地点で 30 分滞留 = 「滞在」) は誤判定リスクが高いので
+ * 当面は実装しない。アクティブ時間帯 (`hours`) のみ使う。
+ *
+ * 距離は連続する 2 点間 haversine の和。jitter 込みなので「歩いた距離」より
+ * やや大きめになるが、概算用途なら十分。
+ */
+export function summarizeGpsForDate(points) {
+  if (!points || points.length === 0) {
+    return {
+      points: 0,
+      devices: [],
+      distance_meters: 0,
+      bbox: null,
+      midpoint: null,
+      hours: [],
+      first_at: null,
+      last_at: null,
+    };
+  }
+  const devices = new Set();
+  const hourSet = new Set();
+  let minLat = +Infinity, maxLat = -Infinity;
+  let minLon = +Infinity, maxLon = -Infinity;
+  let dist = 0;
+  let prev = null;
+  for (const p of points) {
+    if (p.device_id) devices.add(p.device_id);
+    if (p.lat < minLat) minLat = p.lat;
+    if (p.lat > maxLat) maxLat = p.lat;
+    if (p.lon < minLon) minLon = p.lon;
+    if (p.lon > maxLon) maxLon = p.lon;
+    const h = parseSqliteUtc(p.recorded_at)?.getHours();
+    if (Number.isFinite(h)) hourSet.add(h);
+    if (prev) {
+      // Skip outliers: accuracy なし or > 200m の点は連続性を信頼しない
+      const accOk = !p.accuracy_m || p.accuracy_m < 200;
+      if (accOk) dist += haversineMeters(prev, p);
+    }
+    prev = p;
+  }
+  return {
+    points: points.length,
+    devices: [...devices],
+    distance_meters: Math.round(dist),
+    bbox: {
+      lat: [Number(minLat.toFixed(5)), Number(maxLat.toFixed(5))],
+      lon: [Number(minLon.toFixed(5)), Number(maxLon.toFixed(5))],
+    },
+    midpoint: {
+      lat: Number(((minLat + maxLat) / 2).toFixed(5)),
+      lon: Number(((minLon + maxLon) / 2).toFixed(5)),
+    },
+    hours: [...hourSet].sort((a, b) => a - b),
+    first_at: points[0].recorded_at ?? null,
+    last_at: points[points.length - 1].recorded_at ?? null,
   };
 }
 
@@ -446,6 +533,29 @@ const WORK_CONTENT_PROMPT = ({ dateStr, urlList, totalEvents, totalDomains }) =>
   urlList,
 ].join('\n');
 
+function formatGpsBlock(metrics) {
+  const g = metrics?.gps;
+  if (!g || !g.points) return '(GPS 記録なし)';
+  const km = (g.distance_meters / 1000).toFixed(2);
+  const hourSpan = g.hours?.length
+    ? `${g.hours[0]}:00〜${g.hours[g.hours.length - 1]}:00 のあいだ`
+    : '';
+  const bbox = g.bbox
+    ? `緯度 ${g.bbox.lat[0]}〜${g.bbox.lat[1]} / 経度 ${g.bbox.lon[0]}〜${g.bbox.lon[1]}`
+    : '';
+  const center = g.midpoint
+    ? `中心付近 (${g.midpoint.lat}, ${g.midpoint.lon})`
+    : '';
+  const lines = [
+    `- 記録点数: ${g.points} 点 (デバイス: ${g.devices.join(', ') || '不明'})`,
+    `- 概算移動距離: 約 ${km} km`,
+  ];
+  if (hourSpan) lines.push(`- アクティブ時間帯: ${hourSpan}`);
+  if (bbox)     lines.push(`- 範囲: ${bbox}`);
+  if (center)   lines.push(`- ${center}`);
+  return lines.join('\n');
+}
+
 function formatDowntimeBlock(metrics) {
   const dts = metrics?.downtimes || [];
   if (!dts.length) return '(なし)';
@@ -486,6 +596,10 @@ const HIGHLIGHTS_PROMPT = ({ dateStr, workContent, githubByRepo, bookmarkSummary
   '',
   '## メタ情報',
   `総アクセス: ${metrics.total_events} / アクティブ時間帯: ${metrics.active_hours.join(',')}`,
+  '',
+  '## 移動 (GPS 軌跡 — OwnTracks 由来、参考情報)',
+  formatGpsBlock(metrics),
+  '※ GPS は jitter があるため数値は概算。場所推定は座標から自然に解釈できる範囲のみ書くこと (推測しすぎない)。',
   '',
   '## サーバ停止 (5 分超のダウンタイム)',
   formatDowntimeBlock(metrics),

--- a/server/index.js
+++ b/server/index.js
@@ -2232,18 +2232,46 @@ app.patch('/api/maps/config', async (c) => {
 // `npm run owntracks` を別シェルで走らせること。
 //
 // 個人ツール想定なので auth は緩め: 環境変数 LOCATIONS_INGEST_KEY が設定
-// されていれば X-Memoria-Ingest-Key header と一致を要求、未設定なら
-// 認証なし (LAN-only バインドが前提)。
+// されていれば 3 経路のいずれか一致で OK、未設定なら認証なし (LAN-only 前提)。
+//
+//   1. `X-Memoria-Ingest-Key: <key>`         (curl 等カスタムヘッダ向け)
+//   2. `Authorization: Bearer <key>`         (一般的な API client)
+//   3. `Authorization: Basic base64(u:<key>)` (OwnTracks iOS HTTP モードはこれ)
+//
+// Cloudflare Tunnel で WAN 公開する時は必ず key を設定すること。
 
 const LOCATIONS_INGEST_KEY = process.env.LOCATIONS_INGEST_KEY ?? '';
 
+function decodeBasicAuth(headerVal) {
+  if (!headerVal || !headerVal.startsWith('Basic ')) return null;
+  try {
+    const decoded = Buffer.from(headerVal.slice(6).trim(), 'base64').toString('utf8');
+    const idx = decoded.indexOf(':');
+    if (idx < 0) return null;
+    return { user: decoded.slice(0, idx), pass: decoded.slice(idx + 1) };
+  } catch {
+    return null;
+  }
+}
+
 function checkIngestKey(c) {
   if (!LOCATIONS_INGEST_KEY) return null;
-  const got = c.req.header('x-memoria-ingest-key') ?? '';
-  if (got !== LOCATIONS_INGEST_KEY) {
-    return c.json({ error: 'invalid ingest key' }, 401);
+  // 1) custom header
+  const xKey = c.req.header('x-memoria-ingest-key') ?? '';
+  if (xKey && xKey === LOCATIONS_INGEST_KEY) return null;
+  // 2/3) Authorization
+  const auth = c.req.header('authorization') ?? '';
+  if (auth.startsWith('Bearer ')) {
+    const tok = auth.slice(7).trim();
+    if (tok === LOCATIONS_INGEST_KEY) return null;
   }
-  return null;
+  const basic = decodeBasicAuth(auth);
+  if (basic && basic.pass === LOCATIONS_INGEST_KEY) return null;
+  // OwnTracks iOS は 401 を見ると basic auth ダイアログを出さず再試行するので
+  // realm 付きで返しておく (ログから "認証要求" が判別しやすくなる)。
+  return c.json({ error: 'invalid ingest key' }, 401, {
+    'WWW-Authenticate': 'Basic realm="memoria-locations"',
+  });
 }
 
 /**
@@ -2290,7 +2318,12 @@ app.post('/api/locations/ingest', async (c) => {
   };
 
   const result = insertGpsLocation(db, rec);
-  return c.json({ ok: true, id: result.id, skipped: result.skipped });
+  // OwnTracks の HTTP モードはレスポンスとして JSON 配列 (友達の cards 等) を
+  // 期待するので空配列で返す。 手動テスト時は X-Memoria-Insert-* header で
+  // 結果を確認できる。
+  c.header('X-Memoria-Insert-Id', String(result.id ?? ''));
+  c.header('X-Memoria-Insert-Skipped', String(!!result.skipped));
+  return c.json([]);
 });
 
 /**

--- a/server/index.js
+++ b/server/index.js
@@ -2231,16 +2231,23 @@ app.patch('/api/maps/config', async (c) => {
 // MQTT 経路で動かすには docker-compose で mosquitto を起動して
 // `npm run owntracks` を別シェルで走らせること。
 //
-// 個人ツール想定なので auth は緩め: 環境変数 LOCATIONS_INGEST_KEY が設定
-// されていれば 3 経路のいずれか一致で OK、未設定なら認証なし (LAN-only 前提)。
-//
+// 認証経路は 3 通りで、 いずれか一致すれば OK:
 //   1. `X-Memoria-Ingest-Key: <key>`         (curl 等カスタムヘッダ向け)
 //   2. `Authorization: Bearer <key>`         (一般的な API client)
 //   3. `Authorization: Basic base64(u:<key>)` (OwnTracks iOS HTTP モードはこれ)
 //
-// Cloudflare Tunnel で WAN 公開する時は必ず key を設定すること。
+// Key の解決順:
+//   a. app_settings.`locations.ingest_key` (UI から生成 / 設定)
+//   b. 環境変数 LOCATIONS_INGEST_KEY (CI / CLI 用)
+//   c. どちらも空 → 認証無効 (LAN-only バインドが前提)
+//
+// WAN 公開する時は UI から key を生成する (推奨) か env を必ず設定すること。
 
-const LOCATIONS_INGEST_KEY = process.env.LOCATIONS_INGEST_KEY ?? '';
+function getIngestKey() {
+  const stored = (getAppSettings(db)['locations.ingest_key'] || '').trim();
+  if (stored) return stored;
+  return (process.env.LOCATIONS_INGEST_KEY ?? '').trim();
+}
 
 function decodeBasicAuth(headerVal) {
   if (!headerVal || !headerVal.startsWith('Basic ')) return null;
@@ -2255,24 +2262,66 @@ function decodeBasicAuth(headerVal) {
 }
 
 function checkIngestKey(c) {
-  if (!LOCATIONS_INGEST_KEY) return null;
+  const key = getIngestKey();
+  if (!key) return null;
   // 1) custom header
   const xKey = c.req.header('x-memoria-ingest-key') ?? '';
-  if (xKey && xKey === LOCATIONS_INGEST_KEY) return null;
+  if (xKey && xKey === key) return null;
   // 2/3) Authorization
   const auth = c.req.header('authorization') ?? '';
   if (auth.startsWith('Bearer ')) {
     const tok = auth.slice(7).trim();
-    if (tok === LOCATIONS_INGEST_KEY) return null;
+    if (tok === key) return null;
   }
   const basic = decodeBasicAuth(auth);
-  if (basic && basic.pass === LOCATIONS_INGEST_KEY) return null;
+  if (basic && basic.pass === key) return null;
   // OwnTracks iOS は 401 を見ると basic auth ダイアログを出さず再試行するので
   // realm 付きで返しておく (ログから "認証要求" が判別しやすくなる)。
   return c.json({ error: 'invalid ingest key' }, 401, {
     'WWW-Authenticate': 'Basic realm="memoria-locations"',
   });
 }
+
+// ---- ingest key 管理 (UI 経由) -------------------------------------------
+//
+// 個人ツールなので key 自体は端末/ブラウザ側で確認できる必要がある。
+// GET 系は読みやすいよう preview (先頭 4 + 末尾 4) を返し、 full 値は
+// 1 度きりの「生成直後」response でしか出さない (再表示はクリア + 再生成)。
+
+function maskKey(key) {
+  if (!key) return '';
+  if (key.length <= 8) return '*'.repeat(key.length);
+  return `${key.slice(0, 4)}…${key.slice(-4)}`;
+}
+
+app.get('/api/locations/settings', (c) => {
+  const key = getIngestKey();
+  return c.json({
+    has_key: !!key,
+    key_preview: maskKey(key),
+    source: (getAppSettings(db)['locations.ingest_key'] || '').trim()
+      ? 'settings'
+      : (process.env.LOCATIONS_INGEST_KEY ? 'env' : 'none'),
+  });
+});
+
+app.post('/api/locations/settings/regenerate', (c) => {
+  // crypto.randomUUID() の方が読みやすいが Basic auth password にする都合で
+  // 32-byte hex の方が typing しやすい (40 文字)。
+  const buf = new Uint8Array(20);
+  // Node 18+ の global crypto。 globalThis 経由で webcrypto も使える
+  // ((globalThis.crypto ?? require('node:crypto').webcrypto)).getRandomValues(buf);
+  const c2 = globalThis.crypto;
+  c2.getRandomValues(buf);
+  const newKey = [...buf].map((b) => b.toString(16).padStart(2, '0')).join('');
+  setAppSettings(db, { 'locations.ingest_key': newKey });
+  return c.json({ key: newKey, key_preview: maskKey(newKey) });
+});
+
+app.delete('/api/locations/settings/key', (c) => {
+  setAppSettings(db, { 'locations.ingest_key': '' });
+  return c.json({ ok: true });
+});
 
 /**
  * 直接 1 点の位置を投入する (OwnTracks HTTP モード or 手動テスト)。

--- a/server/index.js
+++ b/server/index.js
@@ -72,6 +72,10 @@ import {
   setBookmarkOwner, setDigOwner, setDictionaryOwner,
 } from './db.js';
 import {
+  insertGpsLocation, listGpsLocationsInRange, listGpsLocationDays,
+  listGpsLocationsForDate, deleteGpsLocationsOlderThan,
+} from './db.js';
+import {
   readMultiState, isConnected,
   readMultiServers, persistServers, upsertServer, removeServer,
   saveServerSession, clearServerSession, setActive, listConnectedActive,
@@ -2194,6 +2198,143 @@ app.get('/share', async (c) => {
     console.error('[share] bulkSaveUrls failed:', err.message);
   });
   return c.redirect('/?share=ok&u=' + encodeURIComponent(target), 303);
+});
+
+// ---- Google Maps client config -------------------------------------------
+//
+// API key は app_settings.`maps.api_key` か環境変数 GOOGLE_MAPS_API_KEY。
+// ブラウザに渡す必要があるため masked 値ではなく実値を返す。
+// Google Maps の鍵は HTTP referrer 制限 + API 制限を Google Cloud Console で
+// かけて運用するのが筋。
+
+app.get('/api/maps/config', (c) => {
+  const settings = getAppSettings(db);
+  const key = settings['maps.api_key'] || process.env.GOOGLE_MAPS_API_KEY || '';
+  return c.json({ apiKey: key, hasKey: !!key });
+});
+
+app.patch('/api/maps/config', async (c) => {
+  const body = await c.req.json().catch(() => ({}));
+  if (typeof body.apiKey !== 'string') {
+    return c.json({ error: 'apiKey (string) required' }, 400);
+  }
+  setAppSettings(db, { 'maps.api_key': body.apiKey.trim() });
+  return c.json({ ok: true });
+});
+
+// ---- GPS locations (OwnTracks) -------------------------------------------
+//
+// 個人用の歩いた軌跡を記録する。MQTT subscriber (server/owntracks-server.js)
+// が別 process で挿入するのが本流だが、ここでも HTTP 直投入を許可する
+// (テスト + OwnTracks の HTTP モードからの直接 POST 用)。
+//
+// MQTT 経路で動かすには docker-compose で mosquitto を起動して
+// `npm run owntracks` を別シェルで走らせること。
+//
+// 個人ツール想定なので auth は緩め: 環境変数 LOCATIONS_INGEST_KEY が設定
+// されていれば X-Memoria-Ingest-Key header と一致を要求、未設定なら
+// 認証なし (LAN-only バインドが前提)。
+
+const LOCATIONS_INGEST_KEY = process.env.LOCATIONS_INGEST_KEY ?? '';
+
+function checkIngestKey(c) {
+  if (!LOCATIONS_INGEST_KEY) return null;
+  const got = c.req.header('x-memoria-ingest-key') ?? '';
+  if (got !== LOCATIONS_INGEST_KEY) {
+    return c.json({ error: 'invalid ingest key' }, 401);
+  }
+  return null;
+}
+
+/**
+ * 直接 1 点の位置を投入する (OwnTracks HTTP モード or 手動テスト)。
+ * 受け取れる形式:
+ *   - OwnTracks 形式: { _type:'location', lat, lon, tst, acc?, alt?, vel?, cog?, batt?, conn? }
+ *   - 簡易形式:       { lat, lon, recorded_at?, device_id?, accuracy_m?, ... }
+ */
+app.post('/api/locations/ingest', async (c) => {
+  const denied = checkIngestKey(c);
+  if (denied) return denied;
+
+  const body = await c.req.json().catch(() => null);
+  if (!body || typeof body !== 'object') {
+    return c.json({ error: 'json body required' }, 400);
+  }
+  const lat = Number(body.lat);
+  const lon = Number(body.lon);
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+    return c.json({ error: 'lat / lon required (number)' }, 400);
+  }
+  if (lat < -90 || lat > 90 || lon < -180 || lon > 180) {
+    return c.json({ error: 'lat / lon out of range' }, 400);
+  }
+
+  const deviceId = body.device_id ?? body.tid ?? c.req.header('x-limit-d') ?? null;
+  const tst = typeof body.tst === 'number' ? body.tst : undefined;
+  const recordedAt = body.recorded_at ?? null;
+
+  const rec = {
+    userId: body.user_id ?? 'me',
+    deviceId,
+    tst,
+    recordedAt,
+    lat,
+    lon,
+    accuracy:  body.accuracy_m ?? body.acc ?? null,
+    altitude:  body.altitude_m ?? body.alt ?? null,
+    velocity:  body.velocity_kmh ?? body.vel ?? null,
+    course:    body.course_deg ?? body.cog ?? null,
+    battery:   body.battery_pct ?? body.batt ?? null,
+    conn:      body.conn ?? null,
+    rawJson:   JSON.stringify(body),
+  };
+
+  const result = insertGpsLocation(db, rec);
+  return c.json({ ok: true, id: result.id, skipped: result.skipped });
+});
+
+/**
+ * 期間内の点を時系列順で返す。
+ *   GET /api/locations?from=ISO&to=ISO&device=iphone
+ *   GET /api/locations?date=YYYY-MM-DD              (local TZ)
+ */
+app.get('/api/locations', (c) => {
+  const url = new URL(c.req.url);
+  const date = url.searchParams.get('date');
+  if (date) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      return c.json({ error: 'date must be YYYY-MM-DD' }, 400);
+    }
+    const points = listGpsLocationsForDate(db, date);
+    return c.json({ date, points });
+  }
+  const from = url.searchParams.get('from');
+  const to   = url.searchParams.get('to');
+  const deviceId = url.searchParams.get('device') ?? undefined;
+  const points = listGpsLocationsInRange(db, { from, to, deviceId });
+  return c.json({ from, to, deviceId: deviceId ?? null, points });
+});
+
+/**
+ * 位置情報を持っている日と件数。 UI の date picker 用。
+ */
+app.get('/api/locations/days', (c) => {
+  const limit = Math.min(Number(c.req.query('limit') ?? 365) || 365, 3650);
+  const days = listGpsLocationDays(db, { limit });
+  return c.json({ days });
+});
+
+/**
+ * 古い位置情報を一括削除。 retention 用。
+ *   DELETE /api/locations?older_than=ISO
+ */
+app.delete('/api/locations', (c) => {
+  const denied = checkIngestKey(c);
+  if (denied) return denied;
+  const olderThan = c.req.query('older_than');
+  if (!olderThan) return c.json({ error: 'older_than (ISO) required' }, 400);
+  const removed = deleteGpsLocationsOlderThan(db, olderThan);
+  return c.json({ removed });
 });
 
 // ---- static UI ------------------------------------------------------------

--- a/server/index.js
+++ b/server/index.js
@@ -2497,3 +2497,59 @@ setInterval(() => {
     }
   }
 }, 30_000).unref?.();
+
+// ---- in-process MQTT subscriber (任意) ----------------------------------
+//
+// MEMORIA_MQTT_URL が設定されていれば、 main server process 内で OwnTracks
+// subscriber を立てる。 別 process の owntracks-server.js は legacy として
+// 残るが、 in-process にすると WebSocket broadcaster (broadcastLocation) を
+// 直接呼べるので UI も即時更新される。
+//
+// 構成例 (Cloudflare Tunnel + MQTT over WSS):
+//   [iOS/Android OwnTracks (WSS mode)]
+//      │ wss://memoria.example.com/mqtt
+//      ▼
+//   [Cloudflare Tunnel ingress: /mqtt → ws://localhost:9002]
+//      │
+//      ▼
+//   [mosquitto (docker compose、 host port 9002 → container 9001)]
+//      │
+//      ▼
+//   [この process の subscriber → insertGpsLocation + broadcastLocation]
+
+if (process.env.MEMORIA_MQTT_URL) {
+  try {
+    const { loadOwntracksConfig } = await import('./owntracks/config.js');
+    const { startOwntracksClient } = await import('./owntracks/client.js');
+    const { locationToDbRecord } = await import('./owntracks/payload.js');
+    const cfg = loadOwntracksConfig();
+    console.log(`[mqtt] in-process subscriber starting (url=${cfg.mqtt.url}, topic=${cfg.mqtt.topic})`);
+    startOwntracksClient(cfg, async (topic, loc, ctx) => {
+      const rec = locationToDbRecord(topic, loc, {
+        userId: cfg.userId,
+        rawJson: ctx.rawJson,
+      });
+      const result = insertGpsLocation(db, rec);
+      if (!result.skipped) {
+        broadcastLocation({
+          id: result.id,
+          user_id: rec.userId,
+          device_id: rec.deviceId,
+          recorded_at: new Date(rec.tst * 1000).toISOString(),
+          lat: rec.lat,
+          lon: rec.lon,
+          accuracy_m: rec.accuracy ?? null,
+          altitude_m: rec.altitude ?? null,
+          velocity_kmh: rec.velocity ?? null,
+          course_deg: rec.course ?? null,
+        });
+        console.log(
+          `[mqtt] insert id=${result.id} ${rec.deviceId ?? '?'} ` +
+          `(${rec.lat.toFixed(5)}, ${rec.lon.toFixed(5)})`
+        );
+      }
+    });
+  } catch (e) {
+    console.error(`[mqtt] in-process subscriber failed to start: ${e?.message ?? e}`);
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { serveStatic } from '@hono/node-server/serve-static';
 import { serve } from '@hono/node-server';
+import { WebSocketServer } from 'ws';
 import { mkdirSync, writeFileSync, readFileSync, unlinkSync, existsSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -2367,6 +2368,22 @@ app.post('/api/locations/ingest', async (c) => {
   };
 
   const result = insertGpsLocation(db, rec);
+  if (!result.skipped) {
+    // WebSocket subscriber に新規点をブロードキャスト
+    broadcastLocation({
+      id: result.id,
+      user_id: rec.userId,
+      device_id: rec.deviceId,
+      recorded_at: rec.recordedAt
+        ?? (typeof rec.tst === 'number' ? new Date(rec.tst * 1000).toISOString() : new Date().toISOString()),
+      lat: rec.lat,
+      lon: rec.lon,
+      accuracy_m: rec.accuracy ?? null,
+      altitude_m: rec.altitude ?? null,
+      velocity_kmh: rec.velocity ?? null,
+      course_deg: rec.course ?? null,
+    });
+  }
   // OwnTracks の HTTP モードはレスポンスとして JSON 配列 (友達の cards 等) を
   // 期待するので空配列で返す。 手動テスト時は X-Memoria-Insert-* header で
   // 結果を確認できる。
@@ -2424,8 +2441,59 @@ app.delete('/api/locations', (c) => {
 app.use('/*', serveStatic({ root: './public' }));
 app.get('/', serveStatic({ path: './public/index.html' }));
 
-serve({ fetch: app.fetch, port: PORT }, (info) => {
+// ---- HTTP server + WebSocket -------------------------------------------
+//
+// `@hono/node-server::serve` は内部で http.Server を作って listen するので、
+// その server hook (戻り値) に対して `ws` ライブラリで WebSocketServer を
+// attach すれば HTTP / WS を同 port で兼ねられる。
+//
+// Cloudflare Tunnel は WS upgrade を素通しできるので、 wss://.../ws/locations
+// で外からも繋がる (read-only broadcast。 認証は今後 ingest key で gate 予定)。
+
+/** @type {Set<import('ws').WebSocket>} */
+const wsClients = new Set();
+
+function broadcastLocation(point) {
+  if (wsClients.size === 0) return;
+  const msg = JSON.stringify({ type: 'location', point });
+  for (const c of wsClients) {
+    if (c.readyState === 1 /* OPEN */) {
+      try { c.send(msg); } catch {}
+    }
+  }
+}
+
+const httpServer = serve({ fetch: app.fetch, port: PORT }, (info) => {
   console.log(`Memoria server listening on http://localhost:${info.port}`);
   console.log(`  data dir: ${DATA_DIR}`);
   console.log(`  claude bin: ${CLAUDE_BIN}`);
 });
+
+const wss = new WebSocketServer({ noServer: true });
+
+httpServer.on('upgrade', (req, socket, head) => {
+  if (!req.url || !req.url.startsWith('/ws/locations')) {
+    socket.destroy();
+    return;
+  }
+  wss.handleUpgrade(req, socket, head, (ws) => {
+    wss.emit('connection', ws, req);
+  });
+});
+
+wss.on('connection', (ws) => {
+  wsClients.add(ws);
+  ws.on('close', () => wsClients.delete(ws));
+  ws.on('error', () => wsClients.delete(ws));
+  // 接続直後の hello (UI 側で接続成立を確認しやすくする)
+  try { ws.send(JSON.stringify({ type: 'hello', ts: Date.now() })); } catch {}
+});
+
+// keep-alive: 30s ごとに ping。 Cloudflare の idle timeout (100s 程度) を超えない。
+setInterval(() => {
+  for (const c of wsClients) {
+    if (c.readyState === 1) {
+      try { c.ping(); } catch {}
+    }
+  }
+}, 30_000).unref?.();

--- a/server/owntracks-server.js
+++ b/server/owntracks-server.js
@@ -1,0 +1,64 @@
+/**
+ * OwnTracks subscriber 専用 process。
+ *
+ * Memoria のメイン server (index.js) とは別 process で動かし、 MQTT から
+ * 受けた位置情報を Memoria の SQLite DB へ insert する。 HTTP サーバ機能は
+ * 持たない (REST 経由の問い合わせは index.js の /api/locations が担当)。
+ *
+ * 起動: `npm run owntracks` (dev は `npm run owntracks:dev`)
+ *
+ * 環境変数:
+ *   MEMORIA_MQTT_URL        既定 mqtt://localhost:1884 (Memoria 専有 broker)
+ *   MEMORIA_MQTT_USERNAME   broker auth (任意)
+ *   MEMORIA_MQTT_PASSWORD   broker auth (任意)
+ *   MEMORIA_MQTT_TOPIC      既定 owntracks/+/+
+ *   MEMORIA_MQTT_CLIENT_ID  client identifier (任意)
+ *   MEMORIA_USER_ID         レコードに付ける user_id (既定 'me')
+ *   MEMORIA_DB_PATH         SQLite path (既定 ./data/memoria.db)
+ */
+
+import { resolve as resolvePath } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+import { openDb, insertGpsLocation } from './db.js';
+import { loadOwntracksConfig } from './owntracks/config.js';
+import { startOwntracksClient } from './owntracks/client.js';
+import { locationToDbRecord } from './owntracks/payload.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function main() {
+  const config = loadOwntracksConfig();
+  const dbPath = resolvePath(__dirname, '..', config.dbPath.replace(/^\.\//, ''));
+  console.log(`[owntracks] starting (user_id=${config.userId}, db=${dbPath})`);
+
+  const db = openDb(dbPath);
+
+  const client = startOwntracksClient(config, async (topic, loc, ctx) => {
+    const rec = locationToDbRecord(topic, loc, {
+      userId: config.userId,
+      rawJson: ctx.rawJson,
+    });
+    const result = insertGpsLocation(db, rec);
+    if (!result.skipped) {
+      console.log(
+        `[owntracks] insert id=${result.id} ${rec.deviceId ?? '?'} ` +
+        `(${rec.lat.toFixed(5)}, ${rec.lon.toFixed(5)}) tst=${rec.tst}`
+      );
+    }
+  });
+
+  function shutdown(signal) {
+    console.log(`[owntracks] received ${signal}, shutting down`);
+    client.end(false, {}, () => {
+      try { db.close(); } catch {}
+      process.exit(0);
+    });
+  }
+  process.on('SIGINT',  () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+}
+
+main();

--- a/server/owntracks/client.js
+++ b/server/owntracks/client.js
@@ -1,0 +1,75 @@
+/**
+ * MQTT subscriber (mqtt.js)。 OwnTracks topic を購読し、 受信ごとに
+ * onLocation コールバックを呼ぶ。 broker への切断は自動再接続で吸収。
+ *
+ * Iv (Imperativus) の TypeScript 実装を Memoria 用 plain JS に port。
+ */
+
+import mqtt from 'mqtt';
+import { parseOwntracksLocation, parseOwntracksTopic } from './payload.js';
+
+/**
+ * @callback LocationHandler
+ * @param {{ user: string, device: string }} topic
+ * @param {import('./payload.js').OwntracksLocation} loc
+ * @param {{ rawJson: string }} ctx  受信生データ (DB 保存用)
+ * @returns {void | Promise<void>}
+ */
+
+/**
+ * MQTT に接続して OwnTracks topic を subscribe、 受信ごとに onLocation を呼ぶ。
+ *
+ * @param {import('./config.js').OwntracksConfig} config
+ * @param {LocationHandler} onLocation
+ * @returns {import('mqtt').MqttClient}
+ */
+export function startOwntracksClient(config, onLocation) {
+  /** @type {import('mqtt').IClientOptions} */
+  const opts = {
+    clientId: config.mqtt.clientId,
+    reconnectPeriod: 5000,
+    connectTimeout: 10_000,
+  };
+  if (config.mqtt.username) opts.username = config.mqtt.username;
+  if (config.mqtt.password) opts.password = config.mqtt.password;
+
+  const client = mqtt.connect(config.mqtt.url, opts);
+
+  client.on('connect', () => {
+    console.log(`[owntracks] mqtt connected to ${config.mqtt.url}`);
+    client.subscribe(config.mqtt.topic, { qos: 1 }, (err) => {
+      if (err) {
+        console.error(`[owntracks] subscribe failed: ${err.message}`);
+      } else {
+        console.log(`[owntracks] subscribed to ${config.mqtt.topic}`);
+      }
+    });
+  });
+
+  client.on('reconnect', () => console.log('[owntracks] mqtt reconnecting...'));
+  client.on('close',     () => console.log('[owntracks] mqtt connection closed'));
+  client.on('error',     (err) => console.error(`[owntracks] mqtt error: ${err.message}`));
+
+  client.on('message', async (topic, payload) => {
+    const t = parseOwntracksTopic(topic);
+    if (!t) return;
+    let raw;
+    let rawJson = '';
+    try {
+      rawJson = payload.toString('utf8');
+      raw = JSON.parse(rawJson);
+    } catch {
+      return;
+    }
+    const loc = parseOwntracksLocation(raw);
+    if (!loc) return;
+
+    try {
+      await onLocation(t, loc, { rawJson });
+    } catch (err) {
+      console.error(`[owntracks] location handler threw: ${err?.message ?? err}`);
+    }
+  });
+
+  return client;
+}

--- a/server/owntracks/config.js
+++ b/server/owntracks/config.js
@@ -1,0 +1,33 @@
+/**
+ * OwnTracks subscriber の設定。 環境変数から読み出す。
+ *
+ * Memoria は単一ユーザを前提とする個人用ツールなので、Iv (Imperativus) の
+ * userMapping (OwnTracks user → Cernere user_id) は使わず、`MEMORIA_USER_ID`
+ * (既定 'me') を全レコードに付ける。
+ */
+
+/**
+ * @returns {OwntracksConfig}
+ */
+export function loadOwntracksConfig(env = process.env) {
+  return {
+    mqtt: {
+      url:      env.MEMORIA_MQTT_URL      ?? 'mqtt://localhost:1884',
+      username: env.MEMORIA_MQTT_USERNAME ?? '',
+      password: env.MEMORIA_MQTT_PASSWORD ?? '',
+      topic:    env.MEMORIA_MQTT_TOPIC    ?? 'owntracks/+/+',
+      clientId: env.MEMORIA_MQTT_CLIENT_ID ?? `memoria-owntracks-${process.pid}`,
+    },
+    /** 単一ユーザ前提。multi-tenant 化したくなったら mapping を導入する。 */
+    userId: env.MEMORIA_USER_ID ?? 'me',
+    /** SQLite path。server/index.js と同じ既定を使う。 */
+    dbPath: env.MEMORIA_DB_PATH ?? './data/memoria.db',
+  };
+}
+
+/**
+ * @typedef {Object} OwntracksConfig
+ * @property {{ url: string, username: string, password: string, topic: string, clientId: string }} mqtt
+ * @property {string} userId
+ * @property {string} dbPath
+ */

--- a/server/owntracks/payload.js
+++ b/server/owntracks/payload.js
@@ -1,0 +1,97 @@
+/**
+ * OwnTracks payload / topic パーサ。Iv (Imperativus) の TypeScript 実装を
+ * Memoria 用に plain JS で port した。
+ *
+ * topic: `owntracks/<user>/<device>`
+ * payload (`_type='location'`):
+ *   { lat, lon, tst, acc?, alt?, batt?, vel?, cog?, tid?, conn? }
+ */
+
+/**
+ * `owntracks/<user>/<device>` を分解。 prefix 違反 / parts 不足は null。
+ *
+ * @param {string} topic
+ * @returns {{ user: string, device: string } | null}
+ */
+export function parseOwntracksTopic(topic) {
+  if (typeof topic !== 'string') return null;
+  const parts = topic.split('/');
+  if (parts.length < 3) return null;
+  if (parts[0] !== 'owntracks') return null;
+  const user = parts[1];
+  const device = parts[2];
+  if (!user || !device) return null;
+  return { user, device };
+}
+
+/**
+ * OwnTracks `_type='location'` payload を narrow + 必須 field を検証。
+ * 不正なら null。lat / lon / tst のみ必須、それ以外は省略可。
+ *
+ * @param {unknown} input
+ * @returns {OwntracksLocation | null}
+ */
+export function parseOwntracksLocation(input) {
+  if (typeof input !== 'object' || input === null) return null;
+  const o = /** @type {Record<string, unknown>} */ (input);
+  if (o._type !== 'location') return null;
+  if (typeof o.lat !== 'number' || !Number.isFinite(o.lat)) return null;
+  if (typeof o.lon !== 'number' || !Number.isFinite(o.lon)) return null;
+  if (typeof o.tst !== 'number' || !Number.isFinite(o.tst)) return null;
+  if (o.lat < -90 || o.lat > 90) return null;
+  if (o.lon < -180 || o.lon > 180) return null;
+
+  return {
+    _type: 'location',
+    lat: o.lat,
+    lon: o.lon,
+    tst: o.tst,
+    acc: typeof o.acc === 'number' ? o.acc : undefined,
+    alt: typeof o.alt === 'number' ? o.alt : undefined,
+    batt: typeof o.batt === 'number' ? o.batt : undefined,
+    vel: typeof o.vel === 'number' ? o.vel : undefined,
+    cog: typeof o.cog === 'number' ? o.cog : undefined,
+    tid: typeof o.tid === 'string' ? o.tid : undefined,
+    conn: typeof o.conn === 'string' ? o.conn : undefined,
+  };
+}
+
+/**
+ * OwnTracks Location → DB insert 用 record にマップする。
+ * 呼び出し側は user_id を userMapping (env) から resolve した上で渡す。
+ *
+ * @param {{ user: string, device: string }} topic
+ * @param {OwntracksLocation} loc
+ * @param {{ userId: string, rawJson?: string }} ctx
+ */
+export function locationToDbRecord(topic, loc, ctx) {
+  return {
+    userId: ctx.userId,
+    deviceId: topic.device,
+    tst: loc.tst,
+    lat: loc.lat,
+    lon: loc.lon,
+    accuracy: loc.acc,
+    altitude: loc.alt,
+    velocity: loc.vel,
+    course: loc.cog,
+    battery: loc.batt,
+    conn: loc.conn,
+    rawJson: ctx.rawJson ?? null,
+  };
+}
+
+/**
+ * @typedef {Object} OwntracksLocation
+ * @property {'location'} _type
+ * @property {number} lat
+ * @property {number} lon
+ * @property {number} tst                Unix epoch (秒)
+ * @property {number=} acc               精度 (m)
+ * @property {number=} alt               標高 (m)
+ * @property {number=} batt              バッテリー (%)
+ * @property {number=} vel               速度 (km/h)
+ * @property {number=} cog               コンパス方位 (deg)
+ * @property {string=} tid               track id ("iP" 等)
+ * @property {string=} conn              "w"|"m"|"o"
+ */

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,7 +12,8 @@
         "better-sqlite3": "^11.3.0",
         "hono": "^4.6.10",
         "mqtt": "^5.15.1",
-        "node-html-parser": "^6.1.13"
+        "node-html-parser": "^6.1.13",
+        "ws": "^8.20.0"
       }
     },
     "node_modules/@babel/runtime": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,7 +11,17 @@
         "@hono/node-server": "^1.13.7",
         "better-sqlite3": "^11.3.0",
         "hono": "^4.6.10",
+        "mqtt": "^5.15.1",
         "node-html-parser": "^6.1.13"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@hono/node-server": {
@@ -24,6 +34,45 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.23.tgz",
+      "integrity": "sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
       }
     },
     "node_modules/base64-js": {
@@ -83,6 +132,18 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
     },
+    "node_modules/broker-factory": {
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/broker-factory/-/broker-factory-3.1.14.tgz",
+      "integrity": "sha512-L45k5HMbPIrMid0nTOZ/UPXG/c0aRuQKVrSDFIb1zOkvfiyHgYmIjc3cSiN1KwQIvRDOtKE0tfb3I9EZ3CmpQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1",
+        "worker-factory": "^7.0.49"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -107,11 +168,38 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
+    },
+    "node_modules/commist": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/commist/-/commist-3.2.0.tgz",
+      "integrity": "sha512-4PIMoPniho+LqXmpS5d3NuGYncG6XWlkBSVGiWycL22dd42OYdUGil2CWuzklaJoNxyxUSpO4MKIBU94viWNAw==",
+      "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/css-select": {
       "version": "5.2.2",
@@ -139,6 +227,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decompress-response": {
@@ -250,6 +355,24 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -257,6 +380,19 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/fast-unique-numbers": {
+      "version": "9.0.27",
+      "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-9.0.27.tgz",
+      "integrity": "sha512-nDA9ADeINN8SA2u2wCtU+siWFTTDqQR37XvgPIDDmboWQeExz7X0mImxuaN+kJddliIqy2FpVRmnvRZ+j8i1/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.2.0"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -285,6 +421,12 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT"
     },
     "node_modules/hono": {
       "version": "4.12.15",
@@ -327,6 +469,31 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
+    "node_modules/ip-address": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
+      "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/js-sdsl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
+      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
     "node_modules/mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -352,6 +519,147 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/mqtt": {
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.15.1.tgz",
+      "integrity": "sha512-V1WnkGuJh3ec9QXzy5Iylw8OOBK+Xu1WhxcQ9mMpLThG+/JZIMV1PgLNRgIiqXhZnvnVLsuyxHl5A/3bHHbcAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.21",
+        "@types/ws": "^8.18.1",
+        "commist": "^3.2.0",
+        "concat-stream": "^2.0.0",
+        "debug": "^4.4.1",
+        "help-me": "^5.0.0",
+        "lru-cache": "^10.4.3",
+        "minimist": "^1.2.8",
+        "mqtt-packet": "^9.0.2",
+        "number-allocator": "^1.0.14",
+        "readable-stream": "^4.7.0",
+        "rfdc": "^1.4.1",
+        "socks": "^2.8.6",
+        "split2": "^4.2.0",
+        "worker-timers": "^8.0.23",
+        "ws": "^8.18.3"
+      },
+      "bin": {
+        "mqtt": "build/bin/mqtt.js",
+        "mqtt_pub": "build/bin/pub.js",
+        "mqtt_sub": "build/bin/sub.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/mqtt-packet": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-9.0.2.tgz",
+      "integrity": "sha512-MvIY0B8/qjq7bKxdN1eD+nrljoeaai+qjLJgfRn3TiMuz0pamsIWY2bFODPZMSNmabsLANXsLl4EMoWvlaTZWA==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^6.0.8",
+        "debug": "^4.3.4",
+        "process-nextick-args": "^2.0.1"
+      }
+    },
+    "node_modules/mqtt-packet/node_modules/bl": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-6.1.6.tgz",
+      "integrity": "sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.0",
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/mqtt-packet/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/mqtt-packet/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/mqtt/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/mqtt/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/napi-build-utils": {
@@ -394,6 +702,16 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/number-allocator": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.14.tgz",
+      "integrity": "sha512-OrL44UTVAvkKdOdRQZIJpLkAdjXGTRda052sN4sO77bKEzYYqWKMBjQvrJFzqygI99gL6Z4u2xctPW1tB8ErvA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "js-sdsl": "4.3.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -429,6 +747,21 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.4",
@@ -468,6 +801,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -546,6 +885,39 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
+      "integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -592,6 +964,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -604,17 +982,97 @@
         "node": "*"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "license": "MIT"
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/worker-factory": {
+      "version": "7.0.49",
+      "resolved": "https://registry.npmjs.org/worker-factory/-/worker-factory-7.0.49.tgz",
+      "integrity": "sha512-lW7tpgy6aUv2dFsQhv1yv+XFzdkCf/leoKRTGMPVK5/die6RrUjqgJHJf556qO+ZfytNG6wPXc17E8zzsOLUDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/worker-timers": {
+      "version": "8.0.31",
+      "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-8.0.31.tgz",
+      "integrity": "sha512-ngkq5S6JuZyztom8tDgBzorLo9byhBMko/sXfgiUD945AuzKGg1GCgDMCC3NaYkicLpGKXutONM36wEX8UbBCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1",
+        "worker-timers-broker": "^8.0.16",
+        "worker-timers-worker": "^9.0.14"
+      }
+    },
+    "node_modules/worker-timers-broker": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/worker-timers-broker/-/worker-timers-broker-8.0.16.tgz",
+      "integrity": "sha512-JyP3AvUGyPGbBGW7XiUewm2+0pN/aYo1QpVf5kdXAfkDZcN3p7NbWrG6XnyDEpDIvfHk/+LCnOW/NsuiU9riYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "broker-factory": "^3.1.14",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1",
+        "worker-timers-worker": "^9.0.14"
+      }
+    },
+    "node_modules/worker-timers-worker": {
+      "version": "9.0.14",
+      "resolved": "https://registry.npmjs.org/worker-timers-worker/-/worker-timers-worker-9.0.14.tgz",
+      "integrity": "sha512-/qF06C60sXmSLfUl7WglvrDIbspmPOM8UrG63Dnn4bi2x4/DfqHS/+dxF5B+MdHnYO5tVuZYLHdAodrKdabTIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1",
+        "worker-factory": "^7.0.49"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -6,12 +6,15 @@
   "scripts": {
     "start": "node --env-file-if-exists=.env --env-file-if-exists=../.env index.js",
     "dev": "node --watch --env-file-if-exists=.env --env-file-if-exists=../.env index.js",
+    "owntracks": "node --env-file-if-exists=.env --env-file-if-exists=../.env owntracks-server.js",
+    "owntracks:dev": "node --watch --env-file-if-exists=.env --env-file-if-exists=../.env owntracks-server.js",
     "typecheck": "npm install --no-save --no-package-lock --no-audit --no-fund typescript@5.6 @types/node@20 @types/better-sqlite3@7 && npx tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@hono/node-server": "^1.13.7",
     "better-sqlite3": "^11.3.0",
     "hono": "^4.6.10",
+    "mqtt": "^5.15.1",
     "node-html-parser": "^6.1.13"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -15,6 +15,7 @@
     "better-sqlite3": "^11.3.0",
     "hono": "^4.6.10",
     "mqtt": "^5.15.1",
-    "node-html-parser": "^6.1.13"
+    "node-html-parser": "^6.1.13",
+    "ws": "^8.20.0"
   }
 }

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -553,6 +553,7 @@ function switchTab(tab) {
   $('domainView').classList.toggle('hidden', tab !== 'domain');
   $('diaryView').classList.toggle('hidden', tab !== 'diary');
   $('eventsView').classList.toggle('hidden', tab !== 'events');
+  $('tracksView')?.classList.toggle('hidden', tab !== 'tracks');
   $('multiView')?.classList.toggle('hidden', tab !== 'multi');
   if (tab === 'queue') renderQueue();
   if (tab === 'visits') loadVisits();
@@ -563,6 +564,7 @@ function switchTab(tab) {
   if (tab === 'domain') loadDomainCatalog();
   if (tab === 'diary') loadDiary();
   if (tab === 'events') loadEvents();
+  if (tab === 'tracks') loadTracks();
   if (tab === 'multi') loadMulti();
   bumpTabUsage(tab);
 }
@@ -3563,6 +3565,188 @@ document.getElementById('multiRefresh')?.addEventListener('click', loadMulti);
 
 // First paint: surface the multi tab if we're already connected.
 refreshMultiTabVisibility();
+
+// ── Tracks (GPS overlay on Google Maps) ───────────────────────────────────
+//
+// 当日 (or 任意日) の OwnTracks 由来の GPS 軌跡を Google Maps 上に
+// Polyline で重ねる。 Google Maps API key は /api/maps/config で取得 →
+// script を遅延 inject。 key 未設定なら案内メッセージのみ。
+
+const tracksState = {
+  loaded: false,         // google.maps script を読み終えたか
+  map: null,
+  polyline: null,
+  dotMarkers: [],
+  apiKey: '',
+};
+
+function todayLocalIso() {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+async function loadTracks() {
+  const dateInput = $('tracksDate');
+  if (dateInput && !dateInput.value) dateInput.value = todayLocalIso();
+
+  // bind controls (one-time)
+  if (!tracksState._bound) {
+    tracksState._bound = true;
+    dateInput?.addEventListener('change', renderTracksForCurrentDate);
+    $('tracksRefresh')?.addEventListener('click', renderTracksForCurrentDate);
+  }
+
+  // load API key + days list in parallel
+  try {
+    const [{ apiKey, hasKey }, { days }] = await Promise.all([
+      api('/api/maps/config'),
+      api('/api/locations/days?limit=180'),
+    ]);
+    tracksState.apiKey = apiKey;
+    $('tracksMissingKey').classList.toggle('hidden', !!hasKey);
+    renderTracksDaysList(days);
+    if (hasKey) {
+      await ensureGoogleMapsLoaded(apiKey);
+      ensureMapInstance();
+      renderTracksForCurrentDate();
+    }
+  } catch (e) {
+    console.error('[tracks] load failed', e);
+  }
+}
+
+function renderTracksDaysList(days) {
+  const ul = $('tracksDays');
+  if (!ul) return;
+  if (!days || days.length === 0) {
+    ul.innerHTML = '<li class="muted">記録なし</li>';
+    return;
+  }
+  ul.innerHTML = days.map(d =>
+    `<li><button class="link" data-tracks-day="${escapeHtml(d.day)}">${escapeHtml(d.day)}</button>
+       <span class="muted">${d.points} 点</span></li>`
+  ).join('');
+  ul.querySelectorAll('button[data-tracks-day]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const dateInput = $('tracksDate');
+      if (dateInput) {
+        dateInput.value = btn.dataset.tracksDay;
+        renderTracksForCurrentDate();
+      }
+    });
+  });
+}
+
+function ensureGoogleMapsLoaded(apiKey) {
+  if (tracksState.loaded || (window.google && window.google.maps)) {
+    tracksState.loaded = true;
+    return Promise.resolve();
+  }
+  return new Promise((resolve, reject) => {
+    const cb = `__memoriaMapsCb_${Date.now()}`;
+    window[cb] = () => {
+      tracksState.loaded = true;
+      delete window[cb];
+      resolve();
+    };
+    const s = document.createElement('script');
+    s.src = `https://maps.googleapis.com/maps/api/js?key=${encodeURIComponent(apiKey)}&callback=${cb}&v=weekly`;
+    s.async = true;
+    s.defer = true;
+    s.onerror = () => reject(new Error('Google Maps script failed to load'));
+    document.head.appendChild(s);
+  });
+}
+
+function ensureMapInstance() {
+  if (tracksState.map || !window.google?.maps) return;
+  const el = $('tracksMap');
+  if (!el) return;
+  // 起動時の暫定中心 (東京駅)。最初のロード後に bbox に fit する。
+  tracksState.map = new google.maps.Map(el, {
+    center: { lat: 35.681, lng: 139.767 },
+    zoom: 12,
+    mapTypeControl: false,
+    streetViewControl: false,
+    fullscreenControl: true,
+  });
+}
+
+async function renderTracksForCurrentDate() {
+  if (!tracksState.map) return;
+  const date = $('tracksDate')?.value;
+  if (!date) return;
+  try {
+    const { points } = await api(`/api/locations?date=${encodeURIComponent(date)}`);
+    drawTracks(points || []);
+    const km = computeDistanceMeters(points || []) / 1000;
+    $('tracksStats').textContent = points && points.length
+      ? `${points.length} 点 / 概算 ${km.toFixed(2)} km`
+      : '点なし';
+  } catch (e) {
+    console.error('[tracks] render failed', e);
+    $('tracksStats').textContent = '取得失敗';
+  }
+}
+
+function drawTracks(points) {
+  // 既存 overlay をクリア
+  if (tracksState.polyline) {
+    tracksState.polyline.setMap(null);
+    tracksState.polyline = null;
+  }
+  for (const m of tracksState.dotMarkers) m.setMap(null);
+  tracksState.dotMarkers = [];
+  if (!points.length) return;
+
+  const path = points.map(p => ({ lat: p.lat, lng: p.lon }));
+  tracksState.polyline = new google.maps.Polyline({
+    path,
+    geodesic: true,
+    strokeColor: '#3b82f6',
+    strokeOpacity: 0.85,
+    strokeWeight: 4,
+    map: tracksState.map,
+  });
+
+  // 始点 / 終点に小さなマーカーを置く (path が長くてもマーカーは 2 個だけ)
+  const start = path[0];
+  const end = path[path.length - 1];
+  tracksState.dotMarkers.push(new google.maps.Marker({
+    position: start, map: tracksState.map, title: '開始',
+    icon: { path: google.maps.SymbolPath.CIRCLE, scale: 6, fillColor: '#10b981', fillOpacity: 1, strokeColor: '#065f46', strokeWeight: 1 },
+  }));
+  tracksState.dotMarkers.push(new google.maps.Marker({
+    position: end, map: tracksState.map, title: '終端',
+    icon: { path: google.maps.SymbolPath.CIRCLE, scale: 6, fillColor: '#ef4444', fillOpacity: 1, strokeColor: '#7f1d1d', strokeWeight: 1 },
+  }));
+
+  // bbox に fit
+  const b = new google.maps.LatLngBounds();
+  for (const p of path) b.extend(p);
+  tracksState.map.fitBounds(b, 60);
+}
+
+function computeDistanceMeters(points) {
+  if (!points || points.length < 2) return 0;
+  const R = 6_371_008;
+  const toRad = d => (d * Math.PI) / 180;
+  let dist = 0;
+  for (let i = 1; i < points.length; i++) {
+    const a = points[i - 1], b = points[i];
+    if (b.accuracy_m && b.accuracy_m > 200) continue;
+    const dLat = toRad(b.lat - a.lat);
+    const dLon = toRad(b.lon - a.lon);
+    const sa = Math.sin(dLat / 2);
+    const so = Math.sin(dLon / 2);
+    const h = sa * sa + Math.cos(toRad(a.lat)) * Math.cos(toRad(b.lat)) * so * so;
+    dist += 2 * R * Math.asin(Math.min(1, Math.sqrt(h)));
+  }
+  return dist;
+}
 
 // ── PWA share_target landing ───────────────────────────────────────────────
 // /share redirects back here with ?share=ok&u=<url> after queueing the save.

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -3597,9 +3597,25 @@ async function loadTracks() {
     tracksState._bound = true;
     dateInput?.addEventListener('change', renderTracksForCurrentDate);
     $('tracksRefresh')?.addEventListener('click', renderTracksForCurrentDate);
+    $('tracksKeyToggle')?.addEventListener('click', () => {
+      $('tracksKeyPanel').classList.toggle('hidden');
+      refreshTracksKeyPanel();
+    });
+    $('tracksKeyGenerate')?.addEventListener('click', regenerateTracksKey);
+    $('tracksKeyClear')?.addEventListener('click', clearTracksKey);
+    $('tracksKeyCopy')?.addEventListener('click', () => {
+      const v = $('tracksKeyRevealValue')?.textContent ?? '';
+      if (v) navigator.clipboard?.writeText(v).catch(() => {});
+    });
+    document.addEventListener('visibilitychange', () => {
+      // タブに戻ってきたら最新の状態に再同期 + WS 再接続
+      if (document.visibilityState === 'visible' && state.tab === 'tracks') {
+        renderTracksForCurrentDate();
+        ensureLiveSocket();
+      }
+    });
   }
 
-  // load API key + days list in parallel
   try {
     const [{ apiKey, hasKey }, { days }] = await Promise.all([
       api('/api/maps/config'),
@@ -3613,8 +3629,125 @@ async function loadTracks() {
       ensureMapInstance();
       renderTracksForCurrentDate();
     }
+    refreshTracksKeyPanel();
+    ensureLiveSocket();
   } catch (e) {
     console.error('[tracks] load failed', e);
+  }
+}
+
+// ── ingest key 管理 (HTTP モード用) ──────────────────────────────────────
+
+async function refreshTracksKeyPanel() {
+  try {
+    const r = await api('/api/locations/settings');
+    $('tracksKeyPreview').textContent = r.has_key ? r.key_preview : '未設定';
+    $('tracksKeySource').textContent = r.has_key
+      ? (r.source === 'env' ? '(env から)' : '(設定済)')
+      : '(匿名 ingest 許可中)';
+    if (!r.has_key) $('tracksKeyReveal').classList.add('hidden');
+  } catch (e) { console.error(e); }
+}
+
+async function regenerateTracksKey() {
+  if (!confirm('新しい ingest key を生成しますか？\n既存の key は無効になり、 OwnTracks 側の Password を更新する必要があります。')) return;
+  try {
+    const r = await fetch('/api/locations/settings/regenerate', { method: 'POST' }).then(x => x.json());
+    if (!r.key) throw new Error('no key in response');
+    $('tracksKeyRevealValue').textContent = r.key;
+    $('tracksKeyReveal').classList.remove('hidden');
+    refreshTracksKeyPanel();
+  } catch (e) {
+    alert('key 生成失敗: ' + (e?.message ?? e));
+  }
+}
+
+async function clearTracksKey() {
+  if (!confirm('ingest key をクリアしますか？\nWAN 公開している場合は誰でも /api/locations/ingest に POST できる状態になります。')) return;
+  try {
+    await fetch('/api/locations/settings/key', { method: 'DELETE' });
+    $('tracksKeyReveal').classList.add('hidden');
+    refreshTracksKeyPanel();
+  } catch (e) { console.error(e); }
+}
+
+// ── WebSocket ライブ更新 ─────────────────────────────────────────────────
+
+function ensureLiveSocket() {
+  if (tracksState.ws && tracksState.ws.readyState === WebSocket.OPEN) return;
+  if (tracksState.ws && tracksState.ws.readyState === WebSocket.CONNECTING) return;
+
+  const url = (location.protocol === 'https:' ? 'wss://' : 'ws://')
+    + location.host + '/ws/locations';
+  setLiveStatus('connecting');
+  let ws;
+  try {
+    ws = new WebSocket(url);
+  } catch (e) {
+    setLiveStatus('error');
+    return;
+  }
+  tracksState.ws = ws;
+  ws.addEventListener('open',    () => setLiveStatus('open'));
+  ws.addEventListener('close',   () => { setLiveStatus('closed'); scheduleLiveReconnect(); });
+  ws.addEventListener('error',   () => setLiveStatus('error'));
+  ws.addEventListener('message', (ev) => {
+    let msg;
+    try { msg = JSON.parse(ev.data); } catch { return; }
+    if (msg.type === 'location' && msg.point) handleLivePoint(msg.point);
+  });
+}
+
+function scheduleLiveReconnect() {
+  if (tracksState.wsReconnectTimer) return;
+  if (document.visibilityState !== 'visible') return;
+  tracksState.wsReconnectTimer = setTimeout(() => {
+    tracksState.wsReconnectTimer = null;
+    if (state.tab === 'tracks') ensureLiveSocket();
+  }, 3000);
+}
+
+function setLiveStatus(s) {
+  const el = $('tracksLive');
+  if (!el) return;
+  el.dataset.live = s;
+  el.title = `WS: ${s}`;
+}
+
+function handleLivePoint(point) {
+  const dateStr = $('tracksDate')?.value;
+  if (!dateStr) return;
+  const localDay = isoToLocalYmd(point.recorded_at);
+  if (localDay !== dateStr) {
+    api('/api/locations/days?limit=180').then(({ days }) => renderTracksDaysList(days)).catch(() => {});
+    return;
+  }
+  if (!tracksState.map) return;
+  tracksState.todayPoints.push(point);
+  appendLivePointToPolyline(point);
+  const km = computeDistanceMeters(tracksState.todayPoints) / 1000;
+  $('tracksStats').textContent = `${tracksState.todayPoints.length} 点 / 概算 ${km.toFixed(2)} km (live)`;
+}
+
+function isoToLocalYmd(iso) {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return '';
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function appendLivePointToPolyline(point) {
+  if (!tracksState.polyline) {
+    drawTracks([point]);
+    return;
+  }
+  const path = tracksState.polyline.getPath();
+  path.push(new google.maps.LatLng(point.lat, point.lon));
+  if (tracksState.dotMarkers[1]) {
+    tracksState.dotMarkers[1].setPosition({ lat: point.lat, lng: point.lon });
   }
 }
 
@@ -3681,10 +3814,13 @@ async function renderTracksForCurrentDate() {
   if (!date) return;
   try {
     const { points } = await api(`/api/locations?date=${encodeURIComponent(date)}`);
-    drawTracks(points || []);
-    const km = computeDistanceMeters(points || []) / 1000;
-    $('tracksStats').textContent = points && points.length
-      ? `${points.length} 点 / 概算 ${km.toFixed(2)} km`
+    const pts = points || [];
+    drawTracks(pts);
+    // live append のキャッシュ。 表示中の日付が「今日 (local)」なら使われる。
+    tracksState.todayPoints = (date === todayLocalIso()) ? pts.slice() : [];
+    const km = computeDistanceMeters(pts) / 1000;
+    $('tracksStats').textContent = pts.length
+      ? `${pts.length} 点 / 概算 ${km.toFixed(2)} km`
       : '点なし';
   } catch (e) {
     console.error('[tracks] render failed', e);

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -90,6 +90,7 @@
           <button class="tab" data-tab="dict">📖 辞書</button>
           <button class="tab" data-tab="domain">🏷 ドメイン</button>
           <button class="tab" data-tab="diary">📅 日記</button>
+          <button class="tab" data-tab="tracks">🗺 軌跡</button>
           <button class="tab tab-multi-only" data-tab="multi" hidden>🌐 マルチ</button>
         </div>
       </nav>
@@ -358,6 +359,24 @@
           <button id="eventsRefresh" class="ghost">更新</button>
         </div>
         <ul id="eventsList" class="events-list"></ul>
+      </div>
+
+      <div id="tracksView" class="hidden">
+        <div class="tracks-bar">
+          <input id="tracksDate" type="date" />
+          <button id="tracksRefresh" class="ghost">更新</button>
+          <span class="grow"></span>
+          <span id="tracksStats" class="tracks-stats"></span>
+        </div>
+        <div id="tracksMissingKey" class="tracks-missing-key hidden">
+          Google Maps API key 未設定。 設定 → AI / 連携 で <code>maps_api_key</code>
+          を入れるか、 環境変数 <code>GOOGLE_MAPS_API_KEY</code> を設定してください。
+        </div>
+        <div id="tracksMap" class="tracks-map"></div>
+        <div class="tracks-days">
+          <h4>記録のある日</h4>
+          <ul id="tracksDays" class="tracks-days-list"></ul>
+        </div>
       </div>
 
       <div id="multiView" class="hidden">

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -365,8 +365,29 @@
         <div class="tracks-bar">
           <input id="tracksDate" type="date" />
           <button id="tracksRefresh" class="ghost">更新</button>
+          <span id="tracksLive" class="tracks-live" title="WebSocket ライブ更新の状態">●</span>
           <span class="grow"></span>
           <span id="tracksStats" class="tracks-stats"></span>
+          <button id="tracksKeyToggle" class="ghost" title="ingest key (HTTP モード用)">🔑 key</button>
+        </div>
+        <div id="tracksKeyPanel" class="tracks-key-panel hidden">
+          <div class="tracks-key-row">
+            <strong>ingest key:</strong>
+            <code id="tracksKeyPreview" class="tracks-key-preview">未設定</code>
+            <span id="tracksKeySource" class="muted"></span>
+          </div>
+          <div class="tracks-key-actions">
+            <button id="tracksKeyGenerate">🎲 新しい key を生成</button>
+            <button id="tracksKeyClear" class="ghost">クリア (匿名)</button>
+          </div>
+          <div id="tracksKeyReveal" class="tracks-key-reveal hidden">
+            <div class="muted">⚠ この key は <b>1 度だけ</b> 表示されます。 OwnTracks (HTTP モード) の Password に貼ってください。</div>
+            <code id="tracksKeyRevealValue" class="tracks-key-full"></code>
+            <button id="tracksKeyCopy" class="ghost">📋 copy</button>
+          </div>
+          <p class="muted tracks-key-help">
+            HTTP ingest endpoint (<code>POST /api/locations/ingest</code>) を WAN 公開する場合に必要。 MQTT-over-WSS を使う場合は不要 (broker 側 passwd で認証)。
+          </p>
         </div>
         <div id="tracksMissingKey" class="tracks-missing-key hidden">
           Google Maps API key 未設定。 設定 → AI / 連携 で <code>maps_api_key</code>

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -2203,3 +2203,79 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 .diary-more:hover { background: var(--accent-bg); }
 .diary-more-count { color: var(--muted); margin-left: 6px; font-size: 11px; }
 .diary-more .error { color: var(--danger); }
+
+/* === Tracks (GPS overlay) ============================================ */
+.tracks-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 0;
+  flex-wrap: wrap;
+}
+.tracks-bar input[type="date"] {
+  font-size: 14px;
+  padding: 4px 8px;
+}
+.tracks-bar .grow { flex: 1; }
+.tracks-stats {
+  font-size: 13px;
+  color: var(--muted);
+}
+.tracks-missing-key {
+  padding: 12px;
+  background: var(--accent-bg);
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  margin: 8px 0;
+  font-size: 13px;
+}
+.tracks-missing-key code {
+  background: var(--bg);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 12px;
+}
+.tracks-map {
+  width: 100%;
+  height: 60vh;
+  min-height: 320px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+}
+.tracks-days {
+  margin-top: 16px;
+}
+.tracks-days h4 {
+  margin: 0 0 8px;
+  font-size: 13px;
+  color: var(--muted);
+}
+.tracks-days-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.tracks-days-list li {
+  padding: 4px 8px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 12px;
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+}
+.tracks-days-list .link {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  padding: 0;
+  font-size: 12px;
+  font-family: inherit;
+}
+.tracks-days-list .link:hover { text-decoration: underline; }

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -2279,3 +2279,80 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   font-family: inherit;
 }
 .tracks-days-list .link:hover { text-decoration: underline; }
+
+/* WebSocket ライブステータスインジケータ ─────────────────────────────── */
+.tracks-live {
+  display: inline-block;
+  font-size: 18px;
+  line-height: 1;
+  color: #9ca3af; /* gray (idle) */
+  margin-left: 4px;
+  user-select: none;
+  transition: color 200ms;
+}
+.tracks-live[data-live="open"]       { color: #10b981; /* green */ }
+.tracks-live[data-live="connecting"] { color: #f59e0b; /* amber */ }
+.tracks-live[data-live="closed"],
+.tracks-live[data-live="error"]      { color: #ef4444; /* red   */ }
+
+/* ingest key 管理パネル ────────────────────────────────────────────── */
+.tracks-key-panel {
+  margin: 8px 0;
+  padding: 12px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 13px;
+}
+.tracks-key-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+.tracks-key-preview {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-family: ui-monospace, monospace;
+}
+.tracks-key-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.tracks-key-reveal {
+  margin-top: 8px;
+  padding: 8px;
+  background: var(--accent-bg);
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+}
+.tracks-key-reveal .muted {
+  font-size: 12px;
+  margin-bottom: 6px;
+}
+.tracks-key-full {
+  display: block;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  padding: 6px 8px;
+  border-radius: 4px;
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+  margin: 6px 0;
+  word-break: break-all;
+}
+.tracks-key-help {
+  margin: 8px 0 0;
+  font-size: 12px;
+  line-height: 1.5;
+}
+.tracks-key-help code {
+  background: var(--bg);
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-size: 11px;
+}


### PR DESCRIPTION
## Summary

歩いた軌跡を OwnTracks 経由で Memoria に記録 → Google Maps 上に Polyline で重ねて表示 → 日記の参考情報として参照、を一気通貫で実装した個人ツール。Iv (Imperativus) の OwnTracks 経路と独立させるため、Memoria 専有の Mosquitto broker を docker-compose で同梱した (port 1884 / 9002)。

## 構成

\`\`\`
[iOS/Android OwnTracks]
   └─MQTT─▶ memoria-mosquitto (1884) ─▶ server/owntracks-server.js
                                          └──INSERT──▶ data/memoria.db
                                                          │
                                                          ▼
                                                  /api/locations…
                                                  /api/diary (gps metrics)
                                                  Tracks tab (Google Maps)
\`\`\`

## 主な変更

### Backend
- \`server/db.js\`: \`gps_locations\` テーブル + 5 DAO (insert / listInRange / listDays / listForDate / deleteOlderThan)。 (user_id, device_id, recorded_at) で重複 dedup
- \`server/owntracks/\` (payload / client / config) を Iv の TS 実装から JS port、 \`MEMORIA_USER_ID\` で単一ユーザ前提に簡素化
- \`server/owntracks-server.js\`: 別 process entrypoint (\`npm run owntracks\`)
- \`server/index.js\`:
  - \`POST /api/locations/ingest\` (HTTP 直投入。 OwnTracks HTTP モード or 手動テスト用)
  - \`GET /api/locations?date=YYYY-MM-DD | ?from&to&device\`
  - \`GET /api/locations/days\` (date picker 用、点数つき)
  - \`DELETE /api/locations?older_than=ISO\` (retention)
  - \`GET/PATCH /api/maps/config\` (Google Maps API key)

### 日記統合
- \`aggregateDay\` の戻りに \`gps\` を追加 (points / 概算 distance_meters / bbox / midpoint / アクティブ時間帯 / devices)
- \`summarizeGpsForDate\`: haversine 距離 + bbox。 accuracy > 200m の点は距離計算から除外して jitter を抑制
- HIGHLIGHTS_PROMPT に「移動 (GPS 軌跡)」ブロックを追加。 推測しすぎない旨を注記

### フロント
- 新タブ \`🗺 軌跡\`: 日付 picker + Google Maps + Polyline + 始点 (緑) / 終点 (赤) マーカー + bbox fitBounds
- API key は \`/api/maps/config\` から遅延取得 → script を inject (鍵は HTTP referrer / API 制限を Google Cloud Console でかける運用)
- 「記録のある日」リストで過去日にジャンプ

### インフラ
- \`docker-compose.yml\`: mosquitto (eclipse-mosquitto:2.0)、 既定 host port 1884 (Iv の 1883 と非衝突)
- \`config/mosquitto/mosquitto.conf\`: 既定 anonymous 許可 (LAN 限定運用前提、 WAN 公開時の passwd/acl/TLS の手順をコメントで案内)

## 環境変数

| 名前 | 既定 | 用途 |
|---|---|---|
| \`MEMORIA_MQTT_URL\` | mqtt://localhost:1884 | broker URL |
| \`MEMORIA_MQTT_TOPIC\` | owntracks/+/+ | subscribe topic |
| \`MEMORIA_USER_ID\` | me | レコード user_id |
| \`MEMORIA_DB_PATH\` | ./data/memoria.db | SQLite path |
| \`LOCATIONS_INGEST_KEY\` | "" | HTTP 直投入の key (任意) |
| \`GOOGLE_MAPS_API_KEY\` | "" | Maps script の key (任意) |

## Test plan

- [x] \`node --check\` 全変更モジュール pass
- [x] DB DAO smoke test (新規 insert / 重複 dedup / range / days OK)
- [x] \`summarizeGpsForDate\` smoke test (3 点で 2.47km、 bbox / midpoint OK)
- [ ] 実機 iOS/Android OwnTracks → Memoria broker → 軌跡表示
- [ ] 日記生成 (\`POST /api/diary/:date/regenerate\`) で gps ブロックが Opus 1M ハイライトに反映されること

## 残課題 (本 PR の範囲外)

- 認証経路 (Cernere SSO) の組み込み (現状は LAN 限定 anonymous)
- 静止判定 + cluster 化 (場所推定)
- Heatmap option / 時間帯カラーグラデーション
- 端末別レイヤー切替 (複数端末対応)
- iOS / Android OwnTracks の broker 接続手順を docs/ に整理

🤖 Generated with [Claude Code](https://claude.com/claude-code)