### PR TITLE
feat(dig): テーマドリブン深堀 — 左ペイン + 大型textarea + 文脈引継

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -244,6 +244,11 @@ export function openDb(dbPath) {
   if (!dsCols.includes('preview_json')) {
     db.exec(`ALTER TABLE dig_sessions ADD COLUMN preview_json TEXT`);
   }
+  if (!dsCols.includes('theme')) {
+    db.exec(`ALTER TABLE dig_sessions ADD COLUMN theme TEXT`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_dig_sessions_theme
+              ON dig_sessions(theme, created_at DESC)`);
+  }
 
   const deCols = db.prepare(`PRAGMA table_info(diary_entries)`).all().map(c => c.name);
   if (!deCols.includes('work_content')) db.exec(`ALTER TABLE diary_entries ADD COLUMN work_content TEXT`);
@@ -453,8 +458,10 @@ export function listSuggestedVisits(db, { sinceDays = 30 } = {}) {
 
 // ── dig sessions ----------------------------------------------------------
 
-export function insertDigSession(db, query) {
-  return db.prepare(`INSERT INTO dig_sessions (query) VALUES (?)`).run(query).lastInsertRowid;
+export function insertDigSession(db, query, theme = null) {
+  return db
+    .prepare(`INSERT INTO dig_sessions (query, theme) VALUES (?, ?)`)
+    .run(query, theme || null).lastInsertRowid;
 }
 
 export function setDigResult(db, id, { status, result, error }) {
@@ -479,11 +486,70 @@ export function getDigSession(db, id) {
   };
 }
 
-export function listDigSessions(db, limit = 30) {
+export function listDigSessions(db, { theme, limit = 30 } = {}) {
+  if (theme) {
+    return db.prepare(`
+      SELECT id, query, theme, status, created_at FROM dig_sessions
+      WHERE theme = ?
+      ORDER BY id DESC LIMIT ?
+    `).all(theme, limit);
+  }
   return db.prepare(`
-    SELECT id, query, status, created_at FROM dig_sessions
+    SELECT id, query, theme, status, created_at FROM dig_sessions
     ORDER BY id DESC LIMIT ?
   `).all(limit);
+}
+
+/// テーマ一覧 (各テーマのセッション数 + 最新時刻 + 直近クエリ)。
+/// theme = NULL のセッションは除外。
+export function listDigThemes(db, limit = 60) {
+  return db.prepare(`
+    SELECT
+      theme                      AS theme,
+      COUNT(*)                   AS session_count,
+      MAX(created_at)            AS last_at,
+      (SELECT query FROM dig_sessions s2
+        WHERE s2.theme = s.theme
+        ORDER BY s2.created_at DESC LIMIT 1) AS last_query
+    FROM dig_sessions s
+    WHERE theme IS NOT NULL AND theme <> ''
+    GROUP BY theme
+    ORDER BY last_at DESC
+    LIMIT ?
+  `).all(limit);
+}
+
+/// あるテーマで過去に取得した topics / source 情報をまとめる。
+/// LLM プロンプトに渡すコンテキスト用。
+export function digThemeContext(db, theme, { limit = 8 } = {}) {
+  const sessions = db.prepare(`
+    SELECT id, query, result_json FROM dig_sessions
+    WHERE theme = ? AND status = 'done' AND result_json IS NOT NULL
+    ORDER BY id DESC LIMIT ?
+  `).all(theme, limit);
+  const topics = new Map(); // topic -> count
+  const sources = []; // {url, title}
+  const queries = [];
+  for (const s of sessions) {
+    queries.push(s.query);
+    const r = safeParse(s.result_json);
+    if (!r) continue;
+    for (const src of r.sources || []) {
+      if (src.url && sources.length < 30) {
+        sources.push({ url: src.url, title: src.title || '' });
+      }
+      for (const t of src.topics || []) {
+        const k = String(t).trim().toLowerCase();
+        if (!k) continue;
+        topics.set(k, (topics.get(k) || 0) + 1);
+      }
+    }
+  }
+  const topTopics = [...topics.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 30)
+    .map(([word, count]) => ({ word, count }));
+  return { queries, topics: topTopics, sources };
 }
 
 /** Dig sessions whose created_at falls on the given local date. */

--- a/server/dig.js
+++ b/server/dig.js
@@ -33,9 +33,46 @@ function engineInstruction(engine, query) {
   ].join('\n');
 }
 
-const PROMPT_TEMPLATE = ({ query, engine }) => [
+function themeContextBlock(theme, themeContext) {
+  if (!theme || !themeContext) return '';
+  const { queries = [], topics = [], sources = [] } = themeContext;
+  if (!queries.length && !topics.length && !sources.length) {
+    return [
+      '',
+      `THEME: "${theme}" (まだ過去のディグなし — 最初の調査)`,
+      '',
+    ].join('\n');
+  }
+  const lines = [''];
+  lines.push(`THEME: "${theme}"`);
+  lines.push('THIS IS PART OF AN ONGOING THEME — 既に取得済の文脈は以下:');
+  if (queries.length) {
+    lines.push('  過去のクエリ:');
+    for (const q of queries.slice(0, 6)) {
+      lines.push(`    - ${q}`);
+    }
+  }
+  if (topics.length) {
+    const top = topics.slice(0, 16).map(t => t.word).join(', ');
+    lines.push(`  既知のキーワード: ${top}`);
+  }
+  if (sources.length) {
+    lines.push('  既出のソース (重複は避ける):');
+    for (const s of sources.slice(0, 8)) {
+      lines.push(`    - ${s.url}`);
+    }
+  }
+  lines.push(
+    '注意: 既出のキーワード / ソースを単純に再掲しない。 上記文脈と差分を生む新しい視点 / 新しいソースを優先せよ。'
+  );
+  lines.push('');
+  return lines.join('\n');
+}
+
+const PROMPT_TEMPLATE = ({ query, engine, theme, themeContext }) => [
   'You are a research agent. Use Web search and fetching to gather authoritative sources for the topic the user provides.',
   engineInstruction(engine, query),
+  themeContextBlock(theme, themeContext),
   'Return STRICTLY one JSON object and nothing else (no prose, no code fences):',
   '',
   '{',
@@ -56,9 +93,10 @@ const PROMPT_TEMPLATE = ({ query, engine }) => [
   '- ドメインや視点が偏らないよう多様性を意識する。',
   '- 各ソースの topics は 2〜4 個。後でグラフ化に使う。',
   '- 重複 URL や無関係な広告ページは除外。',
+  theme ? '- THEME 文脈の既出ソースは含めない (上の THEME ブロック参照)。' : '',
   '',
   `QUERY: ${query}`,
-].join('\n');
+].filter(Boolean).join('\n');
 
 const PREVIEW_PROMPT_TEMPLATE = ({ query, engine }) => [
   'You are returning a SERP-style preview as fast as possible.',
@@ -97,13 +135,46 @@ export async function runDigPreview({ query, searchEngine = 'default', timeoutMs
   return parsePreview(stdout);
 }
 
-export async function runDig({ query, searchEngine = 'default', timeoutMs = 600_000 }) {
+export async function runDig({
+  query, searchEngine = 'default', timeoutMs = 600_000,
+  theme = null, themeContext = null,
+}) {
   const engine = engineFor(searchEngine);
-  const prompt = PROMPT_TEMPLATE({ query, engine });
+  const prompt = PROMPT_TEMPLATE({ query, engine, theme, themeContext });
   const stdout = await runLlm({
     task: 'dig', prompt, tools: ['WebSearch', 'WebFetch'], timeoutMs,
   });
   return parseJsonStrict(stdout);
+}
+
+/// ユーザーの query から軽量にテーマ文字列を抽出する。
+/// クライアント / API 双方が同じロジックで揃えられるよう pure 関数。
+///
+/// 方針: 改行や 「。」 で区切った最初のセンテンスから
+///   - URL を除去
+///   - 末尾の助詞 / 句読点を削る
+///   - 30 文字以内に丸める
+///   - 空なら null を返す (= テーマ未設定として扱う)
+export function deriveDigTheme(query) {
+  if (typeof query !== 'string') return null;
+  let text = query.trim();
+  if (!text) return null;
+  // URL を除去
+  text = text.replace(/https?:\/\/\S+/g, ' ');
+  // 改行 / 句点 / ? で最初の塊を取る
+  const first = text.split(/[\n。.\?？]/)[0].trim();
+  // 連続スペースを 1 つに
+  let theme = first.replace(/\s+/g, ' ').trim();
+  if (!theme) return null;
+  // 末尾の助詞 / お願い文をざっくり削る (フォーマルでなく十分)
+  // - について教えて / について調べて / に関して / を教えて / を調べて
+  // - の話 / の件 / とは
+  theme = theme
+    .replace(/(について|に関して)?(教えて|調べて|まとめて|お願い|して?ほしい)?$/u, '')
+    .replace(/(について|に関して|を調べて|を教えて|の話|の件|とは)$/u, '')
+    .trim();
+  if (theme.length > 30) theme = theme.slice(0, 30);
+  return theme || null;
 }
 
 function parsePreview(raw) {

--- a/server/index.js
+++ b/server/index.js
@@ -33,9 +33,10 @@ import {
 import { summarizeWithClaude, htmlToText } from './claude.js';
 import { FifoQueue, ConcurrentPool } from './queue.js';
 import { recommendationsFor, dismissRecommendation, clearDismissals } from './recommendations.js';
-import { runDig, runDigPreview, listSearchEngines } from './dig.js';
+import { runDig, runDigPreview, listSearchEngines, deriveDigTheme } from './dig.js';
 import {
   insertDigSession, setDigResult, setDigPreview, getDigSession, listDigSessions,
+  listDigThemes, digThemeContext,
   digSessionsForDate,
   insertWordCloud, setWordCloudResult, getWordCloud, listWordClouds,
   getBookmarkWordCloud, recentBookmarkWordClouds, trendsVisitDomains,
@@ -466,8 +467,12 @@ app.delete('/api/recommendations/dismissals', (c) => {
 // strictly one job at a time so the user can watch progress in 作業リスト.
 const digQueue = new FifoQueue();
 
-function enqueueDig(id, query, searchEngine = 'default') {
+function enqueueDig(id, query, { searchEngine = 'default', theme = null } = {}) {
   digQueue.enqueue(async () => {
+    // 同テーマの過去セッションから topics / sources / queries を集めて、
+    // LLM プロンプトに 「これまで掘った領域」 として注入。 テーマ無しなら空。
+    const themeCtx = theme ? digThemeContext(db, theme) : null;
+
     // Phase 1: SERP preview (fast — no page fetches). Persisted as soon as
     // it lands so the FE can render before the deep claude pass finishes.
     runDigPreview({ query, searchEngine })
@@ -475,13 +480,13 @@ function enqueueDig(id, query, searchEngine = 'default') {
       .catch(err => console.warn(`[dig#${id}] preview failed: ${err.message}`));
     // Phase 2: full deep analysis with WebFetch (existing behavior).
     try {
-      const result = await runDig({ query, searchEngine });
+      const result = await runDig({ query, searchEngine, theme, themeContext: themeCtx });
       setDigResult(db, id, { status: 'done', result });
     } catch (e) {
       setDigResult(db, id, { status: 'error', error: e.message.slice(0, 500) });
       throw e;
     }
-  }, { kind: 'dig', sessionId: id, title: query, search_engine: searchEngine });
+  }, { kind: 'dig', sessionId: id, title: theme ? `[${theme}] ${query}` : query, search_engine: searchEngine });
 }
 
 app.post('/api/dig', async (c) => {
@@ -489,17 +494,27 @@ app.post('/api/dig', async (c) => {
   const query = body?.query;
   if (!query || typeof query !== 'string') return c.json({ error: 'query required' }, 400);
   const searchEngine = typeof body.search_engine === 'string' ? body.search_engine : 'default';
-  const id = insertDigSession(db, query);
-  enqueueDig(id, query, searchEngine);
-  return c.json({ id, queued: true, search_engine: searchEngine });
+  // テーマ: フロントから明示指定があればそれを採用。 無ければ query から
+  // 簡易抽出 (先頭の意味のあるフレーズ)。
+  const theme = (typeof body.theme === 'string' && body.theme.trim())
+    ? body.theme.trim().slice(0, 60)
+    : deriveDigTheme(query);
+  const id = insertDigSession(db, query, theme);
+  enqueueDig(id, query, { searchEngine, theme });
+  return c.json({ id, queued: true, theme, search_engine: searchEngine });
 });
 
 app.get('/api/dig/engines', (c) => {
   return c.json({ items: listSearchEngines() });
 });
 
+app.get('/api/dig/themes', (c) => {
+  return c.json({ items: listDigThemes(db) });
+});
+
 app.get('/api/dig', (c) => {
-  return c.json({ items: listDigSessions(db) });
+  const theme = c.req.query('theme');
+  return c.json({ items: listDigSessions(db, theme ? { theme } : {}) });
 });
 
 app.get('/api/dig/:id', (c) => {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -17,6 +17,8 @@ const state = {
   digHistory: [],
   digSelected: new Set(),
   digPolling: null,
+  digTheme: '',           // 現在選んでいるテーマ ('' = 全部)
+  digThemes: [],          // GET /api/dig/themes の結果
   cloud: null,           // {id, status, label, result, parent_cloud_id, parent_word, origin, ...}
   cloudPolling: null,
   cloudShowDropped: false,
@@ -719,14 +721,88 @@ function reflowTabsForViewport() {
 }
 
 // ── Dig (deep research) ──────────────────────────────────────────────────
+//
+// テーマドリブン:
+//  - state.digTheme: 現在選んでいるテーマ ('' = 全部)
+//  - 左のテーマペインはセッションが付いたテーマを最新順に並べる
+//  - 「ディグる」 押下時、 state.digTheme があればそれを引き継ぐ。 無ければ
+//    バックエンドが query から自動で導出してくれる。
 
 async function loadDigHistory() {
   try {
-    const { items } = await api('/api/dig');
+    const qs = state.digTheme ? `?theme=${encodeURIComponent(state.digTheme)}` : '';
+    const { items } = await api(`/api/dig${qs}`);
     state.digHistory = items;
     renderDigHistory();
     if (!state.digEnginesLoaded) loadDigEngines();
+    loadDigThemes();
   } catch (e) { console.error(e); }
+}
+
+async function loadDigThemes() {
+  try {
+    const { items } = await api('/api/dig/themes');
+    state.digThemes = items;
+    renderDigThemes();
+  } catch (e) { console.error(e); }
+}
+
+function renderDigThemes() {
+  const list = $('digThemeList');
+  if (!list) return;
+  // Build the "全部" first item, then one per theme.
+  const totalCount = state.digThemes
+    ? state.digThemes.reduce((acc, t) => acc + (t.session_count || 0), 0)
+    : 0;
+  const themes = state.digThemes || [];
+  const items = [
+    `<li class="dig-theme-item ${state.digTheme ? '' : 'active'}" data-theme="">
+       <span class="theme-name">全部</span>
+       <span class="count">${totalCount || ''}</span>
+     </li>`,
+    ...themes.map(t => {
+      const active = state.digTheme === t.theme ? 'active' : '';
+      return `<li class="dig-theme-item ${active}" data-theme="${escapeHtml(t.theme)}"
+                  title="${escapeHtml(t.last_query || '')}\n最終: ${escapeHtml(t.last_at || '')}">
+        <span class="theme-name">${escapeHtml(t.theme)}</span>
+        <span class="count">${t.session_count}</span>
+      </li>`;
+    }),
+  ];
+  list.innerHTML = items.join('');
+  list.querySelectorAll('.dig-theme-item').forEach(li => {
+    li.addEventListener('click', () => {
+      state.digTheme = li.dataset.theme || '';
+      // Theme 切替で履歴 + バッジ + 結果ペインをクリア
+      state.digSession = null;
+      state.digSelected = new Set();
+      const result = $('digResult');
+      if (result) result.innerHTML = '';
+      renderDigThemeBadge();
+      renderDigThemes();
+      loadDigHistory();
+    });
+  });
+}
+
+function renderDigThemeBadge() {
+  const badge = $('digThemeBadge');
+  if (!badge) return;
+  if (state.digTheme) {
+    badge.hidden = false;
+    badge.innerHTML = `<span class="dig-theme-badge-label">テーマ:</span>
+      <strong>${escapeHtml(state.digTheme)}</strong>
+      <button id="digThemeBadgeClear" class="ghost" title="テーマ選択を解除">×</button>`;
+    badge.querySelector('#digThemeBadgeClear')?.addEventListener('click', () => {
+      state.digTheme = '';
+      renderDigThemeBadge();
+      renderDigThemes();
+      loadDigHistory();
+    });
+  } else {
+    badge.hidden = true;
+    badge.innerHTML = '';
+  }
 }
 
 async function loadDigEngines() {
@@ -742,11 +818,14 @@ async function loadDigEngines() {
 function renderDigHistory() {
   const el = $('digHistory');
   if (!state.digHistory.length) {
-    el.innerHTML = '<span style="color:var(--muted);font-size:11px">過去のディグなし</span>';
+    const msg = state.digTheme
+      ? `テーマ "${escapeHtml(state.digTheme)}" のディグなし`
+      : '過去のディグなし';
+    el.innerHTML = `<span style="color:var(--muted);font-size:11px">${msg}</span>`;
     return;
   }
   el.innerHTML = state.digHistory.map(s =>
-    `<span class="pill ${s.status}" data-id="${s.id}" title="${escapeHtml(s.created_at)}">
+    `<span class="pill ${s.status}" data-id="${s.id}" title="${escapeHtml(s.created_at)}${s.theme ? ` [${escapeHtml(s.theme)}]` : ''}">
       ${escapeHtml(s.query.slice(0, 30))}${s.query.length > 30 ? '…' : ''}
     </span>`
   ).join('');
@@ -763,22 +842,31 @@ async function startDig({ chainCloudId, chainParentWord } = {}) {
   try {
     const engineSel = $('digEngine');
     const search_engine = engineSel ? engineSel.value : 'default';
+    // 現在テーマペインで選んでいるテーマを引き継ぐ。 「全部」 なら未指定で
+    // バックエンドに自動導出させる。
+    const body = { query: q, search_engine };
+    if (state.digTheme) body.theme = state.digTheme;
     const r = await api('/api/dig', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ query: q, search_engine }),
+      body: JSON.stringify(body),
     });
     state.digChain = {
       cloudId: chainCloudId ?? null,
       parentWord: chainParentWord ?? null,
     };
+    // 新規 dig が落ち着いたテーマがあれば、 それを current として引き継ぐ。
+    if (r.theme && !state.digTheme) {
+      state.digTheme = r.theme;
+      renderDigThemeBadge();
+    }
     await loadDigHistory();
     pollDigSession(r.id);
   } catch (e) {
     alert(`dig 失敗: ${e.message}`);
   } finally {
     $('digRun').disabled = false;
-    $('digRun').textContent = 'ディグる';
+    $('digRun').textContent = '🔎 ディグる';
   }
 }
 
@@ -3025,10 +3113,14 @@ $('trendsRange').addEventListener('change', (e) => {
 });
 $('recRefresh').addEventListener('click', () => loadRecommendations(true));
 $('digRun').addEventListener('click', () => startDig());
+// textarea で Cmd/Ctrl+Enter は ディグる、 通常 Enter は改行のままにする
+// (5 行 textarea で複数行クエリを書けるようにするため)。
 $('digQuery').addEventListener('keydown', (e) => {
-  if (e.key === 'Enter') { e.preventDefault(); startDig(); }
+  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+    e.preventDefault();
+    startDig();
+  }
 });
-$('digFromBookmarks')?.addEventListener('click', startCloudFromBookmarks);
 $('dictNewBtn')?.addEventListener('click', createDictionaryEntry);
 $('dictSaveBtn')?.addEventListener('click', saveDictionaryEntry);
 $('dictDeleteBtn')?.addEventListener('click', deleteDictionaryEntry);

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -212,19 +212,51 @@
       </div>
 
       <div id="digView" class="hidden">
-        <div class="dig-input">
-          <input id="digQuery" type="text" placeholder="掘りたい単語または質問を入力 (例: WebGPU compute shader readback)" />
-          <select id="digEngine" title="検索エンジン" class="dig-engine"></select>
-          <button id="digRun">ディグる</button>
-          <button id="digFromBookmarks" class="ghost" title="既存のブックマークからワードクラウドを作る">📚 ブクマから雲</button>
+        <div class="dig-layout">
+          <aside class="dig-themes">
+            <h3>テーマ</h3>
+            <ul id="digThemeList" class="dig-theme-list">
+              <li class="dig-theme-item active" data-theme="">
+                <span class="theme-name">全部</span>
+                <span class="count" id="digThemeAllCount"></span>
+              </li>
+            </ul>
+          </aside>
+
+          <div class="dig-main">
+            <header class="dig-head">
+              <h2>テーマを決めて深堀</h2>
+              <p class="dig-howto">
+                掘りたい話題やキーワードを下に書いて <b>ディグる</b> を押すと、
+                Web 検索 + AI が関連ソースを集めて整理します。
+                同じテーマで何度も掘ると、 <b>左のテーマ一覧</b> から再開できる
+                ようになり、 過去に集めたキーワード / ソースを引き継いで差分を
+                探します。
+              </p>
+              <div id="digThemeBadge" class="dig-theme-badge" hidden></div>
+            </header>
+
+            <div class="dig-input">
+              <textarea id="digQuery" rows="5"
+                placeholder="例: WebGPU の compute shader で readback を効率化する方法は? ベンチマークやベストプラクティスを集めたい"></textarea>
+              <button id="digRun" class="dig-run-btn">🔎 ディグる</button>
+            </div>
+            <div class="dig-input-row2">
+              <label class="dig-engine-label">
+                AI / 検索エンジン
+                <select id="digEngine" title="AI が使う検索エンジン" class="dig-engine"></select>
+              </label>
+            </div>
+
+            <div id="digHistory" class="dig-history"></div>
+            <div id="cloudView" class="dig-cloud"></div>
+            <div id="digShareBar" class="dig-share-bar" hidden>
+              <button id="digShareBtn" class="ghost" title="マルチサーバに共有">📤 シェア</button>
+              <span id="digShareStatus" class="share-status"></span>
+            </div>
+            <div id="digResult" class="dig-result"></div>
+          </div>
         </div>
-        <div id="digHistory" class="dig-history"></div>
-        <div id="cloudView" class="dig-cloud"></div>
-        <div id="digShareBar" class="dig-share-bar" hidden>
-          <button id="digShareBtn" class="ghost" title="マルチサーバに共有">📤 シェア</button>
-          <span id="digShareStatus" class="share-status"></span>
-        </div>
-        <div id="digResult" class="dig-result"></div>
       </div>
 
       <div id="recommendView" class="hidden">

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -578,19 +578,141 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   margin-left: 6px;
 }
 
+/* ─── Dig view: テーマドリブン 2 ペイン ─────────────────────────────── */
+
+.dig-layout {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  width: 100%;
+}
+.dig-themes {
+  flex: 0 0 170px;
+  width: 170px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px;
+  box-shadow: var(--shadow);
+}
+.dig-themes h3 {
+  font-size: 12px;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0 0 8px;
+  letter-spacing: 0.04em;
+}
+.dig-theme-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.dig-theme-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  color: var(--text);
+  border-radius: 6px;
+  padding: 6px 8px;
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1.4;
+}
+.dig-theme-item:hover { background: #f0f2f7; }
+.dig-theme-item.active {
+  background: var(--accent-bg);
+  color: var(--accent);
+  font-weight: 600;
+}
+.dig-theme-item .theme-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.dig-theme-item .count {
+  color: var(--muted);
+  font-size: 11px;
+  flex: 0 0 auto;
+}
+.dig-theme-item.active .count { color: var(--accent); }
+
+.dig-main { flex: 1 1 auto; min-width: 0; }
+.dig-head h2 { margin: 0 0 6px; font-size: 18px; }
+.dig-howto {
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.6;
+  margin: 0 0 12px;
+}
+.dig-theme-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--accent-bg);
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 999px;
+  padding: 4px 12px;
+  font-size: 12px;
+  margin-bottom: 12px;
+}
+.dig-theme-badge[hidden] { display: none; }
+.dig-theme-badge-label { color: var(--muted); }
+.dig-theme-badge .ghost {
+  padding: 0 6px;
+  font-size: 14px;
+  line-height: 1;
+  border-radius: 999px;
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  cursor: pointer;
+}
+
 .dig-input {
   display: flex;
   gap: 8px;
-  margin-bottom: 12px;
+  margin-bottom: 8px;
+  align-items: stretch;
 }
-.dig-input input {
-  flex: 1;
+.dig-input textarea {
+  flex: 1 1 auto;
+  min-width: 0;
   padding: 12px 14px;
   border: 1px solid var(--border);
   border-radius: 8px;
   font-size: 14px;
+  font-family: inherit;
+  line-height: 1.5;
+  resize: vertical;
 }
-.dig-input button { padding: 12px 20px; font-size: 14px; }
+.dig-input textarea:focus { outline: 2px solid var(--accent); outline-offset: -1px; }
+.dig-input .dig-run-btn {
+  padding: 0 22px;
+  font-size: 15px;
+  font-weight: 600;
+  flex: 0 0 auto;
+  align-self: stretch;
+  white-space: nowrap;
+}
+.dig-input-row2 {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 16px;
+}
+.dig-engine-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--muted);
+}
 .dig-history {
   display: flex;
   gap: 6px;
@@ -2047,6 +2169,33 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   }
   .diary-detail { padding: 12px; }
   .diary-pie-row { flex-direction: column; }
+
+  /* Dig view: スマホでは左テーマペインを上に積む (PC の 2 ペインから
+   * 縦 2 段構成へ)。 テーマペインは少し低めにして横スクロール可能にする。 */
+  .dig-layout {
+    flex-direction: column;
+    gap: 8px;
+  }
+  .dig-themes {
+    flex: 0 0 auto;
+    width: 100%;
+  }
+  .dig-theme-list {
+    flex-direction: row;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    gap: 6px;
+    scrollbar-width: none;
+  }
+  .dig-theme-list::-webkit-scrollbar { display: none; }
+  .dig-theme-item {
+    flex: 0 0 auto;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 4px 12px;
+  }
+  .dig-input { flex-direction: column; }
+  .dig-input .dig-run-btn { width: 100%; padding: 10px; }
 
   /* Bookmark cards stack rather than tile. ブックマーク (とそれ以外の
    * すべての主要ビュー) は viewport - 8px 内に収める。 */


### PR DESCRIPTION
## 目的
ディグるを「テーマを決めて深堀」する機能に改修。 ブクマ同様の左ペイン + テーマ別履歴 + LLM プロンプトに過去文脈を注入して既出を避けた差分調査を促す。

## DB
- `dig_sessions.theme TEXT` 追加 (migration + index `(theme, created_at DESC)`)
- `listDigThemes(db)` / `digThemeContext(db, theme)` を追加

## API
- `POST /api/dig` が `theme?` を受ける。 未指定なら `deriveDigTheme(query)` で自動抽出
- `GET /api/dig/themes` (新規)
- `GET /api/dig?theme=X` でテーマ絞り

## prompt
- `runDig({ theme, themeContext })` で PROMPT_TEMPLATE に THEME ブロックを差込み
- 過去のクエリ / 既知のキーワード / 既出ソース を列挙し、 LLM に「重複を避けて差分を取れ」と指示

## UI
- `digView` を 2 ペイン化 (左テーマ 170px + 右メイン)
- ヘッダ「テーマを決めて深堀」 + やり方説明
- 大型 `<textarea rows="5">` + 横長 `🔎 ディグる` ボタン
- 検索エンジン pulldown は次の行 (「AI / 検索エンジン」)
- 「📚 ブクマから雲」削除
- スマホ: 縦積み + テーマピルの横スクロール

## Test plan
- [ ] textarea でクエリ + ディグるで動く
- [ ] 左ペインにテーマが追加される
- [ ] テーマ click で履歴フィルタ
- [ ] 同テーマ再ディグで LLM プロンプトに過去 topics/sources が含まれる
- [ ] スマホで横スクロール無し

🤖 Generated with [Claude Code](https://claude.com/claude-code)