### PR TITLE
feat(bookmark): AI 要約完了を batch 化して push 通知

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -201,6 +201,41 @@ function maybeQueueDomain(url) {
   }, { kind: 'domain', domain, title: domain });
 }
 
+// ブクマ AI 要約完了の push 通知は batch 化する。 個別通知は頻度過多
+// (一度に 10〜30 件まとめて入れる運用) なので、 5 件 or 5 分でまとめて 1 回。
+const bookmarkPushState = { items: /** @type {{id: number; title: string}[]} */ ([]), timer: /** @type {NodeJS.Timeout | null} */ (null) };
+const BOOKMARK_PUSH_BATCH_SIZE = 5;
+const BOOKMARK_PUSH_DEBOUNCE_MS = 5 * 60_000;
+
+function flushBookmarkSummaryPush() {
+  if (bookmarkPushState.items.length === 0) return;
+  const items = bookmarkPushState.items;
+  bookmarkPushState.items = [];
+  if (bookmarkPushState.timer) {
+    clearTimeout(bookmarkPushState.timer);
+    bookmarkPushState.timer = null;
+  }
+  const titleLines = items.slice(0, 5).map((it) => `・${(it.title || '').slice(0, 60)}`).join('\n');
+  const more = items.length > 5 ? `\n…他 ${items.length - 5} 件` : '';
+  sendPushToAll(db, {
+    title: `📚 AI 要約完了 (${items.length} 件)`,
+    body: titleLines + more,
+    url: '/?tab=bookmarks',
+    tag: 'memoria-bookmark-summary',
+  }).catch((err) => console.warn(`[push] bookmark batch failed: ${err.message}`));
+}
+
+function notifyBookmarkSummaryDone(id, title) {
+  bookmarkPushState.items.push({ id, title: title || '(untitled)' });
+  if (bookmarkPushState.items.length >= BOOKMARK_PUSH_BATCH_SIZE) {
+    flushBookmarkSummaryPush();
+    return;
+  }
+  if (!bookmarkPushState.timer) {
+    bookmarkPushState.timer = setTimeout(flushBookmarkSummaryPush, BOOKMARK_PUSH_DEBOUNCE_MS);
+  }
+}
+
 function enqueueSummary(id) {
   const b = getBookmark(db, id);
   summaryQueue.enqueue(async () => {
@@ -217,6 +252,8 @@ function enqueueSummary(id) {
         url: cur.url, title: cur.title, html,
       });
       setSummary(db, id, { summary, categories, status: 'done' });
+      // batch 化された push 通知 (5 件 or 5 分)
+      notifyBookmarkSummaryDone(id, cur.title);
     } catch (e) {
       setSummary(db, id, { summary: null, categories: [], status: 'error', error: e.message.slice(0, 500) });
       throw e;


### PR DESCRIPTION
## Summary

PR #85 (日記) / #86 (Dig) と同シリーズで、 ブクマの AI 要約完了でも
push 通知。 ただしブクマ要約は一度に 10-30 件まとめて投入する運用なので、
個別通知は頻度過多 → batch 化。

## batch 戦略

- 5 件たまったら即時 flush
- 1 件目から 5 分経過したら flush (debounce)
- どちらか早い方で 1 通の通知に集約

## 通知内容

| field | 値 |
|---|---|
| title | \`📚 AI 要約完了 (N 件)\` |
| body  | 直近 5 件の title (60 字 cap)、 6 件目以上は「…他 X 件」 |
| url   | \`/?tab=bookmarks\` |
| tag   | \`memoria-bookmark-summary\` (連続 batch も最新で置換、 通知爆撃回避) |

## 注意

- error で終わったブクマは notify しない (失敗を push する価値が低い)
- FifoQueue の serial 性に依存
- batch state は in-memory (process 終了で消える、 永続化不要)

## Test plan

- [ ] \`node --check\` pass (確認済)
- [ ] \`npm run typecheck\` pass (確認済)
- [ ] CI smoke test pass
- [ ] 手動: 通知有効化 + 5 件以上ブクマ追加 → 1 通だけ届く
- [ ] 手動: 1-2 件だけ追加 → 5 分後に 1 通届く

🤖 Generated with [Claude Code](https://claude.com/claude-code)