### PR TITLE
feat(visits): /api/visits/external — Legatus DNS/SNI tap 受け口

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -328,6 +328,16 @@ export function openDb(dbPath) {
     }
   }
 
+  // visit_events: external タップ (Legatus DNS / SNI) 対応カラム
+  // device_label = Tailscale でタグ付けされた発信元 (例: "iphone-of-foo")
+  // device_os    = "iOS" / "Android" / "macOS" / "Windows" / "Linux" / null
+  // source       = "browser" (拡張機能からの POST), "dns" (Legatus dnstap),
+  //                "sni" (Legatus SNI tap, 将来拡張)
+  const veCols = db.prepare(`PRAGMA table_info(visit_events)`).all().map(c => c.name);
+  if (!veCols.includes('device_label')) db.exec(`ALTER TABLE visit_events ADD COLUMN device_label TEXT`);
+  if (!veCols.includes('device_os'))    db.exec(`ALTER TABLE visit_events ADD COLUMN device_os TEXT`);
+  if (!veCols.includes('source'))       db.exec(`ALTER TABLE visit_events ADD COLUMN source TEXT`);
+
   // Forward-compat: ensure newer columns exist on older DBs.
   const cols = db.prepare(`PRAGMA table_info(bookmarks)`).all().map(c => c.name);
   if (!cols.includes('last_accessed_at')) {
@@ -1200,8 +1210,28 @@ export function listServerEventsForDate(db, dateStr) {
 export function insertVisitEvent(db, { url, title }) {
   const domain = extractDomain(url);
   db.prepare(`
-    INSERT INTO visit_events (url, domain, title) VALUES (?, ?, ?)
+    INSERT INTO visit_events (url, domain, title, source) VALUES (?, ?, ?, 'browser')
   `).run(url, domain, title ?? null);
+}
+
+/**
+ * Insert a visit event sourced from outside the browser (e.g. Legatus DNS
+ * tap on the user's home PC). `domain` は LFQDN (already lower-cased) を
+ * 受ける前提。 url は擬似形式 (`dns://<domain>` or `sni://<domain>`) で
+ * 保存し、 既存の page_visits / bookmark テーブルとは衝突させない。
+ */
+export function insertExternalVisitEvent(db, {
+  domain,
+  visitedAt,
+  source,
+  deviceLabel,
+  deviceOs,
+}) {
+  const url = `${source}://${domain}`;
+  db.prepare(`
+    INSERT INTO visit_events (url, domain, title, visited_at, device_label, device_os, source)
+    VALUES (?, ?, NULL, COALESCE(?, datetime('now')), ?, ?, ?)
+  `).run(url, domain, visitedAt ?? null, deviceLabel ?? null, deviceOs ?? null, source);
 }
 
 /** Visit events for a single local date (YYYY-MM-DD). */

--- a/server/index.js
+++ b/server/index.js
@@ -2322,6 +2322,38 @@ app.post('/api/visits/bookmark', async (c) => {
  * 個人 PC ローカル前提なので 認証ヘッダは v0.1 では要求しない (Memoria の
  * 既存 API と同方針)。 v0.2 で PeerAdapter / Cernere 経由化する。
  */
+/**
+ * 外部 visit の取り込み状況サマリ。 「外部情報設定」 タブの status セクション用。
+ * source IN ('dns', 'sni') を対象に件数 / device 数 / 最新時刻 / 直近 N 件を返す。
+ */
+app.get('/api/visits/external/stats', (c) => {
+  const c24 = db.prepare(`
+    SELECT COUNT(*) AS n FROM visit_events
+    WHERE source IN ('dns','sni') AND visited_at >= datetime('now','-1 day')
+  `).get()?.n ?? 0;
+  const c7 = db.prepare(`
+    SELECT COUNT(*) AS n FROM visit_events
+    WHERE source IN ('dns','sni') AND visited_at >= datetime('now','-7 days')
+  `).get()?.n ?? 0;
+  const dev = db.prepare(`
+    SELECT COUNT(DISTINCT device_label) AS n FROM visit_events
+    WHERE source IN ('dns','sni') AND device_label IS NOT NULL
+      AND visited_at >= datetime('now','-7 days')
+  `).get()?.n ?? 0;
+  const latest = db.prepare(`
+    SELECT visited_at FROM visit_events
+    WHERE source IN ('dns','sni')
+    ORDER BY visited_at DESC LIMIT 1
+  `).get()?.visited_at ?? null;
+  const recent = db.prepare(`
+    SELECT visited_at, domain, device_label, device_os, source
+    FROM visit_events
+    WHERE source IN ('dns','sni')
+    ORDER BY visited_at DESC LIMIT 20
+  `).all();
+  return c.json({ count_24h: c24, count_7d: c7, device_count: dev, latest, recent });
+});
+
 app.post('/api/visits/external', async (c) => {
   const body = await c.req.json().catch(() => null);
   const events = Array.isArray(body?.events) ? body.events : null;

--- a/server/index.js
+++ b/server/index.js
@@ -46,7 +46,7 @@ import {
   listDictionaryEntries, getDictionaryEntry, findDictionaryEntryByTerm,
   insertDictionaryEntry, updateDictionaryEntry, deleteDictionaryEntry,
   addDictionaryLink, removeDictionaryLink,
-  insertVisitEvent, getDiary, listDiariesInRange, upsertDiary, updateDiaryNotes,
+  insertVisitEvent, insertExternalVisitEvent, getDiary, listDiariesInRange, upsertDiary, updateDiaryNotes,
   deleteDiary, getDiarySettings, setDiarySettings,
   getWeekly, listWeeklyForMonth, upsertWeekly, deleteWeekly,
   getDomainCatalog, listDomainCatalog, listDomainCatalogWithCounts, getDomainCatalogMap,
@@ -2308,6 +2308,44 @@ app.post('/api/visits/bookmark', async (c) => {
   const body = await c.req.json().catch(() => null);
   if (!body || !Array.isArray(body.urls)) return c.json({ error: 'urls[] required' }, 400);
   return c.json({ results: await bulkSaveUrls(body.urls) });
+});
+
+/**
+ * 外部 (Legatus DNS / SNI tap) からの domain visit batch 取り込み。
+ *
+ * - 受信: Legatus が dnsmasq query log を tail → Tailscale で device tag → 5 秒
+ *   dedupe + 30 秒 flush で集約した {events[], flushed_at} 形式
+ * - 永続化: visit_events に device_label / device_os / source 付きで insert
+ * - 副作用: domain_catalog にヒットがあれば既存 maybeQueueDomain で description
+ *   を背景生成 (URL 単位の page_metadata は走らせない、 domain 集計のみ)
+ *
+ * 個人 PC ローカル前提なので 認証ヘッダは v0.1 では要求しない (Memoria の
+ * 既存 API と同方針)。 v0.2 で PeerAdapter / Cernere 経由化する。
+ */
+app.post('/api/visits/external', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const events = Array.isArray(body?.events) ? body.events : null;
+  if (!events) return c.json({ error: 'events[] required' }, 400);
+
+  let inserted = 0;
+  let skipped = 0;
+  for (const ev of events) {
+    const domain = typeof ev?.domain === 'string' ? ev.domain.toLowerCase() : '';
+    const source = ev?.source === 'sni' ? 'sni' : 'dns';
+    if (!domain || !/^[a-z0-9.-]+$/.test(domain)) { skipped++; continue; }
+    insertExternalVisitEvent(db, {
+      domain,
+      visitedAt: typeof ev.ts === 'string' ? ev.ts : null,
+      source,
+      deviceLabel: typeof ev.device_label === 'string' ? ev.device_label.slice(0, 200) : null,
+      deviceOs: typeof ev.device_os === 'string' ? ev.device_os.slice(0, 50) : null,
+    });
+    // 既知の domain_catalog があれば description を埋める。 maybeQueueDomain
+    // は内部で skipDomain (localhost / 内部 IP) を弾いてくれる。
+    maybeQueueDomain(`https://${domain}/`);
+    inserted++;
+  }
+  return c.json({ ok: true, inserted, skipped });
 });
 
 async function fetchPageHtml(url, timeoutMs = 30_000) {

--- a/server/index.js
+++ b/server/index.js
@@ -2323,6 +2323,78 @@ app.post('/api/visits/bookmark', async (c) => {
  * 既存 API と同方針)。 v0.2 で PeerAdapter / Cernere 経由化する。
  */
 /**
+ * 外部情報の取込状況をまとめて返す ("外部情報設定" タブ用)。
+ * 位置情報 (gps_locations) と DNS/SNI tap (visit_events.source IN dns/sni) を
+ * 1 endpoint で集約する。
+ */
+app.get('/api/external/stats', (c) => {
+  // GPS
+  const g24 = db.prepare(`
+    SELECT COUNT(*) AS n FROM gps_locations
+    WHERE recorded_at >= datetime('now','-1 day')
+  `).get()?.n ?? 0;
+  const g7 = db.prepare(`
+    SELECT COUNT(*) AS n FROM gps_locations
+    WHERE recorded_at >= datetime('now','-7 days')
+  `).get()?.n ?? 0;
+  const gDev = db.prepare(`
+    SELECT COUNT(DISTINCT device_id) AS n FROM gps_locations
+    WHERE device_id IS NOT NULL AND recorded_at >= datetime('now','-7 days')
+  `).get()?.n ?? 0;
+  const gLatest = db.prepare(`
+    SELECT recorded_at FROM gps_locations ORDER BY recorded_at DESC LIMIT 1
+  `).get()?.recorded_at ?? null;
+  const gKey = (getAppSettings(db)['locations.ingest_key'] || '').trim();
+  const gKeyConfigured = !!gKey || !!process.env.LOCATIONS_INGEST_KEY;
+
+  // DNS/SNI
+  const d24 = db.prepare(`
+    SELECT COUNT(*) AS n FROM visit_events
+    WHERE source IN ('dns','sni') AND visited_at >= datetime('now','-1 day')
+  `).get()?.n ?? 0;
+  const d7 = db.prepare(`
+    SELECT COUNT(*) AS n FROM visit_events
+    WHERE source IN ('dns','sni') AND visited_at >= datetime('now','-7 days')
+  `).get()?.n ?? 0;
+  const dDev = db.prepare(`
+    SELECT COUNT(DISTINCT device_label) AS n FROM visit_events
+    WHERE source IN ('dns','sni') AND device_label IS NOT NULL
+      AND visited_at >= datetime('now','-7 days')
+  `).get()?.n ?? 0;
+  const dLatest = db.prepare(`
+    SELECT visited_at FROM visit_events
+    WHERE source IN ('dns','sni') ORDER BY visited_at DESC LIMIT 1
+  `).get()?.visited_at ?? null;
+  const dRecent = db.prepare(`
+    SELECT visited_at, domain, device_label, device_os, source FROM visit_events
+    WHERE source IN ('dns','sni')
+    ORDER BY visited_at DESC LIMIT 20
+  `).all();
+
+  return c.json({
+    location: {
+      configured: gKeyConfigured,
+      active: g24 > 0,
+      count_24h: g24,
+      count_7d: g7,
+      device_count: gDev,
+      latest: gLatest,
+    },
+    dns: {
+      // configured フラグは Legatus 側 env なので Memoria からは正確に分からない。
+      // 直近にデータが届いているかで「実質 ON」 を判定する。
+      configured: d7 > 0,
+      active: d24 > 0,
+      count_24h: d24,
+      count_7d: d7,
+      device_count: dDev,
+      latest: dLatest,
+      recent: dRecent,
+    },
+  });
+});
+
+/**
  * 外部 visit の取り込み状況サマリ。 「外部情報設定」 タブの status セクション用。
  * source IN ('dns', 'sni') を対象に件数 / device 数 / 最新時刻 / 直近 N 件を返す。
  */

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -5084,30 +5084,65 @@ const mealsState = {
   pollTimer: null,
 };
 
-// ── 外部情報設定 (Legatus DNS/SNI tap) ────────────────────────────
+// ── 外部情報設定 (Legatus 系統別ステータス + チュートリアル) ────────
 async function loadExternalConfig() {
-  try {
-    const r = await api('/api/visits/external/stats');
-    const $set = (id, v) => { const el = document.getElementById(id); if (el) el.textContent = v; };
-    $set('extCfgCount24h', String(r.count_24h ?? 0));
-    $set('extCfgCount7d', String(r.count_7d ?? 0));
-    $set('extCfgDeviceCount', String(r.device_count ?? 0));
-    $set('extCfgLatest', r.latest ? new Date(r.latest.replace(' ', 'T') + 'Z').toLocaleString() : '—');
+  const $set = (id, v) => { const el = document.getElementById(id); if (el) el.textContent = v; };
+  const fmtTime = (s) => s ? new Date(s.replace(' ', 'T') + (s.endsWith('Z') ? '' : 'Z')).toLocaleString() : '—';
 
+  try {
+    const r = await api('/api/external/stats');
+
+    // 📍 位置情報 (OwnTracks)
+    const loc = r.location || {};
+    $set('extCfgLocCount24h', String(loc.count_24h ?? 0));
+    $set('extCfgLocCount7d', String(loc.count_7d ?? 0));
+    $set('extCfgLocDeviceCount', String(loc.device_count ?? 0));
+    $set('extCfgLocLatest', fmtTime(loc.latest));
+    setExtCfgPill('extCfgLocationPill', loc, {
+      activeMsg: '稼働中',
+      configuredMsg: '受信待機',
+      inactiveMsg: '未受信',
+    });
+    const locHint = document.getElementById('extCfgLocationHint');
+    if (locHint) {
+      if (loc.active) locHint.textContent = '直近 24 時間に GPS 点が届いています。';
+      else if (loc.configured) locHint.textContent = 'ingest key が設定済み。 OwnTracks 側の publish 状況を確認してください。';
+      else locHint.textContent = 'ingest key 未設定 — まず「🗺 軌跡」 タブで key を生成してください。';
+    }
+
+    // 🌐 DNS / SNI tap
+    const dns = r.dns || {};
+    $set('extCfgCount24h', String(dns.count_24h ?? 0));
+    $set('extCfgCount7d', String(dns.count_7d ?? 0));
+    $set('extCfgDeviceCount', String(dns.device_count ?? 0));
+    $set('extCfgLatest', fmtTime(dns.latest));
+    setExtCfgPill('extCfgDnsPill', dns, {
+      activeMsg: '稼働中',
+      configuredMsg: '受信待機',
+      inactiveMsg: '未受信',
+    });
+    const dnsHint = document.getElementById('extCfgDnsHint');
+    if (dnsHint) {
+      if (dns.active) dnsHint.textContent = '直近 24 時間に Legatus dnstap からドメインアクセスが届いています。';
+      else if (dns.configured) dnsHint.textContent = '直近 1 週間にデータあり、 24h 内は未到達。 Legatus / dnsmasq の稼働を確認してください。';
+      else dnsHint.textContent = 'まだデータが届いていません。 下記「📖 設定方法 B」 を実施してください。';
+    }
+
+    // 直近 20 件 (DNS のみ — domain 単位なので位置情報と混ぜない)
     const recent = document.getElementById('extCfgRecent');
     if (recent) {
-      const items = Array.isArray(r.recent) ? r.recent : [];
+      const items = Array.isArray(dns.recent) ? dns.recent : [];
       if (items.length === 0) {
-        recent.innerHTML = '<div class="hint">まだ取り込みがありません。 下のセットアップ手順を実施してください。</div>';
+        recent.innerHTML = '<div class="hint">DNS / SNI 取り込みは未受信。 下記「設定方法 B」 を実施してください。</div>';
       } else {
         recent.innerHTML = `
-          <h4>直近 20 件</h4>
+          <h4>🌐 DNS / SNI 直近 20 件</h4>
           <table class="ext-cfg-recent-tbl">
             <thead><tr><th>時刻</th><th>device</th><th>OS</th><th>source</th><th>domain</th></tr></thead>
             <tbody>
               ${items.map((e) => `
                 <tr>
-                  <td>${escapeHtml(new Date((e.visited_at || '').replace(' ', 'T') + 'Z').toLocaleString())}</td>
+                  <td>${escapeHtml(fmtTime(e.visited_at))}</td>
                   <td>${escapeHtml(e.device_label || '—')}</td>
                   <td>${escapeHtml(e.device_os || '—')}</td>
                   <td><span class="ext-cfg-src ext-cfg-src-${escapeHtml(e.source || 'unknown')}">${escapeHtml(e.source || '—')}</span></td>
@@ -5121,6 +5156,22 @@ async function loadExternalConfig() {
   } catch (e) {
     const recent = document.getElementById('extCfgRecent');
     if (recent) recent.innerHTML = `<div class="hint">取得エラー: ${escapeHtml(e.message)}</div>`;
+  }
+}
+
+function setExtCfgPill(id, src, msg) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.classList.remove('ext-cfg-pill-loading', 'ext-cfg-pill-active', 'ext-cfg-pill-configured', 'ext-cfg-pill-inactive');
+  if (src.active) {
+    el.classList.add('ext-cfg-pill-active');
+    el.textContent = `🟢 ${msg.activeMsg}`;
+  } else if (src.configured) {
+    el.classList.add('ext-cfg-pill-configured');
+    el.textContent = `🟡 ${msg.configuredMsg}`;
+  } else {
+    el.classList.add('ext-cfg-pill-inactive');
+    el.textContent = `⚪ ${msg.inactiveMsg}`;
   }
 }
 

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -616,6 +616,7 @@ function switchTab(tab) {
   $('eventsView').classList.toggle('hidden', tab !== 'events');
   $('tracksView')?.classList.toggle('hidden', tab !== 'tracks');
   $('mealsView')?.classList.toggle('hidden', tab !== 'meals');
+  $('externalView')?.classList.toggle('hidden', tab !== 'external');
   $('multiView')?.classList.toggle('hidden', tab !== 'multi');
   if (tab === 'queue') renderQueue();
   if (tab === 'visits') loadVisits();
@@ -628,6 +629,7 @@ function switchTab(tab) {
   if (tab === 'events') loadEvents();
   if (tab === 'tracks') loadTracks();
   if (tab === 'meals') loadMeals();
+  if (tab === 'external') loadExternalConfig();
   if (tab === 'multi') loadMulti();
   bumpTabUsage(tab);
   closeTabMoreMenu();
@@ -5081,6 +5083,59 @@ const mealsState = {
   items: [],
   pollTimer: null,
 };
+
+// ── 外部情報設定 (Legatus DNS/SNI tap) ────────────────────────────
+async function loadExternalConfig() {
+  try {
+    const r = await api('/api/visits/external/stats');
+    const $set = (id, v) => { const el = document.getElementById(id); if (el) el.textContent = v; };
+    $set('extCfgCount24h', String(r.count_24h ?? 0));
+    $set('extCfgCount7d', String(r.count_7d ?? 0));
+    $set('extCfgDeviceCount', String(r.device_count ?? 0));
+    $set('extCfgLatest', r.latest ? new Date(r.latest.replace(' ', 'T') + 'Z').toLocaleString() : '—');
+
+    const recent = document.getElementById('extCfgRecent');
+    if (recent) {
+      const items = Array.isArray(r.recent) ? r.recent : [];
+      if (items.length === 0) {
+        recent.innerHTML = '<div class="hint">まだ取り込みがありません。 下のセットアップ手順を実施してください。</div>';
+      } else {
+        recent.innerHTML = `
+          <h4>直近 20 件</h4>
+          <table class="ext-cfg-recent-tbl">
+            <thead><tr><th>時刻</th><th>device</th><th>OS</th><th>source</th><th>domain</th></tr></thead>
+            <tbody>
+              ${items.map((e) => `
+                <tr>
+                  <td>${escapeHtml(new Date((e.visited_at || '').replace(' ', 'T') + 'Z').toLocaleString())}</td>
+                  <td>${escapeHtml(e.device_label || '—')}</td>
+                  <td>${escapeHtml(e.device_os || '—')}</td>
+                  <td><span class="ext-cfg-src ext-cfg-src-${escapeHtml(e.source || 'unknown')}">${escapeHtml(e.source || '—')}</span></td>
+                  <td>${escapeHtml(e.domain || '—')}</td>
+                </tr>`).join('')}
+            </tbody>
+          </table>
+        `;
+      }
+    }
+  } catch (e) {
+    const recent = document.getElementById('extCfgRecent');
+    if (recent) recent.innerHTML = `<div class="hint">取得エラー: ${escapeHtml(e.message)}</div>`;
+  }
+}
+
+// コピーボタン (data-copy-env="legatus" / "dnsmasq")
+document.addEventListener('click', (ev) => {
+  const btn = ev.target?.closest?.('[data-copy-env]');
+  if (!btn) return;
+  const block = btn.previousElementSibling?.querySelector('code');
+  if (!block) return;
+  navigator.clipboard?.writeText(block.textContent || '').then(() => {
+    const orig = btn.textContent;
+    btn.textContent = '✓ コピー済';
+    setTimeout(() => { btn.textContent = orig; }, 1500);
+  }).catch(() => {});
+});
 
 async function loadMeals() {
   const list = document.getElementById('mealsList');

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -110,6 +110,9 @@
           <button class="tab" data-tab="meals">
             <span class="tab-label" data-full="🍽 食事" data-short="🍽 食事">🍽 食事</span>
           </button>
+          <button class="tab" data-tab="external">
+            <span class="tab-label" data-full="🔌 外部情報設定" data-short="🔌 設定">🔌 外部情報設定</span>
+          </button>
           <!-- マルチビューはトップバーのマルチスイッチからのみアクセス。
                機能タブからは外す (PC/スマホ共通)。 -->
         </div>
@@ -513,6 +516,136 @@
           (デフォルトは Claude CLI sonnet)。
         </div>
         <div id="mealsList" class="meals-list"></div>
+      </div>
+
+      <!-- 🔌 外部情報設定 — Legatus / dnsmasq / Tailscale / iPhone のセットアップ手順 -->
+      <div id="externalView" class="hidden">
+        <div class="ext-cfg">
+          <header class="ext-cfg-head">
+            <h2>🔌 外部情報設定</h2>
+            <p class="ext-cfg-intro">
+              iPhone (Tailscale 経由) のドメインアクセスをライフログに取り込む設定。
+              <strong>Legatus</strong> + <strong>dnsmasq</strong> + <strong>Tailscale</strong> の連携で
+              「いつ・どのデバイスが・どのドメイン」を捕捉します。
+              ページ本文 / アプリ内イベントは取得しません (HTTPS のため不可)。
+            </p>
+          </header>
+
+          <section class="ext-cfg-status">
+            <h3>📊 取り込み状況</h3>
+            <div id="extCfgStatus" class="ext-cfg-status-grid">
+              <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">直近 24 時間</span><span id="extCfgCount24h" class="ext-cfg-stat-val">—</span></div>
+              <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">直近 7 日</span><span id="extCfgCount7d" class="ext-cfg-stat-val">—</span></div>
+              <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">識別デバイス数</span><span id="extCfgDeviceCount" class="ext-cfg-stat-val">—</span></div>
+              <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">最新イベント</span><span id="extCfgLatest" class="ext-cfg-stat-val">—</span></div>
+            </div>
+            <div id="extCfgRecent" class="ext-cfg-recent"></div>
+          </section>
+
+          <section class="ext-cfg-step">
+            <h3>1️⃣ Legatus を起動 (env vars)</h3>
+            <p class="ext-cfg-help">個人 PC で動かす Legatus に以下の環境変数を渡します。 全項目 default OFF — 明示的に enable する必要があります。</p>
+            <div class="ext-cfg-env">
+              <pre><code>LEGATUS_DNSTAP_ENABLED=true
+LEGATUS_DNSMASQ_LOG_PATH=/var/log/dnsmasq.log
+LEGATUS_DNSTAP_FLUSH_MS=30000
+LEGATUS_DNSTAP_DEDUPE_MS=5000
+LEGATUS_TAILSCALE_BIN=tailscale
+LEGATUS_TAILSCALE_REFRESH_MS=300000
+LEGATUS_DNSTAP_SKIP_DOMAINS=bank.example,hospital.test
+LEGATUS_DNSTAP_FORWARD_URL=http://localhost:5180/api/visits/external</code></pre>
+              <button class="ghost" data-copy-env="legatus">コピー</button>
+            </div>
+            <details class="ext-cfg-detail">
+              <summary>各キーの意味</summary>
+              <ul>
+                <li><code>LEGATUS_DNSTAP_ENABLED</code> — モジュール ON/OFF。 default <code>false</code></li>
+                <li><code>LEGATUS_DNSMASQ_LOG_PATH</code> — tail 対象の query log。 dnsmasq 側 <code>--log-facility</code> と一致</li>
+                <li><code>LEGATUS_DNSTAP_FLUSH_MS</code> — Memoria への flush 周期 (default 30 秒)</li>
+                <li><code>LEGATUS_DNSTAP_DEDUPE_MS</code> — A/AAAA/HTTPS RR バーストの統合窓 (default 5 秒)</li>
+                <li><code>LEGATUS_TAILSCALE_BIN</code> — <code>tailscale</code> CLI のパス</li>
+                <li><code>LEGATUS_TAILSCALE_REFRESH_MS</code> — IP→hostname map の更新間隔 (default 5 分)</li>
+                <li><code>LEGATUS_DNSTAP_SKIP_DOMAINS</code> — カンマ区切り skip 一覧 (suffix match)</li>
+                <li><code>LEGATUS_DNSTAP_FORWARD_URL</code> — この Memoria の <code>/api/visits/external</code></li>
+              </ul>
+            </details>
+          </section>
+
+          <section class="ext-cfg-step">
+            <h3>2️⃣ dnsmasq の設定 (<code>/etc/dnsmasq.conf</code>)</h3>
+            <div class="ext-cfg-env">
+              <pre><code>log-queries
+log-facility=/var/log/dnsmasq.log
+interface=tailscale0
+interface=lo
+bind-interfaces
+domain-needed
+bogus-priv</code></pre>
+              <button class="ghost" data-copy-env="dnsmasq">コピー</button>
+            </div>
+            <p class="ext-cfg-help"><code>tailscale0</code> インターフェイスでのみ listen させて、 公開しない構成。 logrotate も忘れず。</p>
+          </section>
+
+          <section class="ext-cfg-step">
+            <h3>3️⃣ Tailscale 設定</h3>
+            <div class="ext-cfg-grid">
+              <div>
+                <h4>home PC (Legatus 同居)</h4>
+                <ul>
+                  <li><code>tailscale up --advertise-exit-node</code></li>
+                  <li>admin console で <strong>承認</strong></li>
+                  <li>必要なら <code>--advertise-routes=192.168.x.0/24</code></li>
+                </ul>
+              </div>
+              <div>
+                <h4>Tailscale admin console</h4>
+                <ul>
+                  <li>DNS → <strong>Override local DNS</strong> ON</li>
+                  <li>Nameservers に home PC の Tailscale IP を登録</li>
+                  <li><strong>MagicDNS</strong> ON</li>
+                </ul>
+              </div>
+              <div>
+                <h4>iPhone Tailscale アプリ</h4>
+                <ul>
+                  <li><strong>Use Tailscale DNS</strong> ON</li>
+                  <li><strong>Exit Node</strong> = home PC を選択</li>
+                </ul>
+              </div>
+            </div>
+          </section>
+
+          <section class="ext-cfg-step">
+            <h3>4️⃣ iPhone iOS 側</h3>
+            <div class="ext-cfg-warning">
+              ⚠ 設定 → Apple ID → iCloud → <strong>Private Relay を OFF</strong> (該当 Wi-Fi のみで可)。
+              ON のままだと DNS が Apple/Cloudflare に飛んで home resolver を bypass し、 ログが空になります。
+            </div>
+            <ul class="ext-cfg-ios-list">
+              <li>Tailscale 接続を常時 ON (切れると当然 capture 不可)</li>
+              <li>Wi-Fi → Configure DNS = <strong>Automatic</strong> (Tailscale の DNS に任せる)</li>
+              <li>Tailscale exit node を home PC にしている時のみ home dnsmasq 経由になる</li>
+            </ul>
+          </section>
+
+          <section class="ext-cfg-step">
+            <h3>5️⃣ オプトアウト</h3>
+            <ol class="ext-cfg-optout">
+              <li><strong>デバイス側</strong>: iPhone Tailscale を切る or exit node を外す → 即座に取込停止</li>
+              <li><strong>module 設定</strong>: <code>LEGATUS_DNSTAP_SKIP_DOMAINS</code> に銀行 / 医療 / 内部社内系を列挙</li>
+              <li><strong>全体停止</strong>: <code>LEGATUS_DNSTAP_ENABLED=false</code> (default 値)</li>
+            </ol>
+          </section>
+
+          <section class="ext-cfg-step">
+            <h3>📚 関連</h3>
+            <ul class="ext-cfg-links">
+              <li><a href="https://github.com/LUDIARS/Legatus" target="_blank" rel="noopener">LUDIARS/Legatus (リポジトリ)</a></li>
+              <li>Legatus PR <a href="https://github.com/LUDIARS/Legatus/pull/2" target="_blank" rel="noopener">#2 — feat(dnstap)</a></li>
+              <li>Memoria endpoint: <code>POST /api/visits/external</code></li>
+            </ul>
+          </section>
+        </div>
       </div>
 
       <!-- 単語リングメニュー — グラフ / ワードクラウドの単語クリックで開く -->

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -518,32 +518,118 @@
         <div id="mealsList" class="meals-list"></div>
       </div>
 
-      <!-- 🔌 外部情報設定 — Legatus / dnsmasq / Tailscale / iPhone のセットアップ手順 -->
+      <!-- 🔌 外部情報設定 — Legatus / OwnTracks / dnsmasq / Tailscale / iPhone のセットアップ手順 -->
       <div id="externalView" class="hidden">
         <div class="ext-cfg">
           <header class="ext-cfg-head">
             <h2>🔌 外部情報設定</h2>
             <p class="ext-cfg-intro">
-              iPhone (Tailscale 経由) のドメインアクセスをライフログに取り込む設定。
-              <strong>Legatus</strong> + <strong>dnsmasq</strong> + <strong>Tailscale</strong> の連携で
-              「いつ・どのデバイスが・どのドメイン」を捕捉します。
-              ページ本文 / アプリ内イベントは取得しません (HTTPS のため不可)。
+              iPhone (Tailscale 経由) のライフログ取込み設定。 現在 2 系統対応:
+              <strong>📍 位置情報</strong> (OwnTracks GPS) と
+              <strong>🌐 DNS / SNI tap</strong> (アクセスドメイン) を別々の経路で受け、
+              Memoria に永続化します。 HTTPS 本文 / アプリ内イベントは取得しません。
             </p>
           </header>
 
+          <!-- ステータスサマリ — 各情報源の現状 -->
           <section class="ext-cfg-status">
-            <h3>📊 取り込み状況</h3>
-            <div id="extCfgStatus" class="ext-cfg-status-grid">
-              <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">直近 24 時間</span><span id="extCfgCount24h" class="ext-cfg-stat-val">—</span></div>
-              <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">直近 7 日</span><span id="extCfgCount7d" class="ext-cfg-stat-val">—</span></div>
-              <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">識別デバイス数</span><span id="extCfgDeviceCount" class="ext-cfg-stat-val">—</span></div>
-              <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">最新イベント</span><span id="extCfgLatest" class="ext-cfg-stat-val">—</span></div>
+            <h3>📊 各情報の取込ステータス</h3>
+            <div class="ext-cfg-sources">
+              <div class="ext-cfg-source" id="extCfgSrcLocation">
+                <header>
+                  <span class="ext-cfg-source-icon">📍</span>
+                  <span class="ext-cfg-source-name">位置情報 (OwnTracks GPS)</span>
+                  <span class="ext-cfg-pill ext-cfg-pill-loading" id="extCfgLocationPill">読み込み中…</span>
+                </header>
+                <div class="ext-cfg-status-grid">
+                  <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">直近 24h</span><span id="extCfgLocCount24h" class="ext-cfg-stat-val">—</span></div>
+                  <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">直近 7 日</span><span id="extCfgLocCount7d" class="ext-cfg-stat-val">—</span></div>
+                  <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">デバイス</span><span id="extCfgLocDeviceCount" class="ext-cfg-stat-val">—</span></div>
+                  <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">最新</span><span id="extCfgLocLatest" class="ext-cfg-stat-val">—</span></div>
+                </div>
+                <p class="ext-cfg-help" id="extCfgLocationHint"></p>
+              </div>
+
+              <div class="ext-cfg-source" id="extCfgSrcDns">
+                <header>
+                  <span class="ext-cfg-source-icon">🌐</span>
+                  <span class="ext-cfg-source-name">DNS / SNI tap (Legatus dnstap)</span>
+                  <span class="ext-cfg-pill ext-cfg-pill-loading" id="extCfgDnsPill">読み込み中…</span>
+                </header>
+                <div class="ext-cfg-status-grid">
+                  <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">直近 24h</span><span id="extCfgCount24h" class="ext-cfg-stat-val">—</span></div>
+                  <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">直近 7 日</span><span id="extCfgCount7d" class="ext-cfg-stat-val">—</span></div>
+                  <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">デバイス</span><span id="extCfgDeviceCount" class="ext-cfg-stat-val">—</span></div>
+                  <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">最新</span><span id="extCfgLatest" class="ext-cfg-stat-val">—</span></div>
+                </div>
+                <p class="ext-cfg-help" id="extCfgDnsHint"></p>
+              </div>
             </div>
             <div id="extCfgRecent" class="ext-cfg-recent"></div>
           </section>
 
-          <section class="ext-cfg-step">
-            <h3>1️⃣ Legatus を起動 (env vars)</h3>
+          <!-- ── 設定方法 (情報源別) ─────────────────────────────── -->
+          <section class="ext-cfg-howto">
+            <h3>📖 設定方法</h3>
+            <p class="ext-cfg-help">取り込みたい情報源ごとに必要なステップを実施してください。 どちらも default OFF で、 明示的に enable しないと取込まれません。</p>
+          </section>
+
+          <!-- ── A. 位置情報 (OwnTracks GPS) ─────────────────────── -->
+          <section class="ext-cfg-step ext-cfg-howto-loc">
+            <h3>📍 A. 位置情報 (OwnTracks GPS) の設定</h3>
+            <p class="ext-cfg-help">iPhone の OwnTracks アプリが Tailscale 経由で home PC 同居 Mosquitto に publish → Legatus が subscribe → Memoria の <code>gps_locations</code> に永続化。</p>
+
+            <h4>1️⃣ Memoria 側で ingest key を発行</h4>
+            <p class="ext-cfg-help">「🗺 軌跡」 タブで「ingest key を再生成」 を押す → 32 桁 hex が発行される (= Mosquitto Basic auth password として使える)。</p>
+
+            <h4>2️⃣ home PC で Mosquitto を起動 (Legatus 同居)</h4>
+            <div class="ext-cfg-env">
+              <pre><code># /etc/mosquitto/mosquitto.conf (抜粋)
+listener 1883 0.0.0.0
+allow_anonymous false
+password_file /etc/mosquitto/passwd
+# tailnet 経由のみ受ける場合 (推奨):
+# listener 1883 100.x.y.z   (home PC の Tailscale IP)</code></pre>
+              <button class="ghost" data-copy-env="mosquitto">コピー</button>
+            </div>
+            <p class="ext-cfg-help"><code>mosquitto_passwd -c /etc/mosquitto/passwd owntracks</code> で user 作成、 password に上の ingest key を入れる。</p>
+
+            <h4>3️⃣ Legatus に env vars を渡す</h4>
+            <div class="ext-cfg-env">
+              <pre><code>OWNTRACKS_ENABLED=true
+OWNTRACKS_MQTT_URL=mqtt://127.0.0.1:1883
+OWNTRACKS_MQTT_USERNAME=owntracks
+OWNTRACKS_MQTT_PASSWORD=&lt;ingest key&gt;
+OWNTRACKS_MQTT_TOPIC=owntracks/+/+
+LEGATUS_LOCATION_FLUSH_INTERVAL_MS=300000
+LEGATUS_LOCATION_MIN_DISPLACEMENT_M=100</code></pre>
+              <button class="ghost" data-copy-env="owntracks">コピー</button>
+            </div>
+
+            <h4>4️⃣ iPhone OwnTracks アプリ</h4>
+            <ul class="ext-cfg-ios-list">
+              <li>Mode = <strong>MQTT</strong></li>
+              <li>Host = home PC の Tailscale IP (例 <code>100.64.0.5</code>)</li>
+              <li>Port = <code>1883</code></li>
+              <li>User = <code>owntracks</code> / Password = ingest key</li>
+              <li>Topic format は default (<code>owntracks/&lt;user&gt;/&lt;device&gt;</code>)</li>
+              <li>「Move」 mode 推奨 (バッテリー寄りなら Significant)</li>
+            </ul>
+
+            <h4>5️⃣ オプトアウト</h4>
+            <ol class="ext-cfg-optout">
+              <li>iPhone 側 OwnTracks の publish を OFF</li>
+              <li>Legatus の <code>OWNTRACKS_ENABLED=false</code></li>
+              <li>Memoria 「🗺 軌跡」 タブで ingest key を削除 (= 受信を恒久停止)</li>
+            </ol>
+          </section>
+
+          <!-- ── B. DNS / SNI tap ─────────────────────────────── -->
+          <section class="ext-cfg-step ext-cfg-howto-dns">
+            <h3>🌐 B. DNS / SNI tap (Legatus dnstap) の設定</h3>
+            <p class="ext-cfg-help">home PC の dnsmasq が iPhone (Tailscale exit node) からの DNS query log を吐き、 Legatus dnstap が tail → Tailscale で device tag → Memoria に forward。</p>
+
+            <h4>1️⃣ Legatus dnstap を起動 (env vars)</h4>
             <p class="ext-cfg-help">個人 PC で動かす Legatus に以下の環境変数を渡します。 全項目 default OFF — 明示的に enable する必要があります。</p>
             <div class="ext-cfg-env">
               <pre><code>LEGATUS_DNSTAP_ENABLED=true
@@ -569,10 +655,8 @@ LEGATUS_DNSTAP_FORWARD_URL=http://localhost:5180/api/visits/external</code></pre
                 <li><code>LEGATUS_DNSTAP_FORWARD_URL</code> — この Memoria の <code>/api/visits/external</code></li>
               </ul>
             </details>
-          </section>
 
-          <section class="ext-cfg-step">
-            <h3>2️⃣ dnsmasq の設定 (<code>/etc/dnsmasq.conf</code>)</h3>
+            <h4>2️⃣ dnsmasq の設定 (<code>/etc/dnsmasq.conf</code>)</h4>
             <div class="ext-cfg-env">
               <pre><code>log-queries
 log-facility=/var/log/dnsmasq.log
@@ -583,14 +667,12 @@ domain-needed
 bogus-priv</code></pre>
               <button class="ghost" data-copy-env="dnsmasq">コピー</button>
             </div>
-            <p class="ext-cfg-help"><code>tailscale0</code> インターフェイスでのみ listen させて、 公開しない構成。 logrotate も忘れず。</p>
-          </section>
+            <p class="ext-cfg-help"><code>tailscale0</code> インターフェイスでのみ listen、 公開しない構成。 logrotate も忘れず。</p>
 
-          <section class="ext-cfg-step">
-            <h3>3️⃣ Tailscale 設定</h3>
+            <h4>3️⃣ Tailscale 設定</h4>
             <div class="ext-cfg-grid">
               <div>
-                <h4>home PC (Legatus 同居)</h4>
+                <h5>home PC (Legatus 同居)</h5>
                 <ul>
                   <li><code>tailscale up --advertise-exit-node</code></li>
                   <li>admin console で <strong>承認</strong></li>
@@ -598,7 +680,7 @@ bogus-priv</code></pre>
                 </ul>
               </div>
               <div>
-                <h4>Tailscale admin console</h4>
+                <h5>Tailscale admin console</h5>
                 <ul>
                   <li>DNS → <strong>Override local DNS</strong> ON</li>
                   <li>Nameservers に home PC の Tailscale IP を登録</li>
@@ -606,33 +688,29 @@ bogus-priv</code></pre>
                 </ul>
               </div>
               <div>
-                <h4>iPhone Tailscale アプリ</h4>
+                <h5>iPhone Tailscale アプリ</h5>
                 <ul>
                   <li><strong>Use Tailscale DNS</strong> ON</li>
                   <li><strong>Exit Node</strong> = home PC を選択</li>
                 </ul>
               </div>
             </div>
-          </section>
 
-          <section class="ext-cfg-step">
-            <h3>4️⃣ iPhone iOS 側</h3>
+            <h4>4️⃣ iPhone iOS 側</h4>
             <div class="ext-cfg-warning">
               ⚠ 設定 → Apple ID → iCloud → <strong>Private Relay を OFF</strong> (該当 Wi-Fi のみで可)。
               ON のままだと DNS が Apple/Cloudflare に飛んで home resolver を bypass し、 ログが空になります。
             </div>
             <ul class="ext-cfg-ios-list">
-              <li>Tailscale 接続を常時 ON (切れると当然 capture 不可)</li>
-              <li>Wi-Fi → Configure DNS = <strong>Automatic</strong> (Tailscale の DNS に任せる)</li>
-              <li>Tailscale exit node を home PC にしている時のみ home dnsmasq 経由になる</li>
+              <li>Tailscale 接続を常時 ON</li>
+              <li>Wi-Fi → Configure DNS = <strong>Automatic</strong></li>
+              <li>Tailscale exit node を home PC にしている時のみ home dnsmasq 経由</li>
             </ul>
-          </section>
 
-          <section class="ext-cfg-step">
-            <h3>5️⃣ オプトアウト</h3>
+            <h4>5️⃣ オプトアウト</h4>
             <ol class="ext-cfg-optout">
               <li><strong>デバイス側</strong>: iPhone Tailscale を切る or exit node を外す → 即座に取込停止</li>
-              <li><strong>module 設定</strong>: <code>LEGATUS_DNSTAP_SKIP_DOMAINS</code> に銀行 / 医療 / 内部社内系を列挙</li>
+              <li><strong>module 設定</strong>: <code>LEGATUS_DNSTAP_SKIP_DOMAINS</code> に銀行 / 医療 / 内部系を列挙</li>
               <li><strong>全体停止</strong>: <code>LEGATUS_DNSTAP_ENABLED=false</code> (default 値)</li>
             </ol>
           </section>

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -4085,3 +4085,53 @@ dialog.meal-modal[open] {
   .ext-cfg-step { padding: 10px 12px; }
   .ext-cfg-status-grid { grid-template-columns: 1fr 1fr; }
 }
+
+/* ── 外部情報設定: 情報源別ステータス ────────────────────────── */
+.ext-cfg-sources {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 10px;
+  margin-bottom: 8px;
+}
+.ext-cfg-source {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.ext-cfg-source > header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.ext-cfg-source-icon { font-size: 18px; }
+.ext-cfg-source-name { font-weight: 600; font-size: 13px; }
+.ext-cfg-pill {
+  margin-left: auto;
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  white-space: nowrap;
+}
+.ext-cfg-pill-loading { background: var(--bg-surface, #fff); color: var(--text-muted); }
+.ext-cfg-pill-active { background: #e6f7e6; color: #2a8b2a; border-color: #95cf95; }
+.ext-cfg-pill-configured { background: #fff7d6; color: #8a6d00; border-color: #e6c97a; }
+.ext-cfg-pill-inactive { background: var(--bg-surface, #fff); color: var(--text-muted); }
+
+.ext-cfg-howto {
+  background: var(--bg-surface, #fff);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent, #2a6df4);
+  border-radius: 6px;
+  padding: 10px 14px;
+}
+.ext-cfg-howto h3 { margin: 0 0 4px; font-size: 16px; }
+.ext-cfg-howto-loc { border-left: 3px solid #2a8b2a; }
+.ext-cfg-howto-dns { border-left: 3px solid #2a6df4; }
+
+.ext-cfg-step h5 { margin: 4px 0; font-size: 12px; color: var(--text-muted); }

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -3954,3 +3954,134 @@ dialog.meal-modal[open] {
 .cb-diff.under .cb-value { color: #1455a8; }
 .cb-diff.ok { background: #e6f7e6; border-color: #95cf95; }
 .cb-diff.ok .cb-value { color: #2a8b2a; }
+
+/* ── 外部情報設定タブ (Legatus / dnstap セットアップ) ────────── */
+.ext-cfg {
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.ext-cfg-head h2 { margin: 0 0 8px; font-size: 20px; }
+.ext-cfg-intro { color: var(--text-muted); font-size: 13px; line-height: 1.6; margin: 0; }
+.ext-cfg-status,
+.ext-cfg-step {
+  background: var(--bg-surface, #fff);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 14px 16px;
+}
+.ext-cfg-status h3,
+.ext-cfg-step h3 { margin: 0 0 10px; font-size: 16px; }
+.ext-cfg-step h4 { margin: 8px 0 4px; font-size: 13px; color: var(--text-muted); }
+.ext-cfg-help { color: var(--text-muted); font-size: 12px; margin: 4px 0 8px; line-height: 1.5; }
+
+.ext-cfg-status-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.ext-cfg-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 8px 10px;
+}
+.ext-cfg-stat-label { font-size: 11px; color: var(--text-muted); }
+.ext-cfg-stat-val { font-size: 18px; font-weight: 600; }
+
+.ext-cfg-recent { margin-top: 6px; }
+.ext-cfg-recent h4 { margin: 6px 0; font-size: 12px; }
+.ext-cfg-recent-tbl {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+.ext-cfg-recent-tbl th,
+.ext-cfg-recent-tbl td {
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+}
+.ext-cfg-recent-tbl th { color: var(--text-muted); font-weight: 500; }
+.ext-cfg-src {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 10px;
+  font-size: 10px;
+  border: 1px solid var(--border);
+}
+.ext-cfg-src-dns { background: #e6f0ff; color: #1455a8; border-color: #97b8d4; }
+.ext-cfg-src-sni { background: #f0e6ff; color: #5b1ca8; border-color: #b497d4; }
+
+.ext-cfg-env {
+  position: relative;
+  margin: 6px 0;
+}
+.ext-cfg-env pre {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 10px 12px;
+  margin: 0;
+  font-size: 12px;
+  overflow-x: auto;
+  white-space: pre;
+}
+.ext-cfg-env button {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  font-size: 11px;
+  padding: 2px 8px;
+}
+
+.ext-cfg-detail summary {
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+.ext-cfg-detail ul { margin: 6px 0 0 18px; font-size: 12px; line-height: 1.7; }
+.ext-cfg-detail code { background: var(--bg); padding: 1px 4px; border-radius: 3px; font-size: 11px; }
+
+.ext-cfg-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+.ext-cfg-grid ul { margin: 4px 0 0 18px; font-size: 12px; line-height: 1.7; }
+.ext-cfg-grid code { background: var(--bg); padding: 1px 4px; border-radius: 3px; font-size: 11px; }
+
+.ext-cfg-warning {
+  background: #fff7d6;
+  border: 1px solid #e6c97a;
+  color: #6a4a00;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 12px;
+  line-height: 1.6;
+  margin-bottom: 8px;
+}
+.ext-cfg-ios-list,
+.ext-cfg-optout {
+  font-size: 12px;
+  line-height: 1.7;
+  margin: 4px 0 0 18px;
+}
+.ext-cfg-links { font-size: 13px; margin: 0 0 0 18px; }
+.ext-cfg-links a { color: var(--accent, #2a6df4); text-decoration: none; }
+.ext-cfg-links a:hover { text-decoration: underline; }
+
+@media (max-width: 600px) {
+  .ext-cfg { padding: 8px; gap: 12px; }
+  .ext-cfg-status,
+  .ext-cfg-step { padding: 10px 12px; }
+  .ext-cfg-status-grid { grid-template-columns: 1fr 1fr; }
+}


### PR DESCRIPTION
## Summary

Legatus PR LUDIARS/Legatus#2 (`feat/dnstap-module`) とペアの Memoria 側受け口。 iPhone (Tailscale) の DNS 履歴を device tag 付きで visit_events に流し込む。

## 変更

- `server/db.js`
  - `visit_events` に `device_label / device_os / source` 列を ALTER で追加
  - `insertVisitEvent` を `source='browser'` 固定で書き込むよう更新
  - `insertExternalVisitEvent` を新規追加 (擬似 URL `dns://<domain>` で page_visits と分離)
- `server/index.js`
  - `POST /api/visits/external` endpoint 追加
  - body: `{ events: [{ts, domain, source, src_ip, device_label, device_os}], flushed_at }`
  - domain regex フィルタ + lowercase 統一
  - 未知ドメインは既存 `maybeQueueDomain` で background classify

## 互換性

- 既存 `/api/access` (browser 拡張) の振る舞いは変わらない (`source='browser'` が記録される点のみ)
- ALTER は forward-compat、 古い DB でも起動可

## Test plan

- [x] `node --check` pass
- [x] `npm run typecheck` (tsc --noEmit) pass
- [x] CI lint + smoke (PR で確認)
- [ ] Legatus 実機で end-to-end (Legatus PR #2 マージ後)

## 関連 PR

- LUDIARS/Legatus#2 (送信側 dnstap module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)