### PR TITLE
feat(meals): 食事記録機能 (写真 / EXIF / GPS / Claude Vision / 追加項目 / 日記連動)

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -1972,3 +1972,12 @@ export function listPendingMeals(db, { limit = 20 } = {}) {
   `).all(limit);
 }
 
+/** 指定日 (ローカル YYYY-MM-DD) の食事を eaten_at 昇順で返す。 */
+export function listMealsForDate(db, dateStr) {
+  return db.prepare(`
+    SELECT * FROM meals
+    WHERE date(eaten_at, 'localtime') = ?
+    ORDER BY eaten_at ASC
+  `).all(dateStr);
+}
+

--- a/server/db.js
+++ b/server/db.js
@@ -257,6 +257,7 @@ export function openDb(dbPath) {
       description                 TEXT,
       calories                    INTEGER,
       items_json                  TEXT,
+      nutrients_json              TEXT,
       ai_status                   TEXT NOT NULL DEFAULT 'pending',
       ai_error                    TEXT,
       user_note                   TEXT,
@@ -270,10 +271,13 @@ export function openDb(dbPath) {
     CREATE INDEX IF NOT EXISTS idx_meals_ai_status ON meals(ai_status);
   `);
 
-  // Forward-compat: 既存 DB に additions_json 列が無ければ ALTER で追加
+  // Forward-compat: 既存 DB に列を ALTER で追加
   const mealsCols = db.prepare(`PRAGMA table_info(meals)`).all().map(c => c.name);
   if (mealsCols.length > 0 && !mealsCols.includes('additions_json')) {
     db.exec(`ALTER TABLE meals ADD COLUMN additions_json TEXT`);
+  }
+  if (mealsCols.length > 0 && !mealsCols.includes('nutrients_json')) {
+    db.exec(`ALTER TABLE meals ADD COLUMN nutrients_json TEXT`);
   }
 
   // Forward-compat: ensure newer columns exist on older word_clouds tables.

--- a/server/db.js
+++ b/server/db.js
@@ -1981,3 +1981,38 @@ export function listMealsForDate(db, dateStr) {
   `).all(dateStr);
 }
 
+// ─── user stopwords (ユーザカスタムの語彙除外) ─────────────────
+//
+// dig graph / wordcloud などで「もう出さなくていい」 単語を蓄積する。
+// 表示側 (app.js) で随時 filter するのと、 サーバ抽出側で除外するのと
+// 両方で参照する想定 (今は表示側 filter のみで運用)。
+
+export function ensureUserStopwordsTable(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS user_stopwords (
+      word        TEXT PRIMARY KEY,
+      lower       TEXT NOT NULL,
+      created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_user_stopwords_lower ON user_stopwords(lower);
+  `);
+}
+
+export function listUserStopwords(db) {
+  return db.prepare(`SELECT word, lower, created_at FROM user_stopwords ORDER BY created_at DESC`).all();
+}
+
+export function addUserStopword(db, word) {
+  const w = String(word ?? '').trim();
+  if (!w) return false;
+  db.prepare(`INSERT OR IGNORE INTO user_stopwords (word, lower) VALUES (?, ?)`).run(w, w.toLowerCase());
+  return true;
+}
+
+export function removeUserStopword(db, word) {
+  const w = String(word ?? '').trim();
+  if (!w) return false;
+  const info = db.prepare(`DELETE FROM user_stopwords WHERE lower = ?`).run(w.toLowerCase());
+  return info.changes > 0;
+}
+

--- a/server/db.js
+++ b/server/db.js
@@ -244,6 +244,29 @@ export function openDb(dbPath) {
     );
     CREATE INDEX IF NOT EXISTS idx_push_subscriptions_active
       ON push_subscriptions(revoked_at) WHERE revoked_at IS NULL;
+
+    CREATE TABLE IF NOT EXISTS meals (
+      id                          INTEGER PRIMARY KEY AUTOINCREMENT,
+      photo_path                  TEXT NOT NULL,
+      eaten_at                    TEXT NOT NULL,
+      eaten_at_source             TEXT NOT NULL DEFAULT 'manual',
+      lat                         REAL,
+      lon                         REAL,
+      location_label              TEXT,
+      location_source             TEXT,
+      description                 TEXT,
+      calories                    INTEGER,
+      items_json                  TEXT,
+      ai_status                   TEXT NOT NULL DEFAULT 'pending',
+      ai_error                    TEXT,
+      user_note                   TEXT,
+      user_corrected_description  TEXT,
+      user_corrected_calories     INTEGER,
+      created_at                  TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at                  TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_meals_eaten_at ON meals(eaten_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_meals_ai_status ON meals(ai_status);
   `);
 
   // Forward-compat: ensure newer columns exist on older word_clouds tables.
@@ -1843,4 +1866,102 @@ export function deleteGpsLocationsOlderThan(db, olderThan, { userId = 'me' } = {
 }
 
 void GPS_INSERT_STMT_KEY; // reserved for prepared-stmt cache
+
+// ─── meals ────────────────────────────────────────────────
+
+/** Find the GPS point closest to `at` (ISO8601), within `windowMs`. */
+export function findNearestGpsLocation(db, at, { windowMs = 5 * 60 * 1000, userId = 'me' } = {}) {
+  const center = new Date(at);
+  if (isNaN(center.getTime())) return null;
+  const from = new Date(center.getTime() - windowMs).toISOString();
+  const to = new Date(center.getTime() + windowMs).toISOString();
+  const rows = db.prepare(`
+    SELECT id, recorded_at, lat, lon, accuracy_m
+    FROM gps_locations
+    WHERE user_id = ? AND recorded_at BETWEEN ? AND ?
+    ORDER BY recorded_at
+  `).all(userId, from, to);
+  if (rows.length === 0) return null;
+  let best = rows[0];
+  let bestDiff = Math.abs(new Date(best.recorded_at).getTime() - center.getTime());
+  for (const r of rows.slice(1)) {
+    const d = Math.abs(new Date(r.recorded_at).getTime() - center.getTime());
+    if (d < bestDiff) {
+      bestDiff = d;
+      best = r;
+    }
+  }
+  return best;
+}
+
+export function insertMeal(db, m) {
+  const info = db.prepare(`
+    INSERT INTO meals (
+      photo_path, eaten_at, eaten_at_source,
+      lat, lon, location_label, location_source,
+      description, calories, items_json,
+      ai_status, ai_error, user_note,
+      user_corrected_description, user_corrected_calories
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    m.photo_path, m.eaten_at, m.eaten_at_source ?? 'manual',
+    m.lat ?? null, m.lon ?? null, m.location_label ?? null, m.location_source ?? null,
+    m.description ?? null, m.calories ?? null, m.items_json ?? null,
+    m.ai_status ?? 'pending', m.ai_error ?? null, m.user_note ?? null,
+    m.user_corrected_description ?? null, m.user_corrected_calories ?? null,
+  );
+  return Number(info.lastInsertRowid);
+}
+
+export function getMeal(db, id) {
+  return db.prepare(`SELECT * FROM meals WHERE id = ?`).get(id);
+}
+
+export function listMeals(db, { from, to, limit = 100, offset = 0 } = {}) {
+  const where = [];
+  const args = [];
+  if (from) { where.push(`eaten_at >= ?`); args.push(from); }
+  if (to)   { where.push(`eaten_at <= ?`); args.push(to);   }
+  const sql = `
+    SELECT * FROM meals
+    ${where.length ? 'WHERE ' + where.join(' AND ') : ''}
+    ORDER BY eaten_at DESC
+    LIMIT ? OFFSET ?
+  `;
+  args.push(limit, offset);
+  return db.prepare(sql).all(...args);
+}
+
+export function countMeals(db, { from, to } = {}) {
+  const where = [];
+  const args = [];
+  if (from) { where.push(`eaten_at >= ?`); args.push(from); }
+  if (to)   { where.push(`eaten_at <= ?`); args.push(to);   }
+  const sql = `SELECT COUNT(*) AS c FROM meals ${where.length ? 'WHERE ' + where.join(' AND ') : ''}`;
+  return db.prepare(sql).get(...args).c;
+}
+
+export function updateMeal(db, id, patch) {
+  const cols = [];
+  const args = [];
+  for (const [k, v] of Object.entries(patch)) {
+    cols.push(`${k} = ?`);
+    args.push(v);
+  }
+  if (cols.length === 0) return;
+  cols.push(`updated_at = datetime('now')`);
+  args.push(id);
+  db.prepare(`UPDATE meals SET ${cols.join(', ')} WHERE id = ?`).run(...args);
+}
+
+export function deleteMeal(db, id) {
+  db.prepare(`DELETE FROM meals WHERE id = ?`).run(id);
+}
+
+export function listPendingMeals(db, { limit = 20 } = {}) {
+  return db.prepare(`
+    SELECT * FROM meals WHERE ai_status = 'pending'
+    ORDER BY id ASC LIMIT ?
+  `).all(limit);
+}
 

--- a/server/db.js
+++ b/server/db.js
@@ -262,12 +262,19 @@ export function openDb(dbPath) {
       user_note                   TEXT,
       user_corrected_description  TEXT,
       user_corrected_calories     INTEGER,
+      additions_json              TEXT,
       created_at                  TEXT NOT NULL DEFAULT (datetime('now')),
       updated_at                  TEXT NOT NULL DEFAULT (datetime('now'))
     );
     CREATE INDEX IF NOT EXISTS idx_meals_eaten_at ON meals(eaten_at DESC);
     CREATE INDEX IF NOT EXISTS idx_meals_ai_status ON meals(ai_status);
   `);
+
+  // Forward-compat: 既存 DB に additions_json 列が無ければ ALTER で追加
+  const mealsCols = db.prepare(`PRAGMA table_info(meals)`).all().map(c => c.name);
+  if (mealsCols.length > 0 && !mealsCols.includes('additions_json')) {
+    db.exec(`ALTER TABLE meals ADD COLUMN additions_json TEXT`);
+  }
 
   // Forward-compat: ensure newer columns exist on older word_clouds tables.
   const wcCols = db.prepare(`PRAGMA table_info(word_clouds)`).all().map(c => c.name);

--- a/server/diary.js
+++ b/server/diary.js
@@ -4,7 +4,7 @@
 // Hourly buckets, top domains, and active hours are computed locally;
 // claude is asked only to narrate.
 
-import { visitEventsForDate, getDiary, getDomainCatalogMap, digSessionsForDate, listServerEventsForDate, listGpsLocationsForDate } from './db.js';
+import { visitEventsForDate, getDiary, getDomainCatalogMap, digSessionsForDate, listServerEventsForDate, listGpsLocationsForDate, listMealsForDate } from './db.js';
 import { runLlm } from './llm.js';
 
 // Downtimes >5 min make it into the diary; shorter gaps are treated as
@@ -161,6 +161,42 @@ export function aggregateDay(db, dateStr, { listLimit = DIARY_LIST_INITIAL } = {
   const gpsPoints = listGpsLocationsForDate(db, dateStr);
   const gps = summarizeGpsForDate(gpsPoints);
 
+  // 食事ログ — eaten_at がその日に該当する meal をすべて拾う。
+  // 総カロリーは「base (user_corrected_calories ?? calories) + sum(additions[].calories)」 を
+  // 各レコードで計算した合計。 calories null 値は 0 として扱う (ユーザが
+  // 不明としたものを過大計上しないため、 集計上は欠損扱い)。
+  const mealsRows = listMealsForDate(db, dateStr);
+  const meals = mealsRows.map((m) => {
+    const additions = parseMealAdditions(m.additions_json);
+    const baseCal = (typeof m.user_corrected_calories === 'number') ? m.user_corrected_calories
+      : (typeof m.calories === 'number') ? m.calories : null;
+    const addCalSum = additions.reduce(
+      (s, a) => s + (typeof a.calories === 'number' && isFinite(a.calories) ? a.calories : 0), 0,
+    );
+    const totalCal = (baseCal == null && additions.length === 0)
+      ? null
+      : (baseCal ?? 0) + addCalSum;
+    return {
+      id: m.id,
+      eaten_at: m.eaten_at,
+      description: m.user_corrected_description || m.description || null,
+      base_calories: baseCal,
+      addition_calories: addCalSum,
+      total_calories: totalCal,
+      additions: additions.map((a) => ({
+        name: a.name,
+        calories: typeof a.calories === 'number' ? a.calories : null,
+        added_at: a.added_at || null,
+      })),
+      location_label: m.location_label || null,
+      ai_status: m.ai_status,
+      user_note: m.user_note || null,
+    };
+  });
+  const mealsCalories = meals.reduce(
+    (s, m) => s + (typeof m.total_calories === 'number' ? m.total_calories : 0), 0,
+  );
+
   return {
     date: dateStr,
     total_events: totalEvents,
@@ -176,11 +212,23 @@ export function aggregateDay(db, dateStr, { listLimit = DIARY_LIST_INITIAL } = {
     downtimes,
     total_downtime_ms: totalDowntimeMs,
     gps,
+    meals,
+    meals_total_calories: meals.length > 0 ? mealsCalories : null,
     sources: {
       visit_events: events.length,
       page_visits: pageVisitsContribution,
     },
   };
+}
+
+function parseMealAdditions(json) {
+  if (!json) return [];
+  try {
+    const arr = JSON.parse(json);
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
 }
 
 // Haversine 距離 (m)。地球半径 6371008 m (mean)。短距離では誤差は数 cm 以下。
@@ -602,6 +650,28 @@ function formatDowntimeBlock(metrics) {
   }).join('\n');
 }
 
+function formatMealsBlock(metrics) {
+  const meals = metrics?.meals || [];
+  if (!meals.length) return '(食事の記録なし)';
+  const lines = meals.map((m) => {
+    const t = (m.eaten_at || '').replace('T', ' ').slice(11, 16);
+    const desc = m.description || '(未記入)';
+    const cal = (typeof m.total_calories === 'number') ? `${m.total_calories} kcal` : '— kcal';
+    const loc = m.location_label ? ` @ ${m.location_label}` : '';
+    const adds = (m.additions || [])
+      .map((a) => {
+        const ac = typeof a.calories === 'number' ? ` ${a.calories}kcal` : '';
+        return `＋${a.name}${ac}`;
+      })
+      .join(', ');
+    const addsLine = adds ? ` (追加: ${adds})` : '';
+    return `- ${t} ${desc} — ${cal}${loc}${addsLine}`;
+  });
+  const total = (typeof metrics.meals_total_calories === 'number') ? metrics.meals_total_calories : null;
+  if (total != null) lines.push(`総カロリー (推定): 約 ${total} kcal`);
+  return lines.join('\n');
+}
+
 const HIGHLIGHTS_PROMPT = ({ dateStr, workContent, githubByRepo, bookmarkSummary, digs, notes, metrics }) => [
   `あなたは ${dateStr} の「ハイライト」セクションを書きます。`,
   '以下の情報を統合し、その日の重要なポイントを箇条書きで 3〜6 個。',
@@ -639,6 +709,10 @@ const HIGHLIGHTS_PROMPT = ({ dateStr, workContent, githubByRepo, bookmarkSummary
   '## サーバ停止 (5 分超のダウンタイム)',
   formatDowntimeBlock(metrics),
   '上記時間帯はアクセスログが欠落しているので、その時間帯の活動についてはデータがない旨を簡潔に注記してください。',
+  '',
+  '## 食事 (写真投稿 + AI 推定 / 手動補正、 参考情報)',
+  formatMealsBlock(metrics),
+  '※ カロリーは推定値で誤差を含む。 ハイライトに含める時は「総カロリー約 X kcal」 のような概数表記で。',
   '',
   notes ? `## ユーザのメモ・補足 (反映してください)\n${notes}\n` : '',
   '',

--- a/server/diary.js
+++ b/server/diary.js
@@ -4,7 +4,7 @@
 // Hourly buckets, top domains, and active hours are computed locally;
 // claude is asked only to narrate.
 
-import { visitEventsForDate, getDiary, getDomainCatalogMap, digSessionsForDate, listServerEventsForDate, listGpsLocationsForDate, listMealsForDate } from './db.js';
+import { visitEventsForDate, getDiary, getDomainCatalogMap, digSessionsForDate, listServerEventsForDate, listGpsLocationsForDate, listMealsForDate, getAppSettings } from './db.js';
 import { runLlm } from './llm.js';
 
 // Downtimes >5 min make it into the diary; shorter gaps are treated as
@@ -183,6 +183,7 @@ export function aggregateDay(db, dateStr, { listLimit = DIARY_LIST_INITIAL } = {
       base_calories: baseCal,
       addition_calories: addCalSum,
       total_calories: totalCal,
+      nutrients: parseMealNutrients(m.nutrients_json),
       additions: additions.map((a) => ({
         name: a.name,
         calories: typeof a.calories === 'number' ? a.calories : null,
@@ -196,6 +197,32 @@ export function aggregateDay(db, dateStr, { listLimit = DIARY_LIST_INITIAL } = {
   const mealsCalories = meals.reduce(
     (s, m) => s + (typeof m.total_calories === 'number' ? m.total_calories : 0), 0,
   );
+  // 栄養素合計 — null は 0 として加算しない (= 計上しない)、 ある食事のみ合計
+  const nutrientKeys = ['protein_g', 'fat_g', 'carbs_g', 'fiber_g', 'sugar_g', 'sodium_mg'];
+  const nutrientsSum = Object.fromEntries(nutrientKeys.map((k) => [k, 0]));
+  let nutrientsAnyMeal = false;
+  for (const m of meals) {
+    if (!m.nutrients) continue;
+    nutrientsAnyMeal = true;
+    for (const k of nutrientKeys) {
+      const v = m.nutrients[k];
+      if (typeof v === 'number' && isFinite(v)) nutrientsSum[k] += v;
+    }
+  }
+  // PFC バランスの簡易ラベル (3 大栄養素 g → kcal 比換算)
+  let pfcLabel = null;
+  if (nutrientsAnyMeal) {
+    const pCal = (nutrientsSum.protein_g || 0) * 4;
+    const fCal = (nutrientsSum.fat_g || 0) * 9;
+    const cCal = (nutrientsSum.carbs_g || 0) * 4;
+    const sum = pCal + fCal + cCal;
+    if (sum > 0) {
+      const pPct = Math.round((pCal / sum) * 100);
+      const fPct = Math.round((fCal / sum) * 100);
+      const cPct = 100 - pPct - fPct;
+      pfcLabel = `P:${pPct}% / F:${fPct}% / C:${cPct}%`;
+    }
+  }
 
   return {
     date: dateStr,
@@ -214,6 +241,12 @@ export function aggregateDay(db, dateStr, { listLimit = DIARY_LIST_INITIAL } = {
     gps,
     meals,
     meals_total_calories: meals.length > 0 ? mealsCalories : null,
+    meals_nutrients: nutrientsAnyMeal ? nutrientsSum : null,
+    meals_pfc_label: pfcLabel,
+    caloric_balance: computeCaloricBalance(db, {
+      intake: meals.length > 0 ? mealsCalories : null,
+      gpsDistanceM: gps?.distance_m ?? 0,
+    }),
     sources: {
       visit_events: events.length,
       page_visits: pageVisitsContribution,
@@ -229,6 +262,73 @@ function parseMealAdditions(json) {
   } catch {
     return [];
   }
+}
+
+function parseMealNutrients(json) {
+  if (!json) return null;
+  try {
+    const o = JSON.parse(json);
+    return (o && typeof o === 'object') ? o : null;
+  } catch {
+    return null;
+  }
+}
+
+// ─── カロリーバランス計算 ───────────────────────────────────────
+//
+// app_settings の `user.*` から profile を読み出し、 BMR / TDEE を計算。
+// 摂取 (食事合計) / 消費 (BMR + 軌跡歩行) / 適正 (TDEE) / 過不足 を出す。
+//
+// プロファイル未設定の場合は null を返し、 UI 側で「設定してください」 と促す。
+
+const ACTIVITY_FACTORS = {
+  sedentary: 1.2,
+  light: 1.375,
+  moderate: 1.55,
+  active: 1.725,
+  very_active: 1.9,
+};
+
+function loadUserProfile(db) {
+  const s = getAppSettings(db);
+  const age = parseFloat(s['user.age']);
+  const sex = (s['user.sex'] || '').trim().toLowerCase();
+  const weight = parseFloat(s['user.weight_kg']);
+  const height = parseFloat(s['user.height_cm']);
+  const activity = (s['user.activity_level'] || 'moderate').trim().toLowerCase();
+  if (!isFinite(age) || !isFinite(weight) || !isFinite(height) || (sex !== 'male' && sex !== 'female')) {
+    return null;
+  }
+  return { age, sex, weight_kg: weight, height_cm: height, activity_level: activity };
+}
+
+function computeBmrMifflin(profile) {
+  // Mifflin-St Jeor
+  const base = 10 * profile.weight_kg + 6.25 * profile.height_cm - 5 * profile.age;
+  return profile.sex === 'male' ? base + 5 : base - 161;
+}
+
+function computeCaloricBalance(db, { intake, gpsDistanceM }) {
+  const profile = loadUserProfile(db);
+  if (!profile) return null;
+  const bmr = Math.round(computeBmrMifflin(profile));
+  const factor = ACTIVITY_FACTORS[profile.activity_level] ?? ACTIVITY_FACTORS.moderate;
+  const tdee = Math.round(bmr * factor);
+  // 歩行による追加消費 (m → kcal): 1 km あたり 体重 × 0.6 kcal の概算
+  const walkingKcal = Math.round((gpsDistanceM || 0) / 1000 * profile.weight_kg * 0.6);
+  // 1 日消費 = BMR + 軌跡からの歩行追加 (TDEE の活動係数とは別の上乗せで見せる)
+  const expenditure = bmr + walkingKcal;
+  const intakeNum = (typeof intake === 'number' && isFinite(intake)) ? intake : null;
+  return {
+    profile,
+    bmr,
+    tdee,
+    walking_kcal: walkingKcal,
+    intake: intakeNum,
+    expenditure_total: expenditure, // BMR + walking
+    diff_vs_target: intakeNum != null ? intakeNum - tdee : null,
+    diff_vs_expenditure: intakeNum != null ? intakeNum - expenditure : null,
+  };
 }
 
 // Haversine 距離 (m)。地球半径 6371008 m (mean)。短距離では誤差は数 cm 以下。
@@ -650,6 +750,28 @@ function formatDowntimeBlock(metrics) {
   }).join('\n');
 }
 
+function formatCaloricBalanceBlock(metrics) {
+  const cb = metrics?.caloric_balance;
+  if (!cb) return '(ユーザプロファイル未設定 — 設定 → AI / 連携 で年齢 / 性別 / 体重 / 身長 / 活動レベルを入れてください)';
+  const p = cb.profile;
+  const lines = [];
+  lines.push(`プロファイル: ${p.sex === 'male' ? '男性' : '女性'} / ${p.age}歳 / ${p.weight_kg}kg / ${p.height_cm}cm / 活動 ${p.activity_level}`);
+  lines.push(`基礎代謝 (BMR): 約 ${cb.bmr} kcal`);
+  lines.push(`適正カロリー (TDEE = BMR × 活動係数): 約 ${cb.tdee} kcal`);
+  lines.push(`軌跡からの歩行消費: 約 ${cb.walking_kcal} kcal`);
+  lines.push(`1 日消費 (BMR + 歩行): 約 ${cb.expenditure_total} kcal`);
+  if (cb.intake != null) {
+    lines.push(`摂取カロリー (食事合計): 約 ${cb.intake} kcal`);
+    const diffT = cb.diff_vs_target;
+    const diffE = cb.diff_vs_expenditure;
+    lines.push(`摂取 - 適正: ${diffT > 0 ? '+' : ''}${diffT} kcal`);
+    lines.push(`摂取 - 消費 (収支): ${diffE > 0 ? '+' : ''}${diffE} kcal (プラス = 余剰、 マイナス = 不足)`);
+  } else {
+    lines.push('摂取カロリー: (食事の記録なし)');
+  }
+  return lines.join('\n');
+}
+
 function formatMealsBlock(metrics) {
   const meals = metrics?.meals || [];
   if (!meals.length) return '(食事の記録なし)';
@@ -669,6 +791,14 @@ function formatMealsBlock(metrics) {
   });
   const total = (typeof metrics.meals_total_calories === 'number') ? metrics.meals_total_calories : null;
   if (total != null) lines.push(`総カロリー (推定): 約 ${total} kcal`);
+  const nut = metrics.meals_nutrients;
+  if (nut) {
+    const fmt = (k, unit) => (typeof nut[k] === 'number' && isFinite(nut[k]))
+      ? `${Math.round(nut[k] * 10) / 10}${unit}` : '—';
+    lines.push(`栄養素合計 (推定): P ${fmt('protein_g', 'g')} / F ${fmt('fat_g', 'g')} / C ${fmt('carbs_g', 'g')} / 食物繊維 ${fmt('fiber_g', 'g')} / 糖質 ${fmt('sugar_g', 'g')} / 塩分 ${fmt('sodium_mg', 'mg')}`);
+    if (metrics.meals_pfc_label) lines.push(`PFC バランス: ${metrics.meals_pfc_label}`);
+    lines.push('※ 栄養素は写真 + 食品名から AI が推定した概数。 厳密な値ではない。');
+  }
   return lines.join('\n');
 }
 
@@ -720,6 +850,9 @@ const HIGHLIGHTS_PROMPT = ({ dateStr, workContent, githubByRepo, bookmarkSummary
   '## 食事 (写真投稿 + AI 推定 / 手動補正、 参考情報)',
   formatMealsBlock(metrics),
   '※ カロリーは推定値で誤差を含む。 ハイライトに含める時は「総カロリー約 X kcal」 のような概数表記で。',
+  '',
+  '## カロリーバランス (適正 vs 摂取 vs 消費)',
+  formatCaloricBalanceBlock(metrics),
   '',
   notes ? `## ユーザのメモ・補足 (反映してください)\n${notes}\n` : '',
   '',

--- a/server/diary.js
+++ b/server/diary.js
@@ -654,7 +654,7 @@ function formatMealsBlock(metrics) {
   const meals = metrics?.meals || [];
   if (!meals.length) return '(食事の記録なし)';
   const lines = meals.map((m) => {
-    const t = (m.eaten_at || '').replace('T', ' ').slice(11, 16);
+    const t = formatLocalHm(m.eaten_at); // localtime HH:MM (UTC ISO を local 化)
     const desc = m.description || '(未記入)';
     const cal = (typeof m.total_calories === 'number') ? `${m.total_calories} kcal` : '— kcal';
     const loc = m.location_label ? ` @ ${m.location_label}` : '';
@@ -670,6 +670,13 @@ function formatMealsBlock(metrics) {
   const total = (typeof metrics.meals_total_calories === 'number') ? metrics.meals_total_calories : null;
   if (total != null) lines.push(`総カロリー (推定): 約 ${total} kcal`);
   return lines.join('\n');
+}
+
+function formatLocalHm(iso) {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return String(iso).slice(11, 16);
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
 }
 
 const HIGHLIGHTS_PROMPT = ({ dateStr, workContent, githubByRepo, bookmarkSummary, digs, notes, metrics }) => [

--- a/server/index.js
+++ b/server/index.js
@@ -596,6 +596,12 @@ app.delete('/api/recommendations/dismissals', (c) => {
 const MEAL_PHOTO_MAX_BYTES = 12 * 1024 * 1024; // 12 MiB
 const MEAL_VISION_TIMEOUT = 90_000;
 
+function randomHex8() {
+  const buf = new Uint8Array(4);
+  globalThis.crypto.getRandomValues(buf);
+  return [...buf].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
 function pickPhotoExt(filename, mime) {
   const lower = (filename || '').toLowerCase();
   if (lower.endsWith('.png')) return '.png';
@@ -716,8 +722,21 @@ app.post('/api/meals', async (c) => {
     user_note: userNote,
   });
 
-  const filename = `${id}${ext}`;
-  const fullPath = join(MEAL_DIR, filename);
+  // ファイル名は `<id>-<8hex><ext>` 形式 (id は単調増加 PK + 短い乱数 suffix で
+  // 万一の衝突 / DB リセット後の id 再利用に備える)。 既存ファイルがあれば
+  // suffix を再生成するループでガード。
+  let filename = '';
+  let fullPath = '';
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const suffix = randomHex8();
+    filename = `${id}-${suffix}${ext}`;
+    fullPath = join(MEAL_DIR, filename);
+    if (!existsSync(fullPath)) break;
+  }
+  if (!filename || existsSync(fullPath)) {
+    deleteMeal(db, id);
+    return c.json({ error: 'failed to allocate unique photo filename' }, 500);
+  }
   try {
     writeFileSync(fullPath, buf);
   } catch (e) {

--- a/server/index.js
+++ b/server/index.js
@@ -86,7 +86,7 @@ import {
 } from './db.js';
 import { initWebPush, getVapidPublicKey, saveSubscription, sendPushToAll } from './push.js';
 import {
-  extractPhotoMeta, resolveMealLocation, analyzeMealPhoto,
+  extractPhotoMeta, resolveMealLocation, analyzeMealPhoto, estimateCaloriesFromName,
 } from './meals.js';
 import {
   readMultiState, isConnected,
@@ -652,6 +652,45 @@ function enqueueMealVision(id) {
   }, { kind: 'meal-vision', meal_id: id, title: `meal #${id}` });
 }
 
+// 食品名から標準カロリーを背景で推定する。 結果は対象 meal の additions[idx]
+// (idx == -1 のときは meal 本体の calories) に書き込む。 失敗は黙認 (UI に
+// 「— kcal」 のままを残す)。
+function enqueueCalorieEstimate(mealId, additionIdx, foodName) {
+  mealVisionQueue.enqueue(async () => {
+    try {
+      const r = await estimateCaloriesFromName(foodName);
+      if (r.calories == null) return;
+      const meal = getMeal(db, mealId);
+      if (!meal) return;
+      if (additionIdx === -1) {
+        // meal 本体のカロリーを user_corrected_calories に書く (上書きしない)
+        if (meal.user_corrected_calories == null && meal.calories == null) {
+          updateMeal(db, mealId, { user_corrected_calories: r.calories });
+        }
+        return;
+      }
+      const additions = parseMealAdditionsJson(meal.additions_json);
+      if (!additions[additionIdx]) return;
+      // ユーザがその間に手動入力していたら上書きしない
+      if (additions[additionIdx].calories != null) return;
+      additions[additionIdx].calories = r.calories;
+      updateMeal(db, mealId, { additions_json: JSON.stringify(additions) });
+    } catch (e) {
+      console.warn(`[meal#${mealId}] calorie estimate failed: ${e.message}`);
+    }
+  }, { kind: 'meal-calorie', meal_id: mealId, title: `kcal: ${foodName.slice(0, 40)}` });
+}
+
+function parseMealAdditionsJson(json) {
+  if (!json) return [];
+  try {
+    const arr = JSON.parse(json);
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
+}
+
 // POST /api/meals — multipart/form-data
 //   photo:      File (required)
 //   user_note:  string (optional)
@@ -751,6 +790,77 @@ app.post('/api/meals', async (c) => {
   return c.json({ meal: created }, 201);
 });
 
+// POST /api/meals/manual — 写真なしで食事を直接登録する (JSON body)
+//   description:  string (required) — 食事内容の説明
+//   eaten_at:     ISO8601 string (任意、 デフォルト現在時刻)
+//   calories:     number (任意、 未指定なら LLM で背景推定)
+//   lat / lon:    number (任意、 未指定なら GPS 軌跡から推定)
+//   user_note:    string (任意)
+app.post('/api/meals/manual', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  if (!body || typeof body !== 'object') return c.json({ error: 'json body required' }, 400);
+  const description = typeof body.description === 'string' ? body.description.trim() : '';
+  if (!description) return c.json({ error: 'description (string) required' }, 400);
+
+  // 食事時刻
+  let eatenAt = '';
+  let eatenAtSource = 'manual';
+  if (typeof body.eaten_at === 'string' && body.eaten_at.trim()) {
+    const d = new Date(body.eaten_at);
+    if (!isNaN(d.getTime())) {
+      eatenAt = d.toISOString();
+    }
+  }
+  if (!eatenAt) {
+    eatenAt = new Date().toISOString();
+    eatenAtSource = 'post';
+  }
+
+  // 場所: 手動 → GPS 軌跡 → なし
+  const manualLat = (typeof body.lat === 'number' && isFinite(body.lat)) ? body.lat : null;
+  const manualLon = (typeof body.lon === 'number' && isFinite(body.lon)) ? body.lon : null;
+  const hasManualLatLon = manualLat != null && manualLon != null;
+  const loc = resolveMealLocation(
+    db,
+    { capturedAt: null, lat: null, lon: null }, // EXIF なし
+    eatenAt,
+    hasManualLatLon ? { lat: manualLat, lon: manualLon } : null,
+  );
+
+  // calories: 数値 / 文字列 / 未指定 (= 背景推定)
+  let calories = null;
+  if (typeof body.calories === 'number' && isFinite(body.calories)) {
+    calories = Math.round(body.calories);
+  } else if (typeof body.calories === 'string' && body.calories.trim() !== '') {
+    const n = Number(body.calories);
+    if (isFinite(n)) calories = Math.round(n);
+  }
+
+  const id = insertMeal(db, {
+    photo_path: '', // 写真なしマーカー
+    eaten_at: eatenAt,
+    eaten_at_source: eatenAtSource,
+    lat: loc.lat,
+    lon: loc.lon,
+    location_label: loc.label,
+    location_source: loc.source,
+    description,
+    calories, // 未指定なら null
+    items_json: null,
+    ai_status: calories != null ? 'done' : 'pending',
+    ai_error: null,
+    user_note: typeof body.user_note === 'string' ? (body.user_note.trim() || null) : null,
+  });
+
+  // calories 未指定なら LLM で背景推定 (description を食品名として渡す)
+  if (calories == null) {
+    enqueueCalorieEstimate(id, -1, description);
+  }
+
+  const created = getMeal(db, id);
+  return c.json({ meal: created }, 201);
+});
+
 app.get('/api/meals', (c) => {
   const from = c.req.query('from') || undefined;
   const to = c.req.query('to') || undefined;
@@ -772,6 +882,9 @@ app.get('/api/meals/:id/photo', (c) => {
   const id = Number(c.req.param('id'));
   const meal = getMeal(db, id);
   if (!meal) return c.json({ error: 'not found' }, 404);
+  // 写真なし meal (photo_path === '') は 404 を返し、 frontend は
+  // プレースホルダ画像を表示する。
+  if (!meal.photo_path) return c.json({ error: 'no photo' }, 404);
   const fullPath = join(MEAL_DIR, meal.photo_path);
   if (!existsSync(fullPath)) return c.json({ error: 'photo missing' }, 404);
   const buf = readFileSync(fullPath);
@@ -823,18 +936,31 @@ app.patch('/api/meals/:id', async (c) => {
   }
 
   if (Object.keys(patch).length > 0) updateMeal(db, id, patch);
-  return c.json({ meal: getMeal(db, id) });
+
+  // description が変わって user_corrected_calories を null に戻したケースは
+  // 「内容が変わったのでカロリー再推定して」 という合図。 LLM で背景推定する。
+  const updated = getMeal(db, id);
+  const descChanged = patch.user_corrected_description !== undefined &&
+    patch.user_corrected_description !== meal.user_corrected_description;
+  const calsCleared = patch.user_corrected_calories === null;
+  if (descChanged && calsCleared) {
+    const desc = updated?.user_corrected_description || updated?.description || '';
+    if (desc) enqueueCalorieEstimate(id, -1, desc);
+  }
+  return c.json({ meal: updated });
 });
 
 app.delete('/api/meals/:id', (c) => {
   const id = Number(c.req.param('id'));
   const meal = getMeal(db, id);
   if (!meal) return c.json({ error: 'not found' }, 404);
-  try {
-    const fullPath = join(MEAL_DIR, meal.photo_path);
-    if (existsSync(fullPath)) unlinkSync(fullPath);
-  } catch (e) {
-    console.warn(`[meal#${id}] failed to delete photo: ${e.message}`);
+  if (meal.photo_path) {
+    try {
+      const fullPath = join(MEAL_DIR, meal.photo_path);
+      if (existsSync(fullPath)) unlinkSync(fullPath);
+    } catch (e) {
+      console.warn(`[meal#${id}] failed to delete photo: ${e.message}`);
+    }
   }
   deleteMeal(db, id);
   return c.json({ ok: true });
@@ -895,8 +1021,14 @@ app.post('/api/meals/:id/additions', async (c) => {
     : new Date().toISOString();
 
   const additions = parseAdditions(meal.additions_json);
+  const newIdx = additions.length;
   additions.push({ name, calories, added_at: addedAt });
   updateMeal(db, id, { additions_json: JSON.stringify(additions) });
+
+  // calories 未指定なら背景で LLM 推定して非同期に書き戻す
+  if (calories == null) {
+    enqueueCalorieEstimate(id, newIdx, name);
+  }
   return c.json({ meal: getMeal(db, id) });
 });
 

--- a/server/index.js
+++ b/server/index.js
@@ -849,6 +849,103 @@ app.post('/api/meals/:id/reanalyze', (c) => {
   return c.json({ meal: getMeal(db, id), queued: true });
 });
 
+// ---- meals: 追加で食べた項目 (additions) ---------------------------------
+//
+// 既存 meal レコードに「あとから食べたもの」 を追記する。 data shape:
+//   meal.additions_json = JSON.stringify([
+//     { name: string, calories: number|null, added_at: ISO8601 }, ...
+//   ])
+//
+// カロリー総計は frontend 側で計算 (base + sum(additions))。
+
+const MEAL_ADDITION_NAME_MAX = 200;
+
+function parseAdditions(json) {
+  if (!json) return [];
+  try {
+    const arr = JSON.parse(json);
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
+}
+
+app.post('/api/meals/:id/additions', async (c) => {
+  const id = Number(c.req.param('id'));
+  const meal = getMeal(db, id);
+  if (!meal) return c.json({ error: 'not found' }, 404);
+  const body = await c.req.json().catch(() => null);
+  if (!body || typeof body !== 'object') return c.json({ error: 'json body required' }, 400);
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+  if (!name) return c.json({ error: 'name (string) required' }, 400);
+  if (name.length > MEAL_ADDITION_NAME_MAX) {
+    return c.json({ error: `name too long (max ${MEAL_ADDITION_NAME_MAX})` }, 400);
+  }
+  let calories = null;
+  if (body.calories === null) {
+    calories = null;
+  } else if (typeof body.calories === 'number' && isFinite(body.calories)) {
+    calories = Math.round(body.calories);
+  } else if (typeof body.calories === 'string' && body.calories.trim() !== '') {
+    const n = Number(body.calories);
+    if (isFinite(n)) calories = Math.round(n);
+  }
+  const addedAt = (typeof body.added_at === 'string' && body.added_at.trim())
+    ? (() => { const d = new Date(body.added_at); return isNaN(d.getTime()) ? new Date().toISOString() : d.toISOString(); })()
+    : new Date().toISOString();
+
+  const additions = parseAdditions(meal.additions_json);
+  additions.push({ name, calories, added_at: addedAt });
+  updateMeal(db, id, { additions_json: JSON.stringify(additions) });
+  return c.json({ meal: getMeal(db, id) });
+});
+
+app.patch('/api/meals/:id/additions/:idx', async (c) => {
+  const id = Number(c.req.param('id'));
+  const idx = Number(c.req.param('idx'));
+  const meal = getMeal(db, id);
+  if (!meal) return c.json({ error: 'not found' }, 404);
+  const additions = parseAdditions(meal.additions_json);
+  if (!Number.isInteger(idx) || idx < 0 || idx >= additions.length) {
+    return c.json({ error: 'index out of range' }, 400);
+  }
+  const body = await c.req.json().catch(() => null);
+  if (!body || typeof body !== 'object') return c.json({ error: 'json body required' }, 400);
+  const cur = additions[idx];
+  if (typeof body.name === 'string') {
+    const nm = body.name.trim();
+    if (nm) cur.name = nm.slice(0, MEAL_ADDITION_NAME_MAX);
+  }
+  if (body.calories === null) {
+    cur.calories = null;
+  } else if (typeof body.calories === 'number' && isFinite(body.calories)) {
+    cur.calories = Math.round(body.calories);
+  } else if (typeof body.calories === 'string' && body.calories.trim() !== '') {
+    const n = Number(body.calories);
+    if (isFinite(n)) cur.calories = Math.round(n);
+  }
+  if (typeof body.added_at === 'string' && body.added_at.trim()) {
+    const d = new Date(body.added_at);
+    if (!isNaN(d.getTime())) cur.added_at = d.toISOString();
+  }
+  updateMeal(db, id, { additions_json: JSON.stringify(additions) });
+  return c.json({ meal: getMeal(db, id) });
+});
+
+app.delete('/api/meals/:id/additions/:idx', (c) => {
+  const id = Number(c.req.param('id'));
+  const idx = Number(c.req.param('idx'));
+  const meal = getMeal(db, id);
+  if (!meal) return c.json({ error: 'not found' }, 404);
+  const additions = parseAdditions(meal.additions_json);
+  if (!Number.isInteger(idx) || idx < 0 || idx >= additions.length) {
+    return c.json({ error: 'index out of range' }, 400);
+  }
+  additions.splice(idx, 1);
+  updateMeal(db, id, { additions_json: additions.length > 0 ? JSON.stringify(additions) : null });
+  return c.json({ meal: getMeal(db, id) });
+});
+
 // 起動時に pending 食事があれば解析を再投入 (前回終了時の中断分)
 for (const m of listPendingMeals(db, { limit: 50 })) {
   enqueueMealVision(m.id);

--- a/server/index.js
+++ b/server/index.js
@@ -86,7 +86,7 @@ import {
 } from './db.js';
 import { initWebPush, getVapidPublicKey, saveSubscription, sendPushToAll } from './push.js';
 import {
-  extractPhotoMeta, resolveMealLocation, analyzeMealPhoto, getMealsApiKey,
+  extractPhotoMeta, resolveMealLocation, analyzeMealPhoto,
 } from './meals.js';
 import {
   readMultiState, isConnected,
@@ -619,26 +619,14 @@ function enqueueMealVision(id) {
   mealVisionQueue.enqueue(async () => {
     const meal = getMeal(db, id);
     if (!meal) return;
-    const apiKey = getMealsApiKey(db);
-    if (!apiKey) {
-      updateMeal(db, id, {
-        ai_status: 'pending',
-        ai_error: 'OpenAI API key not configured (set llm.openai.api_key in settings)',
-      });
-      return;
-    }
     const fullPath = join(MEAL_DIR, meal.photo_path);
-    let buf;
-    try {
-      buf = readFileSync(fullPath);
-    } catch (e) {
-      updateMeal(db, id, { ai_status: 'error', ai_error: `read file: ${e.message}` });
+    if (!existsSync(fullPath)) {
+      updateMeal(db, id, { ai_status: 'error', ai_error: 'photo file missing' });
       return;
     }
-    const mime = mimeFromExt(meal.photo_path);
     try {
       const result = await Promise.race([
-        analyzeMealPhoto(apiKey, buf.toString('base64'), mime),
+        analyzeMealPhoto(fullPath),
         new Promise((_, reject) => setTimeout(() => reject(new Error('vision timeout')), MEAL_VISION_TIMEOUT)),
       ]);
       if (!result) {

--- a/server/index.js
+++ b/server/index.js
@@ -81,7 +81,13 @@ import {
   listGpsLocationsForDate, deleteGpsLocationsOlderThan,
 } from './db.js';
 import { listPushSubscriptions, deletePushSubscription } from './db.js';
+import {
+  insertMeal, getMeal, listMeals, countMeals, updateMeal, deleteMeal, listPendingMeals,
+} from './db.js';
 import { initWebPush, getVapidPublicKey, saveSubscription, sendPushToAll } from './push.js';
+import {
+  extractPhotoMeta, resolveMealLocation, analyzeMealPhoto, getMealsApiKey,
+} from './meals.js';
 import {
   readMultiState, isConnected,
   readMultiServers, persistServers, upsertServer, removeServer,
@@ -94,10 +100,12 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const PORT = Number(process.env.MEMORIA_PORT ?? 5180);
 const DATA_DIR = resolve(process.env.MEMORIA_DATA ?? join(__dirname, '..', 'data'));
 const HTML_DIR = join(DATA_DIR, 'html');
+const MEAL_DIR = join(DATA_DIR, 'meals');
 const DB_PATH = join(DATA_DIR, 'memoria.db');
 const CLAUDE_BIN = process.env.MEMORIA_CLAUDE_BIN ?? 'claude';
 
 mkdirSync(HTML_DIR, { recursive: true });
+mkdirSync(MEAL_DIR, { recursive: true });
 const db = openDb(DB_PATH);
 loadLlmConfigFromSettings(getAppSettings(db));
 initWebPush(DATA_DIR);
@@ -107,6 +115,7 @@ const summaryQueue = new FifoQueue();
 const cloudQueue = new FifoQueue();
 const domainCatalogQueue = new FifoQueue();
 const pageMetadataQueue = new FifoQueue();
+const mealVisionQueue = new FifoQueue();
 
 function maybeQueuePageMetadata(url) {
   let host;
@@ -572,6 +581,271 @@ app.delete('/api/recommendations/dismissals', (c) => {
   clearDismissals(db);
   return c.json({ ok: true });
 });
+
+// ---- meals (食事記録) -----------------------------------------------------
+//
+// 写真 + EXIF + GPS 軌跡から食事内容 / カロリー / 場所 / 時刻 を半自動で記録する。
+//
+// 解決順序:
+//   - 食事時刻: EXIF DateTimeOriginal → 投稿時刻 (POST 受信時)
+//   - 場所:     EXIF GPS → 既存 gps_locations ±5 分の最近点 → 手動 (PATCH)
+//   - 内容/cal: OpenAI Vision (gpt-4o-mini) — API key 未設定なら pending のまま
+//
+// 解析失敗時 / API key 未設定時は ai_status='pending' のまま手動入力で運用可能。
+
+const MEAL_PHOTO_MAX_BYTES = 12 * 1024 * 1024; // 12 MiB
+const MEAL_VISION_TIMEOUT = 90_000;
+
+function pickPhotoExt(filename, mime) {
+  const lower = (filename || '').toLowerCase();
+  if (lower.endsWith('.png')) return '.png';
+  if (lower.endsWith('.heic') || lower.endsWith('.heif')) return '.heic';
+  if (lower.endsWith('.webp')) return '.webp';
+  if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return '.jpg';
+  if (mime === 'image/png') return '.png';
+  if (mime === 'image/heic' || mime === 'image/heif') return '.heic';
+  if (mime === 'image/webp') return '.webp';
+  return '.jpg';
+}
+
+function mimeFromExt(p) {
+  if (p.endsWith('.png')) return 'image/png';
+  if (p.endsWith('.heic') || p.endsWith('.heif')) return 'image/heic';
+  if (p.endsWith('.webp')) return 'image/webp';
+  return 'image/jpeg';
+}
+
+function enqueueMealVision(id) {
+  mealVisionQueue.enqueue(async () => {
+    const meal = getMeal(db, id);
+    if (!meal) return;
+    const apiKey = getMealsApiKey(db);
+    if (!apiKey) {
+      updateMeal(db, id, {
+        ai_status: 'pending',
+        ai_error: 'OpenAI API key not configured (set llm.openai.api_key in settings)',
+      });
+      return;
+    }
+    const fullPath = join(MEAL_DIR, meal.photo_path);
+    let buf;
+    try {
+      buf = readFileSync(fullPath);
+    } catch (e) {
+      updateMeal(db, id, { ai_status: 'error', ai_error: `read file: ${e.message}` });
+      return;
+    }
+    const mime = mimeFromExt(meal.photo_path);
+    try {
+      const result = await Promise.race([
+        analyzeMealPhoto(apiKey, buf.toString('base64'), mime),
+        new Promise((_, reject) => setTimeout(() => reject(new Error('vision timeout')), MEAL_VISION_TIMEOUT)),
+      ]);
+      if (!result) {
+        updateMeal(db, id, { ai_status: 'error', ai_error: 'vision returned null' });
+        return;
+      }
+      updateMeal(db, id, {
+        description: result.description ?? null,
+        calories: typeof result.calories === 'number' ? result.calories : null,
+        items_json: result.items ? JSON.stringify(result.items) : null,
+        ai_status: 'done',
+        ai_error: null,
+      });
+    } catch (e) {
+      updateMeal(db, id, { ai_status: 'error', ai_error: String(e.message ?? e).slice(0, 500) });
+    }
+  }, { kind: 'meal-vision', meal_id: id, title: `meal #${id}` });
+}
+
+// POST /api/meals — multipart/form-data
+//   photo:      File (required)
+//   user_note:  string (optional)
+//   eaten_at:   ISO8601 string (optional, 手動上書き)
+//   lat / lon:  number (optional, 手動上書き)
+app.post('/api/meals', async (c) => {
+  const form = await c.req.formData().catch(() => null);
+  if (!form) return c.json({ error: 'multipart/form-data required' }, 400);
+  const photo = form.get('photo');
+  if (!(photo instanceof File)) return c.json({ error: 'photo (File) required' }, 400);
+  if (photo.size === 0) return c.json({ error: 'empty photo' }, 400);
+  if (photo.size > MEAL_PHOTO_MAX_BYTES) {
+    return c.json({ error: `photo too large (max ${MEAL_PHOTO_MAX_BYTES} bytes)` }, 413);
+  }
+  const buf = Buffer.from(await photo.arrayBuffer());
+  const exif = await extractPhotoMeta(buf);
+
+  const userNote = (form.get('user_note') || '').toString().trim() || null;
+  const eatenAtRaw = (form.get('eaten_at') || '').toString().trim();
+  const latRaw = (form.get('lat') || '').toString().trim();
+  const lonRaw = (form.get('lon') || '').toString().trim();
+  const manualLat = latRaw ? Number(latRaw) : null;
+  const manualLon = lonRaw ? Number(lonRaw) : null;
+  const hasManualLatLon =
+    typeof manualLat === 'number' && isFinite(manualLat) &&
+    typeof manualLon === 'number' && isFinite(manualLon);
+
+  // 食事時刻: 手動 > EXIF > 投稿時刻
+  let eatenAt = '';
+  let eatenAtSource = 'manual';
+  if (eatenAtRaw) {
+    const d = new Date(eatenAtRaw);
+    if (!isNaN(d.getTime())) {
+      eatenAt = d.toISOString();
+      eatenAtSource = 'manual';
+    }
+  }
+  if (!eatenAt && exif.capturedAt) {
+    eatenAt = exif.capturedAt;
+    eatenAtSource = 'exif';
+  }
+  if (!eatenAt) {
+    eatenAt = new Date().toISOString();
+    eatenAtSource = 'post';
+  }
+
+  const loc = resolveMealLocation(
+    db,
+    exif,
+    eatenAt,
+    hasManualLatLon ? { lat: manualLat, lon: manualLon } : null,
+  );
+
+  const ext = pickPhotoExt(photo.name, photo.type);
+  const id = insertMeal(db, {
+    photo_path: 'placeholder' + ext,
+    eaten_at: eatenAt,
+    eaten_at_source: eatenAtSource,
+    lat: loc.lat,
+    lon: loc.lon,
+    location_label: loc.label,
+    location_source: loc.source,
+    description: null,
+    calories: null,
+    items_json: null,
+    ai_status: 'pending',
+    ai_error: null,
+    user_note: userNote,
+  });
+
+  const filename = `${id}${ext}`;
+  const fullPath = join(MEAL_DIR, filename);
+  try {
+    writeFileSync(fullPath, buf);
+  } catch (e) {
+    deleteMeal(db, id);
+    return c.json({ error: `write photo: ${e.message}` }, 500);
+  }
+  updateMeal(db, id, { photo_path: filename });
+
+  enqueueMealVision(id);
+
+  const created = getMeal(db, id);
+  return c.json({ meal: created }, 201);
+});
+
+app.get('/api/meals', (c) => {
+  const from = c.req.query('from') || undefined;
+  const to = c.req.query('to') || undefined;
+  const limit = Math.min(Number(c.req.query('limit') || 100), 500);
+  const offset = Math.max(Number(c.req.query('offset') || 0), 0);
+  const meals = listMeals(db, { from, to, limit, offset });
+  const total = countMeals(db, { from, to });
+  return c.json({ meals, total });
+});
+
+app.get('/api/meals/:id', (c) => {
+  const id = Number(c.req.param('id'));
+  const meal = getMeal(db, id);
+  if (!meal) return c.json({ error: 'not found' }, 404);
+  return c.json({ meal });
+});
+
+app.get('/api/meals/:id/photo', (c) => {
+  const id = Number(c.req.param('id'));
+  const meal = getMeal(db, id);
+  if (!meal) return c.json({ error: 'not found' }, 404);
+  const fullPath = join(MEAL_DIR, meal.photo_path);
+  if (!existsSync(fullPath)) return c.json({ error: 'photo missing' }, 404);
+  const buf = readFileSync(fullPath);
+  return new Response(buf, {
+    headers: {
+      'Content-Type': mimeFromExt(meal.photo_path),
+      'Cache-Control': 'private, max-age=86400',
+    },
+  });
+});
+
+app.patch('/api/meals/:id', async (c) => {
+  const id = Number(c.req.param('id'));
+  const meal = getMeal(db, id);
+  if (!meal) return c.json({ error: 'not found' }, 404);
+  const body = await c.req.json().catch(() => null);
+  if (!body || typeof body !== 'object') return c.json({ error: 'json body required' }, 400);
+
+  const patch = {};
+  if (typeof body.user_note === 'string') patch.user_note = body.user_note.trim() || null;
+  if (typeof body.user_corrected_description === 'string') {
+    patch.user_corrected_description = body.user_corrected_description.trim() || null;
+  }
+  if (body.user_corrected_calories === null) {
+    patch.user_corrected_calories = null;
+  } else if (typeof body.user_corrected_calories === 'number' && isFinite(body.user_corrected_calories)) {
+    patch.user_corrected_calories = Math.round(body.user_corrected_calories);
+  }
+  if (typeof body.eaten_at === 'string' && body.eaten_at.trim()) {
+    const d = new Date(body.eaten_at);
+    if (!isNaN(d.getTime())) {
+      patch.eaten_at = d.toISOString();
+      patch.eaten_at_source = 'manual';
+    }
+  }
+  if (body.lat === null && body.lon === null) {
+    patch.lat = null;
+    patch.lon = null;
+    patch.location_source = 'none';
+    patch.location_label = null;
+  } else if (
+    typeof body.lat === 'number' && isFinite(body.lat) &&
+    typeof body.lon === 'number' && isFinite(body.lon)
+  ) {
+    patch.lat = body.lat;
+    patch.lon = body.lon;
+    patch.location_source = 'manual';
+    patch.location_label = '手動指定';
+  }
+
+  if (Object.keys(patch).length > 0) updateMeal(db, id, patch);
+  return c.json({ meal: getMeal(db, id) });
+});
+
+app.delete('/api/meals/:id', (c) => {
+  const id = Number(c.req.param('id'));
+  const meal = getMeal(db, id);
+  if (!meal) return c.json({ error: 'not found' }, 404);
+  try {
+    const fullPath = join(MEAL_DIR, meal.photo_path);
+    if (existsSync(fullPath)) unlinkSync(fullPath);
+  } catch (e) {
+    console.warn(`[meal#${id}] failed to delete photo: ${e.message}`);
+  }
+  deleteMeal(db, id);
+  return c.json({ ok: true });
+});
+
+app.post('/api/meals/:id/reanalyze', (c) => {
+  const id = Number(c.req.param('id'));
+  const meal = getMeal(db, id);
+  if (!meal) return c.json({ error: 'not found' }, 404);
+  updateMeal(db, id, { ai_status: 'pending', ai_error: null });
+  enqueueMealVision(id);
+  return c.json({ meal: getMeal(db, id), queued: true });
+});
+
+// 起動時に pending 食事があれば解析を再投入 (前回終了時の中断分)
+for (const m of listPendingMeals(db, { limit: 50 })) {
+  enqueueMealVision(m.id);
+}
 
 // ---- dig (deep research) -------------------------------------------------
 // All claude-using work (dig / cloud / diary / weekly / domain / page) runs

--- a/server/index.js
+++ b/server/index.js
@@ -647,6 +647,7 @@ function enqueueMealVision(id) {
         description: result.description ?? null,
         calories: typeof result.calories === 'number' ? result.calories : null,
         items_json: result.items ? JSON.stringify(result.items) : null,
+        nutrients_json: result.nutrients ? JSON.stringify(result.nutrients) : null,
         ai_status: 'done',
         ai_error: null,
       });
@@ -668,9 +669,15 @@ function enqueueCalorieEstimate(mealId, additionIdx, foodName) {
       if (!meal) return;
       if (additionIdx === -1) {
         // meal 本体のカロリーを user_corrected_calories に書く (上書きしない)
+        const patch = {};
         if (meal.user_corrected_calories == null && meal.calories == null) {
-          updateMeal(db, mealId, { user_corrected_calories: r.calories });
+          patch.user_corrected_calories = r.calories;
         }
+        // nutrients も未設定なら埋める
+        if (!meal.nutrients_json && r.nutrients) {
+          patch.nutrients_json = JSON.stringify(r.nutrients);
+        }
+        if (Object.keys(patch).length > 0) updateMeal(db, mealId, patch);
         return;
       }
       const additions = parseMealAdditionsJson(meal.additions_json);
@@ -1631,6 +1638,13 @@ app.get('/api/llm/config', (c) => {
       openai_api_key_set: !!cfg.openai_api_key,
       // Standing memo passed to every diary generation.
       diary_global_memo: settings['diary.global_memo'] || '',
+      user_profile: {
+        age: settings['user.age'] ? Number(settings['user.age']) : null,
+        sex: settings['user.sex'] || '',
+        weight_kg: settings['user.weight_kg'] ? Number(settings['user.weight_kg']) : null,
+        height_cm: settings['user.height_cm'] ? Number(settings['user.height_cm']) : null,
+        activity_level: settings['user.activity_level'] || 'moderate',
+      },
     },
     tasks: LLM_TASKS,
     providers: Object.entries(LLM_PROVIDERS).map(([key, v]) => ({
@@ -1658,6 +1672,25 @@ app.patch('/api/llm/config', async (c) => {
   // Diary-specific standing memo lives outside the LLM config object.
   if (typeof body.diary_global_memo === 'string') {
     patch['diary.global_memo'] = body.diary_global_memo;
+  }
+  // ユーザプロファイル (適正カロリー計算用)
+  if (body.user_profile && typeof body.user_profile === 'object') {
+    const up = body.user_profile;
+    if (up.age == null || (typeof up.age === 'number' && isFinite(up.age))) {
+      patch['user.age'] = up.age == null ? '' : String(up.age);
+    }
+    if (typeof up.sex === 'string') {
+      patch['user.sex'] = (up.sex === 'male' || up.sex === 'female') ? up.sex : '';
+    }
+    if (up.weight_kg == null || (typeof up.weight_kg === 'number' && isFinite(up.weight_kg))) {
+      patch['user.weight_kg'] = up.weight_kg == null ? '' : String(up.weight_kg);
+    }
+    if (up.height_cm == null || (typeof up.height_cm === 'number' && isFinite(up.height_cm))) {
+      patch['user.height_cm'] = up.height_cm == null ? '' : String(up.height_cm);
+    }
+    if (typeof up.activity_level === 'string' && Object.keys({sedentary:1, light:1, moderate:1, active:1, very_active:1}).includes(up.activity_level)) {
+      patch['user.activity_level'] = up.activity_level;
+    }
   }
   setAppSettings(db, patch);
   loadLlmConfigFromSettings(getAppSettings(db));

--- a/server/index.js
+++ b/server/index.js
@@ -84,6 +84,9 @@ import { listPushSubscriptions, deletePushSubscription } from './db.js';
 import {
   insertMeal, getMeal, listMeals, countMeals, updateMeal, deleteMeal, listPendingMeals,
 } from './db.js';
+import {
+  ensureUserStopwordsTable, listUserStopwords, addUserStopword, removeUserStopword,
+} from './db.js';
 import { initWebPush, getVapidPublicKey, saveSubscription, sendPushToAll } from './push.js';
 import {
   extractPhotoMeta, resolveMealLocation, analyzeMealPhoto, estimateCaloriesFromName,
@@ -107,6 +110,7 @@ const CLAUDE_BIN = process.env.MEMORIA_CLAUDE_BIN ?? 'claude';
 mkdirSync(HTML_DIR, { recursive: true });
 mkdirSync(MEAL_DIR, { recursive: true });
 const db = openDb(DB_PATH);
+ensureUserStopwordsTable(db);
 loadLlmConfigFromSettings(getAppSettings(db));
 initWebPush(DATA_DIR);
 const HEARTBEAT_FILE = join(DATA_DIR, 'heartbeat.json');
@@ -1503,6 +1507,23 @@ app.get('/api/dictionary/:id', (c) => {
   const e = getDictionaryEntry(db, id);
   if (!e) return c.json({ error: 'not found' }, 404);
   return c.json(e);
+});
+
+// ---- user stopwords (グラフ / ワードクラウド除外語) ----------------------
+app.get('/api/stopwords', (c) => {
+  return c.json({ items: listUserStopwords(db) });
+});
+app.post('/api/stopwords', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const word = (body?.word ?? '').toString().trim();
+  if (!word) return c.json({ error: 'word required' }, 400);
+  addUserStopword(db, word);
+  return c.json({ ok: true, word });
+});
+app.delete('/api/stopwords/:word', (c) => {
+  const word = decodeURIComponent(c.req.param('word'));
+  const removed = removeUserStopword(db, word);
+  return c.json({ ok: removed });
 });
 
 app.post('/api/dictionary', async (c) => {

--- a/server/index.js
+++ b/server/index.js
@@ -1958,6 +1958,7 @@ app.get('/api/queue/items', (c) => {
     weekly: weeklyQueue.snapshot(),
     domain: domainCatalogQueue.snapshot(),
     page: pageMetadataQueue.snapshot(),
+    meal: mealVisionQueue.snapshot(),
     // Backward-compat top-level fields:
     ...summaryQueue.snapshot(),
   });

--- a/server/llm.js
+++ b/server/llm.js
@@ -7,7 +7,8 @@
 //   summarize, dig, dig_preview, cloud_extract, cloud_validate,
 //   domain_classify, page_summary,
 //   diary_work, diary_highlights, diary_weekly,
-//   meal_vision (画像入力あり — Claude CLI 推奨)
+//   meal_vision (画像入力あり — Claude CLI 推奨),
+//   meal_calorie (食品名テキスト → 標準カロリー推定)
 
 import { spawn } from 'node:child_process';
 
@@ -15,7 +16,7 @@ export const TASKS = [
   'summarize', 'dig', 'dig_preview', 'cloud_extract', 'cloud_validate',
   'domain_classify', 'page_summary',
   'diary_work', 'diary_highlights', 'diary_weekly',
-  'meal_vision',
+  'meal_vision', 'meal_calorie',
 ];
 
 // When the user hasn't explicitly chosen a model for a task, fall back to these.
@@ -27,6 +28,7 @@ const TASK_DEFAULT_MODELS = {
   diary_highlights: 'claude-opus-4-7[1m]',
   diary_weekly: 'claude-opus-4-7[1m]',
   meal_vision: 'sonnet',
+  meal_calorie: 'sonnet',
 };
 
 export const PROVIDERS = {

--- a/server/llm.js
+++ b/server/llm.js
@@ -6,7 +6,8 @@
 // app_settings. Tasks recognised at the moment:
 //   summarize, dig, dig_preview, cloud_extract, cloud_validate,
 //   domain_classify, page_summary,
-//   diary_work, diary_highlights, diary_weekly
+//   diary_work, diary_highlights, diary_weekly,
+//   meal_vision (画像入力あり — Claude CLI 推奨)
 
 import { spawn } from 'node:child_process';
 
@@ -14,6 +15,7 @@ export const TASKS = [
   'summarize', 'dig', 'dig_preview', 'cloud_extract', 'cloud_validate',
   'domain_classify', 'page_summary',
   'diary_work', 'diary_highlights', 'diary_weekly',
+  'meal_vision',
 ];
 
 // When the user hasn't explicitly chosen a model for a task, fall back to these.
@@ -24,6 +26,7 @@ const TASK_DEFAULT_MODELS = {
   diary_work: 'sonnet',
   diary_highlights: 'claude-opus-4-7[1m]',
   diary_weekly: 'claude-opus-4-7[1m]',
+  meal_vision: 'sonnet',
 };
 
 export const PROVIDERS = {

--- a/server/meals.js
+++ b/server/meals.js
@@ -2,17 +2,23 @@
 //
 // - EXIF パース (時刻 / GPS) — exifr ライブラリ
 // - GPS 軌跡からの後付け推定
-// - OpenAI Vision (gpt-4o-mini) による食事内容 / カロリー推定
+// - 食事内容 / カロリー推定 — `runLlm({ task: 'meal_vision' })` 経由
+//   (デフォルト Claude CLI、 設定 → AI で provider / model 変更可能)
 //
 // 設計判断:
-//   - Vision API は OpenAI のみ対応 (Claude / Gemini CLI への画像渡しは
-//     一貫性が薄れるため、 別 PR で拡張予定)
-//   - OPENAI_API_KEY が無い時は AI 解析を skip して `pending` のまま放置 →
-//     ユーザが /api/meals/:id/reanalyze で後から実行できる
+//   - Vision は llm.js の dispatch に乗せて、 他タスクと同様にユーザが
+//     provider を選べる (Claude / Gemini / Codex / OpenAI)。 デフォルトは
+//     Claude CLI で sonnet モデル
+//   - Claude CLI は `@<absolute_path>` で画像を attachment 扱い + Read tool
+//     許可で読み取り可能。 本実装では prompt に絶対パスを `@` 付きで埋め込み、
+//     allowedTools に Read を渡す
+//   - CLI / API 失敗時は ai_status='error' を保存。 ユーザは
+//     /api/meals/:id/reanalyze で再投入可能
 //   - 個人データ非保管ルール対象外 (Memoria は単一ユーザ前提のローカル DB)
 
 import exifr from 'exifr';
-import { findNearestGpsLocation, getAppSettings } from './db.js';
+import { findNearestGpsLocation } from './db.js';
+import { runLlm } from './llm.js';
 
 /** 画像バッファから EXIF を抽出する。 失敗しても throw せず空 meta を返す。 */
 export async function extractPhotoMeta(buf) {
@@ -77,69 +83,58 @@ function formatHm(iso) {
   return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
 }
 
-// ─── OpenAI Vision ────────────────────────────────────────────
+// ─── Vision 解析 (LLM dispatch 経由) ───────────────────────────
 
-const VISION_PROMPT = `あなたは食事記録アプリの AI アシスタントです。 画像を見て食事内容を JSON で返してください。
+const VISION_PROMPT_TEMPLATE = (absPath) => [
+  '次の食事写真を見て、 食事内容を JSON 1 オブジェクトで返してください。',
+  '前後の説明文 / コードフェンス / コメントは禁止です。',
+  '',
+  `写真: @${absPath}`,
+  '',
+  'スキーマ:',
+  '{',
+  '  "description": "ひと言での食事内容 (例: \'カレーライスとサラダ\')",',
+  '  "calories": <推定総カロリー (数値, kcal)>,',
+  '  "items": [',
+  '    {"name": "個別の料理名", "calories": <推定 kcal>}',
+  '  ]',
+  '}',
+  '',
+  '不明な値: description は推測 (例 "料理 (推定不可)")、 数値は null。',
+  '食事以外の写真: description="食事ではない", calories=null, items=[]。',
+].join('\n');
 
-返答は **次の JSON だけ** にしてください (コードブロック不要):
-{
-  "description": "ひと言での食事内容 (例: 'カレーライスとサラダ')",
-  "calories": <推定総カロリー (数値, kcal)>,
-  "items": [
-    {"name": "個別の料理名", "calories": <推定 kcal>}
-  ]
+/**
+ * 食事写真を解析する。 photoAbsPath は OS 絶対パス (Claude CLI が `@` 経由で
+ * 画像を読むため)。 失敗時は throw する (caller 側で error を記録)。
+ */
+export async function analyzeMealPhoto(photoAbsPath) {
+  const prompt = VISION_PROMPT_TEMPLATE(photoAbsPath);
+  const stdout = await runLlm({
+    task: 'meal_vision',
+    prompt,
+    tools: ['Read'],
+    timeoutMs: 90_000,
+  });
+  return parseVisionJson(stdout);
 }
 
-不明な値は description は推測 (例: "料理 (推定不可)")、 数値は null にしてください。 食事以外の写真の場合は description に "食事ではない" と書き、 calories は null、 items は [] にしてください。`;
+function parseVisionJson(raw) {
+  let s = (raw || '').trim();
+  // コードフェンスを取り除く
+  const fence = s.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/);
+  if (fence) s = fence[1].trim();
+  // 最初の { から最後の } までを切り出す
+  const first = s.indexOf('{');
+  const last = s.lastIndexOf('}');
+  if (first >= 0 && last > first) s = s.slice(first, last + 1);
 
-/** 画像 (base64) から食事内容 / カロリーを推定。 OPENAI_API_KEY が無い / API
- *  失敗時は throw or null。 caller 側で error を記録する。 */
-export async function analyzeMealPhoto(apiKey, imageBase64, mimeType) {
-  if (!apiKey) return null;
-  const ac = new AbortController();
-  const timer = setTimeout(() => ac.abort(), 60_000);
+  let obj;
   try {
-    const res = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: 'gpt-4o-mini',
-        messages: [
-          {
-            role: 'user',
-            content: [
-              { type: 'text', text: VISION_PROMPT },
-              {
-                type: 'image_url',
-                image_url: { url: `data:${mimeType};base64,${imageBase64}` },
-              },
-            ],
-          },
-        ],
-        temperature: 0.2,
-      }),
-      signal: ac.signal,
-    });
-    if (!res.ok) {
-      const body = (await res.text()).slice(0, 400);
-      throw new Error(`OpenAI Vision ${res.status}: ${body}`);
-    }
-    const data = await res.json();
-    const text = data?.choices?.[0]?.message?.content?.trim() ?? '';
-    return parseVisionJson(text);
-  } finally {
-    clearTimeout(timer);
+    obj = JSON.parse(s);
+  } catch (e) {
+    throw new Error(`vision output is not JSON: ${e.message}\nRaw (first 300): ${(raw || '').slice(0, 300)}`);
   }
-}
-
-function parseVisionJson(text) {
-  // モデルがコードブロックで返してきた場合に取り除く
-  let s = text.trim();
-  s = s.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '');
-  const obj = JSON.parse(s);
   const description = typeof obj.description === 'string' ? obj.description : '';
   const calories = typeof obj.calories === 'number' && isFinite(obj.calories) ? Math.round(obj.calories) : null;
   let items = [];
@@ -152,12 +147,4 @@ function parseVisionJson(text) {
       }));
   }
   return { description, calories, items };
-}
-
-/** app_settings から OpenAI API key を取得。 llm.openai.api_key が優先、 env が fallback。 */
-export function getMealsApiKey(db) {
-  const settings = getAppSettings(db);
-  const fromSettings = (settings['llm.openai.api_key'] || '').trim();
-  if (fromSettings) return fromSettings;
-  return (process.env.OPENAI_API_KEY || '').trim();
 }

--- a/server/meals.js
+++ b/server/meals.js
@@ -119,6 +119,59 @@ export async function analyzeMealPhoto(photoAbsPath) {
   return parseVisionJson(stdout);
 }
 
+// ─── 食品名 → 標準カロリー推定 (LLM 経由) ─────────────────────
+
+const CALORIE_PROMPT = (foodName) => [
+  `食品名: ${foodName}`,
+  '',
+  '上記の食品の標準的な 1 食分 / 1 個分のカロリー (kcal) を推定してください。',
+  '一般的なレシピサイト・栄養データベースの値を参考にした概数で構いません。',
+  '',
+  '返答は **次の JSON 1 オブジェクトだけ** にしてください (前後の説明 / コードフェンス禁止):',
+  '{',
+  '  "calories": <推定 kcal (数値) または null>,',
+  '  "serving": "想定する分量 (例: \\"1 杯 (200g)\\", \\"1 個\\", \\"1 食分\\")",',
+  '  "confidence": "high | medium | low"',
+  '}',
+  '',
+  '一般的な食品でない / 推定不能なら calories を null、 confidence を low にしてください。',
+].join('\n');
+
+/**
+ * 食品名から標準カロリーを LLM で推定する。 失敗時は throw。
+ * 戻り値: { calories: number|null, serving: string, confidence: 'high'|'medium'|'low' }
+ */
+export async function estimateCaloriesFromName(foodName) {
+  const cleaned = String(foodName ?? '').trim();
+  if (!cleaned) return { calories: null, serving: '', confidence: 'low' };
+  const stdout = await runLlm({
+    task: 'meal_calorie',
+    prompt: CALORIE_PROMPT(cleaned),
+    timeoutMs: 60_000,
+  });
+  return parseCalorieJson(stdout);
+}
+
+function parseCalorieJson(raw) {
+  let s = (raw || '').trim();
+  const fence = s.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/);
+  if (fence) s = fence[1].trim();
+  const first = s.indexOf('{');
+  const last = s.lastIndexOf('}');
+  if (first >= 0 && last > first) s = s.slice(first, last + 1);
+  let obj;
+  try {
+    obj = JSON.parse(s);
+  } catch (e) {
+    throw new Error(`calorie output is not JSON: ${e.message}\nRaw (first 200): ${(raw || '').slice(0, 200)}`);
+  }
+  const calories = (typeof obj.calories === 'number' && isFinite(obj.calories)) ? Math.round(obj.calories) : null;
+  const serving = typeof obj.serving === 'string' ? obj.serving.slice(0, 120) : '';
+  const confidence = (obj.confidence === 'high' || obj.confidence === 'medium' || obj.confidence === 'low')
+    ? obj.confidence : 'low';
+  return { calories, serving, confidence };
+}
+
 function parseVisionJson(raw) {
   let s = (raw || '').trim();
   // コードフェンスを取り除く

--- a/server/meals.js
+++ b/server/meals.js
@@ -97,11 +97,19 @@ const VISION_PROMPT_TEMPLATE = (absPath) => [
   '  "calories": <推定総カロリー (数値, kcal)>,',
   '  "items": [',
   '    {"name": "個別の料理名", "calories": <推定 kcal>}',
-  '  ]',
+  '  ],',
+  '  "nutrients": {',
+  '    "protein_g":  <タンパク質 (g)>,',
+  '    "fat_g":      <脂質 (g)>,',
+  '    "carbs_g":    <炭水化物 (g)>,',
+  '    "fiber_g":    <食物繊維 (g)>,',
+  '    "sugar_g":    <糖質 (g)>,',
+  '    "sodium_mg":  <塩分 (mg、 食塩相当量で構わない)>',
+  '  }',
   '}',
   '',
   '不明な値: description は推測 (例 "料理 (推定不可)")、 数値は null。',
-  '食事以外の写真: description="食事ではない", calories=null, items=[]。',
+  '食事以外の写真: description="食事ではない", calories=null, items=[], nutrients は全 null。',
 ].join('\n');
 
 /**
@@ -124,17 +132,25 @@ export async function analyzeMealPhoto(photoAbsPath) {
 const CALORIE_PROMPT = (foodName) => [
   `食品名: ${foodName}`,
   '',
-  '上記の食品の標準的な 1 食分 / 1 個分のカロリー (kcal) を推定してください。',
+  '上記の食品の標準的な 1 食分 / 1 個分のカロリーと主要栄養素を推定してください。',
   '一般的なレシピサイト・栄養データベースの値を参考にした概数で構いません。',
   '',
   '返答は **次の JSON 1 オブジェクトだけ** にしてください (前後の説明 / コードフェンス禁止):',
   '{',
   '  "calories": <推定 kcal (数値) または null>,',
   '  "serving": "想定する分量 (例: \\"1 杯 (200g)\\", \\"1 個\\", \\"1 食分\\")",',
-  '  "confidence": "high | medium | low"',
+  '  "confidence": "high | medium | low",',
+  '  "nutrients": {',
+  '    "protein_g":  <タンパク質 (g) または null>,',
+  '    "fat_g":      <脂質 (g) または null>,',
+  '    "carbs_g":    <炭水化物 (g) または null>,',
+  '    "fiber_g":    <食物繊維 (g) または null>,',
+  '    "sugar_g":    <糖質 (g) または null>,',
+  '    "sodium_mg":  <塩分 (mg) または null>',
+  '  }',
   '}',
   '',
-  '一般的な食品でない / 推定不能なら calories を null、 confidence を low にしてください。',
+  '一般的な食品でない / 推定不能なら calories を null、 confidence を low、 nutrients は全 null。',
 ].join('\n');
 
 /**
@@ -169,7 +185,26 @@ function parseCalorieJson(raw) {
   const serving = typeof obj.serving === 'string' ? obj.serving.slice(0, 120) : '';
   const confidence = (obj.confidence === 'high' || obj.confidence === 'medium' || obj.confidence === 'low')
     ? obj.confidence : 'low';
-  return { calories, serving, confidence };
+  const nutrients = sanitizeNutrients(obj.nutrients);
+  return { calories, serving, confidence, nutrients };
+}
+
+/** vision / calorie 共通の nutrients サニタイザ。 数値 (有限) のみ採用、 残りは null。 */
+function sanitizeNutrients(input) {
+  if (!input || typeof input !== 'object') return null;
+  const keys = ['protein_g', 'fat_g', 'carbs_g', 'fiber_g', 'sugar_g', 'sodium_mg'];
+  const out = {};
+  let any = false;
+  for (const k of keys) {
+    const v = input[k];
+    if (typeof v === 'number' && isFinite(v) && v >= 0) {
+      out[k] = Math.round(v * 10) / 10; // 小数 1 桁
+      any = true;
+    } else {
+      out[k] = null;
+    }
+  }
+  return any ? out : null;
 }
 
 function parseVisionJson(raw) {
@@ -199,5 +234,6 @@ function parseVisionJson(raw) {
         calories: typeof it.calories === 'number' && isFinite(it.calories) ? Math.round(it.calories) : null,
       }));
   }
-  return { description, calories, items };
+  const nutrients = sanitizeNutrients(obj.nutrients);
+  return { description, calories, items, nutrients };
 }

--- a/server/meals.js
+++ b/server/meals.js
@@ -1,0 +1,163 @@
+// 食事記録の補助モジュール
+//
+// - EXIF パース (時刻 / GPS) — exifr ライブラリ
+// - GPS 軌跡からの後付け推定
+// - OpenAI Vision (gpt-4o-mini) による食事内容 / カロリー推定
+//
+// 設計判断:
+//   - Vision API は OpenAI のみ対応 (Claude / Gemini CLI への画像渡しは
+//     一貫性が薄れるため、 別 PR で拡張予定)
+//   - OPENAI_API_KEY が無い時は AI 解析を skip して `pending` のまま放置 →
+//     ユーザが /api/meals/:id/reanalyze で後から実行できる
+//   - 個人データ非保管ルール対象外 (Memoria は単一ユーザ前提のローカル DB)
+
+import exifr from 'exifr';
+import { findNearestGpsLocation, getAppSettings } from './db.js';
+
+/** 画像バッファから EXIF を抽出する。 失敗しても throw せず空 meta を返す。 */
+export async function extractPhotoMeta(buf) {
+  try {
+    const data = await exifr.parse(buf, {
+      tiff: true,
+      ifd0: true,
+      exif: true,
+      gps: true,
+      pick: ['DateTimeOriginal', 'CreateDate', 'ModifyDate', 'latitude', 'longitude'],
+    });
+    if (!data) return { capturedAt: null, lat: null, lon: null };
+    let captured = null;
+    for (const k of ['DateTimeOriginal', 'CreateDate', 'ModifyDate']) {
+      const v = data[k];
+      if (v instanceof Date && !isNaN(v.getTime())) {
+        captured = v;
+        break;
+      }
+    }
+    const lat = typeof data.latitude === 'number' && isFinite(data.latitude) ? data.latitude : null;
+    const lon = typeof data.longitude === 'number' && isFinite(data.longitude) ? data.longitude : null;
+    return {
+      capturedAt: captured ? captured.toISOString() : null,
+      lat,
+      lon,
+    };
+  } catch {
+    return { capturedAt: null, lat: null, lon: null };
+  }
+}
+
+/**
+ * 場所を以下の優先順位で解決する:
+ *   1. 手動 (caller が manual={lat,lon} で渡した場合)
+ *   2. EXIF GPS (写真メタデータ)
+ *   3. 既存 gps_locations から食事時刻に最も近い点 (±5 分)
+ *   4. なし
+ */
+export function resolveMealLocation(db, exif, eatenAt, manual) {
+  if (manual && typeof manual.lat === 'number' && typeof manual.lon === 'number') {
+    return { lat: manual.lat, lon: manual.lon, source: 'manual', label: '手動指定' };
+  }
+  if (typeof exif.lat === 'number' && typeof exif.lon === 'number') {
+    return { lat: exif.lat, lon: exif.lon, source: 'exif', label: '写真メタデータ (EXIF)' };
+  }
+  const near = findNearestGpsLocation(db, eatenAt, { windowMs: 5 * 60 * 1000 });
+  if (near && typeof near.lat === 'number' && typeof near.lon === 'number') {
+    return {
+      lat: near.lat,
+      lon: near.lon,
+      source: 'gps_track',
+      label: `GPS 軌跡 ±5分 (${formatHm(near.recorded_at)})`,
+    };
+  }
+  return { lat: null, lon: null, source: 'none', label: null };
+}
+
+function formatHm(iso) {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+}
+
+// ─── OpenAI Vision ────────────────────────────────────────────
+
+const VISION_PROMPT = `あなたは食事記録アプリの AI アシスタントです。 画像を見て食事内容を JSON で返してください。
+
+返答は **次の JSON だけ** にしてください (コードブロック不要):
+{
+  "description": "ひと言での食事内容 (例: 'カレーライスとサラダ')",
+  "calories": <推定総カロリー (数値, kcal)>,
+  "items": [
+    {"name": "個別の料理名", "calories": <推定 kcal>}
+  ]
+}
+
+不明な値は description は推測 (例: "料理 (推定不可)")、 数値は null にしてください。 食事以外の写真の場合は description に "食事ではない" と書き、 calories は null、 items は [] にしてください。`;
+
+/** 画像 (base64) から食事内容 / カロリーを推定。 OPENAI_API_KEY が無い / API
+ *  失敗時は throw or null。 caller 側で error を記録する。 */
+export async function analyzeMealPhoto(apiKey, imageBase64, mimeType) {
+  if (!apiKey) return null;
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), 60_000);
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: VISION_PROMPT },
+              {
+                type: 'image_url',
+                image_url: { url: `data:${mimeType};base64,${imageBase64}` },
+              },
+            ],
+          },
+        ],
+        temperature: 0.2,
+      }),
+      signal: ac.signal,
+    });
+    if (!res.ok) {
+      const body = (await res.text()).slice(0, 400);
+      throw new Error(`OpenAI Vision ${res.status}: ${body}`);
+    }
+    const data = await res.json();
+    const text = data?.choices?.[0]?.message?.content?.trim() ?? '';
+    return parseVisionJson(text);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function parseVisionJson(text) {
+  // モデルがコードブロックで返してきた場合に取り除く
+  let s = text.trim();
+  s = s.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '');
+  const obj = JSON.parse(s);
+  const description = typeof obj.description === 'string' ? obj.description : '';
+  const calories = typeof obj.calories === 'number' && isFinite(obj.calories) ? Math.round(obj.calories) : null;
+  let items = [];
+  if (Array.isArray(obj.items)) {
+    items = obj.items
+      .filter((it) => it && typeof it === 'object' && typeof it.name === 'string')
+      .map((it) => ({
+        name: it.name,
+        calories: typeof it.calories === 'number' && isFinite(it.calories) ? Math.round(it.calories) : null,
+      }));
+  }
+  return { description, calories, items };
+}
+
+/** app_settings から OpenAI API key を取得。 llm.openai.api_key が優先、 env が fallback。 */
+export function getMealsApiKey(db) {
+  const settings = getAppSettings(db);
+  const fromSettings = (settings['llm.openai.api_key'] || '').trim();
+  if (fromSettings) return fromSettings;
+  return (process.env.OPENAI_API_KEY || '').trim();
+}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@hono/node-server": "^1.13.7",
         "better-sqlite3": "^11.3.0",
+        "exifr": "^7.1.3",
         "hono": "^4.6.10",
         "mqtt": "^5.15.1",
         "node-html-parser": "^6.1.13",
@@ -416,6 +417,12 @@
       "engines": {
         "node": ">=0.8.x"
       }
+    },
+    "node_modules/exifr": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/exifr/-/exifr-7.1.3.tgz",
+      "integrity": "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw==",
+      "license": "MIT"
     },
     "node_modules/expand-template": {
       "version": "2.0.3",

--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@hono/node-server": "^1.13.7",
     "better-sqlite3": "^11.3.0",
+    "exifr": "^7.1.3",
     "hono": "^4.6.10",
     "mqtt": "^5.15.1",
     "node-html-parser": "^6.1.13",

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -2683,7 +2683,9 @@ function renderDiaryDetail() {
   renderDiaryDigList(digs, digsTotal);
 
   // 食事
-  renderDiaryMeals(metrics.meals || [], metrics.meals_total_calories);
+  renderDiaryMeals(metrics.meals || [], metrics.meals_total_calories, metrics.meals_nutrients, metrics.meals_pfc_label);
+  // カロリーバランス
+  renderDiaryCaloricBalance(metrics.caloric_balance);
 
   const commits = d.github_commits?.commits || [];
   if (commits.length === 0) {
@@ -2796,7 +2798,55 @@ function renderDiaryBookmarkList(elId, items, total, kind, emptyMsg) {
   }
 }
 
-function renderDiaryMeals(meals, totalCal) {
+function fmtNutrient(v, unit) {
+  if (typeof v !== 'number' || !isFinite(v)) return '—';
+  return `${Math.round(v * 10) / 10}${unit}`;
+}
+
+function renderDiaryCaloricBalance(cb) {
+  const wrap = document.getElementById('diaryCaloricBalance');
+  if (!wrap) return;
+  if (!cb) {
+    wrap.innerHTML = `<div class="hint">プロファイルが未設定です。 設定 (右上 ⚙) → 「🧍 プロファイル」 で年齢 / 性別 / 体重 / 身長 / 活動レベルを入れると、 BMR + TDEE + 軌跡からの歩行消費を計算します。</div>`;
+    return;
+  }
+  const p = cb.profile;
+  const sexLabel = p.sex === 'male' ? '男性' : '女性';
+  const intakeStr = (cb.intake != null) ? `${cb.intake} kcal` : '— (食事なし)';
+  const diffT = cb.diff_vs_target;
+  const diffE = cb.diff_vs_expenditure;
+  const sign = (n) => n == null ? '—' : (n > 0 ? `+${n}` : String(n));
+  const diffTClass = diffT == null ? '' : (diffT > 200 ? 'over' : diffT < -200 ? 'under' : 'ok');
+  const diffEClass = diffE == null ? '' : (diffE > 200 ? 'over' : diffE < -200 ? 'under' : 'ok');
+  wrap.innerHTML = `
+    <div class="cb-profile muted">${escapeHtml(sexLabel)} / ${p.age}歳 / ${p.weight_kg}kg / ${p.height_cm}cm / 活動 ${escapeHtml(p.activity_level)}</div>
+    <div class="cb-grid">
+      <div class="cb-stat">
+        <div class="cb-label">摂取</div>
+        <div class="cb-value">${escapeHtml(intakeStr)}</div>
+      </div>
+      <div class="cb-stat">
+        <div class="cb-label">消費 (BMR + 歩行)</div>
+        <div class="cb-value">${cb.expenditure_total} kcal</div>
+        <div class="cb-sub muted">BMR ${cb.bmr} + 歩行 ${cb.walking_kcal}</div>
+      </div>
+      <div class="cb-stat">
+        <div class="cb-label">適正 (TDEE)</div>
+        <div class="cb-value">${cb.tdee} kcal</div>
+      </div>
+      <div class="cb-stat cb-diff ${diffTClass}">
+        <div class="cb-label">摂取 - 適正</div>
+        <div class="cb-value">${escapeHtml(sign(diffT))} kcal</div>
+      </div>
+      <div class="cb-stat cb-diff ${diffEClass}">
+        <div class="cb-label">摂取 - 消費 (収支)</div>
+        <div class="cb-value">${escapeHtml(sign(diffE))} kcal</div>
+      </div>
+    </div>
+  `;
+}
+
+function renderDiaryMeals(meals, totalCal, nutrients, pfcLabel) {
   const wrap = document.getElementById('diaryMeals');
   if (!wrap) return;
   if (!meals || meals.length === 0) {
@@ -2806,6 +2856,17 @@ function renderDiaryMeals(meals, totalCal) {
   const totalLine = (typeof totalCal === 'number')
     ? `<div class="diary-meals-total">総カロリー: <strong>${totalCal} kcal</strong> (${meals.length} 食)</div>`
     : `<div class="diary-meals-total muted">${meals.length} 食 (カロリー未推定)</div>`;
+  const nutLine = nutrients
+    ? `<div class="diary-meals-nutrients">
+        <span class="nutrient-chip"><b>P</b> ${fmtNutrient(nutrients.protein_g, 'g')}</span>
+        <span class="nutrient-chip"><b>F</b> ${fmtNutrient(nutrients.fat_g, 'g')}</span>
+        <span class="nutrient-chip"><b>C</b> ${fmtNutrient(nutrients.carbs_g, 'g')}</span>
+        <span class="nutrient-chip nutrient-fiber">食物繊維 ${fmtNutrient(nutrients.fiber_g, 'g')}</span>
+        <span class="nutrient-chip nutrient-sugar">糖質 ${fmtNutrient(nutrients.sugar_g, 'g')}</span>
+        <span class="nutrient-chip nutrient-sodium">塩分 ${fmtNutrient(nutrients.sodium_mg, 'mg')}</span>
+        ${pfcLabel ? `<span class="nutrient-chip nutrient-pfc"><b>PFC</b> ${escapeHtml(pfcLabel)}</span>` : ''}
+       </div>`
+    : '';
   const items = meals.map((m) => {
     // ISO は UTC なので localtime に変換して HH:MM を表示
     const td = new Date(m.eaten_at || '');
@@ -2832,7 +2893,7 @@ function renderDiaryMeals(meals, totalCal) {
       </div>
     </li>`;
   }).join('');
-  wrap.innerHTML = `${totalLine}<ul class="diary-meals-list">${items}</ul>`;
+  wrap.innerHTML = `${totalLine}${nutLine}<ul class="diary-meals-list">${items}</ul>`;
   // クリック → 食事タブに飛ばす
   wrap.querySelectorAll('.diary-meal-thumb').forEach((a) => {
     a.addEventListener('click', (ev) => {
@@ -3936,6 +3997,15 @@ async function openAiSettings() {
     $('aiOpenaiModel').value = cfg.openai_model || '';
     $('aiOpenaiKeyStatus').textContent = cfg.openai_api_key_set ? '✓ API key 設定済み (再入力で上書き)' : '(未設定)';
     if ($('aiDiaryGlobalMemo')) $('aiDiaryGlobalMemo').value = cfg.diary_global_memo || '';
+    // ユーザプロファイル (適正カロリー計算用)
+    if (cfg.user_profile) {
+      const up = cfg.user_profile;
+      if ($('userAge')) $('userAge').value = up.age != null ? String(up.age) : '';
+      if ($('userSex')) $('userSex').value = up.sex || '';
+      if ($('userWeightKg')) $('userWeightKg').value = up.weight_kg != null ? String(up.weight_kg) : '';
+      if ($('userHeightCm')) $('userHeightCm').value = up.height_cm != null ? String(up.height_cm) : '';
+      if ($('userActivityLevel')) $('userActivityLevel').value = up.activity_level || 'moderate';
+    }
     if (r.runtime) {
       const rt = r.runtime;
       $('aiRuntimeInfo').innerHTML = `
@@ -4236,7 +4306,18 @@ async function saveAiSettings() {
     openai_model: $('aiOpenaiModel').value.trim() || 'gpt-4o-mini',
     git_bash_path: $('aiGitBashPath').value.trim(),
     diary_global_memo: $('aiDiaryGlobalMemo')?.value || '',
+    user_profile: {
+      age: parseFloat($('userAge')?.value),
+      sex: $('userSex')?.value || '',
+      weight_kg: parseFloat($('userWeightKg')?.value),
+      height_cm: parseFloat($('userHeightCm')?.value),
+      activity_level: $('userActivityLevel')?.value || 'moderate',
+    },
   };
+  // NaN/empty を null に正規化
+  for (const k of ['age', 'weight_kg', 'height_cm']) {
+    if (!isFinite(body.user_profile[k])) body.user_profile[k] = null;
+  }
   const k = $('aiOpenaiKey').value;
   if (k && k !== '***') body.openai_api_key = k;
   try {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -2795,7 +2795,11 @@ function renderDiaryMeals(meals, totalCal) {
     ? `<div class="diary-meals-total">総カロリー: <strong>${totalCal} kcal</strong> (${meals.length} 食)</div>`
     : `<div class="diary-meals-total muted">${meals.length} 食 (カロリー未推定)</div>`;
   const items = meals.map((m) => {
-    const t = (m.eaten_at || '').slice(11, 16);
+    // ISO は UTC なので localtime に変換して HH:MM を表示
+    const td = new Date(m.eaten_at || '');
+    const t = isNaN(td.getTime())
+      ? (m.eaten_at || '').slice(11, 16)
+      : `${String(td.getHours()).padStart(2, '0')}:${String(td.getMinutes()).padStart(2, '0')}`;
     const desc = m.description || '(未記入)';
     const cal = (typeof m.total_calories === 'number') ? `${m.total_calories} kcal` : '— kcal';
     const adds = (m.additions || []).map((a) => {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -499,6 +499,7 @@ const QUEUE_GROUP_LABELS = {
   weekly:    '📆 週報',
   domain:    '🏷 ドメイン分類',
   page:      '📄 ページメタ',
+  meal:      '🍽 食事解析',
 };
 
 function collectQueueJobs(snap) {
@@ -586,6 +587,7 @@ function jobLabel(item) {
   if (item.bookmarkId != null) return `${kindHint}bookmark #${item.bookmarkId}`;
   if (item.sessionId != null) return `${kindHint}dig #${item.sessionId}`;
   if (item.cloudId != null) return `${kindHint}cloud #${item.cloudId}`;
+  if (item.meal_id != null) return `${kindHint}meal #${item.meal_id}`;
   if (item.date) return `${kindHint}${item.date}`;
   if (item.weekStart) return `${kindHint}${item.weekStart}`;
   if (item.domain) return `${kindHint}${item.domain}`;

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -5936,109 +5936,57 @@ function startMealLocationEdit(btn) {
   });
 }
 
-// 追加 / 編集はモバイルで prompt() の popup が見落とされやすかったため、
-// inline form パターン (startMealDescriptionEdit と同系) に移行。
-function addMealAddition(mealId) {
-  const card = document.querySelector(`.meal-card[data-meal-id="${mealId}"]`);
-  if (!card) return;
-  if (card.querySelector('.meal-addition-form')) return; // 既に開いてる
-  const actions = card.querySelector('.meal-actions');
-  if (!actions) return;
-  const form = document.createElement('div');
-  form.className = 'meal-addition-form';
-  form.innerHTML = `
-    <input type="text" class="meal-addition-name-input" placeholder="例: アイスクリーム" />
-    <input type="number" class="meal-addition-cal-input" placeholder="kcal" inputmode="numeric" />
-    <button type="button" class="meal-addition-save" title="追加">✓ 追加</button>
-    <button type="button" class="ghost meal-addition-form-cancel" title="キャンセル">×</button>
-  `;
-  actions.parentElement.insertBefore(form, actions);
-  const nameEl = form.querySelector('.meal-addition-name-input');
-  const calEl = form.querySelector('.meal-addition-cal-input');
-  nameEl?.focus();
-
-  function close() { form.remove(); }
-
-  async function save() {
-    const name = (nameEl?.value || '').trim();
-    if (!name) { nameEl?.focus(); return; }
-    const calRaw = (calEl?.value || '').trim();
-    const body = { name };
-    if (calRaw !== '') {
-      const n = Number(calRaw);
-      if (isFinite(n)) body.calories = n;
-    }
-    try {
-      await api(`/api/meals/${mealId}/additions`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      });
-      await loadMeals();
-    } catch (e) {
-      alert(`追加エラー: ${e.message}`);
-    }
+async function addMealAddition(mealId) {
+  const name = prompt('追加で食べたものは? (例: アイスクリーム)');
+  if (name === null) return;
+  const trimmed = name.trim();
+  if (!trimmed) return;
+  const calRaw = prompt('カロリー (kcal、 不明なら空欄)', '');
+  if (calRaw === null) return;
+  const body = { name: trimmed };
+  if (calRaw.trim() !== '') {
+    const n = Number(calRaw);
+    if (isFinite(n)) body.calories = n;
   }
-
-  form.querySelector('.meal-addition-save')?.addEventListener('click', save);
-  form.querySelector('.meal-addition-form-cancel')?.addEventListener('click', close);
-  [nameEl, calEl].forEach((el) => el?.addEventListener('keydown', (ev) => {
-    if (ev.key === 'Enter') { ev.preventDefault(); save(); }
-    if (ev.key === 'Escape') { ev.preventDefault(); close(); }
-  }));
+  try {
+    await api(`/api/meals/${mealId}/additions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    await loadMeals();
+  } catch (e) {
+    alert(`追加エラー: ${e.message}`);
+  }
 }
 
-function editMealAddition(mealId, idx) {
+async function editMealAddition(mealId, idx) {
   const m = mealsState.items.find((x) => x.id === mealId);
   if (!m) return;
   const additions = parseMealAdditions(m.additions_json);
   const cur = additions[idx];
   if (!cur) return;
-  const li = document.querySelector(`.meal-addition[data-meal-id="${mealId}"][data-idx="${idx}"]`);
-  if (!li || li.classList.contains('editing')) return;
-  li.classList.add('editing');
-  const original = li.innerHTML;
-  li.innerHTML = `
-    <input type="text" class="meal-addition-name-input" value="${escapeHtml(cur.name || '')}" />
-    <input type="number" class="meal-addition-cal-input" placeholder="kcal" inputmode="numeric" value="${cur.calories == null ? '' : escapeHtml(String(cur.calories))}" />
-    <button type="button" class="meal-addition-save" title="保存">✓</button>
-    <button type="button" class="ghost meal-addition-form-cancel" title="キャンセル">×</button>
-  `;
-  const nameEl = li.querySelector('.meal-addition-name-input');
-  const calEl = li.querySelector('.meal-addition-cal-input');
-  nameEl?.focus();
-
-  function restore() { li.innerHTML = original; li.classList.remove('editing'); }
-
-  async function save() {
-    const name = (nameEl?.value || '').trim();
-    if (!name) { nameEl?.focus(); return; }
-    const calRaw = (calEl?.value || '').trim();
-    const body = { name };
-    if (calRaw === '') body.calories = null;
-    else {
-      const n = Number(calRaw);
-      if (isFinite(n)) body.calories = n;
-    }
-    try {
-      await api(`/api/meals/${mealId}/additions/${idx}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      });
-      await loadMeals();
-    } catch (e) {
-      alert(`編集エラー: ${e.message}`);
-      restore();
-    }
+  const name = prompt('項目名', cur.name || '');
+  if (name === null) return;
+  const calRaw = prompt('カロリー (kcal、 空欄でクリア)', cur.calories == null ? '' : String(cur.calories));
+  if (calRaw === null) return;
+  const body = {};
+  if (name.trim()) body.name = name.trim();
+  if (calRaw.trim() === '') body.calories = null;
+  else {
+    const n = Number(calRaw);
+    if (isFinite(n)) body.calories = n;
   }
-
-  li.querySelector('.meal-addition-save')?.addEventListener('click', save);
-  li.querySelector('.meal-addition-form-cancel')?.addEventListener('click', restore);
-  [nameEl, calEl].forEach((el) => el?.addEventListener('keydown', (ev) => {
-    if (ev.key === 'Enter') { ev.preventDefault(); save(); }
-    if (ev.key === 'Escape') { ev.preventDefault(); restore(); }
-  }));
+  try {
+    await api(`/api/meals/${mealId}/additions/${idx}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    await loadMeals();
+  } catch (e) {
+    alert(`編集エラー: ${e.message}`);
+  }
 }
 
 async function deleteMealAddition(mealId, idx) {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -5223,46 +5223,214 @@ function schedulePendingPoll() {
   }, 4000);
 }
 
-async function uploadMealPhotos(files) {
-  if (!files || files.length === 0) return;
-  const status = document.getElementById('mealsUploadStatus');
-  const total = files.length;
-  let ok = 0;
-  let failed = 0;
-  for (let i = 0; i < total; i++) {
-    const file = files[i];
-    if (!file || !file.type?.startsWith?.('image/')) {
-      failed += 1;
-      continue;
-    }
-    if (status) {
-      status.textContent = `📤 ${i + 1}/${total} 送信中… (${file.name || 'image'})`;
-    }
-    try {
-      const fd = new FormData();
-      fd.append('photo', file);
-      const res = await fetch('/api/meals', { method: 'POST', body: fd });
-      if (!res.ok) {
-        const errBody = await res.json().catch(() => ({}));
-        throw new Error(errBody.error || `HTTP ${res.status}`);
-      }
-      ok += 1;
-    } catch (e) {
-      failed += 1;
-      console.warn(`[meals] upload failed (${file.name}):`, e);
-    }
+// ── 食事登録モーダル — 写真 / 写真なし いずれも 1 件ずつ確認画面を出す ──
+//
+// queue にためて 1 件ずつ open / submit / next。 キャンセルで queue 全破棄。
+
+const mealModalState = {
+  queue: [],
+  currentIndex: 0,
+  totalCount: 0,
+  current: null,
+};
+
+function ensureBlobUrlRevoked(item) {
+  if (item?.blobUrl) {
+    URL.revokeObjectURL(item.blobUrl);
+    item.blobUrl = '';
   }
-  if (status) {
-    if (failed === 0) status.textContent = `✅ ${ok} 件 登録しました (解析中)`;
-    else if (ok === 0) status.textContent = `⚠ 全 ${total} 件 失敗しました`;
-    else status.textContent = `⚠ ${ok} 件 成功 / ${failed} 件 失敗`;
-  }
-  await loadMeals();
 }
 
-// 単一互換 (古い call 元用)
-function uploadMealPhoto(file) {
-  return uploadMealPhotos([file]);
+function clearMealQueue() {
+  for (const it of mealModalState.queue) ensureBlobUrlRevoked(it);
+  if (mealModalState.current) ensureBlobUrlRevoked(mealModalState.current);
+  mealModalState.queue = [];
+  mealModalState.currentIndex = 0;
+  mealModalState.totalCount = 0;
+  mealModalState.current = null;
+}
+
+function enqueueMealModal(items) {
+  if (!Array.isArray(items) || items.length === 0) return;
+  const wasIdle = mealModalState.queue.length === 0 && !mealModalState.current;
+  for (const it of items) {
+    if (it.kind === 'photo' && it.file) {
+      it.blobUrl = URL.createObjectURL(it.file);
+    }
+    mealModalState.queue.push(it);
+  }
+  // 進捗総数 = 現在処理中分 + 残りキュー
+  mealModalState.totalCount = mealModalState.currentIndex + (mealModalState.current ? 0 : 0) + mealModalState.queue.length + (mealModalState.current ? 1 : 0);
+  if (wasIdle) advanceMealQueue();
+}
+
+function advanceMealQueue() {
+  if (mealModalState.current) ensureBlobUrlRevoked(mealModalState.current);
+  const next = mealModalState.queue.shift();
+  if (!next) {
+    closeMealModal();
+    return;
+  }
+  mealModalState.current = next;
+  mealModalState.currentIndex += 1;
+  openMealModal(next);
+}
+
+function openMealModal(item) {
+  const modal = document.getElementById('mealModal');
+  if (!modal) return;
+  modal.classList.remove('hidden');
+
+  const photoImg = document.getElementById('mealModalPhoto');
+  const photoEmpty = document.getElementById('mealModalPhotoEmpty');
+  if (item.kind === 'photo' && item.blobUrl) {
+    photoImg.src = item.blobUrl;
+    photoImg.hidden = false;
+    photoEmpty.classList.add('hidden');
+  } else {
+    photoImg.hidden = true;
+    photoImg.removeAttribute('src');
+    photoEmpty.classList.remove('hidden');
+  }
+
+  const descEl = document.getElementById('mealModalDesc');
+  const eatenEl = document.getElementById('mealModalEatenAt');
+  const latEl = document.getElementById('mealModalLat');
+  const lonEl = document.getElementById('mealModalLon');
+  const calEl = document.getElementById('mealModalCal');
+  const noteEl = document.getElementById('mealModalNote');
+  const descHint = document.getElementById('mealModalDescHint');
+
+  if (descEl) descEl.value = '';
+  if (eatenEl) eatenEl.value = toDatetimeLocalValue(new Date().toISOString());
+  if (latEl) latEl.value = '';
+  if (lonEl) lonEl.value = '';
+  if (calEl) calEl.value = '';
+  if (noteEl) noteEl.value = '';
+
+  // 写真ありなら description 任意 (AI 解析)、 写真なしなら必須
+  if (item.kind === 'photo') {
+    descEl?.removeAttribute('required');
+    if (descHint) descHint.textContent = '空欄なら AI が画像から推定 (Claude Vision)';
+  } else {
+    descEl?.setAttribute('required', 'required');
+    if (descHint) descHint.textContent = '写真なしの場合は内容必須。 カロリー空欄なら AI 推定';
+  }
+
+  const total = mealModalState.totalCount;
+  const idx = mealModalState.currentIndex;
+  const prog = document.getElementById('mealModalProgress');
+  if (prog) prog.textContent = total > 1 ? `${idx} / ${total}` : '';
+  const skipBtn = document.getElementById('mealModalSkip');
+  if (skipBtn) skipBtn.hidden = mealModalState.queue.length === 0;
+
+  setTimeout(() => descEl?.focus(), 30);
+}
+
+function closeMealModal() {
+  const modal = document.getElementById('mealModal');
+  if (modal) modal.classList.add('hidden');
+  mealModalState.current = null;
+  mealModalState.currentIndex = 0;
+  mealModalState.totalCount = 0;
+}
+
+function readMealModalForm() {
+  const desc = (document.getElementById('mealModalDesc')?.value || '').trim();
+  const eatenAt = (document.getElementById('mealModalEatenAt')?.value || '').trim();
+  const latRaw = (document.getElementById('mealModalLat')?.value || '').trim();
+  const lonRaw = (document.getElementById('mealModalLon')?.value || '').trim();
+  const calRaw = (document.getElementById('mealModalCal')?.value || '').trim();
+  const note = (document.getElementById('mealModalNote')?.value || '').trim();
+  const lat = latRaw === '' ? null : Number(latRaw);
+  const lon = lonRaw === '' ? null : Number(lonRaw);
+  const calories = calRaw === '' ? null : Number(calRaw);
+  return { desc, eatenAt, lat, lon, calories, note };
+}
+
+async function submitMealModal() {
+  const item = mealModalState.current;
+  if (!item) return;
+  const { desc, eatenAt, lat, lon, calories, note } = readMealModalForm();
+  const status = document.getElementById('mealsUploadStatus');
+
+  if (item.kind === 'manual' && !desc) {
+    alert('食事内容を入力してください');
+    return;
+  }
+
+  if (status) status.textContent = `📤 登録中…`;
+
+  try {
+    if (item.kind === 'photo') {
+      const fd = new FormData();
+      fd.append('photo', item.file);
+      if (eatenAt) fd.append('eaten_at', eatenAt);
+      if (lat != null && lon != null && isFinite(lat) && isFinite(lon)) {
+        fd.append('lat', String(lat));
+        fd.append('lon', String(lon));
+      }
+      if (note) fd.append('user_note', note);
+      const res = await fetch('/api/meals', { method: 'POST', body: fd });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || `HTTP ${res.status}`);
+      }
+      const data = await res.json();
+      const patch = {};
+      if (desc) patch.user_corrected_description = desc;
+      if (calories != null && isFinite(calories)) patch.user_corrected_calories = calories;
+      if (Object.keys(patch).length > 0 && data.meal?.id) {
+        await api(`/api/meals/${data.meal.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(patch),
+        });
+      }
+    } else {
+      const body = { description: desc };
+      if (eatenAt) body.eaten_at = eatenAt;
+      if (lat != null && lon != null && isFinite(lat) && isFinite(lon)) {
+        body.lat = lat; body.lon = lon;
+      }
+      if (calories != null && isFinite(calories)) body.calories = calories;
+      if (note) body.user_note = note;
+      await api('/api/meals/manual', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+    }
+    if (status) status.textContent = `✅ 登録しました`;
+  } catch (e) {
+    if (status) status.textContent = `⚠ 登録エラー: ${e.message}`;
+    console.warn('[meals] submit error:', e);
+  }
+  await loadMeals();
+  advanceMealQueue();
+}
+
+function skipMealModalItem() {
+  if (mealModalState.current) ensureBlobUrlRevoked(mealModalState.current);
+  mealModalState.current = null;
+  advanceMealQueue();
+}
+
+function cancelMealModal() {
+  clearMealQueue();
+  closeMealModal();
+}
+
+function startMealModalForFiles(files) {
+  const items = Array.from(files || [])
+    .filter((f) => f && f.type?.startsWith?.('image/'))
+    .map((file) => ({ kind: 'photo', file, blobUrl: '' }));
+  if (items.length === 0) return;
+  enqueueMealModal(items);
+}
+
+function startMealModalForManual() {
+  enqueueMealModal([{ kind: 'manual' }]);
 }
 
 async function reanalyzeMeal(id) {
@@ -5426,38 +5594,6 @@ function startMealLocationEdit(btn) {
   });
 }
 
-// ── 写真なしで食事を追加 ─────────────────────────────────────
-async function addManualMeal() {
-  const description = prompt('食事内容を入力 (例: ラーメン、 おにぎり 1 個)');
-  if (description == null) return;
-  const trimmed = description.trim();
-  if (!trimmed) return;
-  const eatenAtRaw = prompt('食事時刻 (YYYY-MM-DDTHH:mm、 空欄で現在時刻)', toDatetimeLocalValue(new Date().toISOString()));
-  if (eatenAtRaw == null) return;
-  const calRaw = prompt('カロリー (kcal、 空欄で AI 自動推定)', '');
-  if (calRaw == null) return;
-
-  const body = { description: trimmed };
-  if (eatenAtRaw.trim()) body.eaten_at = eatenAtRaw.trim();
-  if (calRaw.trim()) {
-    const n = Number(calRaw);
-    if (isFinite(n)) body.calories = n;
-  }
-  const status = document.getElementById('mealsUploadStatus');
-  if (status) status.textContent = `📝 ${trimmed.slice(0, 30)} を登録中…`;
-  try {
-    await api('/api/meals/manual', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    });
-    if (status) status.textContent = `✅ 「${trimmed.slice(0, 30)}」 登録${calRaw.trim() ? '' : ' (カロリー推定中)'}`;
-    await loadMeals();
-  } catch (e) {
-    if (status) status.textContent = `⚠ 登録エラー: ${e.message}`;
-  }
-}
-
 async function addMealAddition(mealId) {
   const name = prompt('追加で食べたものは? (例: アイスクリーム)');
   if (name === null) return;
@@ -5526,17 +5662,52 @@ document.getElementById('mealsRefresh')?.addEventListener('click', () => loadMea
 
 document.getElementById('mealsPhotoInput')?.addEventListener('change', (e) => {
   const files = Array.from(e.target.files || []);
+  e.target.value = '';
   if (files.length === 0) return;
-  uploadMealPhotos(files).finally(() => { e.target.value = ''; });
+  startMealModalForFiles(files);
 });
 
 document.getElementById('mealsCameraInput')?.addEventListener('change', (e) => {
-  const file = e.target.files?.[0];
-  if (!file) return;
-  uploadMealPhoto(file).finally(() => { e.target.value = ''; });
+  const files = Array.from(e.target.files || []);
+  e.target.value = '';
+  if (files.length === 0) return;
+  startMealModalForFiles(files);
 });
 
-document.getElementById('mealsManualBtn')?.addEventListener('click', () => addManualMeal());
+document.getElementById('mealsManualBtn')?.addEventListener('click', () => startMealModalForManual());
+
+// ── 食事モーダルのボタン結線 ──────────────────────────────────
+document.getElementById('mealModalSubmit')?.addEventListener('click', () => submitMealModal());
+document.getElementById('mealModalCancel')?.addEventListener('click', () => cancelMealModal());
+document.getElementById('mealModalClose')?.addEventListener('click', () => cancelMealModal());
+document.getElementById('mealModalSkip')?.addEventListener('click', () => skipMealModalItem());
+document.querySelector('#mealModal .meal-modal-backdrop')?.addEventListener('click', () => cancelMealModal());
+document.getElementById('mealModalLocHere')?.addEventListener('click', () => {
+  if (!navigator.geolocation) { alert('この端末は位置情報に対応していません'); return; }
+  navigator.geolocation.getCurrentPosition(
+    (pos) => {
+      const latEl = document.getElementById('mealModalLat');
+      const lonEl = document.getElementById('mealModalLon');
+      if (latEl) latEl.value = String(pos.coords.latitude);
+      if (lonEl) lonEl.value = String(pos.coords.longitude);
+    },
+    (err) => alert(`位置取得失敗: ${err.message}`),
+    { enableHighAccuracy: true, timeout: 10_000 },
+  );
+});
+document.getElementById('mealModalLocClear')?.addEventListener('click', () => {
+  const latEl = document.getElementById('mealModalLat');
+  const lonEl = document.getElementById('mealModalLon');
+  if (latEl) latEl.value = '';
+  if (lonEl) lonEl.value = '';
+});
+// Esc キーで全 cancel
+window.addEventListener('keydown', (ev) => {
+  if (ev.key !== 'Escape') return;
+  const modal = document.getElementById('mealModal');
+  if (!modal || modal.classList.contains('hidden')) return;
+  cancelMealModal();
+});
 
 // ── ドラッグ&ドロップ ──────────────────────────────────────────
 (function setupMealsDropZone() {
@@ -5574,7 +5745,7 @@ document.getElementById('mealsManualBtn')?.addEventListener('click', () => addMa
     zone.classList.remove('drag-over');
     const files = Array.from(e.dataTransfer?.files || []).filter((f) => f.type?.startsWith?.('image/'));
     if (files.length === 0) return;
-    uploadMealPhotos(files);
+    startMealModalForFiles(files);
   }
 
   window.addEventListener('dragenter', onDragEnter);
@@ -5595,6 +5766,6 @@ document.getElementById('mealsManualBtn')?.addEventListener('click', () => addMa
       .filter((f) => !!f);
     if (files.length === 0) return;
     e.preventDefault();
-    uploadMealPhotos(files);
+    startMealModalForFiles(files);
   });
 })();

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -4967,8 +4967,11 @@ function renderMeals() {
   }
   list.innerHTML = mealsState.items.map((m) => {
     const desc = m.user_corrected_description || m.description || (m.ai_status === 'pending' ? '解析中…' : m.ai_status === 'error' ? '解析失敗' : '(未記入)');
-    const cal = m.user_corrected_calories ?? m.calories;
-    const calStr = (cal == null) ? '— kcal' : `${cal} kcal`;
+    const baseCal = m.user_corrected_calories ?? m.calories;
+    const additions = parseMealAdditions(m.additions_json);
+    const addCalSum = additions.reduce((s, a) => s + (typeof a.calories === 'number' ? a.calories : 0), 0);
+    const totalCal = (baseCal == null && additions.length === 0) ? null : (baseCal ?? 0) + addCalSum;
+    const calStr = totalCal == null ? '— kcal' : `${totalCal} kcal`;
     const eatenAt = formatLocalMealDateTime(m.eaten_at);
     const locStr = m.location_label || (m.lat != null && m.lon != null ? `${m.lat.toFixed(4)}, ${m.lon.toFixed(4)}` : '場所不明');
     const aiBadge = m.ai_status === 'pending'
@@ -4976,6 +4979,23 @@ function renderMeals() {
       : m.ai_status === 'error'
       ? `<span class="meal-badge meal-badge-error" title="${escapeHtml(m.ai_error || '')}">解析失敗</span>`
       : '';
+    const additionsHtml = additions.length === 0 ? '' : `
+      <ul class="meal-additions">
+        ${additions.map((a, i) => {
+          const calLabel = typeof a.calories === 'number' ? `${a.calories} kcal` : '— kcal';
+          const timeLabel = a.added_at ? formatLocalMealDateTime(a.added_at) : '';
+          return `
+            <li class="meal-addition" data-meal-id="${m.id}" data-idx="${i}">
+              <span class="meal-addition-name">＋ ${escapeHtml(a.name)}</span>
+              <span class="meal-addition-cal">${escapeHtml(calLabel)}</span>
+              ${timeLabel ? `<span class="meal-addition-time">${escapeHtml(timeLabel)}</span>` : ''}
+              <button class="ghost meal-addition-edit" data-id="${m.id}" data-idx="${i}" title="編集">✏️</button>
+              <button class="ghost meal-addition-delete" data-id="${m.id}" data-idx="${i}" title="削除">×</button>
+            </li>
+          `;
+        }).join('')}
+      </ul>
+    `;
     return `
       <div class="meal-card" data-meal-id="${m.id}">
         <img class="meal-photo" src="/api/meals/${m.id}/photo" loading="lazy" alt="食事写真" />
@@ -4990,7 +5010,9 @@ function renderMeals() {
             <span class="meal-loc">${escapeHtml(locStr)}</span>
           </div>
           ${m.user_note ? `<div class="meal-note">📝 ${escapeHtml(m.user_note)}</div>` : ''}
+          ${additionsHtml}
           <div class="meal-actions">
+            <button class="ghost meal-add-btn" data-id="${m.id}">➕ 追加で食べた</button>
             <button class="ghost meal-edit-btn" data-id="${m.id}">✏️ 修正</button>
             <button class="ghost meal-reanalyze-btn" data-id="${m.id}">🔄 再解析</button>
             <button class="ghost meal-delete-btn" data-id="${m.id}">🗑️ 削除</button>
@@ -5014,6 +5036,25 @@ function renderMeals() {
   list.querySelectorAll('.meal-delete-btn').forEach((b) => {
     b.addEventListener('click', () => deleteMealRow(Number(b.dataset.id)));
   });
+  list.querySelectorAll('.meal-add-btn').forEach((b) => {
+    b.addEventListener('click', () => addMealAddition(Number(b.dataset.id)));
+  });
+  list.querySelectorAll('.meal-addition-edit').forEach((b) => {
+    b.addEventListener('click', () => editMealAddition(Number(b.dataset.id), Number(b.dataset.idx)));
+  });
+  list.querySelectorAll('.meal-addition-delete').forEach((b) => {
+    b.addEventListener('click', () => deleteMealAddition(Number(b.dataset.id), Number(b.dataset.idx)));
+  });
+}
+
+function parseMealAdditions(json) {
+  if (!json) return [];
+  try {
+    const arr = JSON.parse(json);
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
 }
 
 function formatLocalMealDateTime(iso) {
@@ -5129,6 +5170,69 @@ function editMeal(id) {
   })
     .then(() => loadMeals())
     .catch((e) => alert(`修正エラー: ${e.message}`));
+}
+
+async function addMealAddition(mealId) {
+  const name = prompt('追加で食べたものは? (例: アイスクリーム)');
+  if (name === null) return;
+  const trimmed = name.trim();
+  if (!trimmed) return;
+  const calRaw = prompt('カロリー (kcal、 不明なら空欄)', '');
+  if (calRaw === null) return;
+  const body = { name: trimmed };
+  if (calRaw.trim() !== '') {
+    const n = Number(calRaw);
+    if (isFinite(n)) body.calories = n;
+  }
+  try {
+    await api(`/api/meals/${mealId}/additions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    await loadMeals();
+  } catch (e) {
+    alert(`追加エラー: ${e.message}`);
+  }
+}
+
+async function editMealAddition(mealId, idx) {
+  const m = mealsState.items.find((x) => x.id === mealId);
+  if (!m) return;
+  const additions = parseMealAdditions(m.additions_json);
+  const cur = additions[idx];
+  if (!cur) return;
+  const name = prompt('項目名', cur.name || '');
+  if (name === null) return;
+  const calRaw = prompt('カロリー (kcal、 空欄でクリア)', cur.calories == null ? '' : String(cur.calories));
+  if (calRaw === null) return;
+  const body = {};
+  if (name.trim()) body.name = name.trim();
+  if (calRaw.trim() === '') body.calories = null;
+  else {
+    const n = Number(calRaw);
+    if (isFinite(n)) body.calories = n;
+  }
+  try {
+    await api(`/api/meals/${mealId}/additions/${idx}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    await loadMeals();
+  } catch (e) {
+    alert(`編集エラー: ${e.message}`);
+  }
+}
+
+async function deleteMealAddition(mealId, idx) {
+  if (!confirm('この追加項目を削除しますか?')) return;
+  try {
+    await api(`/api/meals/${mealId}/additions/${idx}`, { method: 'DELETE' });
+    await loadMeals();
+  } catch (e) {
+    alert(`削除エラー: ${e.message}`);
+  }
 }
 
 // ── イベント結線 ─────────────────────────────────────────────

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -5380,6 +5380,9 @@ function advanceMealQueue() {
 function openMealModal(item) {
   const modal = document.getElementById('mealModal');
   if (!modal) return;
+  // グローバル `.hidden { display: none !important }` が残っていると
+  // showModal で [open] が付いても表示されないので、 念のため毎回 remove。
+  modal.classList.remove('hidden');
   // <dialog>.showModal() でネイティブ popup として開く (focus trap / Esc 自動)。
   // 古い iOS Safari (< 15.4) や一部の WebView では showModal が未実装。
   // どんな環境でも確実に開けるよう、 stub 失敗時は手動で open 属性 + flex を強制。
@@ -5395,7 +5398,6 @@ function openMealModal(item) {
   if (!openedNatively) {
     // dialog 非対応 / showModal 失敗時の fallback — open 属性 + 直接 style 指定
     modal.setAttribute('open', '');
-    modal.classList.remove('hidden');
     modal.style.display = 'flex';
     modal.style.position = 'fixed';
     modal.style.inset = '0';
@@ -5487,9 +5489,11 @@ function closeMealModal() {
       try { modal.close(); }
       catch (e) { console.warn('[meal-modal] close failed:', e); }
     }
-    // fallback で付けた open 属性 / inline style もクリア
+    // fallback で付けた open 属性 / inline style をクリア。
+    // `.hidden` は付けない — 次回 showModal 時に `display: none !important`
+    // が `dialog[open]` を上書きしてしまうため。 dialog は UA 既定で
+    // `:not([open])` のとき非表示になる。
     modal.removeAttribute('open');
-    modal.classList.add('hidden');
     modal.style.display = '';
     modal.style.position = '';
     modal.style.inset = '';

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -5299,14 +5299,31 @@ function advanceMealQueue() {
 function openMealModal(item) {
   const modal = document.getElementById('mealModal');
   if (!modal) return;
-  // <dialog>.showModal() でネイティブ popup として開く (focus trap / Esc 自動)
-  if (typeof modal.showModal === 'function') {
-    if (!modal.open) {
-      try { modal.showModal(); }
-      catch { modal.classList.remove('hidden'); }
+  // <dialog>.showModal() でネイティブ popup として開く (focus trap / Esc 自動)。
+  // 古い iOS Safari (< 15.4) や一部の WebView では showModal が未実装。
+  // どんな環境でも確実に開けるよう、 stub 失敗時は手動で open 属性 + flex を強制。
+  let openedNatively = false;
+  if (typeof modal.showModal === 'function' && !modal.open) {
+    try {
+      modal.showModal();
+      openedNatively = true;
+    } catch (e) {
+      console.warn('[meal-modal] showModal failed, falling back:', e);
     }
-  } else {
+  }
+  if (!openedNatively) {
+    // dialog 非対応 / showModal 失敗時の fallback — open 属性 + 直接 style 指定
+    modal.setAttribute('open', '');
     modal.classList.remove('hidden');
+    modal.style.display = 'flex';
+    modal.style.position = 'fixed';
+    modal.style.inset = '0';
+    modal.style.zIndex = '1000';
+    // ネイティブ ::backdrop が出ない fallback の場合、 dialog 自体の背景で
+    // 半透明黒を塗って他クリックを封じる
+    modal.style.background = 'rgba(0, 0, 0, 0.45)';
+    modal.style.alignItems = 'center';
+    modal.style.justifyContent = 'center';
   }
 
   const photoImg = document.getElementById('mealModalPhoto');
@@ -5386,10 +5403,19 @@ function closeMealModal() {
   const modal = document.getElementById('mealModal');
   if (modal) {
     if (typeof modal.close === 'function' && modal.open) {
-      try { modal.close(); } catch { modal.classList.add('hidden'); }
-    } else {
-      modal.classList.add('hidden');
+      try { modal.close(); }
+      catch (e) { console.warn('[meal-modal] close failed:', e); }
     }
+    // fallback で付けた open 属性 / inline style もクリア
+    modal.removeAttribute('open');
+    modal.classList.add('hidden');
+    modal.style.display = '';
+    modal.style.position = '';
+    modal.style.inset = '';
+    modal.style.zIndex = '';
+    modal.style.background = '';
+    modal.style.alignItems = '';
+    modal.style.justifyContent = '';
   }
   // 地図リソースもクリア
   mealMapState.marker = null;

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -281,7 +281,9 @@ function renderDetailCloud() {
   const kept = (r.words || []).filter(w => w.kept);
   el.innerHTML = renderCloudWords(kept);
   el.querySelectorAll('.cloud-word').forEach(w => {
-    w.addEventListener('click', () => onCloudWordClick(w.dataset.word));
+    w.addEventListener('click', (ev) => {
+      openWordRingMenu(w.dataset.word, ev.clientX, ev.clientY, { onDig: () => onCloudWordClick(w.dataset.word) });
+    });
   });
 }
 
@@ -1143,21 +1145,21 @@ function renderDigSession() {
     </div>
     <div class="dig-sources">${sourceCards}</div>
   `;
-  // Cloud node clicks — explored word jumps to its past session, new word
-  // hands off to digOnWordPick (one-cushion flow: focus the textarea with a
-  // prefilled "○○ について 何を知りたいか?" prompt, plus a "別テーマとして
-  // 検索" button alongside the regular ディグる).
-  const handleNodeClick = (target) => {
+  // Cloud node clicks — explored word はその過去 session へジャンプ。
+  // それ以外は単語リングメニューを開いて 「ディグる / 辞書登録 / 削除」
+  // を選ばせる (one-cushion 廃止、 明示的な分岐に)。
+  const handleNodeClick = (target, ev) => {
     const exploredId = target.dataset.exploredId;
     if (exploredId) {
       loadDigSession(Number(exploredId));
       return;
     }
     const word = target.dataset.word;
-    if (word) digOnWordPick(s, word);
+    if (!word) return;
+    openWordRingMenu(word, ev?.clientX, ev?.clientY, { session: s });
   };
   el.querySelectorAll('.dig-graph-node, .dig-cloud-word').forEach(node => {
-    node.addEventListener('click', () => handleNodeClick(node));
+    node.addEventListener('click', (ev) => handleNodeClick(node, ev));
   });
   el.querySelectorAll('.dig-source').forEach(card => {
     const url = card.dataset.url;
@@ -1844,7 +1846,9 @@ function renderCloud() {
     });
   });
   el.querySelectorAll('.cloud-word').forEach(w => {
-    w.addEventListener('click', () => onCloudWordClick(w.dataset.word));
+    w.addEventListener('click', (ev) => {
+      openWordRingMenu(w.dataset.word, ev.clientX, ev.clientY, { onDig: () => onCloudWordClick(w.dataset.word) });
+    });
   });
   el.querySelector('#cloudManualBtn')?.addEventListener('click', submitManualWord);
   el.querySelector('#cloudManualInput')?.addEventListener('keydown', (e) => {
@@ -5907,3 +5911,156 @@ document.getElementById('mealsFilterClear')?.addEventListener('click', () => {
   if (el) el.value = '';
   loadMeals();
 });
+
+// ── 単語リングメニュー ────────────────────────────────────────
+//
+// グラフ / ワードクラウドの単語をクリックすると、 黒背景の上に
+// 単語を中心としたリング状のボタン (ディグる / 辞書登録 / 削除) が
+// 浮く。 削除は user_stopwords (server) に保存し、 既存の表示からは
+// userStopwordSet で hide。
+
+const wordRingState = {
+  word: null,
+  context: null, // { session?, onDig? }
+};
+const userStopwordSet = new Set();
+
+async function loadUserStopwords() {
+  try {
+    const r = await api('/api/stopwords');
+    userStopwordSet.clear();
+    for (const it of (r.items || [])) userStopwordSet.add(String(it.lower || it.word || '').toLowerCase());
+  } catch {
+    // 無視 — 失敗しても致命的ではない
+  }
+}
+
+function isUserStopword(word) {
+  if (!word) return false;
+  return userStopwordSet.has(String(word).toLowerCase());
+}
+
+function openWordRingMenu(word, clientX, clientY, ctx = {}) {
+  const menu = document.getElementById('wordRingMenu');
+  const wEl = document.getElementById('wordRingWord');
+  const pop = menu?.querySelector('.word-ring-pop');
+  if (!menu || !wEl || !pop) return;
+  wordRingState.word = String(word || '').trim();
+  wordRingState.context = ctx;
+  wEl.textContent = wordRingState.word;
+
+  // ポップ位置: クリック座標を中心に。 端だと画面外へ出るので clamp
+  const W = window.innerWidth;
+  const H = window.innerHeight;
+  const PAD = 130; // pop の半径 (110) + 余白
+  const cx = Math.max(PAD, Math.min(W - PAD, Number.isFinite(clientX) ? clientX : W / 2));
+  const cy = Math.max(PAD, Math.min(H - PAD, Number.isFinite(clientY) ? clientY : H / 2));
+  pop.style.left = `${cx}px`;
+  pop.style.top = `${cy}px`;
+
+  menu.classList.remove('hidden');
+}
+
+function closeWordRingMenu() {
+  const menu = document.getElementById('wordRingMenu');
+  if (menu) menu.classList.add('hidden');
+  wordRingState.word = null;
+  wordRingState.context = null;
+}
+
+async function wordRingAction(action) {
+  const word = wordRingState.word;
+  const ctx = wordRingState.context || {};
+  closeWordRingMenu();
+  if (!word) return;
+
+  if (action === 'dig') {
+    if (typeof ctx.onDig === 'function') {
+      ctx.onDig(word);
+    } else {
+      // dig session 文脈の場合は textarea にプリフィル
+      digOnWordPick(ctx.session || null, word);
+    }
+    return;
+  }
+
+  if (action === 'dict') {
+    try {
+      const r = await api('/api/dictionary', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ term: word }),
+      });
+      const msg = r.existed
+        ? `「${word}」 は既に辞書に登録済 (id ${r.id})`
+        : `📖 「${word}」 を辞書に登録しました`;
+      // 辞書タブに反映 + 通知
+      flashMessage(msg);
+    } catch (e) {
+      alert(`辞書登録エラー: ${e.message}`);
+    }
+    return;
+  }
+
+  if (action === 'delete') {
+    if (!confirm(`「${word}」 を今後表示しない (stopword) ように設定しますか?`)) return;
+    try {
+      await api('/api/stopwords', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ word }),
+      });
+      userStopwordSet.add(word.toLowerCase());
+      // 即時 hide: 該当 dataset.word を持つノード / cloud-word を CSS で隠す
+      hideWordsInDom(word);
+      flashMessage(`🗑 「${word}」 を以後の表示から除外しました`);
+    } catch (e) {
+      alert(`stopword 追加エラー: ${e.message}`);
+    }
+    return;
+  }
+}
+
+function hideWordsInDom(word) {
+  const lower = String(word || '').toLowerCase();
+  document.querySelectorAll('[data-word]').forEach((el) => {
+    if (String(el.dataset.word || '').toLowerCase() === lower) {
+      el.style.display = 'none';
+    }
+  });
+}
+
+function flashMessage(text) {
+  // 軽量な toast (既存 .share-toast 流用)
+  const div = document.createElement('div');
+  div.className = 'share-toast';
+  div.textContent = text;
+  document.body.appendChild(div);
+  setTimeout(() => div.remove(), 3500);
+}
+
+// イベント結線
+document.addEventListener('DOMContentLoaded', () => {
+  // 起動時に user stopwords をロード
+  loadUserStopwords();
+});
+
+document.getElementById('wordRingMenu')?.querySelectorAll('.word-ring-btn').forEach((btn) => {
+  btn.addEventListener('click', (ev) => {
+    ev.stopPropagation();
+    const action = btn.dataset.action;
+    if (action) wordRingAction(action);
+  });
+});
+document.getElementById('wordRingClose')?.addEventListener('click', () => closeWordRingMenu());
+document.querySelector('#wordRingMenu .word-ring-backdrop')?.addEventListener('click', () => closeWordRingMenu());
+window.addEventListener('keydown', (ev) => {
+  const menu = document.getElementById('wordRingMenu');
+  if (menu && !menu.classList.contains('hidden') && ev.key === 'Escape') {
+    ev.preventDefault();
+    closeWordRingMenu();
+  }
+});
+
+// 起動時にも一度ロード (DOMContentLoaded を待たないコード経路用)
+loadUserStopwords();

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -4999,11 +4999,11 @@ function renderMeals() {
       </div>
     `;
   }).join('');
-  // OpenAI API key 不足の検出 (pending かつ ai_error にメッセージ)
+  // 直近の写真で解析エラーが続いたら設定確認の hint を表示
   const hint = document.getElementById('mealsHint');
   if (hint) {
-    const keyMissing = mealsState.items.some((m) => m.ai_status === 'pending' && (m.ai_error || '').includes('OpenAI API key'));
-    hint.classList.toggle('hidden', !keyMissing);
+    const recentErrors = mealsState.items.slice(0, 5).filter((m) => m.ai_status === 'error').length;
+    hint.classList.toggle('hidden', recentErrors < 2);
   }
   list.querySelectorAll('.meal-edit-btn').forEach((b) => {
     b.addEventListener('click', () => editMeal(Number(b.dataset.id)));

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -5001,7 +5001,10 @@ function renderMeals() {
         <img class="meal-photo" src="/api/meals/${m.id}/photo" loading="lazy" alt="食事写真" />
         <div class="meal-body">
           <div class="meal-head">
-            <span class="meal-time">${escapeHtml(eatenAt)}</span>
+            <button class="meal-time-edit" data-id="${m.id}" data-current="${escapeHtml(toDatetimeLocalValue(m.eaten_at))}" title="クリックで時刻を編集">
+              <span class="meal-time">${escapeHtml(eatenAt)}</span>
+              <span class="meal-time-pencil">✏️</span>
+            </button>
             ${aiBadge}
           </div>
           <div class="meal-desc">${escapeHtml(desc)}</div>
@@ -5039,6 +5042,13 @@ function renderMeals() {
   list.querySelectorAll('.meal-add-btn').forEach((b) => {
     b.addEventListener('click', () => addMealAddition(Number(b.dataset.id)));
   });
+  list.querySelectorAll('.meal-time-edit').forEach((b) => {
+    b.addEventListener('click', (ev) => {
+      // editing 状態の中の input/button が再帰しないように
+      if (ev.target.closest('.meal-time-actions') || ev.target.tagName === 'INPUT') return;
+      startMealTimeEdit(b);
+    });
+  });
   list.querySelectorAll('.meal-addition-edit').forEach((b) => {
     b.addEventListener('click', () => editMealAddition(Number(b.dataset.id), Number(b.dataset.idx)));
   });
@@ -5055,6 +5065,70 @@ function parseMealAdditions(json) {
   } catch {
     return [];
   }
+}
+
+/** ISO8601 → `YYYY-MM-DDTHH:MM` (datetime-local 用 / ローカル時刻基準)。 */
+function toDatetimeLocalValue(iso) {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return '';
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mi = String(d.getMinutes()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}T${hh}:${mi}`;
+}
+
+/** 時刻表示の隣の ✏️ をクリックしたら inline picker に切り替えて即時 PATCH。 */
+function startMealTimeEdit(btn) {
+  const mealId = Number(btn.dataset.id);
+  const current = btn.dataset.current || '';
+  if (btn.classList.contains('editing')) return;
+  btn.classList.add('editing');
+
+  // 元の中身 (span 2 つ) を退避してから input に置き換える
+  const original = btn.innerHTML;
+  btn.innerHTML = `
+    <input type="datetime-local" class="meal-time-input" value="${current}" />
+    <span class="meal-time-actions">
+      <button class="meal-time-save" type="button" title="保存">✓</button>
+      <button class="meal-time-cancel" type="button" title="キャンセル">×</button>
+    </span>
+  `;
+  const input = btn.querySelector('input');
+  const saveBtn = btn.querySelector('.meal-time-save');
+  const cancelBtn = btn.querySelector('.meal-time-cancel');
+  input?.focus();
+
+  function restore() {
+    btn.innerHTML = original;
+    btn.classList.remove('editing');
+  }
+
+  async function save() {
+    const v = input?.value || '';
+    if (!v) { restore(); return; }
+    try {
+      // datetime-local の文字列をそのまま PATCH に渡す (サーバ側で new Date() → ISO8601)
+      await api(`/api/meals/${mealId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ eaten_at: v }),
+      });
+      await loadMeals();
+    } catch (e) {
+      alert(`時刻修正エラー: ${e.message}`);
+      restore();
+    }
+  }
+
+  saveBtn?.addEventListener('click', (ev) => { ev.stopPropagation(); save(); });
+  cancelBtn?.addEventListener('click', (ev) => { ev.stopPropagation(); restore(); });
+  input?.addEventListener('keydown', (ev) => {
+    if (ev.key === 'Enter') { ev.preventDefault(); save(); }
+    if (ev.key === 'Escape') { ev.preventDefault(); restore(); }
+  });
+  input?.addEventListener('click', (ev) => ev.stopPropagation());
 }
 
 function formatLocalMealDateTime(iso) {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -611,6 +611,7 @@ function switchTab(tab) {
   $('diaryView').classList.toggle('hidden', tab !== 'diary');
   $('eventsView').classList.toggle('hidden', tab !== 'events');
   $('tracksView')?.classList.toggle('hidden', tab !== 'tracks');
+  $('mealsView')?.classList.toggle('hidden', tab !== 'meals');
   $('multiView')?.classList.toggle('hidden', tab !== 'multi');
   if (tab === 'queue') renderQueue();
   if (tab === 'visits') loadVisits();
@@ -622,6 +623,7 @@ function switchTab(tab) {
   if (tab === 'diary') loadDiary();
   if (tab === 'events') loadEvents();
   if (tab === 'tracks') loadTracks();
+  if (tab === 'meals') loadMeals();
   if (tab === 'multi') loadMulti();
   bumpTabUsage(tab);
   closeTabMoreMenu();
@@ -4926,3 +4928,189 @@ document.getElementById('aiSettingsBtn')?.addEventListener('click', () => {
   history.replaceState({}, '', location.pathname);
 })();
 
+
+// ── Meals (食事記録) ─────────────────────────────────────────────────────
+//
+// /api/meals (multipart) で写真投稿 → サーバが EXIF / GPS / Vision で
+// 補完 → 一覧 + 編集。 OPENAI_API_KEY が無いと内容 / カロリーは pending のまま、
+// 手動入力で運用可能。
+
+const mealsState = {
+  items: [],
+  pollTimer: null,
+};
+
+async function loadMeals() {
+  const list = document.getElementById('mealsList');
+  if (!list) return;
+  const fromEl = document.getElementById('mealsFromDate');
+  const toEl = document.getElementById('mealsToDate');
+  const params = new URLSearchParams();
+  if (fromEl?.value) params.set('from', fromEl.value);
+  if (toEl?.value) params.set('to', toEl.value + 'T23:59:59');
+  try {
+    const r = await api(`/api/meals?${params.toString()}`);
+    mealsState.items = r.meals || [];
+    renderMeals();
+    schedulePendingPoll();
+  } catch (e) {
+    list.innerHTML = `<div class="hint">読み込みエラー: ${escapeHtml(e.message)}</div>`;
+  }
+}
+
+function renderMeals() {
+  const list = document.getElementById('mealsList');
+  if (!list) return;
+  if (mealsState.items.length === 0) {
+    list.innerHTML = '<div class="hint">まだ食事の記録はありません。 「📷 写真を追加」 から登録してください。</div>';
+    return;
+  }
+  list.innerHTML = mealsState.items.map((m) => {
+    const desc = m.user_corrected_description || m.description || (m.ai_status === 'pending' ? '解析中…' : m.ai_status === 'error' ? '解析失敗' : '(未記入)');
+    const cal = m.user_corrected_calories ?? m.calories;
+    const calStr = (cal == null) ? '— kcal' : `${cal} kcal`;
+    const eatenAt = formatLocalMealDateTime(m.eaten_at);
+    const locStr = m.location_label || (m.lat != null && m.lon != null ? `${m.lat.toFixed(4)}, ${m.lon.toFixed(4)}` : '場所不明');
+    const aiBadge = m.ai_status === 'pending'
+      ? '<span class="meal-badge meal-badge-pending">解析中</span>'
+      : m.ai_status === 'error'
+      ? `<span class="meal-badge meal-badge-error" title="${escapeHtml(m.ai_error || '')}">解析失敗</span>`
+      : '';
+    return `
+      <div class="meal-card" data-meal-id="${m.id}">
+        <img class="meal-photo" src="/api/meals/${m.id}/photo" loading="lazy" alt="食事写真" />
+        <div class="meal-body">
+          <div class="meal-head">
+            <span class="meal-time">${escapeHtml(eatenAt)}</span>
+            ${aiBadge}
+          </div>
+          <div class="meal-desc">${escapeHtml(desc)}</div>
+          <div class="meal-meta">
+            <span class="meal-cal">${escapeHtml(calStr)}</span>
+            <span class="meal-loc">${escapeHtml(locStr)}</span>
+          </div>
+          ${m.user_note ? `<div class="meal-note">📝 ${escapeHtml(m.user_note)}</div>` : ''}
+          <div class="meal-actions">
+            <button class="ghost meal-edit-btn" data-id="${m.id}">✏️ 修正</button>
+            <button class="ghost meal-reanalyze-btn" data-id="${m.id}">🔄 再解析</button>
+            <button class="ghost meal-delete-btn" data-id="${m.id}">🗑️ 削除</button>
+          </div>
+        </div>
+      </div>
+    `;
+  }).join('');
+  // OpenAI API key 不足の検出 (pending かつ ai_error にメッセージ)
+  const hint = document.getElementById('mealsHint');
+  if (hint) {
+    const keyMissing = mealsState.items.some((m) => m.ai_status === 'pending' && (m.ai_error || '').includes('OpenAI API key'));
+    hint.classList.toggle('hidden', !keyMissing);
+  }
+  list.querySelectorAll('.meal-edit-btn').forEach((b) => {
+    b.addEventListener('click', () => editMeal(Number(b.dataset.id)));
+  });
+  list.querySelectorAll('.meal-reanalyze-btn').forEach((b) => {
+    b.addEventListener('click', () => reanalyzeMeal(Number(b.dataset.id)));
+  });
+  list.querySelectorAll('.meal-delete-btn').forEach((b) => {
+    b.addEventListener('click', () => deleteMealRow(Number(b.dataset.id)));
+  });
+}
+
+function formatLocalMealDateTime(iso) {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso || '';
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mi = String(d.getMinutes()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd} ${hh}:${mi}`;
+}
+
+function schedulePendingPoll() {
+  if (mealsState.pollTimer) clearTimeout(mealsState.pollTimer);
+  const hasPending = mealsState.items.some((m) => m.ai_status === 'pending');
+  if (!hasPending) return;
+  mealsState.pollTimer = setTimeout(() => {
+    if (state.tab !== 'meals') return;
+    loadMeals();
+  }, 4000);
+}
+
+async function uploadMealPhoto(file) {
+  const status = document.getElementById('mealsUploadStatus');
+  const fd = new FormData();
+  fd.append('photo', file);
+  if (status) status.textContent = `📤 ${file.name} を送信中…`;
+  try {
+    const res = await fetch('/api/meals', { method: 'POST', body: fd });
+    if (!res.ok) {
+      const errBody = await res.json().catch(() => ({}));
+      throw new Error(errBody.error || `HTTP ${res.status}`);
+    }
+    if (status) status.textContent = '✅ 登録しました (解析中)';
+    await loadMeals();
+  } catch (e) {
+    if (status) status.textContent = `⚠ エラー: ${e.message}`;
+  }
+}
+
+async function reanalyzeMeal(id) {
+  try {
+    await api(`/api/meals/${id}/reanalyze`, { method: 'POST' });
+    await loadMeals();
+  } catch (e) {
+    alert(`再解析エラー: ${e.message}`);
+  }
+}
+
+async function deleteMealRow(id) {
+  if (!confirm('この食事記録を削除しますか?')) return;
+  try {
+    await api(`/api/meals/${id}`, { method: 'DELETE' });
+    await loadMeals();
+  } catch (e) {
+    alert(`削除エラー: ${e.message}`);
+  }
+}
+
+function editMeal(id) {
+  const m = mealsState.items.find((x) => x.id === id);
+  if (!m) return;
+  const desc = prompt('食事内容 (補正)', m.user_corrected_description || m.description || '');
+  if (desc === null) return;
+  const calRaw = prompt('カロリー (補正、 数字。 空欄でクリア)', String(m.user_corrected_calories ?? m.calories ?? ''));
+  if (calRaw === null) return;
+  const eatenAtRaw = prompt('食事時刻 (YYYY-MM-DDTHH:mm、 空欄で変更しない)', formatLocalMealDateTime(m.eaten_at).replace(' ', 'T'));
+  if (eatenAtRaw === null) return;
+  const note = prompt('補足メモ', m.user_note || '');
+  if (note === null) return;
+
+  const patch = {
+    user_corrected_description: desc.trim() || null,
+    user_note: note.trim() || null,
+  };
+  if (calRaw.trim() === '') {
+    patch.user_corrected_calories = null;
+  } else {
+    const n = Number(calRaw);
+    if (isFinite(n)) patch.user_corrected_calories = n;
+  }
+  if (eatenAtRaw.trim()) patch.eaten_at = eatenAtRaw.trim();
+
+  api(`/api/meals/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  })
+    .then(() => loadMeals())
+    .catch((e) => alert(`修正エラー: ${e.message}`));
+}
+
+// イベント結線
+document.getElementById('mealsRefresh')?.addEventListener('click', () => loadMeals());
+document.getElementById('mealsPhotoInput')?.addEventListener('change', (e) => {
+  const file = e.target.files?.[0];
+  if (!file) return;
+  uploadMealPhoto(file).finally(() => { e.target.value = ''; });
+});

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -5037,22 +5037,46 @@ function schedulePendingPoll() {
   }, 4000);
 }
 
-async function uploadMealPhoto(file) {
+async function uploadMealPhotos(files) {
+  if (!files || files.length === 0) return;
   const status = document.getElementById('mealsUploadStatus');
-  const fd = new FormData();
-  fd.append('photo', file);
-  if (status) status.textContent = `📤 ${file.name} を送信中…`;
-  try {
-    const res = await fetch('/api/meals', { method: 'POST', body: fd });
-    if (!res.ok) {
-      const errBody = await res.json().catch(() => ({}));
-      throw new Error(errBody.error || `HTTP ${res.status}`);
+  const total = files.length;
+  let ok = 0;
+  let failed = 0;
+  for (let i = 0; i < total; i++) {
+    const file = files[i];
+    if (!file || !file.type?.startsWith?.('image/')) {
+      failed += 1;
+      continue;
     }
-    if (status) status.textContent = '✅ 登録しました (解析中)';
-    await loadMeals();
-  } catch (e) {
-    if (status) status.textContent = `⚠ エラー: ${e.message}`;
+    if (status) {
+      status.textContent = `📤 ${i + 1}/${total} 送信中… (${file.name || 'image'})`;
+    }
+    try {
+      const fd = new FormData();
+      fd.append('photo', file);
+      const res = await fetch('/api/meals', { method: 'POST', body: fd });
+      if (!res.ok) {
+        const errBody = await res.json().catch(() => ({}));
+        throw new Error(errBody.error || `HTTP ${res.status}`);
+      }
+      ok += 1;
+    } catch (e) {
+      failed += 1;
+      console.warn(`[meals] upload failed (${file.name}):`, e);
+    }
   }
+  if (status) {
+    if (failed === 0) status.textContent = `✅ ${ok} 件 登録しました (解析中)`;
+    else if (ok === 0) status.textContent = `⚠ 全 ${total} 件 失敗しました`;
+    else status.textContent = `⚠ ${ok} 件 成功 / ${failed} 件 失敗`;
+  }
+  await loadMeals();
+}
+
+// 単一互換 (古い call 元用)
+function uploadMealPhoto(file) {
+  return uploadMealPhotos([file]);
 }
 
 async function reanalyzeMeal(id) {
@@ -5107,10 +5131,78 @@ function editMeal(id) {
     .catch((e) => alert(`修正エラー: ${e.message}`));
 }
 
-// イベント結線
+// ── イベント結線 ─────────────────────────────────────────────
 document.getElementById('mealsRefresh')?.addEventListener('click', () => loadMeals());
+
 document.getElementById('mealsPhotoInput')?.addEventListener('change', (e) => {
+  const files = Array.from(e.target.files || []);
+  if (files.length === 0) return;
+  uploadMealPhotos(files).finally(() => { e.target.value = ''; });
+});
+
+document.getElementById('mealsCameraInput')?.addEventListener('change', (e) => {
   const file = e.target.files?.[0];
   if (!file) return;
   uploadMealPhoto(file).finally(() => { e.target.value = ''; });
 });
+
+// ── ドラッグ&ドロップ ──────────────────────────────────────────
+(function setupMealsDropZone() {
+  const view = document.getElementById('mealsView');
+  const zone = document.getElementById('mealsDropZone');
+  if (!view || !zone) return;
+
+  // window 全体で dragover/drop を受けて、 食事タブが active な場合のみ処理
+  function isMealsActive() {
+    return state.tab === 'meals' && !view.classList.contains('hidden');
+  }
+
+  let dragDepth = 0;
+  function onDragEnter(e) {
+    if (!isMealsActive()) return;
+    if (!Array.from(e.dataTransfer?.types || []).includes('Files')) return;
+    dragDepth += 1;
+    zone.classList.add('drag-over');
+  }
+  function onDragLeave() {
+    if (!isMealsActive()) return;
+    dragDepth = Math.max(0, dragDepth - 1);
+    if (dragDepth === 0) zone.classList.remove('drag-over');
+  }
+  function onDragOver(e) {
+    if (!isMealsActive()) return;
+    if (!Array.from(e.dataTransfer?.types || []).includes('Files')) return;
+    e.preventDefault(); // drop を有効化
+    if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+  }
+  function onDrop(e) {
+    if (!isMealsActive()) return;
+    e.preventDefault();
+    dragDepth = 0;
+    zone.classList.remove('drag-over');
+    const files = Array.from(e.dataTransfer?.files || []).filter((f) => f.type?.startsWith?.('image/'));
+    if (files.length === 0) return;
+    uploadMealPhotos(files);
+  }
+
+  window.addEventListener('dragenter', onDragEnter);
+  window.addEventListener('dragleave', onDragLeave);
+  window.addEventListener('dragover', onDragOver);
+  window.addEventListener('drop', onDrop);
+
+  // ── クリップボード貼り付け (Ctrl+V) ─────────────────────────
+  window.addEventListener('paste', (e) => {
+    if (!isMealsActive()) return;
+    // テキスト入力中は素通し
+    const ae = document.activeElement;
+    if (ae && (ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA' || ae.isContentEditable)) return;
+    const items = Array.from(e.clipboardData?.items || []);
+    const files = items
+      .filter((it) => it.kind === 'file' && it.type?.startsWith?.('image/'))
+      .map((it) => it.getAsFile())
+      .filter((f) => !!f);
+    if (files.length === 0) return;
+    e.preventDefault();
+    uploadMealPhotos(files);
+  });
+})();

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -5936,57 +5936,109 @@ function startMealLocationEdit(btn) {
   });
 }
 
-async function addMealAddition(mealId) {
-  const name = prompt('追加で食べたものは? (例: アイスクリーム)');
-  if (name === null) return;
-  const trimmed = name.trim();
-  if (!trimmed) return;
-  const calRaw = prompt('カロリー (kcal、 不明なら空欄)', '');
-  if (calRaw === null) return;
-  const body = { name: trimmed };
-  if (calRaw.trim() !== '') {
-    const n = Number(calRaw);
-    if (isFinite(n)) body.calories = n;
+// 追加 / 編集はモバイルで prompt() の popup が見落とされやすかったため、
+// inline form パターン (startMealDescriptionEdit と同系) に移行。
+function addMealAddition(mealId) {
+  const card = document.querySelector(`.meal-card[data-meal-id="${mealId}"]`);
+  if (!card) return;
+  if (card.querySelector('.meal-addition-form')) return; // 既に開いてる
+  const actions = card.querySelector('.meal-actions');
+  if (!actions) return;
+  const form = document.createElement('div');
+  form.className = 'meal-addition-form';
+  form.innerHTML = `
+    <input type="text" class="meal-addition-name-input" placeholder="例: アイスクリーム" />
+    <input type="number" class="meal-addition-cal-input" placeholder="kcal" inputmode="numeric" />
+    <button type="button" class="meal-addition-save" title="追加">✓ 追加</button>
+    <button type="button" class="ghost meal-addition-form-cancel" title="キャンセル">×</button>
+  `;
+  actions.parentElement.insertBefore(form, actions);
+  const nameEl = form.querySelector('.meal-addition-name-input');
+  const calEl = form.querySelector('.meal-addition-cal-input');
+  nameEl?.focus();
+
+  function close() { form.remove(); }
+
+  async function save() {
+    const name = (nameEl?.value || '').trim();
+    if (!name) { nameEl?.focus(); return; }
+    const calRaw = (calEl?.value || '').trim();
+    const body = { name };
+    if (calRaw !== '') {
+      const n = Number(calRaw);
+      if (isFinite(n)) body.calories = n;
+    }
+    try {
+      await api(`/api/meals/${mealId}/additions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      await loadMeals();
+    } catch (e) {
+      alert(`追加エラー: ${e.message}`);
+    }
   }
-  try {
-    await api(`/api/meals/${mealId}/additions`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    });
-    await loadMeals();
-  } catch (e) {
-    alert(`追加エラー: ${e.message}`);
-  }
+
+  form.querySelector('.meal-addition-save')?.addEventListener('click', save);
+  form.querySelector('.meal-addition-form-cancel')?.addEventListener('click', close);
+  [nameEl, calEl].forEach((el) => el?.addEventListener('keydown', (ev) => {
+    if (ev.key === 'Enter') { ev.preventDefault(); save(); }
+    if (ev.key === 'Escape') { ev.preventDefault(); close(); }
+  }));
 }
 
-async function editMealAddition(mealId, idx) {
+function editMealAddition(mealId, idx) {
   const m = mealsState.items.find((x) => x.id === mealId);
   if (!m) return;
   const additions = parseMealAdditions(m.additions_json);
   const cur = additions[idx];
   if (!cur) return;
-  const name = prompt('項目名', cur.name || '');
-  if (name === null) return;
-  const calRaw = prompt('カロリー (kcal、 空欄でクリア)', cur.calories == null ? '' : String(cur.calories));
-  if (calRaw === null) return;
-  const body = {};
-  if (name.trim()) body.name = name.trim();
-  if (calRaw.trim() === '') body.calories = null;
-  else {
-    const n = Number(calRaw);
-    if (isFinite(n)) body.calories = n;
+  const li = document.querySelector(`.meal-addition[data-meal-id="${mealId}"][data-idx="${idx}"]`);
+  if (!li || li.classList.contains('editing')) return;
+  li.classList.add('editing');
+  const original = li.innerHTML;
+  li.innerHTML = `
+    <input type="text" class="meal-addition-name-input" value="${escapeHtml(cur.name || '')}" />
+    <input type="number" class="meal-addition-cal-input" placeholder="kcal" inputmode="numeric" value="${cur.calories == null ? '' : escapeHtml(String(cur.calories))}" />
+    <button type="button" class="meal-addition-save" title="保存">✓</button>
+    <button type="button" class="ghost meal-addition-form-cancel" title="キャンセル">×</button>
+  `;
+  const nameEl = li.querySelector('.meal-addition-name-input');
+  const calEl = li.querySelector('.meal-addition-cal-input');
+  nameEl?.focus();
+
+  function restore() { li.innerHTML = original; li.classList.remove('editing'); }
+
+  async function save() {
+    const name = (nameEl?.value || '').trim();
+    if (!name) { nameEl?.focus(); return; }
+    const calRaw = (calEl?.value || '').trim();
+    const body = { name };
+    if (calRaw === '') body.calories = null;
+    else {
+      const n = Number(calRaw);
+      if (isFinite(n)) body.calories = n;
+    }
+    try {
+      await api(`/api/meals/${mealId}/additions/${idx}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      await loadMeals();
+    } catch (e) {
+      alert(`編集エラー: ${e.message}`);
+      restore();
+    }
   }
-  try {
-    await api(`/api/meals/${mealId}/additions/${idx}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    });
-    await loadMeals();
-  } catch (e) {
-    alert(`編集エラー: ${e.message}`);
-  }
+
+  li.querySelector('.meal-addition-save')?.addEventListener('click', save);
+  li.querySelector('.meal-addition-form-cancel')?.addEventListener('click', restore);
+  [nameEl, calEl].forEach((el) => el?.addEventListener('keydown', (ev) => {
+    if (ev.key === 'Enter') { ev.preventDefault(); save(); }
+    if (ev.key === 'Escape') { ev.preventDefault(); restore(); }
+  }));
 }
 
 async function deleteMealAddition(mealId, idx) {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -2652,8 +2652,14 @@ function renderDiaryDetail() {
       const desc = dm.description
         ? `<div class="diary-domain-desc">${dm.kind ? `<span class="visits-kind">${escapeHtml(dm.kind)}</span> ` : ''}${escapeHtml(dm.description)}</div>`
         : '';
-      return `<li>
-        <div class="diary-domain-row"><span class="diary-domain-swatch" style="background:${color}"></span><span class="diary-domain-name">${escapeHtml(display)}</span>${sub}<span class="diary-domain-count">${dm.count} 件 · ${dm.active_hours.length} 時間帯</span></div>
+      return `<li class="diary-domain-card">
+        <div class="diary-domain-head">
+          <span class="diary-domain-swatch" style="background:${color}"></span>
+          <span class="diary-domain-title">${escapeHtml(display)}</span>
+          ${sub}
+          <span class="grow"></span>
+          <span class="diary-domain-count">${dm.count} 件 · ${dm.active_hours.length} 時間帯</span>
+        </div>
         ${desc}
       </li>`;
     }).join('');

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -2670,6 +2670,9 @@ function renderDiaryDetail() {
   const digsTotal = metrics.digs_total ?? digs.length;
   renderDiaryDigList(digs, digsTotal);
 
+  // 食事
+  renderDiaryMeals(metrics.meals || [], metrics.meals_total_calories);
+
   const commits = d.github_commits?.commits || [];
   if (commits.length === 0) {
     $('diaryGithub').innerHTML = `<li class="queue-empty">${d.github_commits?.error ? escapeHtml('GitHub: ' + d.github_commits.error) : 'commit 記録なし'}</li>`;
@@ -2779,6 +2782,48 @@ function renderDiaryBookmarkList(elId, items, total, kind, emptyMsg) {
       return { items: (r.items || []).map(b => bookmarkLi(b, withAccess)), total: r.total };
     });
   }
+}
+
+function renderDiaryMeals(meals, totalCal) {
+  const wrap = document.getElementById('diaryMeals');
+  if (!wrap) return;
+  if (!meals || meals.length === 0) {
+    wrap.innerHTML = '<div class="queue-empty">この日の食事記録はなし</div>';
+    return;
+  }
+  const totalLine = (typeof totalCal === 'number')
+    ? `<div class="diary-meals-total">総カロリー: <strong>${totalCal} kcal</strong> (${meals.length} 食)</div>`
+    : `<div class="diary-meals-total muted">${meals.length} 食 (カロリー未推定)</div>`;
+  const items = meals.map((m) => {
+    const t = (m.eaten_at || '').slice(11, 16);
+    const desc = m.description || '(未記入)';
+    const cal = (typeof m.total_calories === 'number') ? `${m.total_calories} kcal` : '— kcal';
+    const adds = (m.additions || []).map((a) => {
+      const ac = typeof a.calories === 'number' ? ` ${a.calories}kcal` : '';
+      return `＋${a.name}${ac}`;
+    }).join(', ');
+    const addsHtml = adds ? `<span class="diary-meal-adds muted"> · ${escapeHtml(adds)}</span>` : '';
+    return `<li class="diary-meal-row">
+      <a class="diary-meal-thumb" href="#" data-meal-id="${m.id}">
+        <img src="/api/meals/${m.id}/photo" loading="lazy" alt="" />
+      </a>
+      <div class="diary-meal-body">
+        <div class="diary-meal-head">
+          <span class="diary-meal-time">${escapeHtml(t)}</span>
+          <span class="diary-meal-cal">${escapeHtml(cal)}</span>
+        </div>
+        <div class="diary-meal-desc">${escapeHtml(desc)}${addsHtml}</div>
+      </div>
+    </li>`;
+  }).join('');
+  wrap.innerHTML = `${totalLine}<ul class="diary-meals-list">${items}</ul>`;
+  // クリック → 食事タブに飛ばす
+  wrap.querySelectorAll('.diary-meal-thumb').forEach((a) => {
+    a.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      switchTab('meals');
+    });
+  });
 }
 
 function renderDiaryDigList(items, total) {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -4988,11 +4988,14 @@ const mealsState = {
 async function loadMeals() {
   const list = document.getElementById('mealsList');
   if (!list) return;
-  const fromEl = document.getElementById('mealsFromDate');
-  const toEl = document.getElementById('mealsToDate');
+  // 単一日付フィルタ — 値があれば「その日 0:00 〜 23:59」 で絞り込み
+  const dateEl = document.getElementById('mealsFilterDate');
   const params = new URLSearchParams();
-  if (fromEl?.value) params.set('from', fromEl.value);
-  if (toEl?.value) params.set('to', toEl.value + 'T23:59:59');
+  const v = dateEl?.value;
+  if (v) {
+    params.set('from', v + 'T00:00:00');
+    params.set('to', v + 'T23:59:59');
+  }
   try {
     const r = await api(`/api/meals?${params.toString()}`);
     mealsState.items = r.meals || [];
@@ -5065,6 +5068,7 @@ function renderMeals() {
               ${escapeHtml(locStr)}
               <span class="meal-inline-pencil">✏️</span>
             </button>
+            ${(m.lat != null && m.lon != null) ? `<a class="meal-loc-map-link" href="https://www.google.com/maps?q=${encodeURIComponent(m.lat)},${encodeURIComponent(m.lon)}" target="_blank" rel="noopener" title="Google Maps で開く" onclick="event.stopPropagation()">↗ Maps</a>` : ''}
           </div>
           ${m.user_note ? `<div class="meal-note">📝 ${escapeHtml(m.user_note)}</div>` : ''}
           ${additionsHtml}
@@ -5279,7 +5283,15 @@ function advanceMealQueue() {
 function openMealModal(item) {
   const modal = document.getElementById('mealModal');
   if (!modal) return;
-  modal.classList.remove('hidden');
+  // <dialog>.showModal() でネイティブ popup として開く (focus trap / Esc 自動)
+  if (typeof modal.showModal === 'function') {
+    if (!modal.open) {
+      try { modal.showModal(); }
+      catch { modal.classList.remove('hidden'); }
+    }
+  } else {
+    modal.classList.remove('hidden');
+  }
 
   const photoImg = document.getElementById('mealModalPhoto');
   const photoEmpty = document.getElementById('mealModalPhotoEmpty');
@@ -5329,10 +5341,146 @@ function openMealModal(item) {
 
 function closeMealModal() {
   const modal = document.getElementById('mealModal');
-  if (modal) modal.classList.add('hidden');
+  if (modal) {
+    if (typeof modal.close === 'function' && modal.open) {
+      try { modal.close(); } catch { modal.classList.add('hidden'); }
+    } else {
+      modal.classList.add('hidden');
+    }
+  }
+  // 地図リソースもクリア
+  mealMapState.marker = null;
   mealModalState.current = null;
   mealModalState.currentIndex = 0;
   mealModalState.totalCount = 0;
+}
+
+// ── 食事モーダル: Google Map 連携 ───────────────────────────────
+//
+// 既存の tracksMap で使う API key とローダ (ensureGoogleMapsLoaded) を
+// 流用。 モーダル内に小さな地図を埋め込み、 クリック/タップで lat/lon を
+// フォームへ反映。 API key 未設定時は外部リンク (Maps で開く) のみ提供。
+
+const mealMapState = {
+  apiKey: null,         // null=未取得、 ''=未設定確定、 string=取得済
+  fetched: false,
+  map: null,            // google.maps.Map インスタンス
+  marker: null,
+};
+
+async function fetchMapsApiKey() {
+  if (mealMapState.fetched) return mealMapState.apiKey;
+  try {
+    const cfg = await api('/api/maps/config');
+    mealMapState.apiKey = cfg.hasKey ? (cfg.apiKey || '') : '';
+  } catch {
+    mealMapState.apiKey = '';
+  }
+  mealMapState.fetched = true;
+  return mealMapState.apiKey;
+}
+
+async function ensureMealModalMap(initialLat, initialLon) {
+  const wrap = document.getElementById('mealModalMap');
+  if (!wrap) return;
+  const apiKey = await fetchMapsApiKey();
+  if (!apiKey) {
+    wrap.innerHTML = '<div class="hint">Google Maps API key 未設定。 設定 → AI / 連携 で <code>maps.api_key</code> を入れるか、 「↗ Maps で開く」 リンクで外部表示してください。</div>';
+    return;
+  }
+  try {
+    await ensureGoogleMapsLoaded(apiKey);
+  } catch (e) {
+    wrap.innerHTML = `<div class="hint">Google Maps の読み込みに失敗: ${escapeHtml(e.message)}</div>`;
+    return;
+  }
+  if (!window.google?.maps) return;
+
+  // 中心点: 既存値 → 直近の GPS 軌跡 → 東京駅
+  const center = (initialLat != null && initialLon != null)
+    ? { lat: Number(initialLat), lng: Number(initialLon) }
+    : { lat: 35.681, lng: 139.767 };
+
+  // 既存の Map インスタンスがあれば再利用、 そうでなければ新規作成
+  if (!mealMapState.map) {
+    mealMapState.map = new google.maps.Map(wrap, {
+      center,
+      zoom: 15,
+      mapTypeControl: false,
+      streetViewControl: false,
+      fullscreenControl: false,
+    });
+    mealMapState.map.addListener('click', (ev) => {
+      const lat = ev.latLng.lat();
+      const lon = ev.latLng.lng();
+      setMealModalLatLon(lat, lon, /*recenter*/ false);
+    });
+  } else {
+    mealMapState.map.setCenter(center);
+    mealMapState.map.setZoom(15);
+    google.maps.event.trigger(mealMapState.map, 'resize');
+  }
+  if (initialLat != null && initialLon != null) {
+    placeMealModalMarker(Number(initialLat), Number(initialLon));
+  } else if (mealMapState.marker) {
+    mealMapState.marker.setMap(null);
+    mealMapState.marker = null;
+  }
+}
+
+function placeMealModalMarker(lat, lon) {
+  if (!mealMapState.map) return;
+  const pos = new google.maps.LatLng(lat, lon);
+  if (!mealMapState.marker) {
+    mealMapState.marker = new google.maps.Marker({
+      position: pos,
+      map: mealMapState.map,
+      draggable: true,
+    });
+    mealMapState.marker.addListener('dragend', (ev) => {
+      const dlat = ev.latLng.lat();
+      const dlon = ev.latLng.lng();
+      setMealModalLatLon(dlat, dlon, /*recenter*/ false);
+    });
+  } else {
+    mealMapState.marker.setPosition(pos);
+    mealMapState.marker.setMap(mealMapState.map);
+  }
+}
+
+function setMealModalLatLon(lat, lon, recenter) {
+  const latEl = document.getElementById('mealModalLat');
+  const lonEl = document.getElementById('mealModalLon');
+  if (latEl) latEl.value = String(lat.toFixed ? lat.toFixed(6) : lat);
+  if (lonEl) lonEl.value = String(lon.toFixed ? lon.toFixed(6) : lon);
+  placeMealModalMarker(Number(lat), Number(lon));
+  if (recenter && mealMapState.map) {
+    mealMapState.map.setCenter(new google.maps.LatLng(Number(lat), Number(lon)));
+  }
+  updateMealModalMapLink();
+}
+
+function clearMealModalMarker() {
+  if (mealMapState.marker) {
+    mealMapState.marker.setMap(null);
+    mealMapState.marker = null;
+  }
+}
+
+function updateMealModalMapLink() {
+  const link = document.getElementById('mealModalMapOpen');
+  if (!link) return;
+  const latEl = document.getElementById('mealModalLat');
+  const lonEl = document.getElementById('mealModalLon');
+  const lat = latEl?.value?.trim();
+  const lon = lonEl?.value?.trim();
+  if (lat && lon && isFinite(Number(lat)) && isFinite(Number(lon))) {
+    link.href = `https://www.google.com/maps?q=${encodeURIComponent(lat)},${encodeURIComponent(lon)}`;
+    link.hidden = false;
+  } else {
+    link.hidden = true;
+    link.removeAttribute('href');
+  }
 }
 
 function readMealModalForm() {
@@ -5686,10 +5834,7 @@ document.getElementById('mealModalLocHere')?.addEventListener('click', () => {
   if (!navigator.geolocation) { alert('この端末は位置情報に対応していません'); return; }
   navigator.geolocation.getCurrentPosition(
     (pos) => {
-      const latEl = document.getElementById('mealModalLat');
-      const lonEl = document.getElementById('mealModalLon');
-      if (latEl) latEl.value = String(pos.coords.latitude);
-      if (lonEl) lonEl.value = String(pos.coords.longitude);
+      setMealModalLatLon(pos.coords.latitude, pos.coords.longitude, /*recenter*/ true);
     },
     (err) => alert(`位置取得失敗: ${err.message}`),
     { enableHighAccuracy: true, timeout: 10_000 },
@@ -5700,72 +5845,53 @@ document.getElementById('mealModalLocClear')?.addEventListener('click', () => {
   const lonEl = document.getElementById('mealModalLon');
   if (latEl) latEl.value = '';
   if (lonEl) lonEl.value = '';
-});
-// Esc キーで全 cancel
-window.addEventListener('keydown', (ev) => {
-  if (ev.key !== 'Escape') return;
-  const modal = document.getElementById('mealModal');
-  if (!modal || modal.classList.contains('hidden')) return;
-  cancelMealModal();
+  clearMealModalMarker();
+  updateMealModalMapLink();
 });
 
-// ── ドラッグ&ドロップ ──────────────────────────────────────────
-(function setupMealsDropZone() {
-  const view = document.getElementById('mealsView');
-  const zone = document.getElementById('mealsDropZone');
-  if (!view || !zone) return;
+// 🗺 地図ボタンで開閉 + 必要なら Google Maps を初期化
+document.getElementById('mealModalMapToggle')?.addEventListener('click', async () => {
+  const wrap = document.getElementById('mealModalMap');
+  if (!wrap) return;
+  const open = wrap.classList.toggle('hidden');
+  if (open) return; // 閉じた
+  const latEl = document.getElementById('mealModalLat');
+  const lonEl = document.getElementById('mealModalLon');
+  const lat = latEl?.value ? Number(latEl.value) : null;
+  const lon = lonEl?.value ? Number(lonEl.value) : null;
+  await ensureMealModalMap(lat, lon);
+  // resize trigger (hidden → show のとき必須)
+  if (mealMapState.map && window.google?.maps) {
+    setTimeout(() => google.maps.event.trigger(mealMapState.map, 'resize'), 50);
+  }
+});
 
-  // window 全体で dragover/drop を受けて、 食事タブが active な場合のみ処理
-  function isMealsActive() {
-    return state.tab === 'meals' && !view.classList.contains('hidden');
-  }
-
-  let dragDepth = 0;
-  function onDragEnter(e) {
-    if (!isMealsActive()) return;
-    if (!Array.from(e.dataTransfer?.types || []).includes('Files')) return;
-    dragDepth += 1;
-    zone.classList.add('drag-over');
-  }
-  function onDragLeave() {
-    if (!isMealsActive()) return;
-    dragDepth = Math.max(0, dragDepth - 1);
-    if (dragDepth === 0) zone.classList.remove('drag-over');
-  }
-  function onDragOver(e) {
-    if (!isMealsActive()) return;
-    if (!Array.from(e.dataTransfer?.types || []).includes('Files')) return;
-    e.preventDefault(); // drop を有効化
-    if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
-  }
-  function onDrop(e) {
-    if (!isMealsActive()) return;
-    e.preventDefault();
-    dragDepth = 0;
-    zone.classList.remove('drag-over');
-    const files = Array.from(e.dataTransfer?.files || []).filter((f) => f.type?.startsWith?.('image/'));
-    if (files.length === 0) return;
-    startMealModalForFiles(files);
-  }
-
-  window.addEventListener('dragenter', onDragEnter);
-  window.addEventListener('dragleave', onDragLeave);
-  window.addEventListener('dragover', onDragOver);
-  window.addEventListener('drop', onDrop);
-
-  // ── クリップボード貼り付け (Ctrl+V) ─────────────────────────
-  window.addEventListener('paste', (e) => {
-    if (!isMealsActive()) return;
-    // テキスト入力中は素通し
-    const ae = document.activeElement;
-    if (ae && (ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA' || ae.isContentEditable)) return;
-    const items = Array.from(e.clipboardData?.items || []);
-    const files = items
-      .filter((it) => it.kind === 'file' && it.type?.startsWith?.('image/'))
-      .map((it) => it.getAsFile())
-      .filter((f) => !!f);
-    if (files.length === 0) return;
-    e.preventDefault();
-    startMealModalForFiles(files);
+// lat/lon 手入力時に map と link を追従
+['mealModalLat', 'mealModalLon'].forEach((id) => {
+  document.getElementById(id)?.addEventListener('input', () => {
+    const lat = Number(document.getElementById('mealModalLat')?.value);
+    const lon = Number(document.getElementById('mealModalLon')?.value);
+    if (isFinite(lat) && isFinite(lon)) {
+      placeMealModalMarker(lat, lon);
+    } else {
+      clearMealModalMarker();
+    }
+    updateMealModalMapLink();
   });
-})();
+});
+
+// <dialog> のネイティブ close (Esc 含む) を cancel として扱う
+document.getElementById('mealModal')?.addEventListener('close', () => {
+  // showModal で開いた場合、 Esc で close → ここに来る
+  if (mealModalState.queue.length > 0 || mealModalState.current) {
+    clearMealQueue();
+  }
+});
+
+// 単一日付フィルタの結線 (絞り込み変更で即時 reload + クリアボタン)
+document.getElementById('mealsFilterDate')?.addEventListener('change', () => loadMeals());
+document.getElementById('mealsFilterClear')?.addEventListener('click', () => {
+  const el = document.getElementById('mealsFilterDate');
+  if (el) el.value = '';
+  loadMeals();
+});

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -5041,9 +5041,12 @@ function renderMeals() {
         }).join('')}
       </ul>
     `;
+    const photoHtml = m.photo_path
+      ? `<img class="meal-photo" src="/api/meals/${m.id}/photo" loading="lazy" alt="食事写真" />`
+      : `<div class="meal-photo meal-photo-empty" aria-label="写真なし"><span class="meal-photo-empty-icon">📝</span><span class="meal-photo-empty-label">写真なし</span></div>`;
     return `
       <div class="meal-card" data-meal-id="${m.id}">
-        <img class="meal-photo" src="/api/meals/${m.id}/photo" loading="lazy" alt="食事写真" />
+        ${photoHtml}
         <div class="meal-body">
           <div class="meal-head">
             <button class="meal-time-edit" data-id="${m.id}" data-current="${escapeHtml(toDatetimeLocalValue(m.eaten_at))}" title="クリックで時刻を編集">
@@ -5052,17 +5055,23 @@ function renderMeals() {
             </button>
             ${aiBadge}
           </div>
-          <div class="meal-desc">${escapeHtml(desc)}</div>
+          <button class="meal-desc meal-inline-editable" data-id="${m.id}" data-field="description" data-current="${escapeHtml(m.user_corrected_description || m.description || '')}" title="クリックで内容を編集">
+            ${escapeHtml(desc)}
+            <span class="meal-inline-pencil">✏️</span>
+          </button>
           <div class="meal-meta">
             <span class="meal-cal">${escapeHtml(calStr)}</span>
-            <span class="meal-loc">${escapeHtml(locStr)}</span>
+            <button class="meal-loc meal-inline-editable" data-id="${m.id}" data-field="location" data-lat="${m.lat ?? ''}" data-lon="${m.lon ?? ''}" title="クリックで場所を編集">
+              ${escapeHtml(locStr)}
+              <span class="meal-inline-pencil">✏️</span>
+            </button>
           </div>
           ${m.user_note ? `<div class="meal-note">📝 ${escapeHtml(m.user_note)}</div>` : ''}
           ${additionsHtml}
           <div class="meal-actions">
             <button class="ghost meal-add-btn" data-id="${m.id}">➕ 追加で食べた</button>
-            <button class="ghost meal-edit-btn" data-id="${m.id}">✏️ 修正</button>
-            <button class="ghost meal-reanalyze-btn" data-id="${m.id}">🔄 再解析</button>
+            <button class="ghost meal-note-btn" data-id="${m.id}" title="補足メモを編集">📝 メモ</button>
+            <button class="ghost meal-reanalyze-btn" data-id="${m.id}" ${m.photo_path ? '' : 'hidden'}>🔄 再解析</button>
             <button class="ghost meal-delete-btn" data-id="${m.id}">🗑️ 削除</button>
           </div>
         </div>
@@ -5075,8 +5084,8 @@ function renderMeals() {
     const recentErrors = mealsState.items.slice(0, 5).filter((m) => m.ai_status === 'error').length;
     hint.classList.toggle('hidden', recentErrors < 2);
   }
-  list.querySelectorAll('.meal-edit-btn').forEach((b) => {
-    b.addEventListener('click', () => editMeal(Number(b.dataset.id)));
+  list.querySelectorAll('.meal-note-btn').forEach((b) => {
+    b.addEventListener('click', () => editMealNote(Number(b.dataset.id)));
   });
   list.querySelectorAll('.meal-reanalyze-btn').forEach((b) => {
     b.addEventListener('click', () => reanalyzeMeal(Number(b.dataset.id)));
@@ -5092,6 +5101,18 @@ function renderMeals() {
       // editing 状態の中の input/button が再帰しないように
       if (ev.target.closest('.meal-time-actions') || ev.target.tagName === 'INPUT') return;
       startMealTimeEdit(b);
+    });
+  });
+  list.querySelectorAll('.meal-inline-editable[data-field="description"]').forEach((el) => {
+    el.addEventListener('click', (ev) => {
+      if (ev.target.closest('.meal-inline-actions') || ev.target.tagName === 'INPUT' || ev.target.tagName === 'TEXTAREA') return;
+      startMealDescriptionEdit(el);
+    });
+  });
+  list.querySelectorAll('.meal-inline-editable[data-field="location"]').forEach((el) => {
+    el.addEventListener('click', (ev) => {
+      if (ev.target.closest('.meal-inline-actions') || ev.target.tagName === 'INPUT' || ev.target.tagName === 'BUTTON') return;
+      startMealLocationEdit(el);
     });
   });
   list.querySelectorAll('.meal-addition-edit').forEach((b) => {
@@ -5189,7 +5210,12 @@ function formatLocalMealDateTime(iso) {
 
 function schedulePendingPoll() {
   if (mealsState.pollTimer) clearTimeout(mealsState.pollTimer);
-  const hasPending = mealsState.items.some((m) => m.ai_status === 'pending');
+  // 解析中 (ai_status=pending) または addition の calories 未確定なら polling
+  const hasPending = mealsState.items.some((m) => {
+    if (m.ai_status === 'pending') return true;
+    const adds = parseMealAdditions(m.additions_json);
+    return adds.some((a) => a.calories == null);
+  });
   if (!hasPending) return;
   mealsState.pollTimer = setTimeout(() => {
     if (state.tab !== 'meals') return;
@@ -5258,37 +5284,178 @@ async function deleteMealRow(id) {
   }
 }
 
-function editMeal(id) {
+// ── 補足メモのみ編集 (旧 editMeal の縮小版) ─────────────────
+async function editMealNote(id) {
   const m = mealsState.items.find((x) => x.id === id);
   if (!m) return;
-  const desc = prompt('食事内容 (補正)', m.user_corrected_description || m.description || '');
-  if (desc === null) return;
-  const calRaw = prompt('カロリー (補正、 数字。 空欄でクリア)', String(m.user_corrected_calories ?? m.calories ?? ''));
-  if (calRaw === null) return;
-  const eatenAtRaw = prompt('食事時刻 (YYYY-MM-DDTHH:mm、 空欄で変更しない)', formatLocalMealDateTime(m.eaten_at).replace(' ', 'T'));
-  if (eatenAtRaw === null) return;
   const note = prompt('補足メモ', m.user_note || '');
   if (note === null) return;
-
-  const patch = {
-    user_corrected_description: desc.trim() || null,
-    user_note: note.trim() || null,
-  };
-  if (calRaw.trim() === '') {
-    patch.user_corrected_calories = null;
-  } else {
-    const n = Number(calRaw);
-    if (isFinite(n)) patch.user_corrected_calories = n;
+  try {
+    await api(`/api/meals/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_note: note }),
+    });
+    await loadMeals();
+  } catch (e) {
+    alert(`メモ保存エラー: ${e.message}`);
   }
-  if (eatenAtRaw.trim()) patch.eaten_at = eatenAtRaw.trim();
+}
 
-  api(`/api/meals/${id}`, {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(patch),
-  })
-    .then(() => loadMeals())
-    .catch((e) => alert(`修正エラー: ${e.message}`));
+// ── 食事内容 inline 編集 (textarea) ─────────────────────────
+function startMealDescriptionEdit(btn) {
+  if (btn.classList.contains('editing')) return;
+  const mealId = Number(btn.dataset.id);
+  const current = btn.dataset.current || '';
+  btn.classList.add('editing');
+  const original = btn.innerHTML;
+  btn.innerHTML = `
+    <textarea class="meal-desc-input" rows="2">${escapeHtml(current)}</textarea>
+    <span class="meal-inline-actions">
+      <button class="meal-inline-save" type="button" title="保存 (カロリー再推定)">✓</button>
+      <button class="meal-inline-cancel" type="button" title="キャンセル">×</button>
+    </span>
+  `;
+  const ta = btn.querySelector('textarea');
+  ta?.focus();
+  ta?.setSelectionRange(ta.value.length, ta.value.length);
+
+  function restore() { btn.innerHTML = original; btn.classList.remove('editing'); }
+
+  async function save() {
+    const v = (ta?.value ?? '').trim();
+    if (!v) { restore(); return; }
+    if (v === current) { restore(); return; }
+    try {
+      // PATCH 後に backend が「description 変更を検出 → カロリー LLM 再推定」 を kick する。
+      // user_corrected_description を空にして基本 description (AI 推定 or manual 登録時) を活かす場合と
+      // user_corrected_description で上書きする場合があるが、 シンプルに常に user_corrected を使う。
+      await api(`/api/meals/${mealId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          user_corrected_description: v,
+          // 内容が変わったらユーザ補正カロリーをクリアして自動再推定させる
+          user_corrected_calories: null,
+        }),
+      });
+      await loadMeals();
+    } catch (e) {
+      alert(`内容保存エラー: ${e.message}`);
+      restore();
+    }
+  }
+
+  btn.querySelector('.meal-inline-save')?.addEventListener('click', (ev) => { ev.stopPropagation(); save(); });
+  btn.querySelector('.meal-inline-cancel')?.addEventListener('click', (ev) => { ev.stopPropagation(); restore(); });
+  ta?.addEventListener('keydown', (ev) => {
+    if (ev.key === 'Enter' && (ev.ctrlKey || ev.metaKey)) { ev.preventDefault(); save(); }
+    if (ev.key === 'Escape') { ev.preventDefault(); restore(); }
+  });
+  ta?.addEventListener('click', (ev) => ev.stopPropagation());
+}
+
+// ── 場所 inline 編集 (lat,lon + 「現在地から」 + 「クリア」) ─────
+function startMealLocationEdit(btn) {
+  if (btn.classList.contains('editing')) return;
+  const mealId = Number(btn.dataset.id);
+  const curLat = btn.dataset.lat || '';
+  const curLon = btn.dataset.lon || '';
+  btn.classList.add('editing');
+  const original = btn.innerHTML;
+  btn.innerHTML = `
+    <input type="number" step="any" class="meal-loc-lat" placeholder="緯度" value="${escapeHtml(curLat)}" />
+    <input type="number" step="any" class="meal-loc-lon" placeholder="経度" value="${escapeHtml(curLon)}" />
+    <span class="meal-inline-actions">
+      <button class="meal-loc-here" type="button" title="現在地から取得">📍</button>
+      <button class="meal-loc-clear" type="button" title="場所を削除">∅</button>
+      <button class="meal-inline-save" type="button" title="保存">✓</button>
+      <button class="meal-inline-cancel" type="button" title="キャンセル">×</button>
+    </span>
+  `;
+  const latIn = btn.querySelector('.meal-loc-lat');
+  const lonIn = btn.querySelector('.meal-loc-lon');
+
+  function restore() { btn.innerHTML = original; btn.classList.remove('editing'); }
+
+  async function save() {
+    const lat = (latIn?.value ?? '').trim() === '' ? null : Number(latIn.value);
+    const lon = (lonIn?.value ?? '').trim() === '' ? null : Number(lonIn.value);
+    const body = { lat: null, lon: null };
+    if (lat != null && lon != null && isFinite(lat) && isFinite(lon)) {
+      body.lat = lat; body.lon = lon;
+    }
+    try {
+      await api(`/api/meals/${mealId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      await loadMeals();
+    } catch (e) {
+      alert(`場所保存エラー: ${e.message}`);
+      restore();
+    }
+  }
+
+  btn.querySelector('.meal-loc-here')?.addEventListener('click', (ev) => {
+    ev.stopPropagation();
+    if (!navigator.geolocation) { alert('この端末は位置情報に対応していません'); return; }
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        if (latIn) latIn.value = String(pos.coords.latitude);
+        if (lonIn) lonIn.value = String(pos.coords.longitude);
+      },
+      (err) => alert(`位置取得失敗: ${err.message}`),
+      { enableHighAccuracy: true, timeout: 10_000 },
+    );
+  });
+  btn.querySelector('.meal-loc-clear')?.addEventListener('click', (ev) => {
+    ev.stopPropagation();
+    if (latIn) latIn.value = '';
+    if (lonIn) lonIn.value = '';
+  });
+  btn.querySelector('.meal-inline-save')?.addEventListener('click', (ev) => { ev.stopPropagation(); save(); });
+  btn.querySelector('.meal-inline-cancel')?.addEventListener('click', (ev) => { ev.stopPropagation(); restore(); });
+  [latIn, lonIn].forEach((el) => {
+    el?.addEventListener('keydown', (ev) => {
+      if (ev.key === 'Enter') { ev.preventDefault(); save(); }
+      if (ev.key === 'Escape') { ev.preventDefault(); restore(); }
+    });
+    el?.addEventListener('click', (ev) => ev.stopPropagation());
+  });
+}
+
+// ── 写真なしで食事を追加 ─────────────────────────────────────
+async function addManualMeal() {
+  const description = prompt('食事内容を入力 (例: ラーメン、 おにぎり 1 個)');
+  if (description == null) return;
+  const trimmed = description.trim();
+  if (!trimmed) return;
+  const eatenAtRaw = prompt('食事時刻 (YYYY-MM-DDTHH:mm、 空欄で現在時刻)', toDatetimeLocalValue(new Date().toISOString()));
+  if (eatenAtRaw == null) return;
+  const calRaw = prompt('カロリー (kcal、 空欄で AI 自動推定)', '');
+  if (calRaw == null) return;
+
+  const body = { description: trimmed };
+  if (eatenAtRaw.trim()) body.eaten_at = eatenAtRaw.trim();
+  if (calRaw.trim()) {
+    const n = Number(calRaw);
+    if (isFinite(n)) body.calories = n;
+  }
+  const status = document.getElementById('mealsUploadStatus');
+  if (status) status.textContent = `📝 ${trimmed.slice(0, 30)} を登録中…`;
+  try {
+    await api('/api/meals/manual', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (status) status.textContent = `✅ 「${trimmed.slice(0, 30)}」 登録${calRaw.trim() ? '' : ' (カロリー推定中)'}`;
+    await loadMeals();
+  } catch (e) {
+    if (status) status.textContent = `⚠ 登録エラー: ${e.message}`;
+  }
 }
 
 async function addMealAddition(mealId) {
@@ -5368,6 +5535,8 @@ document.getElementById('mealsCameraInput')?.addEventListener('change', (e) => {
   if (!file) return;
   uploadMealPhoto(file).finally(() => { e.target.value = ''; });
 });
+
+document.getElementById('mealsManualBtn')?.addEventListener('click', () => addManualMeal());
 
 // ── ドラッグ&ドロップ ──────────────────────────────────────────
 (function setupMealsDropZone() {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -5089,8 +5089,8 @@ function renderMeals() {
           ${m.user_note ? `<div class="meal-note">📝 ${escapeHtml(m.user_note)}</div>` : ''}
           ${additionsHtml}
           <div class="meal-actions">
+            <button class="ghost meal-edit-full-btn" data-id="${m.id}" title="ダイアログで全項目を編集">✏️ 編集</button>
             <button class="ghost meal-add-btn" data-id="${m.id}">➕ 追加で食べた</button>
-            <button class="ghost meal-note-btn" data-id="${m.id}" title="補足メモを編集">📝 メモ</button>
             <button class="ghost meal-reanalyze-btn" data-id="${m.id}" ${m.photo_path ? '' : 'hidden'}>🔄 再解析</button>
             <button class="ghost meal-delete-btn" data-id="${m.id}">🗑️ 削除</button>
           </div>
@@ -5104,8 +5104,8 @@ function renderMeals() {
     const recentErrors = mealsState.items.slice(0, 5).filter((m) => m.ai_status === 'error').length;
     hint.classList.toggle('hidden', recentErrors < 2);
   }
-  list.querySelectorAll('.meal-note-btn').forEach((b) => {
-    b.addEventListener('click', () => editMealNote(Number(b.dataset.id)));
+  list.querySelectorAll('.meal-edit-full-btn').forEach((b) => {
+    b.addEventListener('click', () => openMealEditModal(Number(b.dataset.id)));
   });
   list.querySelectorAll('.meal-reanalyze-btn').forEach((b) => {
     b.addEventListener('click', () => reanalyzeMeal(Number(b.dataset.id)));
@@ -5315,6 +5315,11 @@ function openMealModal(item) {
     photoImg.src = item.blobUrl;
     photoImg.hidden = false;
     photoEmpty.classList.add('hidden');
+  } else if (item.kind === 'edit' && item.meal?.photo_path) {
+    // 編集 mode: 既存写真をサーバ URL から表示
+    photoImg.src = `/api/meals/${item.meal.id}/photo?t=${Date.now()}`;
+    photoImg.hidden = false;
+    photoEmpty.classList.add('hidden');
   } else {
     photoImg.hidden = true;
     photoImg.removeAttribute('src');
@@ -5328,18 +5333,40 @@ function openMealModal(item) {
   const calEl = document.getElementById('mealModalCal');
   const noteEl = document.getElementById('mealModalNote');
   const descHint = document.getElementById('mealModalDescHint');
+  const titleEl = document.getElementById('mealModalTitle');
+  const submitEl = document.getElementById('mealModalSubmit');
 
-  if (descEl) descEl.value = '';
-  if (eatenEl) eatenEl.value = toDatetimeLocalValue(new Date().toISOString());
-  if (latEl) latEl.value = '';
-  if (lonEl) lonEl.value = '';
-  if (calEl) calEl.value = '';
-  if (noteEl) noteEl.value = '';
+  if (item.kind === 'edit' && item.meal) {
+    // 既存値を埋める
+    const m = item.meal;
+    if (descEl) descEl.value = m.user_corrected_description || m.description || '';
+    if (eatenEl) eatenEl.value = toDatetimeLocalValue(m.eaten_at);
+    if (latEl) latEl.value = m.lat != null ? String(m.lat) : '';
+    if (lonEl) lonEl.value = m.lon != null ? String(m.lon) : '';
+    const cal = m.user_corrected_calories ?? m.calories;
+    if (calEl) calEl.value = cal != null ? String(cal) : '';
+    if (noteEl) noteEl.value = m.user_note || '';
+    if (titleEl) titleEl.textContent = `食事を編集 #${m.id}`;
+    if (submitEl) submitEl.textContent = '保存';
+  } else {
+    if (descEl) descEl.value = '';
+    if (eatenEl) eatenEl.value = toDatetimeLocalValue(new Date().toISOString());
+    if (latEl) latEl.value = '';
+    if (lonEl) lonEl.value = '';
+    if (calEl) calEl.value = '';
+    if (noteEl) noteEl.value = '';
+    if (titleEl) titleEl.textContent = '食事を登録';
+    if (submitEl) submitEl.textContent = '登録';
+  }
+  updateMealModalMapLink();
 
-  // 写真ありなら description 任意 (AI 解析)、 写真なしなら必須
-  if (item.kind === 'photo') {
+  // 写真あり (新規 / 編集) なら description 任意、 写真なし (manual) は必須
+  const hasPhoto = item.kind === 'photo' || (item.kind === 'edit' && item.meal?.photo_path);
+  if (hasPhoto) {
     descEl?.removeAttribute('required');
-    if (descHint) descHint.textContent = '空欄なら AI が画像から推定 (Claude Vision)';
+    if (descHint) descHint.textContent = item.kind === 'edit'
+      ? '空欄なら AI 結果に戻ります'
+      : '空欄なら AI が画像から推定 (Claude Vision)';
   } else {
     descEl?.setAttribute('required', 'required');
     if (descHint) descHint.textContent = '写真なしの場合は内容必須。 カロリー空欄なら AI 推定';
@@ -5523,10 +5550,40 @@ async function submitMealModal() {
     return;
   }
 
-  if (status) status.textContent = `📤 登録中…`;
+  if (status) status.textContent = item.kind === 'edit' ? `📝 保存中…` : `📤 登録中…`;
 
   try {
-    if (item.kind === 'photo') {
+    if (item.kind === 'edit') {
+      // 既存 meal の編集 → PATCH /api/meals/:id
+      const m = item.meal;
+      const patch = {};
+      // description: 空文字なら null (= AI 結果へ戻す) に明示
+      const prevDesc = m.user_corrected_description || m.description || '';
+      if (desc !== prevDesc) {
+        patch.user_corrected_description = desc || null;
+        // 内容変更でカロリー再推定をかけたい場合は user_corrected_calories=null
+        // (背景再推定が走る)。 ただしユーザが明示的にカロリー入れた場合は保持
+      }
+      if (eatenAt) patch.eaten_at = eatenAt;
+      if (lat != null && lon != null && isFinite(lat) && isFinite(lon)) {
+        patch.lat = lat; patch.lon = lon;
+      } else if (lat == null && lon == null) {
+        patch.lat = null; patch.lon = null;
+      }
+      // calories: 入力値があればそのまま、 空欄なら null (再推定許可)
+      if (calories != null && isFinite(calories)) {
+        patch.user_corrected_calories = calories;
+      } else {
+        patch.user_corrected_calories = null;
+      }
+      patch.user_note = note || null;
+      await api(`/api/meals/${m.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patch),
+      });
+      if (status) status.textContent = `✅ 保存しました`;
+    } else if (item.kind === 'photo') {
       const fd = new FormData();
       fd.append('photo', item.file);
       if (eatenAt) fd.append('eaten_at', eatenAt);
@@ -5551,6 +5608,7 @@ async function submitMealModal() {
           body: JSON.stringify(patch),
         });
       }
+      if (status) status.textContent = `✅ 登録しました`;
     } else {
       const body = { description: desc };
       if (eatenAt) body.eaten_at = eatenAt;
@@ -5564,10 +5622,12 @@ async function submitMealModal() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
       });
+      if (status) status.textContent = `✅ 登録しました`;
     }
-    if (status) status.textContent = `✅ 登録しました`;
   } catch (e) {
-    if (status) status.textContent = `⚠ 登録エラー: ${e.message}`;
+    if (status) status.textContent = item.kind === 'edit'
+      ? `⚠ 保存エラー: ${e.message}`
+      : `⚠ 登録エラー: ${e.message}`;
     console.warn('[meals] submit error:', e);
   }
   await loadMeals();
@@ -5595,6 +5655,13 @@ function startMealModalForFiles(files) {
 
 function startMealModalForManual() {
   enqueueMealModal([{ kind: 'manual' }]);
+}
+
+function openMealEditModal(mealId) {
+  const m = mealsState.items.find((x) => x.id === mealId);
+  if (!m) return;
+  // 編集 mode は 1 件のみ — 既存キューがあれば優先 (連続編集は順次)
+  enqueueMealModal([{ kind: 'edit', meal: m }]);
 }
 
 async function reanalyzeMeal(id) {

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -496,6 +496,9 @@
             📸 撮影
             <input id="mealsCameraInput" type="file" accept="image/*" capture="environment" hidden />
           </label>
+          <button id="mealsManualBtn" class="meals-upload-btn ghost" title="食品名を入力して登録 (写真なし)">
+            ✍️ 写真なしで追加
+          </button>
           <span id="mealsUploadStatus" class="muted"></span>
           <span class="grow"></span>
           <input id="mealsFromDate" type="date" title="開始日" />

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -497,7 +497,9 @@
           <button id="mealsRefresh" class="ghost">更新</button>
         </div>
         <div id="mealsHint" class="meals-hint muted hidden">
-          OpenAI API key 未設定です (設定 → AI / 連携 → llm.openai.api_key)。 写真は登録できますが、 食事内容 / カロリーは自動推定されません。
+          画像解析が失敗しています。 設定 → AI / 連携 で
+          <code>meal_vision</code> タスクの provider / モデルを確認してください
+          (デフォルトは Claude CLI sonnet)。
         </div>
         <div id="mealsList" class="meals-list"></div>
       </div>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -378,18 +378,18 @@
             <div id="diaryWork" class="diary-summary"></div>
             <h4>ハイライト (Opus 1M)</h4>
             <div id="diaryHighlights" class="diary-summary"></div>
-            <h4>時間帯別アクセス (0-24時)</h4>
-            <div id="diaryHourly" class="diary-hourly"></div>
-            <div class="diary-pie-row">
-              <div class="diary-pie-wrap">
+            <div class="diary-charts-row">
+              <div class="diary-chart-cell">
+                <h4>時間帯別アクセス (0-24時)</h4>
+                <div id="diaryHourly" class="diary-hourly"></div>
+              </div>
+              <div class="diary-chart-cell">
                 <h4>ドメイン内訳</h4>
                 <div id="diaryPie" class="diary-pie"></div>
               </div>
-              <div class="diary-pie-legend-wrap">
-                <h4>よく見たドメイン</h4>
-                <ul id="diaryDomains" class="diary-domains"></ul>
-              </div>
             </div>
+            <h4>よく見たドメイン</h4>
+            <ul id="diaryDomains" class="diary-domains-pane"></ul>
             <h4>新規ブックマーク</h4>
             <ul id="diaryBookmarksCreated" class="diary-bookmarks"></ul>
             <h4>再訪したブックマーク</h4>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -396,6 +396,8 @@
             <ul id="diaryBookmarksAccessed" class="diary-bookmarks"></ul>
             <h4>当日のディグ調査</h4>
             <ul id="diaryDigs" class="diary-digs"></ul>
+            <h4>🍽 食事</h4>
+            <div id="diaryMeals" class="diary-meals"></div>
             <h4>GitHub commits (リポ別件数)</h4>
             <ul id="diaryGithub" class="diary-github"></ul>
             <h4>メモ・補足</h4>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -520,6 +520,68 @@
         <div id="mealsList" class="meals-list"></div>
       </div>
 
+      <!-- 食事登録モーダル — 写真 / 写真なしどちらの経路も 1 件ずつここで確認 -->
+      <div id="mealModal" class="meal-modal hidden" role="dialog" aria-modal="true" aria-labelledby="mealModalTitle">
+        <div class="meal-modal-backdrop"></div>
+        <div class="meal-modal-card">
+          <header class="meal-modal-head">
+            <h3 id="mealModalTitle">食事を登録</h3>
+            <span id="mealModalProgress" class="meal-modal-progress muted"></span>
+            <button type="button" id="mealModalClose" class="meal-modal-x" aria-label="閉じる">×</button>
+          </header>
+
+          <div id="mealModalPhotoWrap" class="meal-modal-photo-wrap">
+            <img id="mealModalPhoto" alt="食事写真プレビュー" />
+            <div id="mealModalPhotoEmpty" class="meal-modal-photo-empty hidden">
+              <span class="meal-photo-empty-icon">📝</span>
+              <span class="meal-photo-empty-label">写真なし</span>
+            </div>
+          </div>
+
+          <form id="mealModalForm" class="meal-modal-form" onsubmit="return false;">
+            <label class="meal-modal-row">
+              <span class="meal-modal-label">食事内容 <span class="required">*</span></span>
+              <textarea id="mealModalDesc" rows="2" placeholder="例: カレーライスとサラダ" required></textarea>
+              <span class="meal-modal-hint muted" id="mealModalDescHint">写真ありで空欄なら AI が解析します</span>
+            </label>
+
+            <label class="meal-modal-row">
+              <span class="meal-modal-label">食事時刻</span>
+              <input id="mealModalEatenAt" type="datetime-local" />
+              <span class="meal-modal-hint muted">EXIF があれば後でサーバが上書き</span>
+            </label>
+
+            <div class="meal-modal-row">
+              <span class="meal-modal-label">場所</span>
+              <div class="meal-modal-loc">
+                <input id="mealModalLat" type="number" step="any" placeholder="緯度" />
+                <input id="mealModalLon" type="number" step="any" placeholder="経度" />
+                <button type="button" id="mealModalLocHere" class="ghost" title="現在地から取得">📍</button>
+                <button type="button" id="mealModalLocClear" class="ghost" title="場所を削除">∅</button>
+              </div>
+              <span class="meal-modal-hint muted">空欄なら EXIF / GPS 軌跡から推定</span>
+            </div>
+
+            <label class="meal-modal-row">
+              <span class="meal-modal-label">カロリー (kcal)</span>
+              <input id="mealModalCal" type="number" inputmode="numeric" placeholder="空欄で AI 推定" />
+            </label>
+
+            <label class="meal-modal-row">
+              <span class="meal-modal-label">補足メモ</span>
+              <textarea id="mealModalNote" rows="2" placeholder="任意"></textarea>
+            </label>
+          </form>
+
+          <footer class="meal-modal-actions">
+            <button type="button" id="mealModalSkip" class="ghost" hidden>このファイルは登録しない</button>
+            <span class="grow"></span>
+            <button type="button" id="mealModalCancel" class="ghost">キャンセル</button>
+            <button type="button" id="mealModalSubmit">登録</button>
+          </footer>
+        </div>
+      </div>
+
       <div id="multiView" class="hidden">
         <div class="multi-bar">
           <span id="multiUserBadge" class="multi-user-badge"></span>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -501,16 +501,9 @@
           </button>
           <span id="mealsUploadStatus" class="muted"></span>
           <span class="grow"></span>
-          <input id="mealsFromDate" type="date" title="開始日" />
-          <input id="mealsToDate" type="date" title="終了日" />
+          <input id="mealsFilterDate" type="date" title="日付で絞り込む (空欄で全件)" />
+          <button id="mealsFilterClear" class="ghost" title="絞り込みクリア">×</button>
           <button id="mealsRefresh" class="ghost">更新</button>
-        </div>
-        <div id="mealsDropZone" class="meals-drop-zone">
-          <div class="meals-drop-zone-inner">
-            <div class="meals-drop-icon">📷</div>
-            <div>ファイルをドロップ、 または <kbd>Ctrl</kbd>+<kbd>V</kbd> で貼り付け</div>
-            <div class="muted">複数選択可 — JPEG / PNG / HEIC / WebP (各 12 MB まで)</div>
-          </div>
         </div>
         <div id="mealsHint" class="meals-hint muted hidden">
           画像解析が失敗しています。 設定 → AI / 連携 で
@@ -520,9 +513,8 @@
         <div id="mealsList" class="meals-list"></div>
       </div>
 
-      <!-- 食事登録モーダル — 写真 / 写真なしどちらの経路も 1 件ずつここで確認 -->
-      <div id="mealModal" class="meal-modal hidden" role="dialog" aria-modal="true" aria-labelledby="mealModalTitle">
-        <div class="meal-modal-backdrop"></div>
+      <!-- 食事登録ダイアログ — <dialog> でネイティブ popup として動作 -->
+      <dialog id="mealModal" class="meal-modal" aria-labelledby="mealModalTitle">
         <div class="meal-modal-card">
           <header class="meal-modal-head">
             <h3 id="mealModalTitle">食事を登録</h3>
@@ -556,10 +548,13 @@
               <div class="meal-modal-loc">
                 <input id="mealModalLat" type="number" step="any" placeholder="緯度" />
                 <input id="mealModalLon" type="number" step="any" placeholder="経度" />
-                <button type="button" id="mealModalLocHere" class="ghost" title="現在地から取得">📍</button>
-                <button type="button" id="mealModalLocClear" class="ghost" title="場所を削除">∅</button>
+                <button type="button" id="mealModalLocHere" class="ghost" title="現在地から取得">📍 現在地</button>
+                <button type="button" id="mealModalLocClear" class="ghost" title="場所を削除">∅ クリア</button>
+                <button type="button" id="mealModalMapToggle" class="ghost" title="地図を表示 / 非表示">🗺 地図</button>
+                <a id="mealModalMapOpen" href="#" target="_blank" rel="noopener" class="ghost meal-modal-map-link" title="Google Maps で開く" hidden>↗ Maps で開く</a>
               </div>
-              <span class="meal-modal-hint muted">空欄なら EXIF / GPS 軌跡から推定</span>
+              <div id="mealModalMap" class="meal-modal-map hidden"></div>
+              <span class="meal-modal-hint muted">地図をクリック / タップで座標を取得。 空欄なら EXIF / GPS 軌跡から推定</span>
             </div>
 
             <label class="meal-modal-row">
@@ -580,7 +575,7 @@
             <button type="button" id="mealModalSubmit">登録</button>
           </footer>
         </div>
-      </div>
+      </dialog>
 
       <div id="multiView" class="hidden">
         <div class="multi-bar">

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -107,6 +107,9 @@
           <button class="tab" data-tab="tracks">
             <span class="tab-label" data-full="🗺 軌跡" data-short="🗺 軌跡">🗺 軌跡</span>
           </button>
+          <button class="tab" data-tab="meals">
+            <span class="tab-label" data-full="🍽 食事" data-short="🍽 食事">🍽 食事</span>
+          </button>
           <!-- マルチビューはトップバーのマルチスイッチからのみアクセス。
                機能タブからは外す (PC/スマホ共通)。 -->
         </div>
@@ -479,6 +482,24 @@
           <h4>記録のある日</h4>
           <ul id="tracksDays" class="tracks-days-list"></ul>
         </div>
+      </div>
+
+      <div id="mealsView" class="hidden">
+        <div class="meals-bar">
+          <label class="meals-upload-btn ghost">
+            📷 写真を追加
+            <input id="mealsPhotoInput" type="file" accept="image/*" capture="environment" hidden />
+          </label>
+          <span id="mealsUploadStatus" class="muted"></span>
+          <span class="grow"></span>
+          <input id="mealsFromDate" type="date" title="開始日" />
+          <input id="mealsToDate" type="date" title="終了日" />
+          <button id="mealsRefresh" class="ghost">更新</button>
+        </div>
+        <div id="mealsHint" class="meals-hint muted hidden">
+          OpenAI API key 未設定です (設定 → AI / 連携 → llm.openai.api_key)。 写真は登録できますが、 食事内容 / カロリーは自動推定されません。
+        </div>
+        <div id="mealsList" class="meals-list"></div>
       </div>
 
       <div id="multiView" class="hidden">

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -486,15 +486,26 @@
 
       <div id="mealsView" class="hidden">
         <div class="meals-bar">
-          <label class="meals-upload-btn ghost">
+          <label class="meals-upload-btn">
             📷 写真を追加
-            <input id="mealsPhotoInput" type="file" accept="image/*" capture="environment" hidden />
+            <input id="mealsPhotoInput" type="file" accept="image/*" multiple hidden />
+          </label>
+          <label class="meals-upload-btn ghost" title="モバイルではカメラを直接起動">
+            📸 撮影
+            <input id="mealsCameraInput" type="file" accept="image/*" capture="environment" hidden />
           </label>
           <span id="mealsUploadStatus" class="muted"></span>
           <span class="grow"></span>
           <input id="mealsFromDate" type="date" title="開始日" />
           <input id="mealsToDate" type="date" title="終了日" />
           <button id="mealsRefresh" class="ghost">更新</button>
+        </div>
+        <div id="mealsDropZone" class="meals-drop-zone">
+          <div class="meals-drop-zone-inner">
+            <div class="meals-drop-icon">📷</div>
+            <div>ファイルをドロップ、 または <kbd>Ctrl</kbd>+<kbd>V</kbd> で貼り付け</div>
+            <div class="muted">複数選択可 — JPEG / PNG / HEIC / WebP (各 12 MB まで)</div>
+          </div>
         </div>
         <div id="mealsHint" class="meals-hint muted hidden">
           画像解析が失敗しています。 設定 → AI / 連携 で

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -398,6 +398,8 @@
             <ul id="diaryDigs" class="diary-digs"></ul>
             <h4>🍽 食事</h4>
             <div id="diaryMeals" class="diary-meals"></div>
+            <h4>⚖️ カロリーバランス (適正 vs 摂取 vs 消費)</h4>
+            <div id="diaryCaloricBalance" class="diary-caloric-balance"></div>
             <h4>GitHub commits (リポ別件数)</h4>
             <ul id="diaryGithub" class="diary-github"></ul>
             <h4>メモ・補足</h4>
@@ -746,6 +748,30 @@
     </div>
     <div id="pushStatus" class="multi-status"></div>
     <ul id="pushDevicesList" class="multi-servers"></ul>
+
+    <h4>🧍 プロファイル (適正カロリー計算用)</h4>
+    <p class="ai-settings-help">日記のカロリーバランス分析で使用。 未設定だと分析されません。</p>
+    <div class="user-profile-grid">
+      <label>年齢 <input id="userAge" type="number" min="1" max="120" /></label>
+      <label>性別
+        <select id="userSex">
+          <option value="">(未選択)</option>
+          <option value="male">男性</option>
+          <option value="female">女性</option>
+        </select>
+      </label>
+      <label>体重 (kg) <input id="userWeightKg" type="number" min="20" max="300" step="0.1" /></label>
+      <label>身長 (cm) <input id="userHeightCm" type="number" min="100" max="250" step="0.1" /></label>
+      <label>活動レベル
+        <select id="userActivityLevel">
+          <option value="sedentary">座りがち (×1.2)</option>
+          <option value="light">軽運動 (×1.375)</option>
+          <option value="moderate" selected>中運動 (×1.55)</option>
+          <option value="active">活発 (×1.725)</option>
+          <option value="very_active">非常に活発 (×1.9)</option>
+        </select>
+      </label>
+    </div>
 
     <h4>🛠 ランタイム情報 (読み取り専用)</h4>
     <p class="ai-settings-help">これらは起動時に決まる値で、変更には再起動が必要です。デスクトップアプリから自動で渡されます。</p>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -513,6 +513,20 @@
         <div id="mealsList" class="meals-list"></div>
       </div>
 
+      <!-- 単語リングメニュー — グラフ / ワードクラウドの単語クリックで開く -->
+      <div id="wordRingMenu" class="word-ring hidden" role="menu" aria-label="単語アクション">
+        <div class="word-ring-backdrop"></div>
+        <div class="word-ring-pop">
+          <button class="word-ring-btn word-ring-btn-dig" data-action="dig" title="この単語でディグる">🔎<span>ディグる</span></button>
+          <button class="word-ring-btn word-ring-btn-dict" data-action="dict" title="辞書に登録">📖<span>辞書登録</span></button>
+          <button class="word-ring-btn word-ring-btn-del" data-action="delete" title="今後表示しない (stopword)">🗑<span>削除</span></button>
+          <div class="word-ring-center">
+            <span class="word-ring-word" id="wordRingWord"></span>
+            <button class="word-ring-close" id="wordRingClose" title="閉じる">×</button>
+          </div>
+        </div>
+      </div>
+
       <!-- 食事登録ダイアログ — <dialog> でネイティブ popup として動作 -->
       <dialog id="mealModal" class="meal-modal" aria-labelledby="mealModalTitle">
         <div class="meal-modal-card">

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -3343,3 +3343,106 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 .diary-meal-adds {
   font-size: 11px;
 }
+
+/* ── Meals: 写真なしカード ───────────────────────────────────── */
+.meal-photo-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  background: linear-gradient(135deg, #f4f4f4, #e9e9e9);
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.meal-photo-empty-icon {
+  font-size: 36px;
+  line-height: 1;
+}
+
+/* ── Meals: 内容 / 場所 inline 編集 ──────────────────────────── */
+.meal-inline-editable {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  padding: 2px 6px;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  color: inherit;
+}
+.meal-inline-editable:hover {
+  background: var(--bg);
+  border-color: var(--border);
+}
+.meal-inline-editable.editing {
+  background: var(--bg);
+  border-color: var(--accent, #2a6df4);
+  cursor: default;
+  flex-wrap: wrap;
+  padding: 4px;
+}
+.meal-inline-pencil {
+  font-size: 10px;
+  opacity: 0.5;
+}
+.meal-inline-editable:hover .meal-inline-pencil {
+  opacity: 1;
+}
+.meal-inline-editable.editing .meal-inline-pencil {
+  display: none;
+}
+.meal-inline-actions {
+  display: inline-flex;
+  gap: 2px;
+}
+.meal-inline-actions button {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--bg-surface, #fff);
+  cursor: pointer;
+  font-size: 11px;
+}
+.meal-inline-save { color: #2a8b2a; }
+.meal-inline-cancel { color: #b00; }
+.meal-desc-input {
+  flex: 1 1 100%;
+  min-height: 32px;
+  padding: 4px 6px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  font-size: 13px;
+  resize: vertical;
+}
+.meal-loc-lat, .meal-loc-lon {
+  width: 80px;
+  padding: 2px 6px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  font-size: 12px;
+}
+
+/* meal-desc は元 div、 button 化したので block 風スタイルを保持 */
+button.meal-desc {
+  display: block;
+  width: 100%;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.4;
+}
+.meal-loc {
+  display: inline-flex;
+}
+
+/* meal-actions に新しい note ボタンも横並びで */
+.meal-note-btn {
+  font-size: 12px;
+  padding: 3px 8px;
+}

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -3448,17 +3448,8 @@ button.meal-desc {
 }
 
 /* ── Meals: 登録モーダル ─────────────────────────────────────── */
-.meal-modal {
-  position: fixed;
-  inset: 0;
-  z-index: 1000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.meal-modal.hidden {
-  display: none;
-}
+/* 旧 .meal-modal (div) 用スタイルは <dialog> 化により撤去。
+   dialog.meal-modal セレクタの方を使う。 */
 .meal-modal-backdrop {
   position: absolute;
   inset: 0;

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -3446,3 +3446,175 @@ button.meal-desc {
   font-size: 12px;
   padding: 3px 8px;
 }
+
+/* ── Meals: 登録モーダル ─────────────────────────────────────── */
+.meal-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.meal-modal.hidden {
+  display: none;
+}
+.meal-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+}
+.meal-modal-card {
+  position: relative;
+  z-index: 1;
+  width: min(560px, 96vw);
+  max-height: 92vh;
+  background: var(--bg-surface, #fff);
+  border-radius: 8px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.25);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+.meal-modal-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+}
+.meal-modal-head h3 {
+  margin: 0;
+  font-size: 16px;
+  flex: 1;
+}
+.meal-modal-progress {
+  font-size: 12px;
+}
+.meal-modal-x {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  font-size: 22px;
+  cursor: pointer;
+  color: var(--text-muted);
+}
+.meal-modal-x:hover { color: var(--text); }
+
+.meal-modal-photo-wrap {
+  width: 100%;
+  background: #000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-height: 36vh;
+  overflow: hidden;
+}
+.meal-modal-photo-wrap img {
+  max-width: 100%;
+  max-height: 36vh;
+  object-fit: contain;
+  display: block;
+}
+.meal-modal-photo-empty {
+  width: 100%;
+  aspect-ratio: 16 / 6;
+  background: linear-gradient(135deg, #f4f4f4, #e9e9e9);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  font-size: 13px;
+  gap: 4px;
+}
+.meal-modal-photo-empty.hidden { display: none; }
+
+.meal-modal-form {
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.meal-modal-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.meal-modal-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+.meal-modal-label .required {
+  color: #c00;
+  margin-left: 2px;
+}
+.meal-modal-row input[type="datetime-local"],
+.meal-modal-row input[type="number"],
+.meal-modal-row textarea {
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 14px;
+  font-family: inherit;
+  background: var(--bg);
+}
+.meal-modal-row textarea {
+  resize: vertical;
+  min-height: 50px;
+}
+.meal-modal-hint {
+  font-size: 11px;
+}
+.meal-modal-loc {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.meal-modal-loc input {
+  flex: 1;
+  min-width: 100px;
+}
+.meal-modal-loc button {
+  padding: 6px 10px;
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.meal-modal-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border);
+  position: sticky;
+  bottom: 0;
+  background: var(--bg-surface, #fff);
+}
+.meal-modal-actions .grow { flex: 1; }
+.meal-modal-actions button {
+  padding: 8px 16px;
+  font-size: 14px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  cursor: pointer;
+}
+#mealModalSubmit {
+  background: var(--accent, #2a6df4);
+  color: #fff;
+  border-color: transparent;
+  font-weight: 500;
+}
+#mealModalSubmit:hover { filter: brightness(1.05); }
+
+@media (max-width: 480px) {
+  .meal-modal-card {
+    width: 100%;
+    max-height: 100vh;
+    border-radius: 0;
+  }
+}

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -3110,3 +3110,74 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
     grid-template-columns: 1fr;
   }
 }
+
+/* ── Meals: drop zone & multi-button bar ─────────────────────── */
+.meals-drop-zone {
+  border: 2px dashed var(--border);
+  border-radius: 8px;
+  padding: 14px 12px;
+  margin: 8px 0 12px;
+  text-align: center;
+  font-size: 13px;
+  color: var(--text-muted);
+  background: var(--bg);
+  transition: background 120ms, border-color 120ms;
+}
+.meals-drop-zone.drag-over {
+  border-color: var(--accent, #2a6df4);
+  background: rgba(42, 109, 244, 0.06);
+  color: var(--text);
+}
+.meals-drop-zone-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: center;
+  pointer-events: none;
+}
+.meals-drop-icon {
+  font-size: 28px;
+  line-height: 1;
+}
+.meals-drop-zone kbd {
+  display: inline-block;
+  padding: 1px 5px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--bg-surface, #fff);
+  font-family: ui-monospace, monospace;
+  font-size: 11px;
+  margin: 0 2px;
+}
+
+/* primary/ghost styling for the new upload buttons */
+.meals-upload-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 13px;
+  background: var(--accent, #2a6df4);
+  color: #fff;
+  border: 1px solid transparent;
+}
+.meals-upload-btn.ghost {
+  background: transparent;
+  color: var(--text);
+  border-color: var(--border);
+}
+.meals-upload-btn:hover {
+  filter: brightness(1.05);
+}
+
+@media (max-width: 600px) {
+  .meals-drop-zone {
+    padding: 10px 8px;
+    font-size: 12px;
+  }
+  .meals-drop-icon {
+    font-size: 22px;
+  }
+}

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -3431,11 +3431,21 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 
 /* meal-desc は元 div、 button 化したので block 風スタイルを保持 */
 button.meal-desc {
-  display: block;
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
   width: 100%;
   font-size: 14px;
   font-weight: 500;
   line-height: 1.4;
+  white-space: normal;
+  word-break: break-word;
+  text-align: left;
+  min-height: 1.4em;
+}
+button.meal-desc > .meal-inline-pencil {
+  flex-shrink: 0;
+  margin-top: 2px;
 }
 .meal-loc {
   display: inline-flex;

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -3222,6 +3222,47 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 .meal-addition button:hover {
   filter: brightness(0.96);
 }
+/* 追加 / 編集 inline form (prompt の代替) */
+.meal-addition-form {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  margin: 4px 0;
+  background: var(--bg);
+  border: 1px dashed var(--border);
+  border-radius: 4px;
+  font-size: 12px;
+}
+.meal-addition-name-input {
+  flex: 1 1 140px;
+  min-width: 100px;
+  padding: 3px 6px;
+  font-size: 12px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+}
+.meal-addition-cal-input {
+  width: 80px;
+  padding: 3px 6px;
+  font-size: 12px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+}
+.meal-addition-save {
+  padding: 2px 8px;
+  font-size: 12px;
+  border: 1px solid var(--accent, #2a6df4);
+  background: var(--accent, #2a6df4);
+  color: #fff;
+  border-radius: 3px;
+  cursor: pointer;
+}
+.meal-addition-save:hover { filter: brightness(0.95); }
+.meal-addition.editing {
+  flex-wrap: wrap;
+}
 
 /* ── Meals: 時刻 inline 編集 ─────────────────────────────────── */
 .meal-time-edit {

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -3670,3 +3670,73 @@ dialog.meal-modal[open] {
     height: 200px;
   }
 }
+
+/* ── Diary: charts side-by-side + domains pane ───────────────── */
+.diary-charts-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  align-items: start;
+  margin-bottom: 12px;
+}
+.diary-chart-cell {
+  min-width: 0;
+}
+.diary-chart-cell h4 {
+  margin: 0 0 6px;
+}
+.diary-chart-cell .diary-hourly,
+.diary-chart-cell .diary-pie {
+  width: 100%;
+}
+
+@media (max-width: 720px) {
+  .diary-charts-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* よく見たドメイン: ブクマと同じカード型ペイン */
+.diary-domains-pane {
+  list-style: none;
+  margin: 0 0 12px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+}
+.diary-domain-card {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 10px;
+}
+.diary-domain-card:hover { border-color: var(--accent, #2a6df4); }
+.diary-domain-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.diary-domain-head .grow { flex: 1; }
+.diary-domain-title {
+  font-weight: 600;
+  word-break: break-all;
+}
+.diary-domain-card .diary-domain-sub {
+  font-size: 11px;
+  color: var(--text-muted);
+  word-break: break-all;
+}
+.diary-domain-card .diary-domain-count {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: ui-monospace, monospace;
+  white-space: nowrap;
+}
+.diary-domain-card .diary-domain-desc {
+  font-size: 11px;
+  line-height: 1.4;
+  color: #2c3344;
+  margin-top: 3px;
+}

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -3864,3 +3864,93 @@ dialog.meal-modal[open] {
     height: 56px;
   }
 }
+
+/* ── Diary: 栄養素チップ ─────────────────────────────────────── */
+.diary-meals-nutrients {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin: 4px 0 8px;
+}
+.nutrient-chip {
+  font-size: 11px;
+  padding: 2px 7px;
+  border-radius: 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+}
+.nutrient-chip b {
+  color: #2a6df4;
+  font-weight: 600;
+  margin-right: 2px;
+}
+.nutrient-fiber b, .nutrient-sugar b, .nutrient-sodium b { color: #6c757d; }
+.nutrient-pfc {
+  background: #fff7d6;
+  border-color: #e6c97a;
+}
+.nutrient-pfc b { color: #8a6d00; }
+
+/* ── Settings: ユーザプロファイル grid ────────────────────────── */
+.user-profile-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 8px;
+  margin: 8px 0 16px;
+}
+.user-profile-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.user-profile-grid input,
+.user-profile-grid select {
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 13px;
+  background: var(--bg);
+  color: var(--text);
+}
+
+/* ── Diary: カロリーバランス ──────────────────────────────────── */
+.diary-caloric-balance {
+  margin: 4px 0 12px;
+}
+.diary-caloric-balance .cb-profile {
+  font-size: 11px;
+  margin-bottom: 6px;
+}
+.cb-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 8px;
+}
+.cb-stat {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+}
+.cb-label {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.cb-value {
+  font-size: 18px;
+  font-weight: 600;
+  margin-top: 2px;
+}
+.cb-sub {
+  font-size: 10px;
+  margin-top: 2px;
+}
+.cb-diff.over { background: #ffe2e2; border-color: #d49797; }
+.cb-diff.over .cb-value { color: #b00; }
+.cb-diff.under { background: #e2f0ff; border-color: #97b8d4; }
+.cb-diff.under .cb-value { color: #1455a8; }
+.cb-diff.ok { background: #e6f7e6; border-color: #95cf95; }
+.cb-diff.ok .cb-value { color: #2a8b2a; }

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -3618,3 +3618,55 @@ button.meal-desc {
     border-radius: 0;
   }
 }
+
+/* ── Meal modal: <dialog> 化 + Map 連携 ──────────────────────── */
+dialog.meal-modal {
+  border: none;
+  padding: 0;
+  background: transparent;
+  max-width: none;
+  max-height: none;
+  width: auto;
+  height: auto;
+}
+dialog.meal-modal::backdrop {
+  background: rgba(0, 0, 0, 0.45);
+}
+dialog.meal-modal[open] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Map 埋め込み */
+.meal-modal-map {
+  width: 100%;
+  height: 240px;
+  margin-top: 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  overflow: hidden;
+  background: #f4f4f4;
+}
+.meal-modal-map.hidden { display: none; }
+.meal-modal-map-link {
+  font-size: 12px;
+  text-decoration: none;
+  padding: 6px 10px;
+}
+.meal-modal-map-link[hidden] { display: none; }
+
+/* meal-card の場所行: Map 外部リンク */
+.meal-loc-map-link {
+  margin-left: 4px;
+  font-size: 11px;
+  color: var(--accent, #2a6df4);
+  text-decoration: none;
+}
+.meal-loc-map-link:hover { text-decoration: underline; }
+
+@media (max-width: 480px) {
+  .meal-modal-map {
+    height: 200px;
+  }
+}

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -2997,3 +2997,116 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   border-radius: 3px;
   font-size: 11px;
 }
+
+/* ── Meals (食事記録) ──────────────────────────────────────────── */
+.meals-bar {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  padding: 8px 0;
+}
+.meals-upload-btn {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+}
+.meals-hint {
+  padding: 8px 10px;
+  background: var(--bg);
+  border-left: 3px solid var(--accent, #2a6df4);
+  border-radius: 4px;
+  margin-bottom: 8px;
+  font-size: 13px;
+}
+.meals-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 12px;
+}
+.meal-card {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-surface, #fff);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.meal-photo {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  background: #eee;
+  display: block;
+}
+.meal-body {
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.meal-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  justify-content: space-between;
+}
+.meal-time {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.meal-badge {
+  font-size: 11px;
+  padding: 1px 6px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+}
+.meal-badge-pending {
+  background: #fff7d6;
+  color: #8a6d00;
+  border-color: #e6c97a;
+}
+.meal-badge-error {
+  background: #ffe2e2;
+  color: #a40000;
+  border-color: #d49797;
+  cursor: help;
+}
+.meal-desc {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.4;
+}
+.meal-meta {
+  display: flex;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-muted);
+  flex-wrap: wrap;
+}
+.meal-cal {
+  font-weight: 500;
+  color: #c25500;
+}
+.meal-note {
+  font-size: 12px;
+  background: var(--bg);
+  padding: 6px 8px;
+  border-radius: 4px;
+  border-left: 2px solid var(--accent, #2a6df4);
+}
+.meal-actions {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.meal-actions button {
+  font-size: 12px;
+  padding: 3px 8px;
+}
+
+@media (max-width: 600px) {
+  .meals-list {
+    grid-template-columns: 1fr;
+  }
+}

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -3222,3 +3222,64 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 .meal-addition button:hover {
   filter: brightness(0.96);
 }
+
+/* ── Meals: 時刻 inline 編集 ─────────────────────────────────── */
+.meal-time-edit {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.meal-time-edit:hover {
+  background: var(--bg);
+  border-color: var(--border);
+  color: var(--text);
+}
+.meal-time-edit.editing {
+  background: var(--bg);
+  border-color: var(--accent, #2a6df4);
+  cursor: default;
+}
+.meal-time-pencil {
+  font-size: 10px;
+  opacity: 0.6;
+}
+.meal-time-edit:hover .meal-time-pencil {
+  opacity: 1;
+}
+.meal-time-input {
+  font-size: 12px;
+  padding: 2px 4px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--bg-surface, #fff);
+}
+.meal-time-actions {
+  display: inline-flex;
+  gap: 2px;
+}
+.meal-time-actions button {
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--bg-surface, #fff);
+  cursor: pointer;
+  font-size: 12px;
+}
+.meal-time-actions button:hover {
+  filter: brightness(0.96);
+}
+.meal-time-save {
+  color: #2a8b2a;
+}
+.meal-time-cancel {
+  color: #b00;
+}

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -3731,3 +3731,126 @@ dialog.meal-modal[open] {
   color: #2c3344;
   margin-top: 3px;
 }
+
+/* ── 単語リングメニュー (グラフ / ワードクラウドのクリックで開く) ─── */
+.word-ring {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+}
+.word-ring.hidden { display: none; }
+.word-ring-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+}
+.word-ring-pop {
+  position: absolute;
+  width: 220px;
+  height: 220px;
+  margin-left: -110px;
+  margin-top: -110px;
+  /* JS で left/top を設定 (クリックされた単語の中心) */
+}
+.word-ring-center {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 10px 14px;
+  background: var(--bg-surface, #fff);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  font-size: 14px;
+  font-weight: 600;
+  max-width: 160px;
+  text-align: center;
+}
+.word-ring-word {
+  word-break: break-all;
+  line-height: 1.2;
+}
+.word-ring-close {
+  font-size: 11px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 0;
+}
+.word-ring-close:hover { color: var(--text); }
+
+.word-ring-btn {
+  position: absolute;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: var(--bg-surface, #fff);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  font-size: 11px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  transition: transform 120ms;
+}
+.word-ring-btn:hover {
+  transform: scale(1.08);
+  z-index: 1;
+}
+.word-ring-btn span {
+  font-size: 10px;
+  font-weight: 500;
+}
+/* 上 (ディグる) / 左 (辞書登録) / 右 (削除) の 3 方向に配置 */
+.word-ring-btn-dig {
+  left: 50%;
+  top: 0;
+  transform: translate(-50%, 0);
+  background: linear-gradient(135deg, #fff, #e6f0ff);
+  color: #2a6df4;
+}
+.word-ring-btn-dig:hover {
+  transform: translate(-50%, -4px) scale(1.08);
+}
+.word-ring-btn-dict {
+  left: 0;
+  top: 50%;
+  transform: translate(0, -50%);
+  background: linear-gradient(135deg, #fff, #fff3d6);
+  color: #8a6d00;
+}
+.word-ring-btn-dict:hover {
+  transform: translate(-4px, -50%) scale(1.08);
+}
+.word-ring-btn-del {
+  right: 0;
+  top: 50%;
+  transform: translate(0, -50%);
+  background: linear-gradient(135deg, #fff, #ffd6d6);
+  color: #b00;
+}
+.word-ring-btn-del:hover {
+  transform: translate(4px, -50%) scale(1.08);
+}
+
+@media (max-width: 480px) {
+  .word-ring-pop {
+    width: 180px;
+    height: 180px;
+    margin-left: -90px;
+    margin-top: -90px;
+  }
+  .word-ring-btn {
+    width: 56px;
+    height: 56px;
+  }
+}

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -3181,3 +3181,44 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
     font-size: 22px;
   }
 }
+
+/* ── Meals: additions (追加で食べた項目) ────────────────────── */
+.meal-additions {
+  list-style: none;
+  padding: 0;
+  margin: 4px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.meal-addition {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  background: var(--bg);
+  border-radius: 4px;
+  font-size: 12px;
+}
+.meal-addition-name {
+  flex: 1;
+}
+.meal-addition-cal {
+  color: #c25500;
+  font-weight: 500;
+}
+.meal-addition-time {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+.meal-addition button {
+  padding: 1px 6px;
+  font-size: 11px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--bg-surface, #fff);
+  cursor: pointer;
+}
+.meal-addition button:hover {
+  filter: brightness(0.96);
+}

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -3222,47 +3222,6 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 .meal-addition button:hover {
   filter: brightness(0.96);
 }
-/* 追加 / 編集 inline form (prompt の代替) */
-.meal-addition-form {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 8px;
-  margin: 4px 0;
-  background: var(--bg);
-  border: 1px dashed var(--border);
-  border-radius: 4px;
-  font-size: 12px;
-}
-.meal-addition-name-input {
-  flex: 1 1 140px;
-  min-width: 100px;
-  padding: 3px 6px;
-  font-size: 12px;
-  border: 1px solid var(--border);
-  border-radius: 3px;
-}
-.meal-addition-cal-input {
-  width: 80px;
-  padding: 3px 6px;
-  font-size: 12px;
-  border: 1px solid var(--border);
-  border-radius: 3px;
-}
-.meal-addition-save {
-  padding: 2px 8px;
-  font-size: 12px;
-  border: 1px solid var(--accent, #2a6df4);
-  background: var(--accent, #2a6df4);
-  color: #fff;
-  border-radius: 3px;
-  cursor: pointer;
-}
-.meal-addition-save:hover { filter: brightness(0.95); }
-.meal-addition.editing {
-  flex-wrap: wrap;
-}
 
 /* ── Meals: 時刻 inline 編集 ─────────────────────────────────── */
 .meal-time-edit {

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -3283,3 +3283,63 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 .meal-time-cancel {
   color: #b00;
 }
+
+/* ── Diary: 食事セクション ──────────────────────────────────── */
+.diary-meals-total {
+  font-size: 13px;
+  margin-bottom: 6px;
+}
+.diary-meals-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.diary-meal-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 4px 6px;
+  background: var(--bg);
+  border-radius: 4px;
+}
+.diary-meal-thumb {
+  flex-shrink: 0;
+  width: 48px;
+  height: 48px;
+  display: block;
+  border-radius: 4px;
+  overflow: hidden;
+  background: #eee;
+}
+.diary-meal-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.diary-meal-body {
+  flex: 1;
+  min-width: 0;
+}
+.diary-meal-head {
+  display: flex;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.diary-meal-cal {
+  color: #c25500;
+  font-weight: 500;
+}
+.diary-meal-desc {
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.diary-meal-adds {
+  font-size: 11px;
+}


### PR DESCRIPTION
## Summary

写真投稿だけで食事内容 / カロリー / 場所 / 時刻を半自動で記録する機能を新規追加。 「🍽 食事」 タブが PWA UI に追加され、 日記とも連動する。

## 機能 (コミット順)

### 1. `0077ac8` ベース実装
- meals テーブル (photo_path / eaten_at / lat,lon / description / calories / status)
- POST `/api/meals` (multipart) — 写真 + EXIF / GPS / Vision で自動補完
- GET / PATCH / DELETE / `/api/meals/:id/reanalyze`
- 食事時刻: EXIF DateTimeOriginal → 投稿時刻
- 場所: EXIF GPS → 既存 gps_locations ±5 分の最近点 → 手動

### 2. `daab37a` 画像解析を LLM dispatch 経由に
- OpenAI 直叩きをやめ、 既存 `runLlm({ task: 'meal_vision' })` に統合
- Claude CLI に `@<absolute_path>` で画像を attach + Read tool 許可
- 設定 → AI / 連携 で provider / モデル変更可能 (デフォルト Claude CLI sonnet)

### 3. `f4a772c` 写真アップロード強化
- 複数ファイル選択 (`<input multiple>`)
- ドラッグ&ドロップ (drag-over 時にハイライト)
- クリップボード貼り付け (Ctrl+V でスクショ → 即時投稿)
- 📸 撮影ボタン (モバイル `capture="environment"`)
- ファイル名は `<id>-<8hex><ext>` 形式で衝突回避

### 4. `0e9601b` 追加で食べた項目 (additions)
- 既存 meal レコードに「あとから食べたもの」 を追記
- `meals.additions_json` カラム追加 (forward-compat ALTER)
- POST / PATCH / DELETE `/api/meals/:id/additions[/:idx]`
- カロリー総計 = base + sum(additions)

### 5. `d1e2eef` 食事時刻 inline 編集
- 時刻表示クリックで `<input type="datetime-local">` に切り替え
- ✓ で `PATCH /api/meals/:id { eaten_at }`、 × / Esc でキャンセル

### 6. `b87572e` 日記連動 + 総カロリー計算
- `aggregateDay()` に `meals` + `meals_total_calories` 追加
- 日記の HIGHLIGHTS_PROMPT (Opus 1M) に食事ブロックを注入
- 日記 UI に「🍽 食事」 セクション (サムネリスト + 総カロリー)
- 既存日記は `live_metrics` で即時反映 (再生成不要)

## Test plan

- [x] CI lint + smoke ✅ pass
- [x] `npm run typecheck` ✅ pass
- [ ] 写真投稿 (📷 / 📸 / drop / paste) で meals tab に行が出る
- [ ] EXIF 付き写真で時刻 / GPS 自動取得
- [ ] EXIF なし写真で投稿時刻 + GPS 軌跡から場所推定
- [ ] LLM 解析 → description / calories / items が埋まる
- [ ] 「➕ 追加で食べた」 で項目追加 → 総カロリー再計算
- [ ] 時刻表示クリック → inline editor で修正
- [ ] 日記タブを開くと「🍽 食事」 セクションに当日の食事リストと総カロリー
- [ ] 日記再生成でハイライトに食事内容が反映

## 依存追加

- `exifr@^7.1.3` (EXIF パース)

## 設定

OpenAI / Gemini / Codex を使う場合は 設定 → AI / 連携 → `meal_vision` 行で provider 変更。 デフォルト Claude CLI で sonnet モデル。

🤖 Generated with [Claude Code](https://claude.com/claude-code)