### PR TITLE
fix(mobile): 長文 wrap + ピンチ無効 + タブ 4 件 + やり方白背景 + 設定 2 行

### DIFF
--- a/server/public/app.js
+++ b/server/public/app.js
@@ -602,10 +602,10 @@ function tabsInUsageOrder() {
     return sb - sa;
   });
 }
-// Mobile tab nav is "top 3 most-used (active stays visible) + the rest in
-// a ⋯ More dropdown". 合計 strip にいるタブは常に <= 3 件。 active が
-// top-3 圏外なら top-3 の最下位を 1 件 evict して active を入れる。
-const TABS_VISIBLE_ON_MOBILE = 3;
+// Mobile tab nav is "top 4 most-used (active stays visible) + the rest in
+// a ⋯ More dropdown". 合計 strip にいるタブは常に <= 4 件。 active が
+// top-4 圏外なら top-4 の最下位を 1 件 evict して active を入れる。
+const TABS_VISIBLE_ON_MOBILE = 4;
 
 function isNarrowViewport() {
   return window.innerWidth <= 760;

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
   <meta name="theme-color" content="#2a6df4" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-title" content="Memoria" />

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -1832,11 +1832,36 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
     max-width: 100vw;
   }
   body { overscroll-behavior-x: none; }
-  /* Long URL / コードブロックが画面幅をはみ出さないよう一律 wrap させる。 */
-  pre, code, .url, .bookmark-url, .visits-url, .dig-url {
+  /* 長文 / 長 URL / コードブロック / カード文字列を画面幅で確実に折り返す。
+   * `overflow-wrap: anywhere` を全カード系コンテナに広く適用し、 1 単語が
+   * viewport を超える場合でも強制改行させる。 ピンチズーム禁止前提なので
+   * 横スクロールが出ない = 折り返さない限り読めない、 が要件。 */
+  pre, code, .url, .bookmark-url, .visits-url, .dig-url,
+  .title, .summary, .snippet, .meta, .err,
+  .card, .card *, .rec-card, .rec-card *,
+  .dig-source, .dig-source *, .dig-preview-result, .dig-preview-result *,
+  .visits-list li, .visits-list li *,
+  .multi-card, .multi-card *,
+  .diary-bookmark, .diary-bookmark *,
+  .cloud-related-item, .cloud-related-item *,
+  .qg-row, .qg-row *,
+  .queue-running, .queue-running *,
+  .queue-list li, .queue-list li *,
+  .queue-history li, .queue-history li *,
+  .domain-card, .domain-card *,
+  .dict-card, .dict-card *,
+  .ext-setup-help, .ai-settings-help {
     overflow-wrap: anywhere;
     word-break: break-word;
+    min-width: 0;
   }
+  /* テーブルや input は別軸の制御が必要なので強制 wrap から除外 */
+  .tabs, .tabs *, table, input, select, textarea, button {
+    overflow-wrap: normal;
+    word-break: normal;
+  }
+  /* 念のためボタンのラベルは折り返さず ellipsis (タブの幅は管理側で決まる) */
+  .tab { white-space: nowrap; }
 
   /* Mobile topbar: pin .topbar-controls to the top-right via absolute
    * positioning so the ⚙ 設定 + 💡 やり方 buttons always sit in the

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -1023,12 +1023,15 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   max-height: 88vh;
   overflow-y: auto;
   z-index: 100;
-  background: var(--panel);                /* 説明テキストが白背景で読める */
+  /* 説明テキストが白背景で読める。 後ろのバックドロップ (alpha 0.4) を
+   * 透かさないよう !important で確実に opaque にする。 */
+  background: var(--panel) !important;
   border: 1px solid var(--border);
   border-radius: 12px;
   padding: 18px 22px;
   box-shadow: 0 12px 48px rgba(0,0,0,0.2);
 }
+.modal-panel.ext-setup { background: var(--panel) !important; }
 .modal-close {
   /* 右上ピン留めの×。 スマホでも押しやすいよう 44x44 を確保。 */
   position: absolute;
@@ -2048,13 +2051,31 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
     width: calc(100vw - 8px) !important;
     max-width: calc(100vw - 8px);
     box-sizing: border-box;
+    padding: 14px 12px;
   }
   .diary-settings { right: 4px; bottom: 4px; }
+
+  /* AI タスク行 (label / provider / model) は PC で 130 / 160 / 1fr の 3 列
+   * grid。 スマホ幅では 290px+ 確保できないので 2 行に再構成: 1 行目は
+   * label を全幅、 2 行目は provider + model を 2 列。 */
+  .ai-task-row {
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas:
+      "label label"
+      "provider model";
+    gap: 6px 8px;
+  }
+  .ai-task-row label { grid-area: label; font-size: 13px; }
+  .ai-task-row select { grid-area: provider; min-width: 0; }
+  .ai-task-row input { grid-area: model; min-width: 0; }
+  .ai-task-row select, .ai-task-row input { width: 100%; }
 
   /* モーダルやドロワー類 (.modal-panel) も同様に。 */
   .modal-panel {
     max-width: calc(100vw - 8px);
+    width: calc(100vw - 8px);
     box-sizing: border-box;
+    padding: 14px 12px;
   }
 }
 


### PR DESCRIPTION
## 報告された不具合
1. ブックマーク等の文字が長い場合は画面幅で折り返す
2. ピンチ無効で
3. やり方まだ透明
4. 設定が画面幅を超えてるのでレイアウトを 2 行にするなどで調整
5. メニューいつまで 8 個だしてるの？ 4 つにする

## 修正

### 1 + 2. 長文 wrap + ピンチ無効
- viewport meta に `maximum-scale=1, user-scalable=no, viewport-fit=cover`
- スマホ (≤ 760px) のカード系コンテナに `overflow-wrap: anywhere + word-break: break-word + min-width: 0` を一括付与 (`.card / .rec-card / .dig-source / .visits-list / .multi-card / .diary-bookmark / .cloud-related-item / .qg-row / .queue-* / .domain-card / .dict-card / .title / .summary / .snippet` 等)
- `.tab` だけ `white-space: nowrap` でラベル折返し抑止

### 3. やり方の透明
- `.modal-panel` の `background: var(--panel)` に `!important` を付け、 どこで上書きされても opaque な白背景になるよう保証
- `.modal-panel.ext-setup` 専用ルールも追加

### 4. 設定が画面幅超え
- `.ai-task-row` (`130px 160px 1fr` の 3 列 grid) をスマホで 2 行に: `label` 全幅 → `provider | model`
- `.ai-settings` padding を `14px 12px` に縮小、 `width: calc(100vw - 8px)`

### 5. タブ 4 件
- `TABS_VISIBLE_ON_MOBILE` を 3 → 4
- active 圏外時は top-4 末尾を 1 件 evict (上限 4 件は維持)

## Test plan
- [ ] 長 URL のブックマークが viewport 幅で折り返す
- [ ] ピンチ操作で拡大しない
- [ ] スマホ幅で strip に 4 タブ + ⋯
- [ ] やり方オーバーレイが白背景になる
- [ ] 設定パネルが画面幅以内、 AI タスクが 2 行で読める

🤖 Generated with [Claude Code](https://claude.com/claude-code)