### PR TITLE
fix(mobile): タブ初期収納 (queue/events) + viewport-fit (横スクロール禁止)

### DIFF
--- a/server/public/app.js
+++ b/server/public/app.js
@@ -581,10 +581,26 @@ function bumpTabUsage(tab) {
   u[tab] = (u[tab] || 0) + 1;
   try { localStorage.setItem(TAB_USAGE_KEY, JSON.stringify(u)); } catch {}
 }
+// 既定の表示優先度。 履歴が空 (= 新規ユーザ / localStorage クリア直後) の時は
+// この順で上位 4 件が strip に出る。 何かを 1 度でも触れば実 usage が必ず勝つ
+// よう、 default score は 1 click 未満に収めている。
+const TAB_DEFAULT_PRIORITY = [
+  'bookmarks', 'dig', 'diary', 'tracks', 'dict', 'domain',
+  'visits', 'trends', 'recommend', 'queue', 'events', 'multi',
+];
+function tabDefaultScore(name) {
+  const idx = TAB_DEFAULT_PRIORITY.indexOf(name);
+  if (idx < 0) return 0;
+  return (TAB_DEFAULT_PRIORITY.length - idx) / 1000;  // 0.001 〜 0.012
+}
 function tabsInUsageOrder() {
   const tabs = [...document.querySelectorAll('.tabs-scroll .tab[data-tab]')];
   const u = readTabUsage();
-  return tabs.slice().sort((a, b) => (u[b.dataset.tab] || 0) - (u[a.dataset.tab] || 0));
+  return tabs.slice().sort((a, b) => {
+    const sa = (u[a.dataset.tab] || 0) + tabDefaultScore(a.dataset.tab);
+    const sb = (u[b.dataset.tab] || 0) + tabDefaultScore(b.dataset.tab);
+    return sb - sa;
+  });
 }
 // Mobile tab nav is "top 4 most-used + active visible inline, the rest
 // tucked into a ⋯ More dropdown". Desktop shows every tab inline. The

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -256,12 +256,14 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   border-radius: 8px;
   box-shadow: 0 8px 24px rgba(0,0,0,0.18);
   min-width: 180px;
+  max-width: calc(100vw - 8px);   /* スマホでも viewport を絶対にはみ出さない */
   max-height: 70vh;
   overflow-y: auto;
   z-index: 1000;
   display: flex;
   flex-direction: column;
   gap: 2px;
+  box-sizing: border-box;
 }
 .tab-more-menu[hidden] { display: none; }
 .tab-more-menu .tab {
@@ -1787,17 +1789,33 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 @media (max-width: 760px) {
   body { font-size: 13px; }
 
+  /* スマホでは横スクロールを完全に殺す。 viewport 幅 - 8px (両端 4px 余白)
+   * 以内に全コンテンツを収めることで、 拡大 / 横スクロールが必要になる
+   * 操作を避ける。 */
+  html, body {
+    overflow-x: hidden;
+    max-width: 100vw;
+  }
+  body { overscroll-behavior-x: none; }
+  /* Long URL / コードブロックが画面幅をはみ出さないよう一律 wrap させる。 */
+  pre, code, .url, .bookmark-url, .visits-url, .dig-url {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
   /* Mobile topbar: pin .topbar-controls to the top-right via absolute
    * positioning so the ⚙ 設定 + 💡 やり方 buttons always sit in the
    * top-right corner regardless of how brand / multi-switch /
    * extension badge / queue badge wrap. */
   .topbar {
     flex-wrap: wrap;
-    gap: 8px;
-    padding: 8px 56px 8px 12px;        /* leave room on the right */
+    gap: 6px;
+    padding: 8px 52px 8px 4px;        /* 4px 余白 + 右側は 設定ボタン分 */
     position: sticky;
     top: 0;
     z-index: 10;
+    box-sizing: border-box;
+    max-width: 100vw;
   }
   .topbar-controls {
     position: absolute;
@@ -1815,8 +1833,8 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 
   /* Mobile uses the same horizontally-scrollable tab strip as desktop. */
   .tabs {
-    margin: 0 -12px 12px;
-    padding: 6px 8px;
+    margin: 0 -4px 12px;
+    padding: 6px 4px;
   }
 
   /* Keep the layout itself viewport-bound on mobile so .content remains
@@ -1826,6 +1844,7 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   .layout {
     flex-direction: column;
     height: calc(100vh - 53px);
+    max-width: 100vw;
   }
   .layout > .content { flex: 1 1 auto; min-height: 0; }
   /* On mobile the detail aside is positioned as a fullscreen overlay
@@ -1843,8 +1862,8 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
     display: none;
     position: fixed;
     top: 110px;             /* below sticky topbar (~53px) + tabs (~45px) */
-    left: 12px;
-    right: 12px;
+    left: 4px;
+    right: 4px;
     width: auto;
     flex: 0 0 auto !important;
     height: 50vh;
@@ -1896,20 +1915,26 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   }
   .detail.hidden { display: none; }
 
-  .content { padding: 12px; }
+  .content {
+    padding: 12px 4px;             /* 横は 4px ずつ → 計 8px (-8px 要件) */
+    max-width: 100vw;
+    box-sizing: border-box;
+  }
 
   /* Sticky tabs on mobile + "top 4 + More" model: only the four most-
    * used tabs (plus the active one) sit in the visible strip; the
    * rest are tucked into the ⋯ More dropdown. The strip itself stops
    * scrolling horizontally since it always fits. */
   .tabs {
-    margin: 0 -12px 12px;
-    padding: 6px 8px 0;
+    margin: 0 -4px 12px;
+    padding: 6px 4px 0;
     top: 0;
     background: var(--panel);
     border-bottom: 1px solid var(--border);
     box-shadow: 0 1px 0 rgba(0,0,0,0.04);
     align-items: center;
+    max-width: 100vw;
+    box-sizing: border-box;
   }
   .tabs-scroll {
     overflow-x: hidden;
@@ -1937,6 +1962,21 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 
   /* Dictionary / domain detail panes float over the list. */
   .dict-layout { grid-template-columns: 1fr; }
+
+  /* 設定 / 日記設定 panel: PC では 380/560px の固定幅だが、 スマホでは
+   * viewport を絶対にはみ出さないよう (vw - 8px) に縮める。 */
+  .diary-settings, .ai-settings {
+    width: calc(100vw - 8px) !important;
+    max-width: calc(100vw - 8px);
+    box-sizing: border-box;
+  }
+  .diary-settings { right: 4px; bottom: 4px; }
+
+  /* モーダルやドロワー類 (.modal-panel) も同様に。 */
+  .modal-panel {
+    max-width: calc(100vw - 8px);
+    box-sizing: border-box;
+  }
 }
 
 /* ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 報告された不具合
- 機能フローティングタブの自動収納できてない (最初から全部 visible)。最初は **作業キュー** とかを収納する。
- スマホの横幅 -8px とかで合わせる。**拡大などスクロールが必要になる操作も禁止**。

## 修正

### 1. タブの初期 More 収納
- 履歴ゼロ (新規ユーザ / localStorage クリア後) で並びが HTML 順になっていたため、`top-4 = bookmarks / queue / events / visits` になっていた
- `TAB_DEFAULT_PRIORITY` を導入: `bookmarks → dig → diary → tracks → dict → domain → visits → trends → recommend → queue → events → multi`
- usage に対して default score を 0.001〜0.012 だけ加算 → 履歴ゼロでは default が勝ち、 1 click でも触れば実 usage が必ず default を上回る

### 2. viewport-fit (横スクロール禁止)
- `html, body { overflow-x: hidden; max-width: 100vw }`
- `.topbar / .layout / .content / .tabs` を `box-sizing: border-box` + `max-width: 100vw`、 横 padding を 4px (合計 8px) に縮小
- 380/560px 固定の `.diary-settings` / `.ai-settings` / `.modal-panel` を `calc(100vw - 8px)` で cap
- `.tab-more-menu` も同様
- 長 URL / pre / code に `overflow-wrap: anywhere`
- bookmarks-categories drawer の inset を 12px → 4px

## Test plan
- [x] `node --check server/public/app.js`
- [ ] localStorage クリア後、 スマホ幅で top-4 = bookmarks / dig / diary / tracks
- [ ] 何度か queue を tap すると queue が strip 入りする
- [ ] 360px 〜 414px 幅で横スクロールが一切出ない
- [ ] 設定 / 日記設定 / 各 modal が viewport 内に収まる

🤖 Generated with [Claude Code](https://claude.com/claude-code)