### PR TITLE
feat(diary): 日記完成時に push 通知を送る

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1933,6 +1933,15 @@ function enqueueDiaryStages(dateStr, opts = {}) {
         status: 'done',
         error: null,
       });
+      // 日記が完成したら登録済端末に push 通知。 失敗しても本体には影響させない。
+      sendPushToAll(db, {
+        title: `📝 ${dateStr} の日記が完成しました`,
+        body: ctx.highlights ? ctx.highlights.split('\n').slice(0, 2).join(' ').slice(0, 140) : '作業内容とハイライトが揃いました',
+        url: `/?tab=diary&date=${encodeURIComponent(dateStr)}`,
+        tag: `memoria-diary-${dateStr}`,
+      }).catch((err) => {
+        console.warn(`[push] diary notification failed: ${err.message}`);
+      });
     } catch (e) {
       rememberFailure('highlights', e);
       throw e;


### PR DESCRIPTION
## Summary

PR #84 で導入した内蔵 WebPush 実装の最初のトリガー。 日記がハイライト
生成まで終わって `status=done` になったタイミングで、 登録済端末に
\`sendPushToAll\` で通知を送る。

## 通知内容

| field | 値 |
|---|---|
| title | \`📝 {dateStr} の日記が完成しました\` |
| body  | ハイライト先頭 2 行 (140 文字 cap) or デフォルト文 |
| url   | \`/?tab=diary&date=YYYY-MM-DD\` |
| tag   | \`memoria-diary-YYYY-MM-DD\` |

タグで同日複数回生成しても最新で置換される。

## エラーハンドリング

push 失敗は \`.catch()\` で warn ログ + 黙殺、 日記保存自体には伝播させない。

## Test plan

- [ ] \`node --check\` pass (確認済)
- [ ] \`npm run typecheck\` pass (確認済)
- [ ] CI smoke test pass
- [ ] 手動: 「通知を有効化」 した端末で日記生成 → push 通知が届く
- [ ] 手動: 通知未許可端末では何も起きず、 日記は通常完成する

🤖 Generated with [Claude Code](https://claude.com/claude-code)