### PR TITLE
fix(mobile): タブ絵文字+短縮ラベル + strip を Top3 (3+More=4 アイテム)

### DIFF
--- a/server/public/app.js
+++ b/server/public/app.js
@@ -602,10 +602,10 @@ function tabsInUsageOrder() {
     return sb - sa;
   });
 }
-// Mobile tab nav is "top 4 most-used (active stays visible) + the rest in
-// a ⋯ More dropdown". 合計 strip にいるタブは常に <= 4 件。 active が
-// top-4 圏外なら top-4 の最下位を 1 件 evict して active を入れる。
-const TABS_VISIBLE_ON_MOBILE = 4;
+// Mobile tab nav is "top 3 most-used (active stays visible) + ⋯ More".
+// strip 全体は 3 タブ + More の 4 アイテム。 active が top-3 圏外なら
+// top-3 の最下位を 1 件 evict して active と入れ替える。
+const TABS_VISIBLE_ON_MOBILE = 3;
 
 function isNarrowViewport() {
   return window.innerWidth <= 760;
@@ -655,9 +655,9 @@ function reflowTabsForViewport() {
     return;
   }
 
-  // 上位 3 件 (使用回数 + default priority) を strip に残す。 active は必ず
-  // 含めるが、 圏外なら top-3 の最下位を 1 件抜いて active と入れ替える。
-  // → strip 内のタブは常に最大 3 件で、 「More」 を押せば残りが見える。
+  // 上位 N 件 (使用回数 + default priority) を strip に残す。 active は必ず
+  // 含めるが、 圏外なら N 件目を 1 件抜いて active と入れ替える。
+  // → strip 内のタブは常に最大 N 件で、 「More」 を押せば残りが見える。
   const active = state.tab;
   const ordered = tabsInUsageOrder()
     .filter(t => !t.hidden);          // skip hidden tabs (e.g. multi)

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -71,24 +71,24 @@
     <section class="content">
       <nav class="tabs">
         <div class="tabs-scroll">
-          <button class="tab active" data-tab="bookmarks">ブックマーク</button>
+          <button class="tab active" data-tab="bookmarks">📚 ブクマ</button>
           <button class="tab" data-tab="queue">
-            作業キュー
+            ⚙ キュー
             <span id="tabQueueCount" class="tab-count hidden">0</span>
           </button>
-          <button class="tab" data-tab="events">📋 イベント</button>
+          <button class="tab" data-tab="events">📋 予定</button>
           <button class="tab" data-tab="visits">
-            アクセス履歴
+            🕘 履歴
             <span id="tabVisitsCount" class="tab-count hidden">0</span>
           </button>
-          <button class="tab" data-tab="trends">傾向</button>
+          <button class="tab" data-tab="trends">📊 傾向</button>
           <button class="tab" data-tab="recommend">
-            おすすめ
+            ✨ 推薦
             <span id="tabRecommendCount" class="tab-count hidden">0</span>
           </button>
-          <button class="tab" data-tab="dig">ディグる</button>
+          <button class="tab" data-tab="dig">🔎 ディグ</button>
           <button class="tab" data-tab="dict">📖 辞書</button>
-          <button class="tab" data-tab="domain">🏷 ドメイン</button>
+          <button class="tab" data-tab="domain">🏷 ドメ</button>
           <button class="tab" data-tab="diary">📅 日記</button>
           <button class="tab" data-tab="tracks">🗺 軌跡</button>
           <button class="tab tab-multi-only" data-tab="multi" hidden>🌐 マルチ</button>


### PR DESCRIPTION
## 報告された不具合
1. 機能タブの文言を絵文字込みで 3-4 文字に
2. ブックマーク→ブクマ、 アクセス履歴→履歴 など略す
3. Top5 になってるので Top4 にする

## 修正

### ラベル短縮 (絵文字 1 + 日本語 2-3 文字)
| 旧 | 新 |
|----|----|
| ブックマーク | 📚 ブクマ |
| 作業キュー | ⚙ キュー |
| 📋 イベント | 📋 予定 |
| アクセス履歴 | 🕘 履歴 |
| 傾向 | 📊 傾向 |
| おすすめ | ✨ 推薦 |
| ディグる | 🔎 ディグ |
| 🏷 ドメイン | 🏷 ドメ |

辞書 / 日記 / 軌跡 / マルチは元から短いので据え置き。

### TABS_VISIBLE_ON_MOBILE 4 → 3
- strip = 3 タブ + ⋯ More = **4 アイテム** にしてユーザー指示と一致
- active が top-3 圏外なら 3 番目を evict して active を入れる、 のロジックは維持

## Test plan
- [ ] スマホ幅で各タブが折り返さず 1 行に収まる
- [ ] strip のアイテム数が 4 (3 タブ + ⋯)
- [ ] active タブは常に strip にいる

🤖 Generated with [Claude Code](https://claude.com/claude-code)