### PR TITLE
fix(mobile): top-3 + More 確実 + 全ビュー viewport-fit + 説明白背景 + 閉じる×大きく

### DIFF
--- a/server/public/app.js
+++ b/server/public/app.js
@@ -602,11 +602,10 @@ function tabsInUsageOrder() {
     return sb - sa;
   });
 }
-// Mobile tab nav is "top 4 most-used + active visible inline, the rest
-// tucked into a ⋯ More dropdown". Desktop shows every tab inline. The
-// dropdown is `position: fixed` and JS positions it under the More
-// button to dodge sticky/overflow clipping.
-const TABS_VISIBLE_ON_MOBILE = 4;
+// Mobile tab nav is "top 3 most-used (active stays visible) + the rest in
+// a ⋯ More dropdown". 合計 strip にいるタブは常に <= 3 件。 active が
+// top-3 圏外なら top-3 の最下位を 1 件 evict して active を入れる。
+const TABS_VISIBLE_ON_MOBILE = 3;
 
 function isNarrowViewport() {
   return window.innerWidth <= 760;
@@ -656,13 +655,20 @@ function reflowTabsForViewport() {
     return;
   }
 
-  // Decide which 4 stay visible: most-used first, but always pin the
-  // active tab (so the user never loses sight of where they are).
+  // 上位 3 件 (使用回数 + default priority) を strip に残す。 active は必ず
+  // 含めるが、 圏外なら top-3 の最下位を 1 件抜いて active と入れ替える。
+  // → strip 内のタブは常に最大 3 件で、 「More」 を押せば残りが見える。
   const active = state.tab;
   const ordered = tabsInUsageOrder()
     .filter(t => !t.hidden);          // skip hidden tabs (e.g. multi)
-  const visible = new Set(ordered.slice(0, TABS_VISIBLE_ON_MOBILE).map(t => t.dataset.tab));
-  if (active) visible.add(active);
+  const top = ordered.slice(0, TABS_VISIBLE_ON_MOBILE);
+  const visible = new Set(top.map(t => t.dataset.tab));
+  if (active && !visible.has(active)) {
+    if (top.length >= TABS_VISIBLE_ON_MOBILE) {
+      visible.delete(top[top.length - 1].dataset.tab);
+    }
+    visible.add(active);
+  }
 
   let overflowCount = 0;
   for (const t of allTabs) {

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -1023,9 +1023,20 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   max-height: 88vh;
   overflow-y: auto;
   z-index: 100;
+  background: var(--panel);                /* 説明テキストが白背景で読める */
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 18px 22px;
+  box-shadow: 0 12px 48px rgba(0,0,0,0.2);
 }
 .modal-close {
-  margin-left: auto;
+  /* 右上ピン留めの×。 スマホでも押しやすいよう 44x44 を確保。 */
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 44px;
+  height: 44px;
+  margin-left: 0;
   background: transparent;
   border: 0;
   color: var(--muted);
@@ -1435,8 +1446,32 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   overflow-y: auto;
   z-index: 100;
 }
-.ai-settings-head { display: flex; justify-content: space-between; align-items: center; }
+.ai-settings-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  /* h3 と並んでくる × を絶対配置にして見出しの右上に置く */
+  position: relative;
+  padding-right: 48px;
+}
 .ai-settings-head h3 { margin: 0; }
+.ai-settings-head #aiSettingsClose {
+  /* スマホでも押せる 44x44。 ghost 系の border / padding は上書き。 */
+  position: absolute;
+  top: -4px;
+  right: 0;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  color: var(--muted);
+  font-size: 22px;
+  line-height: 1;
+  border-radius: 50%;
+  cursor: pointer;
+}
+.ai-settings-head #aiSettingsClose:hover { background: #f0f2f7; color: var(--text); }
 .ai-settings-help { font-size: 11px; color: var(--muted); margin: 8px 0 16px; line-height: 1.5; }
 .ai-settings h4 { margin: 14px 0 6px; font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; }
 .ai-task-row {
@@ -1831,9 +1866,10 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   }
   .topbar-howto[hidden] { display: none !important; }
 
-  /* Mobile uses the same horizontally-scrollable tab strip as desktop. */
+  /* Mobile uses the same horizontally-scrollable tab strip as desktop.
+   * (詳細指定は下の "Sticky tabs on mobile" ブロックで上書き。) */
   .tabs {
-    margin: 0 -12px 12px;
+    margin: 0 -4px 12px;
     padding: 6px 8px;
   }
 
@@ -1921,13 +1957,12 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
     box-sizing: border-box;
   }
 
-  /* Sticky tabs on mobile + "top 4 + More" model: only the four most-
-   * used tabs (plus the active one) sit in the visible strip; the
-   * rest are tucked into the ⋯ More dropdown. The strip itself stops
-   * scrolling horizontally since it always fits.
-   * 機能ヘッダは viewport-fit (-8px) は適用しない (元の余白を維持)。 */
+  /* Sticky tabs on mobile + "top 3 + More" model: 上位 3 件 (active を必ず
+   * 含む) + ⋯ More を strip に配置。 inner padding は 8px キープ (機能
+   * ヘッダ自体は -8px 化しない方針)、 ただし negative margin は親 .content
+   * の padding (4px) に合わせて -4px とし、 viewport を絶対にはみ出さない。 */
   .tabs {
-    margin: 0 -12px 12px;
+    margin: 0 -4px 12px;
     padding: 6px 8px 0;
     top: 0;
     background: var(--panel);
@@ -1953,8 +1988,28 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   .diary-detail { padding: 12px; }
   .diary-pie-row { flex-direction: column; }
 
-  /* Bookmark cards stack rather than tile. */
-  .cards { grid-template-columns: 1fr; }
+  /* Bookmark cards stack rather than tile. ブックマーク (とそれ以外の
+   * すべての主要ビュー) は viewport - 8px 内に収める。 */
+  .cards { grid-template-columns: 1fr; max-width: 100%; }
+  #bookmarksView, #bookmarksView .bookmarks-main, .bookmark-card,
+  #digView, #dictView, #domainView, #diaryView, #visitsView,
+  #trendsView, #recommendView, #queueView, #eventsView, #tracksView,
+  #multiView {
+    max-width: 100%;
+    box-sizing: border-box;
+  }
+  /* bookmark カードや tile が長 URL や image でこじ開けるのを防ぐ */
+  .bookmark-card img, .dict-card img, .domain-card img {
+    max-width: 100%;
+    height: auto;
+  }
+  /* toolbar のアイテムは折り返し (search が 240/320px 固定だと幅を超える) */
+  .bookmarks-toolbar { gap: 6px; }
+  .bookmarks-toolbar input[type=search] {
+    min-width: 0 !important;
+    flex: 1 1 100%;
+    width: 100%;
+  }
 
   /* Trends grid → single column. */
   .trends-grid { grid-template-columns: 1fr; }


### PR DESCRIPTION
## 報告された不具合
1. More の対応できてない。 アクティブなタブの数は **3 つ** にする。 More を押すと残りのメニューを表示
2. ブックマークの幅はデバイスの横幅 -8px。 それ以外も全部そう
3. 全体の幅もデバイスの横幅に合うようにする
4. 「やり方」 で説明が書いてある部分には白背景を載せる
5. 設定 / やり方は右上に × ボタンを置いて閉じれるように。 スマホでも押せるように

## 修正

### 1. top-3 + More
- `TABS_VISIBLE_ON_MOBILE` を 4 → 3
- active が top-3 圏外なら top-3 末尾を 1 件 evict、 strip 内は常に <= 3 件
- PR #72 の `.tabs { margin: 0 -12px }` (=  .content padding 4px と不整合) が viewport を 8px はみ出して上のクリックを食っていたのを `-4px` に揃えて根治

### 2 + 3. 全ビュー viewport-fit
- 各タブの root view (`#bookmarksView` 〜 `#multiView`) と `.bookmarks-main` / `.bookmark-card` / `.cards` に `max-width: 100% + border-box`
- `<input type=search>` の `min-width 240px` がスマホ幅で確実に overflow していたので `min-width: 0; flex: 1 1 100%`
- card 内 `<img>` も `max-width: 100%`

### 4. 白背景
- `.modal-panel` がそもそも `background:` 未設定 → 暗いバックドロップに説明文が直接乗っていた。 `var(--panel)` + `padding` + `box-shadow` を追加

### 5. 閉じる × の大型化 + 右上ピン
- `.modal-close` (やり方 / Chrome 拡張 setup): position absolute, top-right, 44 × 44
- `#aiSettingsClose` (設定): `.ai-settings-head` を相対 + 44 × 44 円形を右上に absolute

## Test plan
- [ ] スマホ幅で strip に 3 タブ + ⋯、 ⋯ で残りが menu で出る
- [ ] active タブが top-3 圏外でも strip は 3 件のまま active が visible
- [ ] 360px〜414px 幅で横スクロール無し、 全タブのコンテンツが viewport 内
- [ ] やり方オーバーレイの説明文が白背景に乗っていて読める
- [ ] 設定 / やり方の右上 × が指で押せる (44x44)

🤖 Generated with [Claude Code](https://claude.com/claude-code)