### PR TITLE
feat(mobile): マルチタブ廃止 + Top4 + More選択で leftmost promote

### DIFF
--- a/server/public/app.js
+++ b/server/public/app.js
@@ -602,10 +602,24 @@ function tabsInUsageOrder() {
     return sb - sa;
   });
 }
-// Mobile tab nav is "top 3 most-used (active stays visible) + ⋯ More".
-// strip 全体は 3 タブ + More の 4 アイテム。 active が top-3 圏外なら
-// top-3 の最下位を 1 件 evict して active と入れ替える。
-const TABS_VISIBLE_ON_MOBILE = 3;
+// Mobile tab nav is "top 4 most-used + ⋯ More". active は必ず strip に
+// 表示される。 More から選択したタブは promote されて leftmost に来る
+// (= 旧 4 位を More に押し出す)。
+const TABS_VISIBLE_ON_MOBILE = 4;
+
+/// More メニューから選ばれたタブを strip の 1 番左に持ってくる。
+/// 仕組みは「現状の最大 usage + 1 を割り当てる」 ことで、 既存の usage 並び
+/// では誰よりも上に来る。 通常の strip クリックは bumpTabUsage で +1 され
+/// るので、 promoted タブは新しい promote が起きるまで leftmost を保つ。
+function promoteTabToTop(tab) {
+  const u = readTabUsage();
+  let max = 0;
+  for (const v of Object.values(u)) {
+    if (typeof v === 'number' && v > max) max = v;
+  }
+  u[tab] = max + 1;
+  try { localStorage.setItem(TAB_USAGE_KEY, JSON.stringify(u)); } catch {}
+}
 
 function isNarrowViewport() {
   return window.innerWidth <= 760;
@@ -689,6 +703,9 @@ function reflowTabsForViewport() {
       item.addEventListener('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
+        // More から選んだタブは leftmost に promote。 reflow 時にこのタブが
+        // top-4 のトップに来て、 旧 4 位の機能が More に押し出される。
+        promoteTabToTop(t.dataset.tab);
         switchTab(t.dataset.tab);
         closeTabMoreMenu();
       });

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -91,7 +91,8 @@
           <button class="tab" data-tab="domain">🏷 ドメ</button>
           <button class="tab" data-tab="diary">📅 日記</button>
           <button class="tab" data-tab="tracks">🗺 軌跡</button>
-          <button class="tab tab-multi-only" data-tab="multi" hidden>🌐 マルチ</button>
+          <!-- マルチビューはトップバーのマルチスイッチからのみアクセス。
+               機能タブからは外す (PC/スマホ共通)。 -->
         </div>
         <button type="button" id="tabMoreBtn" class="tab tab-more-btn" aria-haspopup="true" aria-expanded="false" hidden>⋯</button>
         <ul id="tabMoreMenu" class="tab-more-menu" hidden role="menu"></ul>


### PR DESCRIPTION
## 報告された不具合
1. 機能タブの「マルチ」は消す (PC/スマホ両方)
2. スマホの Top4 のカウントが効いていない。 選んだメニューのカウントを計算し、 ページの初回読み込み時に多い順の Top4 を出す
3. More から選択した機能メニューは 1 番左に配置し、 4 位の機能を隠す

## 修正

### 1. マルチタブ削除
- `index.html` から `<button data-tab="multi">` を削除 (PC/スマホ共通)
- マルチビューは topbar のマルチスイッチ経由でのみアクセス
- 残った `.tab-multi-only` 参照は空配列を返す no-op になり、 害なし

### 2. Top4 復活 (3→4)
- `TABS_VISIBLE_ON_MOBILE` を 3→4 に戻す
- 既存の usage 加算 + default priority で初回 Top4 表示は動作

### 3. More 選択で leftmost promote
- `promoteTabToTop(tab)`: usage を `max + 1` にセット → reflow で leftmost
- More メニュー click handler で `switchTab` の前に呼ぶ
- 旧 4 位は usage 降順ソートで自動的に More に押し出される
- 通常の strip クリックは `bumpTabUsage` で +1 のまま、 promote されたタブは新しい promote が来るまで leftmost を保つ

## Test plan
- [ ] PC/スマホ共に機能タブから「マルチ」が消える
- [ ] スマホ strip に 4 タブ + ⋯ More
- [ ] More からタブを選ぶと leftmost に来る、 旧 4 位が More に入る
- [ ] strip 内クリックは順位を緩やかに上げる

🤖 Generated with [Claude Code](https://claude.com/claude-code)