### PR TITLE
feat(dig): ディグ完了時に push 通知を送る

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -553,6 +553,13 @@ function enqueueDig(id, query, { searchEngine = 'default', theme = null } = {}) 
     try {
       const result = await runDig({ query, searchEngine, theme, themeContext: themeCtx });
       setDigResult(db, id, { status: 'done', result });
+      // Dig 完了で push 通知 (登録済端末のみ)。 失敗は本体に影響させない。
+      sendPushToAll(db, {
+        title: `🔍 ディグ完了: ${query.slice(0, 40)}`,
+        body: theme ? `テーマ: ${theme}` : 'AI 分析が出揃いました',
+        url: `/?tab=dig&dig=${id}`,
+        tag: `memoria-dig-${id}`,
+      }).catch((err) => console.warn(`[push] dig#${id} notification failed: ${err.message}`));
     } catch (e) {
       setDigResult(db, id, { status: 'error', error: e.message.slice(0, 500) });
       throw e;


### PR DESCRIPTION
## Summary

PR #85 (日記完成時通知) と同型で、 Dig 完了時にも \`sendPushToAll\` を呼ぶ。
LLM の deep 分析は数十秒かかるため、 完了通知が体感的に効果が大きい。

## 通知内容

| field | 値 |
|---|---|
| title | \`🔍 ディグ完了: <query 40 字>\` |
| body  | テーマがあれば「テーマ: <theme>」、 なければ汎用文 |
| url   | \`/?tab=dig&dig=<id>\` |
| tag   | \`memoria-dig-<id>\` |

エラー時 (status=error) は通知しない (失敗を push で伝える価値が低い)。

## Test plan

- [ ] \`node --check\` pass (確認済)
- [ ] CI smoke test pass
- [ ] 手動: 「通知を有効化」 した端末で dig 投入 → 完了時に push 通知が届く

🤖 Generated with [Claude Code](https://claude.com/claude-code)