### PR TITLE
perf(bookmarks): /api/bookmarks を 50 件ページングに

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -361,7 +361,20 @@ export function deletePushSubscription(db, id) {
 
 // ── bookmarks DAO ─────────────────────────────────────────────
 
-export function listBookmarks(db, { category, sort = 'created_desc' } = {}) {
+/**
+ * List bookmarks with optional category / search / pagination.
+ *
+ * - `q` does a SQL LIKE across title / url / summary so the front-end
+ *   doesn't have to keep all rows in memory just to do client-side filtering
+ *   (the original UI fetched everything and filtered locally — fine at
+ *   100 bookmarks, painful at thousands).
+ * - `limit` is opt-in. Internal callers that want every bookmark (cloud
+ *   extraction, export, recommendations) keep working unchanged because
+ *   the function still returns a plain array; pagination is only applied
+ *   when `limit` is a positive number. Use `countBookmarks` for the total
+ *   when paginating.
+ */
+export function listBookmarks(db, { category, sort = 'created_desc', limit, offset = 0, q } = {}) {
   const orderClauses = {
     created_desc: 'b.created_at DESC',
     created_asc: 'b.created_at ASC',
@@ -370,18 +383,50 @@ export function listBookmarks(db, { category, sort = 'created_desc' } = {}) {
     title_asc: 'b.title ASC',
   };
   const orderBy = orderClauses[sort] ?? orderClauses.created_desc;
-  let rows;
+  const where = [];
+  const params = [];
+  let join = '';
   if (category) {
-    rows = db.prepare(`
-      SELECT b.* FROM bookmarks b
-      JOIN bookmark_categories bc ON bc.bookmark_id = b.id
-      WHERE bc.category = ?
-      ORDER BY ${orderBy}
-    `).all(category);
-  } else {
-    rows = db.prepare(`SELECT b.* FROM bookmarks b ORDER BY ${orderBy}`).all();
+    join = 'JOIN bookmark_categories bc ON bc.bookmark_id = b.id';
+    where.push('bc.category = ?');
+    params.push(category);
   }
+  if (q) {
+    where.push('(b.title LIKE ? OR b.url LIKE ? OR COALESCE(b.summary, \'\') LIKE ?)');
+    const pat = `%${q}%`;
+    params.push(pat, pat, pat);
+  }
+  const whereClause = where.length ? `WHERE ${where.join(' AND ')}` : '';
+  let sql = `SELECT b.* FROM bookmarks b ${join} ${whereClause} ORDER BY ${orderBy}`;
+  const queryParams = [...params];
+  if (Number.isFinite(limit) && limit > 0) {
+    sql += ' LIMIT ? OFFSET ?';
+    queryParams.push(Math.floor(limit), Math.max(0, Math.floor(offset) || 0));
+  }
+  const rows = db.prepare(sql).all(...queryParams);
   return rows.map(r => ({ ...r, categories: getCategories(db, r.id) }));
+}
+
+/** Count bookmarks matching the same filters as `listBookmarks`. Cheaper
+ * than fetching everything just to check `length`, and lets the UI show
+ * "全 N 件中 M 件表示中" when paginating. */
+export function countBookmarks(db, { category, q } = {}) {
+  const where = [];
+  const params = [];
+  let join = '';
+  if (category) {
+    join = 'JOIN bookmark_categories bc ON bc.bookmark_id = b.id';
+    where.push('bc.category = ?');
+    params.push(category);
+  }
+  if (q) {
+    where.push('(b.title LIKE ? OR b.url LIKE ? OR COALESCE(b.summary, \'\') LIKE ?)');
+    const pat = `%${q}%`;
+    params.push(pat, pat, pat);
+  }
+  const whereClause = where.length ? `WHERE ${where.join(' AND ')}` : '';
+  const row = db.prepare(`SELECT COUNT(DISTINCT b.id) AS n FROM bookmarks b ${join} ${whereClause}`).get(...params);
+  return row.n;
 }
 
 export function getBookmark(db, id) {

--- a/server/index.js
+++ b/server/index.js
@@ -11,6 +11,7 @@ import {
   insertBookmark,
   setSummary,
   listBookmarks,
+  countBookmarks,
   getBookmark,
   listAllCategories,
   updateMemoAndCategories,
@@ -332,9 +333,19 @@ app.post('/api/bookmark', async (c) => {
 });
 
 app.get('/api/bookmarks', (c) => {
+  // Pagination: bookmark count grew enough that returning every row + every
+  // category lookup got noticeably slow. The UI now requests 50 at a time
+  // (with `?q=` for server-side search) and asks for the next page on
+  // demand. Internal callers (export / wordcloud / recommendations) skip
+  // the limit and keep getting the full array.
   const category = c.req.query('category') || undefined;
   const sort = c.req.query('sort') || undefined;
-  return c.json({ items: listBookmarks(db, { category, sort }) });
+  const q = c.req.query('q')?.trim() || undefined;
+  const limit = Math.min(200, Math.max(1, Number(c.req.query('limit')) || 50));
+  const offset = Math.max(0, Number(c.req.query('offset')) || 0);
+  const items = listBookmarks(db, { category, sort, q, limit, offset });
+  const total = countBookmarks(db, { category, q });
+  return c.json({ items, total, limit, offset });
 });
 
 app.get('/api/bookmarks/:id', (c) => {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -1,10 +1,14 @@
+const BOOKMARKS_PAGE_SIZE = 50;
+
 const state = {
   bookmarks: [],
+  bookmarksTotal: 0,
   categories: [],
   category: null,
   selected: new Set(),
   detailId: null,
   search: '',
+  searchDebounce: null,
   sort: 'created_desc',
   tab: 'bookmarks',
   queue: { items: [], history: [] },
@@ -59,16 +63,28 @@ function fmtDate(s) {
   return d.toLocaleString();
 }
 
-async function load() {
-  const q = new URLSearchParams();
-  if (state.category) q.set('category', state.category);
-  if (state.sort) q.set('sort', state.sort);
-  const [{ items: bookmarks }, { items: categories }] = await Promise.all([
-    api(`/api/bookmarks?${q.toString()}`),
+async function load(opts = {}) {
+  // 50 件ずつのページング。 「もっと表示」 で append=true、 それ以外
+  // (カテゴリ切替 / ソート変更 / 検索 / 自動 refresh) は先頭から取り直す。
+  const append = opts.append === true;
+  const offset = append ? state.bookmarks.length : 0;
+  const qs = new URLSearchParams();
+  if (state.category) qs.set('category', state.category);
+  if (state.sort) qs.set('sort', state.sort);
+  if (state.search) qs.set('q', state.search);
+  qs.set('limit', String(BOOKMARKS_PAGE_SIZE));
+  qs.set('offset', String(offset));
+  const [bookmarksRes, categoriesRes] = await Promise.all([
+    api(`/api/bookmarks?${qs.toString()}`),
     api('/api/categories'),
   ]);
-  state.bookmarks = bookmarks;
-  state.categories = categories;
+  state.bookmarks = append
+    ? [...state.bookmarks, ...(bookmarksRes.items || [])]
+    : (bookmarksRes.items || []);
+  state.bookmarksTotal = Number.isFinite(bookmarksRes.total)
+    ? bookmarksRes.total
+    : state.bookmarks.length;
+  state.categories = categoriesRes.items;
   render();
 }
 
@@ -81,7 +97,9 @@ function render() {
 
 function renderCategories() {
   const ul = $('categoryList');
-  const total = state.bookmarks.length;
+  // Use the server-reported total (across the whole DB) rather than
+  // `state.bookmarks.length` which is just the current page (≤ 50).
+  const total = state.bookmarksTotal;
   let html = '';
   html += `<li class="${state.category === null ? 'active' : ''}" data-cat="">すべて<span class="count">${total}</span></li>`;
   for (const c of state.categories) {
@@ -127,12 +145,10 @@ function setupCategoriesDrawer() {
 function renderCards() {
   const wrap = $('cards');
   const empty = $('empty');
-  const search = state.search.toLowerCase();
-  const items = state.bookmarks.filter(b => {
-    if (!search) return true;
-    const haystack = `${b.title} ${b.url} ${b.summary ?? ''} ${(b.categories||[]).join(' ')}`.toLowerCase();
-    return haystack.includes(search);
-  });
+  // Search filtering now happens server-side (?q=...). The full page is
+  // already what we want to render — no local re-filtering.
+  const items = state.bookmarks;
+  renderBookmarksMore();
   if (items.length === 0) {
     wrap.innerHTML = '';
     empty.classList.remove('hidden');
@@ -181,6 +197,40 @@ function renderBulk() {
   const bar = $('bulkBar');
   $('bulkCount').textContent = state.selected.size;
   bar.classList.toggle('hidden', state.selected.size === 0);
+}
+
+function renderBookmarksMore() {
+  // The "もっと表示" button at the bottom of the card grid. Visible only
+  // when the server says there are more rows than we've loaded so far.
+  const btn = $('bookmarksMore');
+  const status = $('bookmarksMoreStatus');
+  if (!btn) return;
+  const loaded = state.bookmarks.length;
+  const total = state.bookmarksTotal;
+  const remaining = Math.max(0, total - loaded);
+  if (status) {
+    status.textContent = total > 0
+      ? `${loaded} / ${total} 件表示中`
+      : '';
+  }
+  if (remaining > 0) {
+    btn.hidden = false;
+    btn.disabled = false;
+    btn.textContent = `もっと表示 (残り ${remaining} 件)`;
+  } else {
+    btn.hidden = true;
+  }
+}
+
+async function loadMoreBookmarks() {
+  const btn = $('bookmarksMore');
+  if (btn) { btn.disabled = true; btn.textContent = '読み込み中…'; }
+  try {
+    await load({ append: true });
+  } catch (e) {
+    alert(`追加読み込み失敗: ${e.message}`);
+    if (btn) btn.disabled = false;
+  }
 }
 
 async function openDetail(id) {
@@ -355,13 +405,18 @@ function escapeHtml(s) {
 // ---- wire up ---------------------------------------------------------------
 
 $('search').addEventListener('input', (e) => {
+  // Search is now server-side (?q=) so each keystroke triggers a fetch.
+  // Debounce by 250ms — long enough to skip "in-flight typing" but short
+  // enough that the result list feels live.
   state.search = e.target.value;
-  renderCards();
+  if (state.searchDebounce) clearTimeout(state.searchDebounce);
+  state.searchDebounce = setTimeout(() => load(), 250);
 });
 $('sort').addEventListener('change', (e) => {
   state.sort = e.target.value;
   load();
 });
+$('bookmarksMore')?.addEventListener('click', () => loadMoreBookmarks());
 $('detailClose').addEventListener('click', closeDetail);
 $('dSave').addEventListener('click', saveDetail);
 $('dResummarize').addEventListener('click', resummarizeDetail);

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -139,6 +139,10 @@
           <div class="bookmarks-main">
             <div id="cards" class="cards"></div>
             <div id="empty" class="empty hidden">ブックマークがありません。Chrome 拡張からページを保存してください。</div>
+            <div class="bookmarks-more-bar">
+              <span id="bookmarksMoreStatus" class="bookmarks-more-status"></span>
+              <button id="bookmarksMore" type="button" class="bookmarks-more-btn" hidden>もっと表示</button>
+            </div>
           </div>
         </div>
       </div>

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -105,6 +105,39 @@ body {
 .bookmarks-toolbar input[type=search] { min-width: 240px; flex: 0 1 320px; }
 .bookmarks-toolbar .categories-toggle { display: none; }
 
+/* Pagination footer — sits under the card grid. Shows "M / N 件表示中" and
+ * a 「もっと表示」 button when more rows are available server-side. */
+.bookmarks-more-bar {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 8px 8px;
+  flex-wrap: wrap;
+}
+.bookmarks-more-status {
+  font-size: 12px;
+  color: var(--muted);
+}
+.bookmarks-more-btn {
+  background: var(--panel);
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  padding: 8px 18px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  border-radius: 6px;
+}
+.bookmarks-more-btn:hover:not(:disabled) {
+  background: var(--accent-bg);
+}
+.bookmarks-more-btn:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+.bookmarks-more-btn[hidden] { display: none; }
+
 button, .ghost, .file-btn {
   font-size: 13px;
   padding: 6px 12px;


### PR DESCRIPTION
## Summary

- ブクマ件数が増えて \`/api/bookmarks\` の全件取得 + 各 row の \`getCategories\` N+1 で目に見えて重くなってきたので、 サーバ側ページングに切り替え。
- 50 件単位で取得 → 「もっと表示」 ボタンで追加読み込み。 検索もサーバ側 LIKE に変更 (250ms debounce)。

## サーバ側変更 (db.js / index.js)

- \`listBookmarks\` に \`limit\` / \`offset\` / \`q\` を opt-in で追加。 **内部呼び出し (export / wordcloud / recommendations 等 5 箇所) は \`limit\` を渡さなければ従来通り全件配列を返すので破壊的変更なし。**
- \`countBookmarks\` 新設: 同フィルタでの総件数。 ページング UI で 「全 N 件中 M 件表示中」 が出せる。
- \`/api/bookmarks\`: \`limit\` デフォルト 50, max 200。 \`q\` もサーバ側で処理されるので、 何千件持っていてもクライアントメモリを圧迫しない。 レスポンスは \`{ items, total, limit, offset }\`。

## フロント側変更 (app.js / index.html / style.css)

- \`state.bookmarksTotal\` 追加。 50 件単位で取得し、 cards 直下の **「もっと表示 (残り N 件)」** ボタンで \`append=true\` 取得。
- 検索を サーバ side \`?q=\` に切り替え (250ms debounce)。 フロントの \`filter\` ループは廃止 (旧コードは取得済みの 全配列を on every keystroke で filter していた)。
- カテゴリの「すべて」 件数表示は \`state.bookmarks.length\` (= page、 ≤50) ではなく \`state.bookmarksTotal\` (= 全 DB) を使う。

## 動作確認

- \`node --check\` 全ファイル PASS
- in-memory SQLite で 120 件挿入してページング smoke test:
  - page1 (offset 0) → 50 件
  - page2 (offset 50) → 50 件
  - page3 (offset 100) → 20 件
  - \`q=\"webgpu\"\` total: 24 件 / page: 24 件
  - \`limit\` 無し: 120 件 (内部呼び出し互換 OK)

## Test plan

- [x] node --check
- [x] in-memory SQL smoke
- [ ] 実機: Memoria を起動して 50 件取得 + 「もっと表示」 + 検索の挙動確認
- [ ] カテゴリ切替 / sort 切替時に offset がリセットされる
- [ ] 「もっと表示」 押すとページ末に追加され重複なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)