### PR TITLE
fix(mobile): ブックマーク等の長文を viewport 端で確実に折り返す (3 段防衛)

### DIFF
--- a/server/public/style.css
+++ b/server/public/style.css
@@ -1835,36 +1835,42 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
     max-width: 100vw;
   }
   body { overscroll-behavior-x: none; }
-  /* 長文 / 長 URL / コードブロック / カード文字列を画面幅で確実に折り返す。
-   * `overflow-wrap: anywhere` を全カード系コンテナに広く適用し、 1 単語が
-   * viewport を超える場合でも強制改行させる。 ピンチズーム禁止前提なので
-   * 横スクロールが出ない = 折り返さない限り読めない、 が要件。 */
-  pre, code, .url, .bookmark-url, .visits-url, .dig-url,
-  .title, .summary, .snippet, .meta, .err,
-  .card, .card *, .rec-card, .rec-card *,
-  .dig-source, .dig-source *, .dig-preview-result, .dig-preview-result *,
-  .visits-list li, .visits-list li *,
-  .multi-card, .multi-card *,
-  .diary-bookmark, .diary-bookmark *,
-  .cloud-related-item, .cloud-related-item *,
-  .qg-row, .qg-row *,
-  .queue-running, .queue-running *,
-  .queue-list li, .queue-list li *,
-  .queue-history li, .queue-history li *,
-  .domain-card, .domain-card *,
-  .dict-card, .dict-card *,
-  .ext-setup-help, .ai-settings-help {
-    overflow-wrap: anywhere;
-    word-break: break-word;
-    min-width: 0;
+  /* スマホでは .content 配下の全要素を強制的に viewport 内に閉じ込める。
+   * ピンチズーム禁止前提なので「折り返さない = 読めない」 が要件。
+   *  - * { min-width: 0 } で flex/grid 子の暗黙 min-content を解除
+   *  - * { max-width: 100% } で親幅を超えない
+   *  - 文字系要素 (`:where(...)`) に `word-break: break-all` (最も強い改行
+   *     ルール) と `overflow-wrap: anywhere` を !important 付きで強制
+   *  - .content 自身に `overflow-x: hidden` (最終防衛線)
+   * 例外:
+   *  - .tabs / .tab — タブラベルは折り返したくない
+   *  - input / select / textarea — テキスト wrap の対象ではない
+   */
+  .content, .content * { min-width: 0; max-width: 100%; }
+  .content { overflow-x: hidden; }
+  .content :where(p, span, div, a, h1, h2, h3, h4, h5, h6, li, td, th, dt, dd,
+                  pre, code, label, strong, em, b, i,
+                  .title, .url, .summary, .snippet, .meta, .err,
+                  .card, .rec-card, .dig-source, .dig-preview-result,
+                  .visits-list li, .multi-card, .diary-bookmark,
+                  .cloud-related-item, .qg-row,
+                  .queue-running, .queue-list li, .queue-history li,
+                  .domain-card, .dict-card,
+                  .ext-setup-help, .ai-settings-help) {
+    overflow-wrap: anywhere !important;
+    word-break: break-all !important;
   }
-  /* テーブルや input は別軸の制御が必要なので強制 wrap から除外 */
-  .tabs, .tabs *, table, input, select, textarea, button {
-    overflow-wrap: normal;
-    word-break: normal;
+  /* タブ周りは強制 wrap から除外 (tab label は折り返さない) */
+  .tabs, .tabs *, .tab, .tab * {
+    overflow-wrap: normal !important;
+    word-break: normal !important;
+    white-space: nowrap !important;
   }
-  /* 念のためボタンのラベルは折り返さず ellipsis (タブの幅は管理側で決まる) */
-  .tab { white-space: nowrap; }
+  /* input / select / textarea / button label も対象外 */
+  input, select, textarea, button {
+    overflow-wrap: normal !important;
+    word-break: normal !important;
+  }
 
   /* Mobile topbar: pin .topbar-controls to the top-right via absolute
    * positioning so the ⚙ 設定 + 💡 やり方 buttons always sit in the


### PR DESCRIPTION
## 報告された不具合
ブックマーク折り返されてない。 端で切るようにして

## 原因
PR #75 までは
- `.card / .card *` を列挙して `word-break: break-word` を当てていた
- だが `.card .title { padding-right: 26px }` 等の specificity (0,2,0) と grid track の min-content 解決の組み合わせで wrap が効かないケースが残っていた
- `word-break: break-word` は規格上 `overflow-wrap: anywhere` のエイリアス。 ブラウザ実装の差で hard-wrap (1 文字単位) にならない場合がある

## 修正 (3 段防衛)
1. `.content, .content * { min-width: 0; max-width: 100% }`
   → flex / grid 子の暗黙 `min-content` を解除し、 親幅を絶対に超えない
2. `.content :where(...) { word-break: break-all !important; overflow-wrap: anywhere !important }`
   → `:where()` で specificity を上げずに広範囲をカバー、 `!important` で既存規則を上書き、 `break-all` で 1 文字単位の hard-wrap を強制
3. `.content { overflow-x: hidden }`
   → 最終防衛線

例外:
- `.tabs / .tab / .tab *` → `white-space: nowrap !important` (タブ labelは折り返したくない)
- `input / select / textarea / button` → wrap 対象外

## Test plan
- [ ] 360px viewport で長い URL のブックマークタイトルが viewport 端で折り返す
- [ ] 横スクロールが出ない
- [ ] タブラベルは折り返さない
- [ ] フォーム入力 / 検索ボックスの placeholder が崩れない

🤖 Generated with [Claude Code](https://claude.com/claude-code)