### PR TITLE
feat(mobile): top-4 tabs visible + rest in ⋯ More dropdown + JP mobile-share.md

### DIFF
--- a/docs/mobile-share.md
+++ b/docs/mobile-share.md
@@ -1,64 +1,63 @@
-# Mobile share → Memoria
+# モバイル共有 → Memoria
 
-Memoria registers itself as a Web Share Target so the OS share sheet can hand a
-URL straight to the server, which queues the page just like a Chrome-extension
-save.
+Memoria は Web Share Target として登録されるので、OS の共有シートから URL を
+直接サーバへ渡して、Chrome 拡張で保存したときと同じようにキューに積めます。
 
-The plumbing:
+仕組み:
 
-1. `server/public/manifest.webmanifest` declares `share_target.action = /share`.
-2. The browser sends `GET /share?url=…&title=…&text=…` once the user installs
-   Memoria as a PWA.
-3. `app.get('/share')` in `server/index.js` extracts the first http(s) URL it
-   can find (preferring `url`, falling back to a regex over `text` / `title`),
-   calls `bulkSaveUrls([url])`, and 303-redirects to `/?share=ok&u=…`.
-4. The SPA shows a one-shot toast confirming the save.
+1. `server/public/manifest.webmanifest` で `share_target.action = /share` を宣言。
+2. ユーザーが Memoria を PWA としてインストールすると、ブラウザが
+   `GET /share?url=…&title=…&text=…` を送る。
+3. `server/index.js` の `app.get('/share')` が最初に見つかった http(s) URL を
+   抽出し (`url` を優先、なければ `text` / `title` から正規表現で拾う)、
+   `bulkSaveUrls([url])` を呼んで `/?share=ok&u=…` に 303 リダイレクトする。
+4. SPA が保存完了のワンショットトーストを表示する。
 
 ## Android (Chrome / Edge / Brave)
 
-1. Open `https://<your-memoria-host>/` in Chrome.
-2. Menu → **Add to Home screen** (or **Install app**).
-3. Once installed, **Memoria** appears in the share sheet of any app.
-4. Sharing a page hands the URL to `/share`. Memoria fetches the HTML on the
-   server, summarises, and adds it to the bookmark queue.
+1. Chrome で `https://<your-memoria-host>/` を開く。
+2. メニュー → **ホーム画面に追加**（または **アプリをインストール**）。
+3. インストール後、任意のアプリの共有シートに **Memoria** が出るようになる。
+4. ページを共有すると URL が `/share` に渡される。サーバ側で HTML を取得して
+   要約し、ブックマークキューに追加される。
 
 ## iOS (Safari)
 
-iOS Safari does **not** implement Web Share Target — there is no way for a PWA
-to register in the iOS share sheet. The workaround is an iOS Shortcut:
+iOS Safari は Web Share Target を**実装していない**ため、PWA を iOS 共有
+シートに登録する手段がありません。回避策として iOS ショートカットを使います:
 
-1. Open the **Shortcuts** app.
-2. Tap **+** → **New Shortcut**.
-3. Add the **Get URLs from Input** action.
-4. Add **URL** (`https://<your-memoria-host>/share?url=`).
-5. Add **Combine Text** to concatenate the URL above with the URL from step 3
-   (URL-encoded). The simplest way: use the **URL Encode** action between
-   them, then **Get Contents of URL** with method `GET`.
-6. Toggle **Show in Share Sheet** in shortcut settings.
-7. Set **Share Sheet Types** to **URLs**.
+1. **ショートカット** アプリを開く。
+2. **+** → **新規ショートカット** をタップ。
+3. **入力から URL を取得** アクションを追加。
+4. **URL** (`https://<your-memoria-host>/share?url=`) を追加。
+5. **テキストを結合** で 4 のURLと 3 で取り出した URL（URL エンコード済み）を
+   連結する。一番素直な手順は、間に **URL エンコード** アクションを挟んでから
+   **URL の内容を取得** をメソッド `GET` で実行する。
+6. ショートカット設定で **共有シートに表示** をオンにする。
+7. **共有シートのタイプ** を **URL** に設定する。
 
-A starter `.shortcut` JSON-equivalent (paste into the Shortcut text editor):
+`.shortcut` に相当する最小構成（ショートカットエディタに貼り付け可能なイメージ）:
 
 ```text
-Action 1: Get Contents of URL
-  URL: https://YOUR-HOST/share?url=[URL Encoded Shortcut Input]
-  Method: GET
-  Headers: (none)
+アクション 1: URL の内容を取得
+  URL: https://YOUR-HOST/share?url=[URL エンコード済みショートカット入力]
+  メソッド: GET
+  ヘッダ: （なし）
 ```
 
-Once saved, sharing any URL from Safari → Memoria runs the shortcut, the
-server saves the page, and the response (the redirect to `/?share=ok…`) is
-discarded.
+保存しておくと、Safari で URL を共有 → Memoria を選ぶとショートカットが走り、
+サーバがページを保存し、レスポンス (`/?share=ok…` へのリダイレクト) は
+破棄される、という流れになります。
 
-## Local-only / private deployments
+## ローカル限定 / 非公開デプロイ
 
-If Memoria is reachable only on localhost, the PWA install path still works on
-desktop (Chrome → Install app). Mobile share targets require a publicly
-addressable HTTPS host — typical patterns:
+Memoria が localhost からしか到達できない場合でも、PWA インストール自体は
+デスクトップで動作します（Chrome → アプリをインストール）。ただしモバイルの
+共有ターゲットは公開された HTTPS ホストが必須です。よくある構成:
 
-- Tailscale + custom DNS for personal use.
-- Reverse-proxy (Caddy / Cloudflare Tunnel) in front of `npm start`.
+- 個人用途なら Tailscale + 独自 DNS。
+- `npm start` の前段にリバースプロキシ (Caddy / Cloudflare Tunnel) を置く。
 
-The `/share` handler trusts whoever can reach it, so do not expose the server
-to the open internet without authentication. Multi-server mode (issue #34)
-will add Cernere SSO in front of `/share` and the rest of the API.
+`/share` ハンドラは到達できる相手を区別しないので、認証なしでインターネットに
+公開しないでください。マルチサーバモード (issue #34) では `/share` と他の
+API の前段に Cernere SSO を入れる予定です。

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -565,6 +565,8 @@ function switchTab(tab) {
   if (tab === 'events') loadEvents();
   if (tab === 'multi') loadMulti();
   bumpTabUsage(tab);
+  closeTabMoreMenu();
+  reflowTabsForViewport();
 }
 
 // ── Tab use-count + mobile More menu ──────────────────────────────────────
@@ -582,12 +584,98 @@ function tabsInUsageOrder() {
   const u = readTabUsage();
   return tabs.slice().sort((a, b) => (u[b.dataset.tab] || 0) - (u[a.dataset.tab] || 0));
 }
-// Custom More menu and mobile <select> have been removed — the tab
-// strip now scrolls horizontally on every viewport, which is more
-// reliable than juggling overflow logic. These no-ops stay around so
-// existing call sites (switchTab → reflowTabsForViewport) don't error.
-function closeTabMoreMenu() { /* no-op */ }
-function reflowTabsForViewport() { /* no-op */ }
+// Mobile tab nav is "top 4 most-used + active visible inline, the rest
+// tucked into a ⋯ More dropdown". Desktop shows every tab inline. The
+// dropdown is `position: fixed` and JS positions it under the More
+// button to dodge sticky/overflow clipping.
+const TABS_VISIBLE_ON_MOBILE = 4;
+
+function isNarrowViewport() {
+  return window.innerWidth <= 760;
+}
+
+function closeTabMoreMenu() {
+  const m = $('tabMoreMenu');
+  const b = $('tabMoreBtn');
+  if (m) m.hidden = true;
+  if (b) b.setAttribute('aria-expanded', 'false');
+}
+
+function positionTabMoreMenu() {
+  const btn = $('tabMoreBtn');
+  const menu = $('tabMoreMenu');
+  if (!btn || !menu || menu.hidden) return;
+  const r = btn.getBoundingClientRect();
+  const w = menu.offsetWidth || 200;
+  const left = Math.max(8, Math.min(window.innerWidth - w - 8, r.right - w));
+  menu.style.top = `${r.bottom + 4}px`;
+  menu.style.left = `${left}px`;
+}
+
+function openTabMoreMenu() {
+  const btn = $('tabMoreBtn');
+  const menu = $('tabMoreMenu');
+  if (!btn || !menu) return;
+  menu.hidden = false;
+  btn.setAttribute('aria-expanded', 'true');
+  positionTabMoreMenu();
+}
+
+function reflowTabsForViewport() {
+  const scroll = document.querySelector('.tabs-scroll');
+  const moreBtn = $('tabMoreBtn');
+  const moreMenu = $('tabMoreMenu');
+  if (!scroll || !moreBtn || !moreMenu) return;
+
+  const allTabs = [...scroll.querySelectorAll('.tab[data-tab]')];
+  // Reset every state.
+  for (const t of allTabs) t.style.display = '';
+  moreMenu.replaceChildren();
+
+  if (!isNarrowViewport()) {
+    moreBtn.hidden = true;
+    moreMenu.hidden = true;
+    return;
+  }
+
+  // Decide which 4 stay visible: most-used first, but always pin the
+  // active tab (so the user never loses sight of where they are).
+  const active = state.tab;
+  const ordered = tabsInUsageOrder()
+    .filter(t => !t.hidden);          // skip hidden tabs (e.g. multi)
+  const visible = new Set(ordered.slice(0, TABS_VISIBLE_ON_MOBILE).map(t => t.dataset.tab));
+  if (active) visible.add(active);
+
+  let overflowCount = 0;
+  for (const t of allTabs) {
+    if (t.hidden) {
+      // tab-multi-only stays out of both strip and menu when not connected.
+      continue;
+    }
+    if (visible.has(t.dataset.tab)) {
+      t.style.display = '';
+    } else {
+      const li = document.createElement('li');
+      const item = document.createElement('button');
+      item.type = 'button';
+      item.className = 'tab' + (t.dataset.tab === active ? ' active' : '');
+      item.dataset.tab = t.dataset.tab;
+      // Strip child counts from the cloned label so the menu reads cleanly.
+      item.textContent = (t.textContent || t.dataset.tab).replace(/\s+/g, ' ').trim();
+      item.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        switchTab(t.dataset.tab);
+        closeTabMoreMenu();
+      });
+      li.appendChild(item);
+      moreMenu.appendChild(li);
+      t.style.display = 'none';
+      overflowCount += 1;
+    }
+  }
+  moreBtn.hidden = overflowCount === 0;
+}
 
 // ── Dig (deep research) ──────────────────────────────────────────────────
 
@@ -2774,9 +2862,38 @@ async function deleteSelectedVisits() {
   await loadVisits();
 }
 
-document.querySelectorAll('.tabs-scroll .tab').forEach(t => {
+document.querySelectorAll('.tabs-scroll .tab[data-tab]').forEach(t => {
   t.addEventListener('click', () => switchTab(t.dataset.tab));
 });
+{
+  const moreBtn = $('tabMoreBtn');
+  const moreMenu = $('tabMoreMenu');
+  if (moreBtn) {
+    moreBtn.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (moreMenu && moreMenu.hidden === false) {
+        closeTabMoreMenu();
+      } else {
+        openTabMoreMenu();
+      }
+    });
+  }
+  document.addEventListener('click', (e) => {
+    if (!moreMenu || moreMenu.hidden) return;
+    if (e.target === moreBtn || moreBtn?.contains(e.target)) return;
+    if (moreMenu.contains(e.target)) return;
+    closeTabMoreMenu();
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') closeTabMoreMenu();
+  });
+  window.addEventListener('resize', () => {
+    reflowTabsForViewport();
+    positionTabMoreMenu();
+  });
+  reflowTabsForViewport();
+}
 setupCategoriesDrawer();
 setupExtensionBadge();
 setupHowToBookmark();

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -92,6 +92,8 @@
           <button class="tab" data-tab="diary">📅 日記</button>
           <button class="tab tab-multi-only" data-tab="multi" hidden>🌐 マルチ</button>
         </div>
+        <button type="button" id="tabMoreBtn" class="tab tab-more-btn" aria-haspopup="true" aria-expanded="false" hidden>⋯</button>
+        <ul id="tabMoreMenu" class="tab-more-menu" hidden role="menu"></ul>
       </nav>
 
       <div id="bookmarksView">

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -231,10 +231,8 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   align-items: stretch;
   box-shadow: 0 1px 0 rgba(0,0,0,0.04);
 }
-/* Single horizontally-scrollable tab strip on every viewport.
- * Custom More dropdown got dropped — it kept rendering empty in some
- * setups and `overflow-x: auto` on the strip is the simplest reliable
- * fallback for narrow widths. Hide the scrollbar for cosmetics. */
+/* Tabs strip — desktop is horizontally scrollable, mobile is "top 4 +
+ * More" as set up by the @media block at the bottom of this file. */
 .tabs-scroll {
   display: flex;
   gap: 4px;
@@ -244,6 +242,42 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   scrollbar-width: none;
 }
 .tabs-scroll::-webkit-scrollbar { display: none; }
+.tab-more-btn { font-weight: 700; flex: 0 0 auto; }
+.tab-more-btn[hidden] { display: none !important; }
+/* Dropdown is `position: fixed` so it can't be clipped by parent overflow
+ * or sticky stacking quirks. JS positions it under the More button. */
+.tab-more-menu {
+  position: fixed;
+  list-style: none;
+  margin: 0;
+  padding: 4px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.18);
+  min-width: 180px;
+  max-height: 70vh;
+  overflow-y: auto;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.tab-more-menu[hidden] { display: none; }
+.tab-more-menu .tab {
+  border-bottom: 0 !important;
+  border-radius: 6px;
+  padding: 10px 14px;
+  justify-content: flex-start;
+  text-align: left;
+  font-size: 14px;
+  width: 100%;
+}
+.tab-more-menu .tab.active {
+  background: var(--accent-bg);
+  color: var(--accent);
+  font-weight: 600;
+}
 .tab {
   background: transparent;
   border: 0;
@@ -1864,10 +1898,10 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 
   .content { padding: 12px; }
 
-  /* Sticky tabs on mobile. Drop the negative-margin trick because it
-   * makes sticky pin against an offset that's hard to reason about when
-   * the URL bar shows/hides. Just set top:0 inside the .content scroll
-   * container. */
+  /* Sticky tabs on mobile + "top 4 + More" model: only the four most-
+   * used tabs (plus the active one) sit in the visible strip; the
+   * rest are tucked into the ⋯ More dropdown. The strip itself stops
+   * scrolling horizontally since it always fits. */
   .tabs {
     margin: 0 -12px 12px;
     padding: 6px 8px 0;
@@ -1875,12 +1909,17 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
     background: var(--panel);
     border-bottom: 1px solid var(--border);
     box-shadow: 0 1px 0 rgba(0,0,0,0.04);
+    align-items: center;
   }
   .tabs-scroll {
-    overflow-x: auto;
-    scrollbar-width: none;
+    overflow-x: hidden;
+    flex-wrap: nowrap;
   }
-  .tabs-scroll::-webkit-scrollbar { display: none; }
+  .tabs-scroll .tab { padding: 8px 10px; font-size: 13px; }
+  .tab-more-btn {
+    /* Make the More button reach the right edge. */
+    margin-left: auto;
+  }
 
   /* Diary collapses to a single column; calendar then detail. */
   .diary-layout {


### PR DESCRIPTION
## Summary
- スマホでは最頻使用 4 タブ（+ アクティブタブ）だけ strip に出して、残りは ⋯ **More** ドロップダウンに格納する
- More メニューは `position: fixed` + JS で位置決めして sticky / overflow のクリッピングを回避
- `localStorage` の使用回数 (`memoria.tabUsage.v1`) を見て表示順を決定。アクティブタブは必ず可視に固定
- リサイズ・タブ切替・外側クリック・Escape で開閉とリフローを正しく扱う
- `docs/mobile-share.md` を日本語版にリライト（他のドキュメントと言語をそろえる）

## Test plan
- [x] `node --check server/public/app.js`
- [ ] スマホ幅 (≤ 760px) で 4 タブ + ⋯ が並ぶ／ ⋯ で残りが出る
- [ ] PC 幅では ⋯ が消えて全タブが横一列
- [ ] アクティブタブが 4 件圏外でも常に visible
- [ ] タブ切替で More を閉じる／外側クリック / Escape で閉じる
- [ ] resize で再リフロー＆位置追従

🤖 Generated with [Claude Code](https://claude.com/claude-code)