### PR TITLE
feat(location): 場所編集モーダル — 検索 + ピン + 施設名取得 + 食事連携

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -255,8 +255,17 @@ export function openDb(dbPath) {
       -- samples_count: この行が代表する raw 発行数 (通常は 1、 圧縮後の終点行は 2+)
       -- samples_first_at: 圧縮窓の開始時刻 (NULL = recorded_at と同じ = 未圧縮)
       samples_count    INTEGER NOT NULL DEFAULT 1,
-      samples_first_at TEXT
+      samples_first_at TEXT,
+      -- 位置照合 (Google Geocoding/Places で取得した日本語の場所説明)
+      -- place_resolved_at が NULL なら未解決 / バックフィル対象
+      place_name       TEXT,
+      place_address    TEXT,
+      place_source     TEXT,                       -- 'places' | 'geocode' | 'cached' | 'failed'
+      place_resolved_at INTEGER
     );
+    -- 注: idx_gps_locations_unresolved は ALTER TABLE で place_resolved_at を
+    -- 後付けしてから作るため、 ここでは作らない (旧 DB に対する CREATE INDEX で
+    -- "no such column" になるのを避ける).
     CREATE INDEX IF NOT EXISTS idx_gps_locations_at
       ON gps_locations(recorded_at DESC);
     CREATE INDEX IF NOT EXISTS idx_gps_locations_user_at
@@ -351,6 +360,21 @@ export function openDb(dbPath) {
   if (gpsCols.length > 0 && !gpsCols.includes('samples_first_at')) {
     db.exec(`ALTER TABLE gps_locations ADD COLUMN samples_first_at TEXT`);
   }
+  // 位置照合 (Google Geocoding/Places で日本語の場所説明を付ける) 用 4 列
+  if (gpsCols.length > 0 && !gpsCols.includes('place_name')) {
+    db.exec(`ALTER TABLE gps_locations ADD COLUMN place_name TEXT`);
+  }
+  if (gpsCols.length > 0 && !gpsCols.includes('place_address')) {
+    db.exec(`ALTER TABLE gps_locations ADD COLUMN place_address TEXT`);
+  }
+  if (gpsCols.length > 0 && !gpsCols.includes('place_source')) {
+    db.exec(`ALTER TABLE gps_locations ADD COLUMN place_source TEXT`);
+  }
+  if (gpsCols.length > 0 && !gpsCols.includes('place_resolved_at')) {
+    db.exec(`ALTER TABLE gps_locations ADD COLUMN place_resolved_at INTEGER`);
+  }
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_gps_locations_unresolved
+           ON gps_locations(place_resolved_at) WHERE place_resolved_at IS NULL`);
 
   const dcCols = db.prepare(`PRAGMA table_info(domain_catalog)`).all().map(c => c.name);
   if (!dcCols.includes('site_name'))   db.exec(`ALTER TABLE domain_catalog ADD COLUMN site_name TEXT`);
@@ -2046,6 +2070,58 @@ export function insertGpsLocation(db, loc) {
   return { inserted: true, id: info.lastInsertRowid };
 }
 
+// ── 位置照合 (place name/address) 関連 helpers ──────────────────────────────
+
+/**
+ * 近接 (約 gridM 以内) で既に place_name が解決済の点を 1 件返す.
+ * 数百件規模の DB なら full scan で十分速い (lat/lon 範囲条件で枝刈り).
+ */
+export function findNearbyResolvedPlace(db, lat, lon, gridM = 10) {
+  // 1 度 ≈ 111,320m → 10m なら 0.00009 度. 緯度方向は固定、 経度は cos 補正.
+  const dLat = gridM / 111_320;
+  const dLon = gridM / (111_320 * Math.max(0.1, Math.cos((lat * Math.PI) / 180)));
+  const row = db.prepare(`
+    SELECT place_name, place_address, place_source
+      FROM gps_locations
+     WHERE place_resolved_at IS NOT NULL
+       AND place_source IN ('places', 'geocode', 'cached')
+       AND lat BETWEEN ? AND ?
+       AND lon BETWEEN ? AND ?
+     ORDER BY place_resolved_at DESC
+     LIMIT 1
+  `).get(lat - dLat, lat + dLat, lon - dLon, lon + dLon);
+  return row ?? null;
+}
+
+/** id の行に place 結果を書き込む. resolved_at は now (unix sec). */
+export function setGpsPlace(db, id, { name, address, source }) {
+  const now = Math.floor(Date.now() / 1000);
+  db.prepare(`
+    UPDATE gps_locations
+       SET place_name = ?, place_address = ?, place_source = ?, place_resolved_at = ?
+     WHERE id = ?
+  `).run(name ?? null, address ?? null, source ?? 'failed', now, id);
+}
+
+/**
+ * 未解決の点 (place_resolved_at IS NULL) を新しい順に N 件返す.
+ * バックフィルジョブ用.
+ */
+export function listUnresolvedGpsLocations(db, limit = 50) {
+  return db.prepare(`
+    SELECT id, lat, lon, recorded_at, device_id
+      FROM gps_locations
+     WHERE place_resolved_at IS NULL
+     ORDER BY id DESC
+     LIMIT ?
+  `).all(limit);
+}
+
+/** 1 行を id 指定で読む (resolver の race 防止用). */
+export function findGpsLocationById(db, id) {
+  return db.prepare(`SELECT id, lat, lon, place_resolved_at FROM gps_locations WHERE id = ?`).get(id) ?? null;
+}
+
 /**
  * 既存 GPS データに対して圧縮を遡及適用する (backfill)。
  *
@@ -2200,7 +2276,8 @@ export function listGpsLocationsForDate(db, dateStr, { userId = 'me' } = {}) {
   return db.prepare(`
     SELECT id, device_id, recorded_at, lat, lon,
            accuracy_m, altitude_m, velocity_kmh, course_deg,
-           samples_count, samples_first_at
+           samples_count, samples_first_at,
+           place_name, place_address, place_source
     FROM gps_locations
     WHERE user_id = ? AND date(recorded_at, 'localtime') = ?
     ORDER BY recorded_at ASC

--- a/server/index.js
+++ b/server/index.js
@@ -3283,6 +3283,84 @@ app.delete('/api/locations/settings/key', (c) => {
 });
 
 /**
+ * Legatus が 60 秒ごとにまとめて投げる location summary を受ける。
+ * loopback / tailnet 内のみ。 認証なし (Memoria 自体が同じ範囲で公開)。
+ *
+ * 受信した summary を 2 点 (start / end) として gps_locations に INSERT。
+ * via=legatus / requestId / pointCount などは raw_json に保管。
+ *
+ * payload (Legatus owntracks/types.ts:LocationSummary + userId / source):
+ *   { userId, intervalStart (ISO), intervalEnd (ISO), start: {lat,lon}, end: {lat,lon},
+ *     totalDistanceMeters, netDistanceMeters, maxSpeedKmh?, meanSpeedKmh?, pointCount,
+ *     deviceIds[], source: { via, tool, requestId } }
+ */
+app.post('/api/legatus/location-summary', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  if (!body || typeof body !== 'object') {
+    return c.json({ error: 'json body required' }, 400);
+  }
+  const userId = (body.userId || 'legatus').toString().slice(0, 64);
+  const start = body.start;
+  const end = body.end;
+  if (!start || !end || typeof start.lat !== 'number' || typeof start.lon !== 'number'
+      || typeof end.lat !== 'number' || typeof end.lon !== 'number') {
+    return c.json({ error: 'start / end (lat,lon) required' }, 400);
+  }
+  const deviceId = (Array.isArray(body.deviceIds) && body.deviceIds[0]) || 'legatus';
+  const requestId = body.source?.requestId ?? null;
+  const meta = {
+    via: 'legatus',
+    tool: body.source?.tool ?? 'owntracks-mqtt',
+    requestId,
+    pointCount: body.pointCount,
+    totalDistanceMeters: body.totalDistanceMeters,
+    netDistanceMeters: body.netDistanceMeters,
+    maxSpeedKmh: body.maxSpeedKmh,
+    meanSpeedKmh: body.meanSpeedKmh,
+  };
+
+  const inserted = [];
+  for (const [point, recordedAt, role] of [
+    [start, body.intervalStart, 'start'],
+    [end,   body.intervalEnd,   'end'],
+  ]) {
+    const rec = {
+      userId,
+      deviceId,
+      tst: undefined,
+      recordedAt: recordedAt ?? new Date().toISOString(),
+      lat: point.lat,
+      lon: point.lon,
+      accuracy: null,
+      altitude: null,
+      velocity: role === 'end' ? (body.maxSpeedKmh ?? null) : null,
+      course: null,
+      battery: null,
+      conn: null,
+      rawJson: JSON.stringify({ ...meta, role }),
+    };
+    const result = insertGpsLocation(db, rec);
+    if (!result.skipped) {
+      inserted.push({ id: result.id, role });
+      broadcastLocation({
+        id: result.id,
+        user_id: userId,
+        device_id: deviceId,
+        recorded_at: rec.recordedAt,
+        lat: point.lat,
+        lon: point.lon,
+        accuracy_m: null,
+        altitude_m: null,
+        velocity_kmh: rec.velocity ?? null,
+        course_deg: null,
+      });
+    }
+  }
+
+  return c.json({ ok: true, inserted, requestId });
+});
+
+/**
  * 直接 1 点の位置を投入する (OwnTracks HTTP モード or 手動テスト)。
  * 受け取れる形式:
  *   - OwnTracks 形式: { _type:'location', lat, lon, tst, acc?, alt?, vel?, cog?, batt?, conn? }
@@ -3348,6 +3426,99 @@ app.post('/api/locations/ingest', async (c) => {
   c.header('X-Memoria-Insert-Id', String(result.id ?? ''));
   c.header('X-Memoria-Insert-Skipped', String(!!result.skipped));
   return c.json([]);
+});
+
+/**
+ * Tracks タブ全般の設定 (現状は ノイズ間引き距離).
+ *   GET  /api/tracks/settings → { decimate_meters: number }
+ *   PATCH /api/tracks/settings { decimate_meters?: number }
+ */
+app.get('/api/tracks/settings', (c) => {
+  const s = getAppSettings(db);
+  const v = Number(s['tracks.decimate_meters'] ?? '2');
+  return c.json({ decimate_meters: Number.isFinite(v) ? v : 2 });
+});
+app.patch('/api/tracks/settings', async (c) => {
+  const body = await c.req.json().catch(() => ({}));
+  const patch = {};
+  if (body.decimate_meters !== undefined) {
+    const v = Number(body.decimate_meters);
+    if (!Number.isFinite(v) || v < 0 || v > 1000) {
+      return c.json({ error: 'decimate_meters must be 0-1000' }, 400);
+    }
+    patch['tracks.decimate_meters'] = String(v);
+  }
+  if (Object.keys(patch).length > 0) setAppSettings(db, patch);
+  const s = getAppSettings(db);
+  return c.json({ decimate_meters: Number(s['tracks.decimate_meters'] ?? '2') });
+});
+
+/**
+ * GPS ログを最新 N 件 (default 50, max 500) 返す.
+ * Tracks page の右下リスト用.
+ *
+ * 既定で **2m 以内の連続点を間引いた後の N 件** を返す.
+ * 生 GPS ジッタ (停止中の数 m ノイズ) を取り除いて「実際に動いた点」だけ
+ * 列挙するため. 間引きを切りたい時は ?decimate=0.
+ *
+ * 実装: 新→旧 順で walk しながら、 直前 kept 点との距離が >= decimate m
+ * の点だけ keep. limit 件貯まったら停止. raw が pool 上限 (500) より
+ * 多くても OK.
+ */
+app.get('/api/locations/recent', (c) => {
+  const limit = Math.min(500, Math.max(1, Number(c.req.query('limit') ?? '50')));
+  const settingsDecimate = Number(getAppSettings(db)['tracks.decimate_meters'] ?? '2');
+  const decimateM = Math.max(0, Number(c.req.query('decimate') ?? settingsDecimate));
+  const device = c.req.query('device') || null;
+  const params = [];
+  let where = '';
+  if (device) { where = ' WHERE device_id = ?'; params.push(device); }
+
+  // 新しい順に大きめに取ってから decimate. limit*30 か 1500 の小さい方.
+  // (停止中ジッタが多くても 50 件確保できる量).
+  const pool = Math.max(limit, Math.min(1500, limit * 30));
+  const rows = db.prepare(
+    `SELECT id, user_id, device_id, recorded_at, lat, lon,
+            accuracy_m, altitude_m, velocity_kmh, course_deg, raw_json
+     FROM gps_locations${where} ORDER BY id DESC LIMIT ?`
+  ).all(...params, pool);
+
+  if (decimateM <= 0) {
+    return c.json({ points: rows.slice(0, limit), decimated: 0, pool: rows.length });
+  }
+
+  const R = 6_371_008;
+  const toRad = d => (d * Math.PI) / 180;
+  function distM(a, b) {
+    const f1 = toRad(a.lat), f2 = toRad(b.lat);
+    const df = toRad(b.lat - a.lat), dl = toRad(b.lon - a.lon);
+    const h = Math.sin(df/2) ** 2 + Math.cos(f1) * Math.cos(f2) * Math.sin(dl/2) ** 2;
+    return 2 * R * Math.asin(Math.min(1, Math.sqrt(h)));
+  }
+
+  const kept = [];
+  for (const p of rows) {
+    if (kept.length === 0) { kept.push(p); continue; }
+    const last = kept[kept.length - 1];
+    if (distM(last, p) >= decimateM) {
+      kept.push(p);
+      if (kept.length >= limit) break;
+    }
+  }
+  return c.json({ points: kept, decimated: decimateM, pool: rows.length });
+});
+
+/**
+ * 直近 1 件の GPS 点を返す (Tracks page の map 初期 center 用)。
+ * 何も無ければ { point: null } を返す。
+ */
+app.get('/api/locations/latest', (c) => {
+  const row = db.prepare(
+    `SELECT id, user_id, device_id, recorded_at, lat, lon,
+            accuracy_m, altitude_m, velocity_kmh, course_deg
+     FROM gps_locations ORDER BY recorded_at DESC LIMIT 1`
+  ).get();
+  return c.json({ point: row ?? null });
 });
 
 /**
@@ -3523,5 +3694,102 @@ if (process.env.MEMORIA_MQTT_URL) {
     });
   } catch (e) {
     console.error(`[mqtt] in-process subscriber failed to start: ${e?.message ?? e}`);
+  }
+}
+
+// ---- Legatus WS subscriber (recommended path) -----------------------------
+//
+// 同じ PC 上で動く Legatus (loopback 17320) が OwnTracks → MQTT → /ws で
+// 個別 GPS 点を broadcast する。 Memoria はそれを subscribe して
+// gps_locations に即時 insert + /ws/locations に broadcast →
+// Tracks UI の地図にリアルタイムで点が増える設計。
+//
+// Legatus 側の summary 経路 (5 分集計) は startイ/end の 2 点しか作らない
+// ので、 細かい軌跡が欲しい場合はこちらが正解 (用途が違う path として共存)。
+//
+// 無効化: MEMORIA_LEGATUS_WS=off
+const LEGATUS_WS_URL = process.env.MEMORIA_LEGATUS_WS_URL || 'ws://127.0.0.1:17320/ws';
+if (process.env.MEMORIA_LEGATUS_WS !== 'off') {
+  try {
+    const { default: WebSocket } = await import('ws');
+    // Memoria single-user 運用前提: gps_locations は user_id='me' で query される
+    // (listGpsLocationsForDate の default). Lg の owner_user_id は Cernere UUID で
+    // 別 namespace なので、 Memoria 内では 'me' で統一する.
+    // 上書きしたい場合は MEMORIA_LEGATUS_USER_ID で指定.
+    let lgUserId = process.env.MEMORIA_LEGATUS_USER_ID || 'me';
+    let attempt = 0;
+    let reconnectTimer = null;
+    let ws = null;
+    const RECONNECT_BASE_MS = 1000;
+    const RECONNECT_MAX_MS = 30000;
+
+    function connect() {
+      if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) return;
+      try { ws = new WebSocket(LEGATUS_WS_URL); }
+      catch (e) { scheduleReconnect(); return; }
+      ws.on('open', () => {
+        attempt = 0;
+        console.log(`[legatus-ws] connected ${LEGATUS_WS_URL}`);
+      });
+      ws.on('message', (raw) => {
+        let ev;
+        try { ev = JSON.parse(raw.toString('utf8')); } catch { return; }
+        if (!ev || typeof ev.type !== 'string') return;
+        // owner_user_id は Cernere namespace なので Memoria の 'me' は上書きしない.
+        // ただし MEMORIA_LEGATUS_USER_ID で明示的に Cernere UUID 使う設定にしたい
+        // 場合のみ override 可能.
+        // (現状 'me' 固定で動く設計)
+        if (ev.type !== 'owntracks.received') return;
+        const lat = Number(ev.lat), lon = Number(ev.lon);
+        if (!Number.isFinite(lat) || !Number.isFinite(lon)) return;
+        const rec = {
+          userId: lgUserId,
+          deviceId: ev.device || ev.topic_user || 'phone',
+          tst: typeof ev.tst === 'number' ? ev.tst : Math.floor(Date.now() / 1000),
+          recordedAt: null,
+          lat, lon,
+          accuracy: typeof ev.acc === 'number' ? ev.acc : null,
+          altitude: null,
+          velocity: null,
+          course: null,
+          battery: null,
+          conn: null,
+          rawJson: JSON.stringify({ via: 'legatus-ws', topic_user: ev.topic_user, device: ev.device }),
+        };
+        const result = insertGpsLocation(db, rec);
+        if (!result.skipped) {
+          broadcastLocation({
+            id: result.id,
+            user_id: rec.userId,
+            device_id: rec.deviceId,
+            recorded_at: new Date(rec.tst * 1000).toISOString(),
+            lat: rec.lat,
+            lon: rec.lon,
+            accuracy_m: rec.accuracy,
+            altitude_m: null,
+            velocity_kmh: null,
+            course_deg: null,
+          });
+          console.log(`[legatus-ws] insert id=${result.id} ${rec.deviceId} (${rec.lat.toFixed(5)}, ${rec.lon.toFixed(5)})`);
+        }
+      });
+      ws.on('close', () => {
+        ws = null;
+        scheduleReconnect();
+      });
+      ws.on('error', () => { /* close handler に任せる */ });
+    }
+
+    function scheduleReconnect() {
+      if (reconnectTimer) return;
+      const delay = Math.min(RECONNECT_BASE_MS * Math.pow(2, attempt), RECONNECT_MAX_MS);
+      attempt += 1;
+      reconnectTimer = setTimeout(() => { reconnectTimer = null; connect(); }, delay);
+    }
+
+    connect();
+    console.log(`[legatus-ws] subscriber started (url=${LEGATUS_WS_URL})`);
+  } catch (e) {
+    console.error(`[legatus-ws] subscriber failed to start: ${e?.message ?? e}`);
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -3593,6 +3593,15 @@ app.post('/api/locations/compress', async (c) => {
 
 // ---- static UI ------------------------------------------------------------
 
+// SPA assets: ブラウザの aggressive cache を無効化 (古い app.js が掴まれて
+// UI 機能 — Tracks の最新 GPS リスト等 — が出ない事故を防ぐ).
+app.use('/*', async (c, next) => {
+  await next();
+  const p = c.req.path;
+  if (p === '/' || p.endsWith('.html') || p.endsWith('.js') || p.endsWith('.css')) {
+    c.header('cache-control', 'no-cache, must-revalidate');
+  }
+});
 app.use('/*', serveStatic({ root: './public' }));
 app.get('/', serveStatic({ path: './public/index.html' }));
 

--- a/server/index.js
+++ b/server/index.js
@@ -82,7 +82,7 @@ import {
   listGpsLocationsForDate, deleteGpsLocationsOlderThan, compressGpsHistory,
   findGpsLocationById, listUnresolvedGpsLocations,
 } from './db.js';
-import { resolvePlaceForRow, resolveUnresolvedBatch } from './lib/place-resolver.js';
+import { resolvePlaceForRow, resolveUnresolvedBatch, getResolverDebug } from './lib/place-resolver.js';
 import { listPushSubscriptions, deletePushSubscription } from './db.js';
 import {
   insertMeal, getMeal, listMeals, countMeals, updateMeal, deleteMeal, listPendingMeals,
@@ -3592,6 +3592,8 @@ app.delete('/api/locations', (c) => {
  * 'location.resolved' で UI に通知される. レート制限対策に各リクエスト間
  * step_ms (default 150ms) 空ける.
  */
+app.get('/api/locations/resolve-debug', (c) => c.json(getResolverDebug()));
+
 app.post('/api/locations/resolve-all', async (c) => {
   let body = {};
   try { body = await c.req.json(); } catch {}

--- a/server/index.js
+++ b/server/index.js
@@ -80,7 +80,9 @@ import {
 import {
   insertGpsLocation, listGpsLocationsInRange, listGpsLocationDays,
   listGpsLocationsForDate, deleteGpsLocationsOlderThan, compressGpsHistory,
+  findGpsLocationById, listUnresolvedGpsLocations,
 } from './db.js';
+import { resolvePlaceForRow, resolveUnresolvedBatch } from './lib/place-resolver.js';
 import { listPushSubscriptions, deletePushSubscription } from './db.js';
 import {
   insertMeal, getMeal, listMeals, countMeals, updateMeal, deleteMeal, listPendingMeals,
@@ -3354,6 +3356,7 @@ app.post('/api/legatus/location-summary', async (c) => {
         velocity_kmh: rec.velocity ?? null,
         course_deg: null,
       });
+      triggerResolveAsync(result.id, point.lat, point.lon);
     }
   }
 
@@ -3419,6 +3422,7 @@ app.post('/api/locations/ingest', async (c) => {
       velocity_kmh: rec.velocity ?? null,
       course_deg: rec.course ?? null,
     });
+    triggerResolveAsync(result.id, rec.lat, rec.lon);
   }
   // OwnTracks の HTTP モードはレスポンスとして JSON 配列 (友達の cards 等) を
   // 期待するので空配列で返す。 手動テスト時は X-Memoria-Insert-* header で
@@ -3491,7 +3495,8 @@ app.get('/api/locations/recent', (c) => {
   const pool = Math.max(limit, Math.min(1500, limit * 30));
   const rows = db.prepare(
     `SELECT id, user_id, device_id, recorded_at, lat, lon,
-            accuracy_m, altitude_m, velocity_kmh, course_deg, raw_json
+            accuracy_m, altitude_m, velocity_kmh, course_deg, raw_json,
+            place_name, place_address, place_source
      FROM gps_locations${where} ORDER BY id DESC LIMIT ?`
   ).all(...params, pool);
 
@@ -3527,7 +3532,8 @@ app.get('/api/locations/recent', (c) => {
 app.get('/api/locations/latest', (c) => {
   const row = db.prepare(
     `SELECT id, user_id, device_id, recorded_at, lat, lon,
-            accuracy_m, altitude_m, velocity_kmh, course_deg
+            accuracy_m, altitude_m, velocity_kmh, course_deg,
+            place_name, place_address, place_source
      FROM gps_locations ORDER BY recorded_at DESC LIMIT 1`
   ).get();
   return c.json({ point: row ?? null });
@@ -3575,6 +3581,37 @@ app.delete('/api/locations', (c) => {
   if (!olderThan) return c.json({ error: 'older_than (ISO) required' }, 400);
   const removed = deleteGpsLocationsOlderThan(db, olderThan);
   return c.json({ removed });
+});
+
+/**
+ * 未解決 GPS 点をまとめて場所照合する (Google Geocoding/Places).
+ *   POST /api/locations/resolve-all
+ *   body: { limit?, step_ms? } — 省略可
+ *
+ * 1 件ずつ /v1/processes ws subscriber と同じ経路で resolve. 完了行は WS の
+ * 'location.resolved' で UI に通知される. レート制限対策に各リクエスト間
+ * step_ms (default 150ms) 空ける.
+ */
+app.post('/api/locations/resolve-all', async (c) => {
+  let body = {};
+  try { body = await c.req.json(); } catch {}
+  const limit = Math.min(500, Math.max(1, Number(body.limit ?? 100)));
+  const stepMs = Math.max(0, Number(body.step_ms ?? 150));
+  // reset=1 で 'failed' 状態をリセット (Cloud Console で API 有効化後の再試行用).
+  let resetCount = 0;
+  if (body.reset === true || body.reset === 1) {
+    const info = db.prepare(
+      `UPDATE gps_locations SET place_resolved_at = NULL, place_source = NULL
+        WHERE place_source = 'failed'`
+    ).run();
+    resetCount = info.changes;
+  }
+  const r = await resolveUnresolvedBatch(db, {
+    limit,
+    stepMs,
+    onResolved: (id, result) => broadcastLocationResolved(id, result),
+  });
+  return c.json({ ...r, reset: resetCount });
 });
 
 /**
@@ -3627,11 +3664,59 @@ function broadcastLocation(point) {
   }
 }
 
+function broadcastLocationResolved(id, result) {
+  if (wsClients.size === 0) return;
+  const msg = JSON.stringify({
+    type: 'location.resolved',
+    id,
+    place_name: result?.name ?? null,
+    place_address: result?.address ?? null,
+    place_source: result?.source ?? 'failed',
+  });
+  for (const c of wsClients) {
+    if (c.readyState === 1) { try { c.send(msg); } catch {} }
+  }
+}
+
+/**
+ * 新着 GPS 点 1 件の location 解決を fire-and-forget で起動.
+ * insertGpsLocation の戻り値 (`inserted: true, id`) を渡す.
+ * resolvePlaceForRow が完了したら WS で `location.resolved` を broadcast.
+ */
+function triggerResolveAsync(id, lat, lon) {
+  if (!Number.isFinite(id) || !Number.isFinite(lat) || !Number.isFinite(lon)) return;
+  setImmediate(async () => {
+    try {
+      const r = await resolvePlaceForRow(db, { id, lat, lon });
+      broadcastLocationResolved(id, r);
+    } catch (e) {
+      console.warn(`[place-resolver] id=${id} failed: ${e?.message ?? e}`);
+    }
+  });
+}
+
 const httpServer = serve({ fetch: app.fetch, port: PORT }, (info) => {
   console.log(`Memoria server listening on http://localhost:${info.port}`);
   console.log(`  data dir: ${DATA_DIR}`);
   console.log(`  claude bin: ${CLAUDE_BIN}`);
 });
+
+// 起動時に未解決 GPS の backfill を 1 batch だけ走らせる. listen 直後でなく
+// 5 秒遅延させて、 Memoria 起動直後のバタつき (server / WS / RAG init) と
+// 重ならないようにする. API key 未設定なら全件 'failed' で帰すので副作用なし.
+setTimeout(() => {
+  resolveUnresolvedBatch(db, {
+    limit: 100,
+    stepMs: 200,
+    onResolved: (id, result) => broadcastLocationResolved(id, result),
+  })
+    .then((r) => {
+      if (r.processed > 0) {
+        console.log(`[place-resolver] backfill: processed=${r.processed} ok=${r.ok} failed=${r.failed}`);
+      }
+    })
+    .catch((e) => console.warn(`[place-resolver] backfill failed: ${e?.message ?? e}`));
+}, 5_000);
 
 const wss = new WebSocketServer({ noServer: true });
 
@@ -3791,6 +3876,7 @@ if (process.env.MEMORIA_LEGATUS_WS !== 'off') {
             velocity_kmh: null,
             course_deg: null,
           });
+          triggerResolveAsync(result.id, rec.lat, rec.lon);
           console.log(`[legatus-ws] insert id=${result.id} ${rec.deviceId} (${rec.lat.toFixed(5)}, ${rec.lon.toFixed(5)})`);
         }
       });

--- a/server/index.js
+++ b/server/index.js
@@ -3429,14 +3429,20 @@ app.post('/api/locations/ingest', async (c) => {
 });
 
 /**
- * Tracks タブ全般の設定 (現状は ノイズ間引き距離).
- *   GET  /api/tracks/settings → { decimate_meters: number }
- *   PATCH /api/tracks/settings { decimate_meters?: number }
+ * Tracks タブ全般の設定.
+ *   GET  /api/tracks/settings → { decimate_meters, show_polyline }
+ *   PATCH /api/tracks/settings { decimate_meters?, show_polyline? }
+ *
+ * - decimate_meters: 0 = 全点描画 (既定). >0 で連続点を間引く.
+ * - show_polyline:   false = 点マーカーのみ (既定). true で区間色分け線も描く.
  */
 app.get('/api/tracks/settings', (c) => {
   const s = getAppSettings(db);
-  const v = Number(s['tracks.decimate_meters'] ?? '2');
-  return c.json({ decimate_meters: Number.isFinite(v) ? v : 2 });
+  const v = Number(s['tracks.decimate_meters'] ?? '0');
+  return c.json({
+    decimate_meters: Number.isFinite(v) ? v : 0,
+    show_polyline: (s['tracks.show_polyline'] ?? 'false') === 'true',
+  });
 });
 app.patch('/api/tracks/settings', async (c) => {
   const body = await c.req.json().catch(() => ({}));
@@ -3448,9 +3454,15 @@ app.patch('/api/tracks/settings', async (c) => {
     }
     patch['tracks.decimate_meters'] = String(v);
   }
+  if (body.show_polyline !== undefined) {
+    patch['tracks.show_polyline'] = body.show_polyline ? 'true' : 'false';
+  }
   if (Object.keys(patch).length > 0) setAppSettings(db, patch);
   const s = getAppSettings(db);
-  return c.json({ decimate_meters: Number(s['tracks.decimate_meters'] ?? '2') });
+  return c.json({
+    decimate_meters: Number(s['tracks.decimate_meters'] ?? '0'),
+    show_polyline: (s['tracks.show_polyline'] ?? 'false') === 'true',
+  });
 });
 
 /**
@@ -3467,7 +3479,7 @@ app.patch('/api/tracks/settings', async (c) => {
  */
 app.get('/api/locations/recent', (c) => {
   const limit = Math.min(500, Math.max(1, Number(c.req.query('limit') ?? '50')));
-  const settingsDecimate = Number(getAppSettings(db)['tracks.decimate_meters'] ?? '2');
+  const settingsDecimate = Number(getAppSettings(db)['tracks.decimate_meters'] ?? '0');
   const decimateM = Math.max(0, Number(c.req.query('decimate') ?? settingsDecimate));
   const device = c.req.query('device') || null;
   const params = [];

--- a/server/lib/place-resolver.js
+++ b/server/lib/place-resolver.js
@@ -1,0 +1,181 @@
+/**
+ * GPS 点 (lat, lon) を Google API で日本語の場所説明に変換する resolver.
+ *
+ * 経路:
+ *   1. DB の近接 cache (約 10m 以内に既に解決済の点があれば再利用)
+ *   2. Places API Nearby Search (radius=20m, language=ja, limit=1) → 施設名 + 住所
+ *   3. Reverse Geocoding (language=ja) → 住所だけ
+ *   4. 全部失敗 → place_source='failed' で記録 (= 24h は再試行しない)
+ *
+ * - API key は app_settings の `maps.api_key` か env GOOGLE_MAPS_API_KEY.
+ *   key がなければ全件 'failed' で帰す (静かに skip).
+ * - server-side 呼び出しなので referrer 制限は効かない. Google Cloud Console で
+ *   "Places API (New / Legacy)" + "Geocoding API" を有効化すること.
+ * - 日本語化: ja-JP で問い合わせる.
+ *
+ * 出力: { name?, address?, source: 'places' | 'geocode' | 'cached' | 'failed' }
+ */
+
+import {
+  findNearbyResolvedPlace,
+  findGpsLocationById,
+  setGpsPlace,
+  listUnresolvedGpsLocations,
+  getAppSettings,
+} from '../db.js';
+
+const PLACES_RADIUS_M = 20;
+const TIMEOUT_MS = 5000;
+const NEAR_CACHE_GRID_M = 10;
+
+/**
+ * 場所照合に使う API key を返す.
+ * 優先順位:
+ *   1. env `MEMORIA_PLACES_API_KEY`  ← server-side 専用 (Referer 制限なし) を入れる場所
+ *   2. env `GOOGLE_MAPS_API_KEY`
+ *   3. app_settings の `maps.api_key`  ← 通常 Maps JS 用 (Referer 制限あり) なので
+ *      Geocoding/Places を呼ぶと REQUEST_DENIED になる. Cloud Console で:
+ *        - "Places API (New)" + "Geocoding API" を有効化
+ *        - 上の 2 つを許可した Referer 制限なし (or IP 制限) の Server-side key を
+ *          MEMORIA_PLACES_API_KEY に入れる
+ *      の 2 段階が要る.
+ */
+function readApiKey(db) {
+  const env = process.env.MEMORIA_PLACES_API_KEY || process.env.GOOGLE_MAPS_API_KEY;
+  if (env) return env;
+  const settings = getAppSettings(db);
+  return settings?.['maps.api_key'] || '';
+}
+
+async function fetchWithTimeout(url, ms = TIMEOUT_MS) {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), ms);
+  try {
+    const res = await fetch(url, { signal: ctrl.signal });
+    if (!res.ok) {
+      console.warn(`[place-resolver] HTTP ${res.status} ${res.statusText} for ${maskKey(url)}`);
+      return null;
+    }
+    return await res.json();
+  } catch (err) {
+    console.warn(`[place-resolver] fetch failed (${err?.name}: ${err?.message}) for ${maskKey(url)}`);
+    return null;
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+function maskKey(url) {
+  return url.replace(/key=[^&]+/, 'key=***');
+}
+
+/**
+ * Places API Nearby Search で半径 20m 以内の最も近い 1 件を取る (language=ja).
+ * 返り値: { name, address } | null
+ */
+async function tryPlacesNearby(lat, lon, apiKey) {
+  const url =
+    `https://maps.googleapis.com/maps/api/place/nearbysearch/json` +
+    `?location=${lat},${lon}` +
+    `&radius=${PLACES_RADIUS_M}` +
+    `&language=ja&rankby=prominence` +
+    `&key=${encodeURIComponent(apiKey)}`;
+  const j = await fetchWithTimeout(url);
+  if (!j) return null;
+  if (j.status !== 'OK') {
+    if (j.status === 'ZERO_RESULTS') return null;       // 該当無し: 静かに次へ
+    console.warn(`[place-resolver] Places API status=${j.status} error=${j.error_message ?? ''}`);
+    return null;
+  }
+  const r = j.results?.[0];
+  if (!r) return null;
+  // vicinity = 周辺住所 (formatted_address は Place Details で別 call が要る).
+  return { name: r.name ?? null, address: r.vicinity ?? null };
+}
+
+/**
+ * Reverse Geocoding で住所文字列を取る (language=ja).
+ * 返り値: { address } | null
+ */
+async function tryReverseGeocode(lat, lon, apiKey) {
+  const url =
+    `https://maps.googleapis.com/maps/api/geocode/json` +
+    `?latlng=${lat},${lon}` +
+    `&language=ja&result_type=street_address|premise|point_of_interest|establishment` +
+    `&key=${encodeURIComponent(apiKey)}`;
+  let j = await fetchWithTimeout(url);
+  // 細かい result_type で取れなければ全タイプで再取得
+  if (!j || j.status !== 'OK' || !j.results?.length) {
+    const url2 =
+      `https://maps.googleapis.com/maps/api/geocode/json` +
+      `?latlng=${lat},${lon}&language=ja&key=${encodeURIComponent(apiKey)}`;
+    j = await fetchWithTimeout(url2);
+  }
+  if (!j) return null;
+  if (j.status !== 'OK') {
+    if (j.status === 'ZERO_RESULTS') return null;
+    console.warn(`[place-resolver] Geocoding API status=${j.status} error=${j.error_message ?? ''}`);
+    return null;
+  }
+  const r = j.results?.[0];
+  if (!r?.formatted_address) return null;
+  // "日本、〒351-0036 埼玉県朝霞市膝折町..." の先頭の "日本、" を削るとシンプル.
+  const addr = r.formatted_address.replace(/^日本、\s*/, '');
+  return { address: addr };
+}
+
+/**
+ * 1 点を解決. DB cache → Places → Geocode の順.
+ * 結果を gps_locations に書き込み, 出力 dict を返す.
+ */
+export async function resolvePlaceForRow(db, row) {
+  const { id, lat, lon } = row;
+  // 既に解決済なら何もしない
+  const cur = findGpsLocationById(db, id);
+  if (!cur) return { source: 'failed', reason: 'not_found' };
+  if (cur.place_resolved_at) return { source: 'cached', reused: true };
+
+  // 1. 近接 cache
+  const near = findNearbyResolvedPlace(db, lat, lon, NEAR_CACHE_GRID_M);
+  if (near && (near.place_name || near.place_address)) {
+    setGpsPlace(db, id, { name: near.place_name, address: near.place_address, source: 'cached' });
+    return { name: near.place_name, address: near.place_address, source: 'cached' };
+  }
+
+  // 2/3. API
+  const apiKey = readApiKey(db);
+  if (!apiKey) {
+    setGpsPlace(db, id, { name: null, address: null, source: 'failed' });
+    return { source: 'failed', reason: 'no_api_key' };
+  }
+  const places = await tryPlacesNearby(lat, lon, apiKey);
+  if (places && (places.name || places.address)) {
+    setGpsPlace(db, id, { name: places.name, address: places.address, source: 'places' });
+    return { ...places, source: 'places' };
+  }
+  const geo = await tryReverseGeocode(lat, lon, apiKey);
+  if (geo?.address) {
+    setGpsPlace(db, id, { name: null, address: geo.address, source: 'geocode' });
+    return { ...geo, source: 'geocode' };
+  }
+  setGpsPlace(db, id, { name: null, address: null, source: 'failed' });
+  return { source: 'failed' };
+}
+
+/**
+ * 未解決の点をまとめて解決. rate limit 対策に各リクエスト間 stepMs ms 空ける.
+ * onResolved(id, result) callback で 1 件ずつ通知 (WS broadcast 用).
+ */
+export async function resolveUnresolvedBatch(db, { limit = 50, stepMs = 150, onResolved } = {}) {
+  const rows = listUnresolvedGpsLocations(db, limit);
+  let ok = 0, failed = 0;
+  for (const row of rows) {
+    const r = await resolvePlaceForRow(db, row);
+    if (r.source === 'failed') failed++; else ok++;
+    if (onResolved) {
+      try { onResolved(row.id, r); } catch { /* swallow */ }
+    }
+    if (stepMs > 0) await new Promise(res => setTimeout(res, stepMs));
+  }
+  return { processed: rows.length, ok, failed };
+}

--- a/server/lib/place-resolver.js
+++ b/server/lib/place-resolver.js
@@ -27,6 +27,20 @@ import {
 const PLACES_RADIUS_M = 20;
 const TIMEOUT_MS = 5000;
 const NEAR_CACHE_GRID_M = 10;
+const PLACES_NEW_URL = 'https://places.googleapis.com/v1/places:searchNearby';
+
+// 直近の API エラーを保持して /api/locations/resolve-debug で覗けるようにする.
+// stdout が複数 npm run dev に分散して追えないので、 ここに記録するのが最速.
+let lastApiErrors = [];
+function recordError(api, info) {
+  const entry = { ts: Math.floor(Date.now() / 1000), api, ...info };
+  lastApiErrors.unshift(entry);
+  if (lastApiErrors.length > 20) lastApiErrors.length = 20;
+  console.warn(`[place-resolver] ${api} ${JSON.stringify(info).slice(0, 240)}`);
+}
+export function getResolverDebug() {
+  return { recent_errors: lastApiErrors };
+}
 
 /**
  * 場所照合に使う API key を返す.
@@ -47,18 +61,21 @@ function readApiKey(db) {
   return settings?.['maps.api_key'] || '';
 }
 
-async function fetchWithTimeout(url, ms = TIMEOUT_MS) {
+async function fetchWithTimeout(url, init = {}, ms = TIMEOUT_MS) {
   const ctrl = new AbortController();
   const t = setTimeout(() => ctrl.abort(), ms);
   try {
-    const res = await fetch(url, { signal: ctrl.signal });
+    const res = await fetch(url, { ...init, signal: ctrl.signal });
     if (!res.ok) {
-      console.warn(`[place-resolver] HTTP ${res.status} ${res.statusText} for ${maskKey(url)}`);
+      // 新 Places API は 403/400 を返す. Body にエラー詳細があるので拾う.
+      let body = '';
+      try { body = await res.text(); } catch {}
+      recordError('http', { url: maskKey(url), status: res.status, statusText: res.statusText, body: body.slice(0, 400) });
       return null;
     }
     return await res.json();
   } catch (err) {
-    console.warn(`[place-resolver] fetch failed (${err?.name}: ${err?.message}) for ${maskKey(url)}`);
+    recordError('fetch', { url: maskKey(url), error: `${err?.name}: ${err?.message}` });
     return null;
   } finally {
     clearTimeout(t);
@@ -73,24 +90,39 @@ function maskKey(url) {
  * Places API Nearby Search で半径 20m 以内の最も近い 1 件を取る (language=ja).
  * 返り値: { name, address } | null
  */
+/**
+ * Places API (New) — POST {url}/v1/places:searchNearby.
+ * Legacy Places API は段階的に無効化されているため (New) を使う.
+ * key は X-Goog-Api-Key header で渡し, 必要 field を X-Goog-FieldMask で指定 (必須).
+ */
 async function tryPlacesNearby(lat, lon, apiKey) {
-  const url =
-    `https://maps.googleapis.com/maps/api/place/nearbysearch/json` +
-    `?location=${lat},${lon}` +
-    `&radius=${PLACES_RADIUS_M}` +
-    `&language=ja&rankby=prominence` +
-    `&key=${encodeURIComponent(apiKey)}`;
-  const j = await fetchWithTimeout(url);
+  const body = {
+    maxResultCount: 1,
+    locationRestriction: {
+      circle: {
+        center: { latitude: lat, longitude: lon },
+        radius: PLACES_RADIUS_M,
+      },
+    },
+    languageCode: 'ja',
+    regionCode: 'JP',
+  };
+  const j = await fetchWithTimeout(PLACES_NEW_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Goog-Api-Key': apiKey,
+      'X-Goog-FieldMask': 'places.displayName,places.formattedAddress,places.shortFormattedAddress',
+    },
+    body: JSON.stringify(body),
+  });
   if (!j) return null;
-  if (j.status !== 'OK') {
-    if (j.status === 'ZERO_RESULTS') return null;       // 該当無し: 静かに次へ
-    console.warn(`[place-resolver] Places API status=${j.status} error=${j.error_message ?? ''}`);
-    return null;
-  }
-  const r = j.results?.[0];
+  const r = j.places?.[0];
   if (!r) return null;
-  // vicinity = 周辺住所 (formatted_address は Place Details で別 call が要る).
-  return { name: r.name ?? null, address: r.vicinity ?? null };
+  const name = r.displayName?.text ?? null;
+  // shortFormattedAddress は (New) で 短い表記 (例: "東京都渋谷区..."), なければ formattedAddress.
+  const address = r.shortFormattedAddress ?? r.formattedAddress ?? null;
+  return { name, address };
 }
 
 /**
@@ -114,7 +146,7 @@ async function tryReverseGeocode(lat, lon, apiKey) {
   if (!j) return null;
   if (j.status !== 'OK') {
     if (j.status === 'ZERO_RESULTS') return null;
-    console.warn(`[place-resolver] Geocoding API status=${j.status} error=${j.error_message ?? ''}`);
+    recordError('geocode', { status: j.status, error_message: j.error_message ?? '' });
     return null;
   }
   const r = j.results?.[0];

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -4162,6 +4162,28 @@ async function openAiSettings() {
         <div><b>platform</b>: ${escapeHtml(rt.platform)}</div>
       `;
     }
+    // Google Maps API key の現在値ステータス (実値はブラウザに渡さない方針 — masked)
+    if ($('mapsApiKey')) {
+      try {
+        const m = await api('/api/maps/config');
+        $('mapsApiKey').value = '';
+        $('mapsApiKeyStatus').textContent = m.hasKey
+          ? '✓ 設定済み (再入力で上書き / 空欄保存は維持)'
+          : '(未設定)';
+      } catch (e) {
+        $('mapsApiKeyStatus').textContent = `取得失敗: ${e.message}`;
+      }
+    }
+    // Tracks 間引き距離
+    if ($('tracksDecimateMeters')) {
+      try {
+        const ts = await api('/api/tracks/settings');
+        $('tracksDecimateMeters').value = String(ts.decimate_meters ?? 2);
+        $('tracksDecimateStatus').textContent = `現在: ${ts.decimate_meters}m`;
+      } catch (e) {
+        $('tracksDecimateStatus').textContent = `取得失敗: ${e.message}`;
+      }
+    }
     // Electron 配下のときだけ「デスクトップアプリ」セクションを出す。
     // window.memoria は preload.ts (contextBridge) が expose する。
     const desktop = (typeof window !== 'undefined' && window.memoria) || null;
@@ -4474,12 +4496,61 @@ async function saveAiSettings() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     });
+    // Google Maps API key を別 endpoint で保存 (空欄なら維持、 入力済なら上書き)
+    const mk = $('mapsApiKey')?.value || '';
+    if (mk && mk !== '***') {
+      try {
+        await api('/api/maps/config', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ apiKey: mk }),
+        });
+      } catch (e) {
+        alert(`Maps API key 保存失敗: ${e.message}`);
+        return;
+      }
+    }
+    // Tracks 間引き距離
+    const dmRaw = $('tracksDecimateMeters')?.value;
+    if (dmRaw !== undefined && dmRaw !== '') {
+      const v = Number(dmRaw);
+      if (Number.isFinite(v) && v >= 0 && v <= 1000) {
+        try {
+          await api('/api/tracks/settings', {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ decimate_meters: v }),
+          });
+          tracksState.decimateMeters = v; // すぐ map にも反映
+        } catch (e) {
+          alert(`間引き距離保存失敗: ${e.message}`);
+          return;
+        }
+      }
+    }
     alert('保存しました。次回のジョブから反映されます。');
     $('aiSettingsPanel').classList.add('hidden');
   } catch (e) {
     alert(`保存失敗: ${e.message}`);
   }
 }
+
+// ── settings 内部タブ切替 ─────────────────────────────
+document.addEventListener('click', (ev) => {
+  const target = ev.target;
+  if (!(target instanceof HTMLElement)) return;
+  const btn = target.closest('.settings-tab');
+  if (!btn || !btn.dataset.stab) return;
+  const panel = $('aiSettingsPanel');
+  if (!panel || panel.classList.contains('hidden')) return;
+  const stab = btn.dataset.stab;
+  panel.querySelectorAll('.settings-tab').forEach(b => b.classList.toggle('active', b === btn));
+  panel.querySelectorAll('.settings-tab-body').forEach(sec => {
+    sec.classList.toggle('hidden', sec.dataset.stab !== stab);
+  });
+  // タブを切り替えたら panel を上にリセット (各タブの先頭から見たい)
+  panel.scrollTop = 0;
+});
 
 document.getElementById('aiSettingsBtn')?.addEventListener('click', openAiSettings);
 document.getElementById('aiSettingsClose')?.addEventListener('click', () => $('aiSettingsPanel').classList.add('hidden'));
@@ -4787,6 +4858,7 @@ async function loadTracks() {
     tracksState._bound = true;
     dateInput?.addEventListener('change', renderTracksForCurrentDate);
     $('tracksRefresh')?.addEventListener('click', renderTracksForCurrentDate);
+    $('tracksRecentRefresh')?.addEventListener('click', refreshTracksRecent);
     $('tracksKeyToggle')?.addEventListener('click', () => {
       $('tracksKeyPanel').classList.toggle('hidden');
       refreshTracksKeyPanel();
@@ -4807,11 +4879,13 @@ async function loadTracks() {
   }
 
   try {
-    const [{ apiKey, hasKey }, { days }] = await Promise.all([
+    const [{ apiKey, hasKey }, { days }, ts] = await Promise.all([
       api('/api/maps/config'),
       api('/api/locations/days?limit=180'),
+      api('/api/tracks/settings').catch(() => ({ decimate_meters: 2 })),
     ]);
     tracksState.apiKey = apiKey;
+    tracksState.decimateMeters = Number(ts.decimate_meters ?? 2);
     $('tracksMissingKey').classList.toggle('hidden', !!hasKey);
     renderTracksDaysList(days);
     if (hasKey) {
@@ -4820,6 +4894,7 @@ async function loadTracks() {
       renderTracksForCurrentDate();
     }
     refreshTracksKeyPanel();
+    refreshTracksRecent();
     ensureLiveSocket();
   } catch (e) {
     console.error('[tracks] load failed', e);
@@ -4905,6 +4980,9 @@ function setLiveStatus(s) {
 }
 
 function handleLivePoint(point) {
+  // 最新リストには 日付関係なく即時 prepend (live 通知が一番大事)
+  prependTracksRecent(point);
+
   const dateStr = $('tracksDate')?.value;
   if (!dateStr) return;
   const localDay = isoToLocalYmd(point.recorded_at);
@@ -4915,8 +4993,137 @@ function handleLivePoint(point) {
   if (!tracksState.map) return;
   tracksState.todayPoints.push(point);
   appendLivePointToPolyline(point);
-  const km = computeDistanceMeters(tracksState.todayPoints) / 1000;
-  $('tracksStats').textContent = `${tracksState.todayPoints.length} 点 / 概算 ${km.toFixed(2)} km (live)`;
+
+  // 徒歩判定: 直前点との区間で集計. walk は運動、 fast は交通機関 (運動外).
+  const arr = tracksState.todayPoints;
+  if (arr.length >= 2) {
+    const prev = arr[arr.length - 2];
+    const cur = arr[arr.length - 1];
+    const seg = classifySegment(prev, cur);
+    const w = tracksState.walkingStats || { walkMeters: 0, walkSec: 0, transitMeters: 0, transitSec: 0, stillMeters: 0, stillSec: 0 };
+    if (seg.category === 'walk') {
+      w.walkMeters += seg.meters; w.walkSec += seg.dt;
+    } else if (seg.category === 'fast') {
+      w.transitMeters += seg.meters; w.transitSec += seg.dt;
+    } else {
+      w.stillMeters += seg.meters; w.stillSec += seg.dt;
+    }
+    tracksState.walkingStats = w;
+
+    // 新着点を category 色で打つ
+    const c = CAT_COLORS[seg.category] || CAT_COLORS.still;
+    if (window.google?.maps && tracksState.pointMarkers) {
+      tracksState.pointMarkers.push(new google.maps.Marker({
+        position: { lat: cur.lat, lng: cur.lon },
+        map: tracksState.map,
+        title: `#${cur.id ?? '?'} ${seg.category} (${seg.kmh.toFixed(1)} km/h)`,
+        icon: {
+          path: google.maps.SymbolPath.CIRCLE,
+          scale: 3,
+          fillColor: c.fill,
+          fillOpacity: 0.9,
+          strokeColor: c.stroke,
+          strokeWeight: 1,
+        },
+        zIndex: 5,
+      }));
+    }
+    // 直前との区間に専用色 polyline を追加 (drawTracks で全描き直しせず差分のみ)
+    if (window.google?.maps && tracksState.polylines) {
+      const cat = seg.category;
+      tracksState.polylines.push(new google.maps.Polyline({
+        path: [{ lat: prev.lat, lng: prev.lon }, { lat: cur.lat, lng: cur.lon }],
+        geodesic: true,
+        strokeColor: cat === 'walk' ? '#10b981' : cat === 'fast' ? '#3b82f6' : '#9ca3af',
+        strokeOpacity: cat === 'still' ? 0.35 : 0.85,
+        strokeWeight: cat === 'walk' ? 4 : (cat === 'fast' ? 3 : 2),
+        map: tracksState.map,
+        icons: cat === 'fast' ? [{
+          icon: { path: 'M 0,-1 0,1', strokeOpacity: 1, scale: 3 },
+          offset: '0', repeat: '12px',
+        }] : undefined,
+        zIndex: cat === 'walk' ? 3 : (cat === 'fast' ? 2 : 1),
+      }));
+    }
+  }
+
+  updateTracksStatsLine(tracksState.todayPoints, { live: true });
+}
+
+// ── 最新 GPS ログリスト ─────────────────────────────────────────────────
+async function refreshTracksRecent() {
+  try {
+    const r = await api('/api/locations/recent?limit=50');
+    renderTracksRecent(r.points || []);
+  } catch (e) {
+    console.warn('[tracks] recent fetch failed', e);
+  }
+}
+
+function renderTracksRecent(points) {
+  const ul = $('tracksRecentList');
+  if (!ul) return;
+  $('tracksRecentCount').textContent = points.length ? `${points.length} 件` : '';
+  if (!points.length) {
+    ul.innerHTML = '<li class="muted">まだ記録なし</li>';
+    return;
+  }
+  ul.innerHTML = points.map(p => trackRecentRowHtml(p)).join('');
+  bindTracksRecentRows();
+}
+
+function prependTracksRecent(point) {
+  const ul = $('tracksRecentList');
+  if (!ul) return;
+  // 0 件状態の muted li を除去
+  if (ul.querySelector('.muted')) ul.innerHTML = '';
+  const tmp = document.createElement('div');
+  tmp.innerHTML = trackRecentRowHtml(point);
+  const newRow = tmp.firstElementChild;
+  if (newRow) ul.prepend(newRow);
+  // 50 件超えたら末尾切り
+  while (ul.children.length > 50) ul.lastElementChild?.remove();
+  bindTracksRecentRows();
+  $('tracksRecentCount').textContent = `${ul.children.length} 件`;
+}
+
+function trackRecentRowHtml(p) {
+  const t = p.recorded_at ? new Date(p.recorded_at) : null;
+  const tStr = t && !isNaN(t.getTime())
+    ? t.toLocaleString('ja-JP', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit' })
+    : '-';
+  const dev = p.device_id ?? '?';
+  const lat = Number(p.lat).toFixed(5);
+  const lon = Number(p.lon).toFixed(5);
+  const acc = p.accuracy_m != null ? `±${Math.round(p.accuracy_m)}m` : '';
+  const vel = p.velocity_kmh != null ? `${Math.round(p.velocity_kmh)}km/h` : '';
+  return `
+    <li class="tracks-recent-row" data-lat="${lat}" data-lon="${lon}" data-id="${p.id}">
+      <div class="tracks-recent-time">${escapeHtml(tStr)}</div>
+      <div class="tracks-recent-meta">
+        <span class="tracks-recent-dev">${escapeHtml(dev)}</span>
+        <span class="tracks-recent-coord"><code>${lat},${lon}</code></span>
+        <span class="muted">${acc} ${vel}</span>
+      </div>
+    </li>
+  `;
+}
+
+function bindTracksRecentRows() {
+  const ul = $('tracksRecentList');
+  if (!ul) return;
+  ul.querySelectorAll('.tracks-recent-row[data-lat]').forEach(li => {
+    if (li._bound) return;
+    li._bound = true;
+    li.addEventListener('click', () => {
+      const lat = Number(li.dataset.lat);
+      const lon = Number(li.dataset.lon);
+      if (!Number.isFinite(lat) || !Number.isFinite(lon)) return;
+      if (!tracksState.map) return;
+      tracksState.map.panTo({ lat, lng: lon });
+      if ((tracksState.map.getZoom() ?? 12) < 16) tracksState.map.setZoom(17);
+    });
+  });
 }
 
 function isoToLocalYmd(iso) {
@@ -4930,14 +5137,29 @@ function isoToLocalYmd(iso) {
 }
 
 function appendLivePointToPolyline(point) {
-  if (!tracksState.polyline) {
-    drawTracks([point]);
-    return;
+  const ll = new google.maps.LatLng(point.lat, point.lon);
+
+  // 区間色付け済みの polylines 配列が既にある場合 (drawTracks 後 + handleLivePoint で
+  // segment polyline を追加してる場合) は、 追加描画は handleLivePoint 側に任せる.
+  // ここでは終端 marker 追従と panTo のみ.
+  const haveSegmented = (tracksState.polylines && tracksState.polylines.length > 0);
+
+  if (!haveSegmented) {
+    // 初回 (まだ何も描かれてない): 全点配列で drawTracks にやらせる.
+    drawTracks(tracksState.todayPoints || [point]);
+  } else {
+    // 終端 marker を最新点に追従 (dotMarkers[1] = 終端).
+    if (tracksState.dotMarkers[1]) {
+      tracksState.dotMarkers[1].setPosition({ lat: point.lat, lng: point.lon });
+    }
   }
-  const path = tracksState.polyline.getPath();
-  path.push(new google.maps.LatLng(point.lat, point.lon));
-  if (tracksState.dotMarkers[1]) {
-    tracksState.dotMarkers[1].setPosition({ lat: point.lat, lng: point.lon });
+
+  // 現在地追従: 新着点を常に map center にして smooth pan.
+  if (tracksState.map) {
+    tracksState.map.panTo(ll);
+    if ((tracksState.map.getZoom() ?? 12) < 14) {
+      tracksState.map.setZoom(15);
+    }
   }
 }
 
@@ -4990,7 +5212,7 @@ function ensureMapInstance() {
   if (tracksState.map || !window.google?.maps) return;
   const el = $('tracksMap');
   if (!el) return;
-  // 起動時の暫定中心 (東京駅)。最初のロード後に bbox に fit する。
+  // 起動時の暫定中心 (東京駅)。 直後に latest GPS 点 / 現在位置で上書きする。
   tracksState.map = new google.maps.Map(el, {
     center: { lat: 35.681, lng: 139.767 },
     zoom: 12,
@@ -4998,6 +5220,37 @@ function ensureMapInstance() {
     streetViewControl: false,
     fullscreenControl: true,
   });
+  void recenterMapOnLatestOrCurrent();
+}
+
+/**
+ * 初期 center 戦略:
+ *   1. 最終 GPS 点 (/api/locations/latest) があれば その周囲を表示 (zoom 15)
+ *   2. 1 が無ければ navigator.geolocation で現在位置を取得 (zoom 15)
+ *   3. どちらも失敗したら 東京駅のまま放置
+ * 何回呼ばれても安全 (idempotent — 表示中の date が今日の点で fitBounds されると上書きされる).
+ */
+async function recenterMapOnLatestOrCurrent() {
+  if (!tracksState.map) return;
+  try {
+    const r = await api('/api/locations/latest').catch(() => ({ point: null }));
+    if (r?.point && Number.isFinite(r.point.lat) && Number.isFinite(r.point.lon)) {
+      tracksState.map.setCenter({ lat: r.point.lat, lng: r.point.lon });
+      tracksState.map.setZoom(15);
+      return;
+    }
+  } catch (e) { console.warn('[tracks] latest fetch failed', e); }
+  // fallback: 現在位置
+  if (!navigator.geolocation) return;
+  navigator.geolocation.getCurrentPosition(
+    (pos) => {
+      if (!tracksState.map) return;
+      tracksState.map.setCenter({ lat: pos.coords.latitude, lng: pos.coords.longitude });
+      tracksState.map.setZoom(15);
+    },
+    (err) => { console.info('[tracks] geolocation skipped:', err?.message); },
+    { enableHighAccuracy: false, timeout: 5000, maximumAge: 60000 },
+  );
 }
 
 async function renderTracksForCurrentDate() {
@@ -5010,52 +5263,206 @@ async function renderTracksForCurrentDate() {
     drawTracks(pts);
     // live append のキャッシュ。 表示中の日付が「今日 (local)」なら使われる。
     tracksState.todayPoints = (date === todayLocalIso()) ? pts.slice() : [];
-    const km = computeDistanceMeters(pts) / 1000;
-    $('tracksStats').textContent = pts.length
-      ? `${pts.length} 点 / 概算 ${km.toFixed(2)} km`
-      : '点なし';
+    updateTracksStatsLine(pts);
   } catch (e) {
     console.error('[tracks] render failed', e);
     $('tracksStats').textContent = '取得失敗';
   }
 }
 
+function updateTracksStatsLine(pts, { live = false } = {}) {
+  const el = $('tracksStats');
+  if (!el) return;
+  if (!pts.length) { el.textContent = '点なし'; return; }
+  const w = tracksState.walkingStats || { walkMeters: 0, walkSec: 0, transitMeters: 0, transitSec: 0 };
+  const walkKm = w.walkMeters / 1000;
+  const walkMin = w.walkSec / 60;
+  const transitKm = (w.transitMeters || 0) / 1000;
+  const liveTag = live ? ' (live)' : '';
+  // 運動 = 徒歩のみ. 交通機関 (>5 km/h) は移動量として別立てで表示するが運動換算しない.
+  el.textContent =
+    `${pts.length} 点 · 🚶 徒歩 ${walkKm.toFixed(2)} km / ${walkMin.toFixed(0)} 分 (運動) · 🚃 交通機関 ${transitKm.toFixed(2)} km${liveTag}`;
+}
+
+// 徒歩判定 — 連続 2 点の速度が 1〜5 km/h なら walk と分類.
+const WALK_MIN_KMH = 1.0;
+const WALK_MAX_KMH = 5.0;
+
+/**
+ * 連続点を tracksState.decimateMeters (default 2m) で間引く.
+ * 統計 (徒歩 km / 時間) も間引き後で計算する (生 GPS ジッタ除外).
+ */
+function decimatePoints(points) {
+  const minM = Number.isFinite(tracksState.decimateMeters) ? tracksState.decimateMeters : 2;
+  if (minM <= 0) return points || [];
+  if (!points || points.length === 0) return [];
+  const out = [points[0]];
+  for (let i = 1; i < points.length; i++) {
+    const prev = out[out.length - 1];
+    if (haversineMeters(prev, points[i]) >= minM) {
+      out.push(points[i]);
+    }
+  }
+  return out;
+}
+
+function classifySegment(prev, cur) {
+  if (!prev || !cur) return { kmh: 0, category: 'still' };
+  const dt = (Date.parse(cur.recorded_at) - Date.parse(prev.recorded_at)) / 1000;
+  if (!Number.isFinite(dt) || dt <= 0) return { kmh: 0, category: 'still' };
+  const meters = haversineMeters(prev, cur);
+  const kmh = (meters / dt) * 3.6;
+  let category;
+  if (kmh < WALK_MIN_KMH) category = 'still';
+  else if (kmh <= WALK_MAX_KMH) category = 'walk';
+  else category = 'fast';
+  return { kmh, category, meters, dt };
+}
+
+function haversineMeters(a, b) {
+  const R = 6_371_008;
+  const toRad = d => (d * Math.PI) / 180;
+  const f1 = toRad(a.lat), f2 = toRad(b.lat);
+  const df = toRad(b.lat - a.lat), dl = toRad(b.lon - a.lon);
+  const h = Math.sin(df/2) ** 2 + Math.cos(f1) * Math.cos(f2) * Math.sin(dl/2) ** 2;
+  return 2 * R * Math.asin(Math.min(1, Math.sqrt(h)));
+}
+
+function classifyAll(points) {
+  // 各点の category は「自分に向かってきた区間」の category. 先頭は still 扱い.
+  const cats = new Array(points.length);
+  cats[0] = 'still';
+  let walkMeters = 0, walkSec = 0;
+  let transitMeters = 0, transitSec = 0;
+  let stillMeters = 0, stillSec = 0;
+  for (let i = 1; i < points.length; i++) {
+    const seg = classifySegment(points[i-1], points[i]);
+    cats[i] = seg.category;
+    if (seg.category === 'walk') {
+      walkMeters += seg.meters;
+      walkSec += seg.dt;
+    } else if (seg.category === 'fast') {
+      // 5 km/h 超 = 交通機関想定. 軌跡には出すが運動換算しない.
+      transitMeters += seg.meters;
+      transitSec += seg.dt;
+    } else {
+      stillMeters += seg.meters;
+      stillSec += seg.dt;
+    }
+  }
+  return { cats, walkMeters, walkSec, transitMeters, transitSec, stillMeters, stillSec };
+}
+
+const CAT_COLORS = {
+  walk:  { fill: '#10b981', stroke: '#065f46' },
+  still: { fill: '#9ca3af', stroke: '#374151' },
+  fast:  { fill: '#3b82f6', stroke: '#1e3a8a' },
+};
+
 function drawTracks(points) {
   // 既存 overlay をクリア
+  if (tracksState.polylines) for (const p of tracksState.polylines) p.setMap(null);
+  tracksState.polylines = [];
+  // 旧 single polyline 互換クリア (live append が参照)
   if (tracksState.polyline) {
     tracksState.polyline.setMap(null);
     tracksState.polyline = null;
   }
   for (const m of tracksState.dotMarkers) m.setMap(null);
   tracksState.dotMarkers = [];
+  if (tracksState.pointMarkers) for (const m of tracksState.pointMarkers) m.setMap(null);
+  tracksState.pointMarkers = [];
   if (!points.length) return;
 
-  const path = points.map(p => ({ lat: p.lat, lng: p.lon }));
-  tracksState.polyline = new google.maps.Polyline({
-    path,
-    geodesic: true,
-    strokeColor: '#3b82f6',
-    strokeOpacity: 0.85,
-    strokeWeight: 4,
-    map: tracksState.map,
-  });
+  // 2m 以内の連続点を間引く (GPS ノイズ除去). 描画も統計もこれを使う.
+  const raw = points;
+  points = decimatePoints(raw);
+  tracksState.lastDrawnRawCount = raw.length;
+  tracksState.lastDrawnKeptCount = points.length;
 
-  // 始点 / 終点に小さなマーカーを置く (path が長くてもマーカーは 2 個だけ)
+  // 徒歩判定 → 各点を色分けで打つ
+  const { cats, walkMeters, walkSec, transitMeters, transitSec, stillMeters, stillSec } = classifyAll(points);
+
+  // 区間ごとに polyline を 1 本ずつ描画 (cats[i] = points[i-1] → points[i] の category).
+  // 64 点でも polyline 63 本程度なので Maps の負荷的には許容.
+  if (points.length >= 2) {
+    for (let i = 1; i < points.length; i++) {
+      const cat = cats[i] || 'still';
+      tracksState.polylines.push(new google.maps.Polyline({
+        path: [
+          { lat: points[i-1].lat, lng: points[i-1].lon },
+          { lat: points[i].lat,   lng: points[i].lon   },
+        ],
+        geodesic: true,
+        strokeColor: cat === 'walk' ? '#10b981'
+                   : cat === 'fast' ? '#3b82f6'
+                   : '#9ca3af',
+        strokeOpacity: cat === 'still' ? 0.35 : 0.85,
+        strokeWeight: cat === 'walk' ? 4 : (cat === 'fast' ? 3 : 2),
+        map: tracksState.map,
+        // fast (交通機関) は破線で「運動外」を視覚的に示す
+        icons: cat === 'fast' ? [{
+          icon: { path: 'M 0,-1 0,1', strokeOpacity: 1, scale: 3 },
+          offset: '0', repeat: '12px',
+        }] : undefined,
+        zIndex: cat === 'walk' ? 3 : (cat === 'fast' ? 2 : 1),
+      }));
+    }
+    // 旧 API 互換: appendLivePointToPolyline 用に最後の polyline を polyline に
+    tracksState.polyline = tracksState.polylines[tracksState.polylines.length - 1] ?? null;
+  }
+  for (let i = 0; i < points.length; i++) {
+    const c = CAT_COLORS[cats[i]] || CAT_COLORS.still;
+    const m = new google.maps.Marker({
+      position: { lat: points[i].lat, lng: points[i].lon },
+      map: tracksState.map,
+      title: `#${points[i].id ?? '?'} ${cats[i]} ${i > 0 ? '(' + classifySegment(points[i-1], points[i]).kmh.toFixed(1) + ' km/h)' : ''}`,
+      icon: {
+        path: google.maps.SymbolPath.CIRCLE,
+        scale: 3,
+        fillColor: c.fill,
+        fillOpacity: 0.9,
+        strokeColor: c.stroke,
+        strokeWeight: 1,
+      },
+      zIndex: 5,
+    });
+    tracksState.pointMarkers.push(m);
+  }
+
+  // 始点 / 終点に大きい marker
   const start = path[0];
   const end = path[path.length - 1];
   tracksState.dotMarkers.push(new google.maps.Marker({
     position: start, map: tracksState.map, title: '開始',
-    icon: { path: google.maps.SymbolPath.CIRCLE, scale: 6, fillColor: '#10b981', fillOpacity: 1, strokeColor: '#065f46', strokeWeight: 1 },
+    icon: { path: google.maps.SymbolPath.CIRCLE, scale: 7, fillColor: '#10b981', fillOpacity: 1, strokeColor: '#065f46', strokeWeight: 2 },
+    zIndex: 10,
   }));
-  tracksState.dotMarkers.push(new google.maps.Marker({
-    position: end, map: tracksState.map, title: '終端',
-    icon: { path: google.maps.SymbolPath.CIRCLE, scale: 6, fillColor: '#ef4444', fillOpacity: 1, strokeColor: '#7f1d1d', strokeWeight: 1 },
-  }));
+  if (path.length >= 2) {
+    tracksState.dotMarkers.push(new google.maps.Marker({
+      position: end, map: tracksState.map, title: '終端',
+      icon: { path: google.maps.SymbolPath.CIRCLE, scale: 7, fillColor: '#ef4444', fillOpacity: 1, strokeColor: '#7f1d1d', strokeWeight: 2 },
+      zIndex: 10,
+    }));
+  } else {
+    tracksState.dotMarkers.push(new google.maps.Marker({
+      position: start, map: tracksState.map, title: '現在',
+      icon: { path: google.maps.SymbolPath.CIRCLE, scale: 7, fillColor: '#ef4444', fillOpacity: 1, strokeColor: '#7f1d1d', strokeWeight: 2 },
+      zIndex: 10,
+    }));
+  }
 
-  // bbox に fit
-  const b = new google.maps.LatLngBounds();
-  for (const p of path) b.extend(p);
-  tracksState.map.fitBounds(b, 60);
+  // 区分別 stats を保持. 表示は renderTracksForCurrentDate / handleLivePoint が更新.
+  tracksState.walkingStats = { walkMeters, walkSec, transitMeters, transitSec, stillMeters, stillSec };
+
+  if (path.length >= 2) {
+    const b = new google.maps.LatLngBounds();
+    for (const p of path) b.extend(p);
+    tracksState.map.fitBounds(b, 60);
+  } else {
+    tracksState.map.setCenter(end);
+    if ((tracksState.map.getZoom() ?? 12) < 14) tracksState.map.setZoom(15);
+  }
 }
 
 function computeDistanceMeters(points) {
@@ -6811,3 +7218,149 @@ function wireLocationEditModal() {
   });
 }
 wireLocationEditModal();
+
+// ── Legatus WS client (loopback ws://127.0.0.1:17320/ws) ─────────────
+// 接続状態 / MQTT 受信 / relay 成否を live で取り込む。
+// loopback 専用 (mobile PWA からは到達しないので unhide しない)。
+(function setupLegatusWatcher() {
+  const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  // loopback 固定。 Memoria が別ホスト経由 (PWA / 別 PC) で開かれたときは接続試行のみ。
+  const url = `${proto}//127.0.0.1:17320/ws`;
+  const RECONNECT_BASE_MS = 1000;
+  const RECONNECT_MAX_MS = 30000;
+  let ws = null;
+  let attempt = 0;
+  let reconnectTimer = null;
+  let lastHeartbeatTs = 0;
+  let lastEventLine = '';
+  let lastSnapshot = null;
+
+  const dot = () => document.querySelector('#legatusBadge .legatus-dot');
+  const labelEl = () => document.querySelector('#legatusBadge .legatus-label');
+  const badge = () => document.getElementById('legatusBadge');
+
+  function setState(state, hint) {
+    const d = dot();
+    if (d) d.dataset.state = state;
+    const lab = labelEl();
+    if (lab) lab.textContent = hint || 'Legatus';
+    const b = badge();
+    if (b) b.hidden = false;
+  }
+
+  function fmtAgo(ts) {
+    if (!ts) return '—';
+    const now = Math.floor(Date.now() / 1000);
+    const d = Math.max(0, now - ts);
+    if (d < 60) return `${d}s 前`;
+    if (d < 3600) return `${Math.floor(d / 60)}m 前`;
+    return `${Math.floor(d / 3600)}h 前`;
+  }
+
+  function refreshDetailBox() {
+    if (!lastSnapshot) return;
+    const s = lastSnapshot;
+    const $ = (id) => document.getElementById(id);
+    if ($('legatusConnState')) {
+      $('legatusConnState').textContent = lastHeartbeatTs
+        ? `WS open · 最終 heartbeat ${fmtAgo(lastHeartbeatTs)}`
+        : 'connecting…';
+    }
+    if ($('legatusMqttState')) {
+      $('legatusMqttState').textContent = s.mqtt?.connected
+        ? `connected (${s.mqtt.url}, topic ${s.mqtt.topic ?? '?'})`
+        : 'disconnected';
+    }
+    if ($('legatusLastEvent')) {
+      $('legatusLastEvent').textContent = fmtAgo(s.last_event_ts);
+    }
+    if ($('legatusBufferPending')) {
+      $('legatusBufferPending').textContent = String(s.buffer_pending ?? 0);
+    }
+    if ($('legatusRelayStats')) {
+      const r = s.audit_24h || { ok: 0, error: 0 };
+      $('legatusRelayStats').textContent = `ok ${r.ok} / error ${r.error}`;
+    }
+    if ($('legatusEventTail')) {
+      $('legatusEventTail').textContent = lastEventLine || '(まだ受信なし)';
+    }
+  }
+
+  function ageBucketFromHeartbeat() {
+    if (!lastHeartbeatTs) return 'unknown';
+    const age = Math.floor(Date.now() / 1000) - lastHeartbeatTs;
+    if (age <= 30) return 'connected';
+    if (age <= 90) return 'stale';
+    return 'disconnected';
+  }
+
+  function applyEvent(ev) {
+    const ts = Math.floor(Date.now() / 1000);
+    if (ev.type === 'hello' || ev.type === 'heartbeat') {
+      lastHeartbeatTs = ev.ts || ts;
+      if (ev.type === 'heartbeat') {
+        lastSnapshot = {
+          mqtt: ev.mqtt,
+          last_event_ts: ev.last_event_ts,
+          buffer_pending: ev.buffer_pending,
+          audit_24h: ev.audit_24h,
+        };
+      }
+    } else if (ev.type === 'mqtt.status') {
+      if (lastSnapshot) lastSnapshot.mqtt = { connected: ev.connected, url: ev.url };
+      lastEventLine = `[mqtt] ${ev.connected ? 'connected' : 'disconnected'} ${ev.reason || ''}`.trim();
+    } else if (ev.type === 'owntracks.received') {
+      if (lastSnapshot) {
+        lastSnapshot.last_event_ts = ev.ts;
+        lastSnapshot.buffer_pending = (lastSnapshot.buffer_pending || 0) + 1;
+      }
+      lastEventLine = `[gps] ${ev.topic_user}/${ev.device} lat=${ev.lat?.toFixed?.(4) ?? '?'} lon=${ev.lon?.toFixed?.(4) ?? '?'} acc=${ev.acc ?? '?'}`;
+    } else if (ev.type === 'relay.attempt') {
+      if (lastSnapshot) {
+        const a = lastSnapshot.audit_24h || { ok: 0, error: 0 };
+        if (ev.ok) a.ok += 1; else a.error += 1;
+        lastSnapshot.audit_24h = a;
+      }
+      lastEventLine = `[relay] ${ev.target} ${ev.kind} ${ev.ok ? 'OK' : 'ERR ' + (ev.error_code || '')} ${ev.duration_ms ?? '?'}ms`;
+    } else if (ev.type === 'buffer.flushed') {
+      if (lastSnapshot) lastSnapshot.buffer_pending = 0;
+      const skip = ev.skipped ? `skipped (${ev.reason}, net ${ev.net_meters ?? '?'}m)` : `flushed (${ev.points}pt, net ${ev.net_meters ?? '?'}m)`;
+      lastEventLine = `[buffer] ${skip}`;
+    }
+    setState(ageBucketFromHeartbeat(), `Legatus`);
+    refreshDetailBox();
+  }
+
+  function connect() {
+    if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) return;
+    try { ws = new WebSocket(url); } catch (e) { scheduleReconnect(); return; }
+    ws.addEventListener('open', () => { attempt = 0; setState('connected', 'Legatus'); });
+    ws.addEventListener('message', (e) => {
+      let parsed = null;
+      try { parsed = JSON.parse(e.data); } catch { return; }
+      if (parsed && typeof parsed.type === 'string') applyEvent(parsed);
+    });
+    ws.addEventListener('close', () => {
+      ws = null;
+      setState('disconnected', 'Legatus');
+      scheduleReconnect();
+    });
+    ws.addEventListener('error', () => { /* close ハンドラに任せる */ });
+  }
+
+  function scheduleReconnect() {
+    if (reconnectTimer) return;
+    const delay = Math.min(RECONNECT_BASE_MS * Math.pow(2, attempt), RECONNECT_MAX_MS);
+    attempt += 1;
+    reconnectTimer = setTimeout(() => { reconnectTimer = null; connect(); }, delay);
+  }
+
+  // 30 秒おきに status bucket を再評価 (heartbeat タイムアウトを検出)
+  setInterval(() => {
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    setState(ageBucketFromHeartbeat(), 'Legatus');
+    refreshDetailBox();
+  }, 5000);
+
+  connect();
+})();

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -4982,6 +4982,7 @@ function ensureLiveSocket() {
     let msg;
     try { msg = JSON.parse(ev.data); } catch { return; }
     if (msg.type === 'location' && msg.point) handleLivePoint(msg.point);
+    else if (msg.type === 'location.resolved') applyLocationResolved(msg);
   });
 }
 
@@ -5120,9 +5121,20 @@ function trackRecentRowHtml(p) {
   const lon = Number(p.lon).toFixed(5);
   const acc = p.accuracy_m != null ? `±${Math.round(p.accuracy_m)}m` : '';
   const vel = p.velocity_kmh != null ? `${Math.round(p.velocity_kmh)}km/h` : '';
+  // 場所照合結果 (Google Geocoding/Places). 未解決行は薄字で「(調べ中…)」.
+  const placeName = p.place_name || '';
+  const placeAddr = p.place_address || '';
+  const placeLine = placeName || placeAddr
+    ? `<div class="tracks-recent-place" data-source="${escapeHtml(p.place_source || '')}">${
+        placeName ? `<strong>${escapeHtml(placeName)}</strong>` : ''
+      }${placeName && placeAddr ? ' / ' : ''}${
+        placeAddr ? `<span class="muted">${escapeHtml(placeAddr)}</span>` : ''
+      }</div>`
+    : `<div class="tracks-recent-place tracks-recent-place--pending muted">(場所を調べ中…)</div>`;
   return `
     <li class="tracks-recent-row" data-lat="${lat}" data-lon="${lon}" data-id="${p.id}">
       <div class="tracks-recent-time">${escapeHtml(tStr)}</div>
+      ${placeLine}
       <div class="tracks-recent-meta">
         <span class="tracks-recent-dev">${escapeHtml(dev)}</span>
         <span class="tracks-recent-coord"><code>${lat},${lon}</code></span>
@@ -5130,6 +5142,46 @@ function trackRecentRowHtml(p) {
       </div>
     </li>
   `;
+}
+
+/**
+ * `location.resolved` を受け取って既存リスト行と Marker title を差分更新.
+ */
+function applyLocationResolved(payload) {
+  const id = payload?.id;
+  if (!id) return;
+  const ul = $('tracksRecentList');
+  if (ul) {
+    const li = ul.querySelector(`.tracks-recent-row[data-id="${id}"]`);
+    if (li) {
+      const placeEl = li.querySelector('.tracks-recent-place');
+      if (placeEl) {
+        const name = payload.place_name || '';
+        const addr = payload.place_address || '';
+        if (name || addr) {
+          placeEl.classList.remove('tracks-recent-place--pending', 'muted');
+          placeEl.dataset.source = payload.place_source || '';
+          placeEl.innerHTML = (name ? `<strong>${escapeHtml(name)}</strong>` : '')
+            + (name && addr ? ' / ' : '')
+            + (addr ? `<span class="muted">${escapeHtml(addr)}</span>` : '');
+        } else {
+          placeEl.classList.add('muted');
+          placeEl.textContent = '(照合不可)';
+        }
+      }
+    }
+  }
+  // 地図 Marker の title を後付け更新.
+  if (tracksState.pointMarkers && window.google?.maps) {
+    for (const m of tracksState.pointMarkers) {
+      if (!m._gpsId || m._gpsId !== id) continue;
+      const label = payload.place_name || payload.place_address || '';
+      if (label) {
+        try { m.setTitle((m.getTitle?.() ?? '') + ' — ' + label); } catch {}
+      }
+      break;
+    }
+  }
 }
 
 function bindTracksRecentRows() {
@@ -5437,10 +5489,12 @@ function drawTracks(points) {
   }
   for (let i = 0; i < points.length; i++) {
     const c = CAT_COLORS[cats[i]] || CAT_COLORS.still;
+    const place = points[i].place_name || points[i].place_address || '';
+    const baseTitle = `#${points[i].id ?? '?'} ${cats[i]} ${i > 0 ? '(' + classifySegment(points[i-1], points[i]).kmh.toFixed(1) + ' km/h)' : ''}`;
     const m = new google.maps.Marker({
       position: { lat: points[i].lat, lng: points[i].lon },
       map: tracksState.map,
-      title: `#${points[i].id ?? '?'} ${cats[i]} ${i > 0 ? '(' + classifySegment(points[i-1], points[i]).kmh.toFixed(1) + ' km/h)' : ''}`,
+      title: place ? `${baseTitle} — ${place}` : baseTitle,
       icon: {
         path: google.maps.SymbolPath.CIRCLE,
         scale: 3,
@@ -5451,6 +5505,7 @@ function drawTracks(points) {
       },
       zIndex: 5,
     });
+    m._gpsId = points[i].id;
     tracksState.pointMarkers.push(m);
   }
 

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -4964,7 +4964,9 @@ function renderTracksDaysList(days) {
 }
 
 function ensureGoogleMapsLoaded(apiKey) {
-  if (tracksState.loaded || (window.google && window.google.maps)) {
+  // places ライブラリを最初から要求 — 後続の場所編集モーダルで PlacesService /
+  // AutocompleteService を使うため。 既存の tracks / meals モーダルには影響しない。
+  if (tracksState.loaded || (window.google && window.google.maps?.places)) {
     tracksState.loaded = true;
     return Promise.resolve();
   }
@@ -4976,7 +4978,7 @@ function ensureGoogleMapsLoaded(apiKey) {
       resolve();
     };
     const s = document.createElement('script');
-    s.src = `https://maps.googleapis.com/maps/api/js?key=${encodeURIComponent(apiKey)}&callback=${cb}&v=weekly`;
+    s.src = `https://maps.googleapis.com/maps/api/js?key=${encodeURIComponent(apiKey)}&callback=${cb}&v=weekly&libraries=places`;
     s.async = true;
     s.defer = true;
     s.onerror = () => reject(new Error('Google Maps script failed to load'));
@@ -6312,6 +6314,37 @@ document.getElementById('mealModalMapToggle')?.addEventListener('click', async (
   }
 });
 
+// 「📌 詳細編集」 で全画面 location modal を開く。 onApply で meal modal の
+// lat/lon フィールドに反映 (DB 保存は meal modal 側の保存ボタンで実行)。
+document.getElementById('mealModalLocPick')?.addEventListener('click', () => {
+  const latEl = document.getElementById('mealModalLat');
+  const lonEl = document.getElementById('mealModalLon');
+  const noteEl = document.getElementById('mealModalNote');
+  const lat = latEl?.value ? Number(latEl.value) : null;
+  const lon = lonEl?.value ? Number(lonEl.value) : null;
+  const initial = (isFinite(lat) && isFinite(lon))
+    ? { lat, lon, label: '' }
+    : null;
+  openLocationEditModal({
+    initial,
+    title: '食事の場所を編集',
+    subtitle: '',
+    onApply: async ({ lat, lon, place_name }) => {
+      if (latEl) latEl.value = lat.toFixed(6);
+      if (lonEl) lonEl.value = lon.toFixed(6);
+      // 施設名は note に追記提案 (上書きしないで先頭に prepend)
+      if (place_name && noteEl) {
+        const cur = (noteEl.value || '').trim();
+        if (!cur.includes(place_name)) {
+          noteEl.value = cur ? `${place_name}\n${cur}` : place_name;
+        }
+      }
+      placeMealModalMarker(lat, lon);
+      updateMealModalMapLink();
+    },
+  });
+});
+
 // lat/lon 手入力時に map と link を追従
 ['mealModalLat', 'mealModalLon'].forEach((id) => {
   document.getElementById(id)?.addEventListener('input', () => {
@@ -6494,3 +6527,287 @@ window.addEventListener('keydown', (ev) => {
 
 // 起動時にも一度ロード (DOMContentLoaded を待たないコード経路用)
 loadUserStopwords();
+
+// ── 場所編集モーダル (軌跡 / 食事 / その他で再利用される共通) ─────
+//
+// API:
+//   await openLocationEditModal({
+//     initial: { lat, lon, label?, place_id? } | null,
+//     title?: '場所を編集',
+//     subtitle?: 'meal #12 の場所',
+//     onApply?: ({lat, lon, place_name?, place_id?}) => Promise<void>,
+//   })
+
+const locEditState = {
+  map: null,
+  marker: null,
+  placesService: null,
+  autocomplete: null,
+  geocoder: null,
+  current: null,
+};
+
+async function openLocationEditModal(opts = {}) {
+  const modal = document.getElementById('locationEditModal');
+  if (!modal) return;
+
+  locEditState.current = {
+    onApply: typeof opts.onApply === 'function' ? opts.onApply : null,
+    initial: opts.initial || null,
+    place_id: opts.initial?.place_id || null,
+  };
+
+  const titleEl = document.getElementById('locationEditTitle');
+  if (titleEl) titleEl.textContent = opts.title || '場所を編集';
+  const subEl = document.getElementById('locEditSubtitle');
+  if (subEl) subEl.textContent = opts.subtitle || '';
+
+  const latEl = document.getElementById('locEditLat');
+  const lonEl = document.getElementById('locEditLon');
+  const nameEl = document.getElementById('locEditPlaceName');
+  const initial = opts.initial || {};
+  if (latEl) latEl.value = (initial.lat != null) ? String(initial.lat) : '';
+  if (lonEl) lonEl.value = (initial.lon != null) ? String(initial.lon) : '';
+  if (nameEl) nameEl.value = initial.label || '';
+  const sresList = document.getElementById('locEditSearchResults');
+  if (sresList) { sresList.innerHTML = ''; sresList.hidden = true; }
+  const suggest = document.getElementById('locEditPlaceSuggest');
+  if (suggest) suggest.hidden = true;
+  const sinput = document.getElementById('locEditSearchInput');
+  if (sinput) sinput.value = '';
+
+  modal.classList.remove('hidden');
+  if (typeof modal.showModal === 'function' && !modal.open) {
+    try { modal.showModal(); } catch { modal.setAttribute('open', ''); }
+  } else if (!modal.open) {
+    modal.setAttribute('open', '');
+  }
+
+  await ensureLocEditMap(initial);
+}
+
+function closeLocationEditModal() {
+  const modal = document.getElementById('locationEditModal');
+  if (!modal) return;
+  if (typeof modal.close === 'function' && modal.open) {
+    try { modal.close(); } catch (e) { /* ignore */ }
+  }
+  modal.removeAttribute('open');
+  locEditState.current = null;
+}
+
+async function ensureLocEditMap(initial) {
+  const wrap = document.getElementById('locEditMap');
+  const missing = document.getElementById('locEditMapMissing');
+  if (!wrap) return;
+
+  const apiKey = await fetchMapsApiKey();
+  if (!apiKey) {
+    if (missing) missing.classList.remove('hidden');
+    wrap.style.display = 'none';
+    return;
+  }
+  if (missing) missing.classList.add('hidden');
+  wrap.style.display = '';
+
+  try {
+    await ensureGoogleMapsLoaded(apiKey);
+  } catch (e) {
+    if (missing) {
+      missing.textContent = `Google Maps の読み込みに失敗: ${e.message}`;
+      missing.classList.remove('hidden');
+    }
+    return;
+  }
+  if (!window.google?.maps) return;
+
+  const startCenter = (initial?.lat != null && initial?.lon != null)
+    ? { lat: Number(initial.lat), lng: Number(initial.lon) }
+    : { lat: 35.681, lng: 139.767 };
+
+  if (!locEditState.map) {
+    locEditState.map = new google.maps.Map(wrap, {
+      center: startCenter,
+      zoom: (initial?.lat != null) ? 16 : 12,
+      mapTypeControl: false,
+      streetViewControl: false,
+      fullscreenControl: false,
+    });
+    locEditState.map.addListener('click', (ev) => {
+      placeLocEditMarker(ev.latLng.lat(), ev.latLng.lng(), { recenter: false });
+    });
+    locEditState.placesService = new google.maps.places.PlacesService(locEditState.map);
+    locEditState.autocomplete = new google.maps.places.AutocompleteService();
+    locEditState.geocoder = new google.maps.Geocoder();
+  } else {
+    locEditState.map.setCenter(startCenter);
+    locEditState.map.setZoom((initial?.lat != null) ? 16 : 12);
+  }
+
+  setTimeout(() => google.maps.event.trigger(locEditState.map, 'resize'), 60);
+
+  if (initial?.lat != null && initial?.lon != null) {
+    placeLocEditMarker(Number(initial.lat), Number(initial.lon), { recenter: true });
+  } else if (locEditState.marker) {
+    locEditState.marker.setMap(null);
+    locEditState.marker = null;
+  }
+}
+
+function placeLocEditMarker(lat, lng, { recenter = false } = {}) {
+  if (!locEditState.map || !window.google?.maps) return;
+  if (locEditState.marker) {
+    locEditState.marker.setPosition({ lat, lng });
+  } else {
+    locEditState.marker = new google.maps.Marker({
+      position: { lat, lng },
+      map: locEditState.map,
+      draggable: true,
+    });
+    locEditState.marker.addListener('dragend', (ev) => {
+      const p = ev.latLng;
+      placeLocEditMarker(p.lat(), p.lng(), { recenter: false });
+    });
+  }
+  if (recenter) locEditState.map.panTo({ lat, lng });
+  const latEl = document.getElementById('locEditLat');
+  const lonEl = document.getElementById('locEditLon');
+  if (latEl) latEl.value = lat.toFixed(6);
+  if (lonEl) lonEl.value = lng.toFixed(6);
+  const suggest = document.getElementById('locEditPlaceSuggest');
+  if (suggest) suggest.hidden = true;
+}
+
+async function runLocEditSearch() {
+  if (!locEditState.placesService) return;
+  const q = (document.getElementById('locEditSearchInput')?.value || '').trim();
+  const list = document.getElementById('locEditSearchResults');
+  if (!q || !list) { if (list) list.hidden = true; return; }
+  await new Promise((resolve) => {
+    const opts = { query: q };
+    if (locEditState.map) {
+      opts.location = locEditState.map.getCenter();
+      opts.radius = 50_000;
+    }
+    locEditState.placesService.textSearch(opts, (results, status) => {
+      list.innerHTML = '';
+      if (status !== google.maps.places.PlacesServiceStatus.OK || !results?.length) {
+        list.innerHTML = `<li class="muted">該当なし (${escapeHtml(status || 'unknown')})</li>`;
+        list.hidden = false;
+        resolve();
+        return;
+      }
+      const top = results.slice(0, 8);
+      list.innerHTML = top.map((r, i) => `
+        <li data-idx="${i}">
+          <div class="loc-edit-search-result-name">${escapeHtml(r.name || '(名前なし)')}</div>
+          <div class="loc-edit-search-result-addr">${escapeHtml(r.formatted_address || '')}</div>
+        </li>`).join('');
+      list.hidden = false;
+      list.querySelectorAll('li[data-idx]').forEach((li) => {
+        li.addEventListener('click', () => {
+          const idx = Number(li.dataset.idx);
+          const r = top[idx];
+          if (!r?.geometry?.location) return;
+          const lat = r.geometry.location.lat();
+          const lng = r.geometry.location.lng();
+          placeLocEditMarker(lat, lng, { recenter: true });
+          const nameEl = document.getElementById('locEditPlaceName');
+          if (nameEl) nameEl.value = r.name || '';
+          locEditState.current = locEditState.current || {};
+          locEditState.current.place_id = r.place_id || null;
+          list.hidden = true;
+        });
+      });
+      resolve();
+    });
+  });
+}
+
+async function fetchLocEditPlaceSuggestions() {
+  if (!locEditState.placesService || !locEditState.marker) return;
+  const pos = locEditState.marker.getPosition();
+  const suggestEl = document.getElementById('locEditPlaceSuggest');
+  const listEl = document.getElementById('locEditPlaceSuggestList');
+  if (!suggestEl || !listEl) return;
+  listEl.innerHTML = '<span class="muted">取得中…</span>';
+  suggestEl.hidden = false;
+  await new Promise((resolve) => {
+    locEditState.placesService.nearbySearch(
+      { location: pos, rankBy: google.maps.places.RankBy.DISTANCE },
+      (results, status) => {
+        if (status !== google.maps.places.PlacesServiceStatus.OK || !results?.length) {
+          listEl.innerHTML = '<span class="muted">候補なし</span>';
+          resolve();
+          return;
+        }
+        const top = results.slice(0, 6);
+        listEl.innerHTML = top.map((r, i) =>
+          `<button type="button" data-idx="${i}" title="${escapeHtml(r.vicinity || '')}">${escapeHtml(r.name || '')}</button>`
+        ).join('');
+        listEl.querySelectorAll('button').forEach((btn) => {
+          btn.addEventListener('click', () => {
+            const idx = Number(btn.dataset.idx);
+            const r = top[idx];
+            const nameEl = document.getElementById('locEditPlaceName');
+            if (nameEl && r?.name) nameEl.value = r.name;
+            locEditState.current = locEditState.current || {};
+            locEditState.current.place_id = r?.place_id || null;
+          });
+        });
+        resolve();
+      },
+    );
+  });
+}
+
+function wireLocationEditModal() {
+  const modal = document.getElementById('locationEditModal');
+  if (!modal || modal.dataset.wired === '1') return;
+  modal.dataset.wired = '1';
+
+  document.getElementById('locEditClose')?.addEventListener('click', closeLocationEditModal);
+  document.getElementById('locEditCancel')?.addEventListener('click', closeLocationEditModal);
+  modal.addEventListener('cancel', () => { locEditState.current = null; });
+
+  document.getElementById('locEditSearchBtn')?.addEventListener('click', () => runLocEditSearch());
+  document.getElementById('locEditSearchInput')?.addEventListener('keydown', (ev) => {
+    if (ev.key === 'Enter') { ev.preventDefault(); runLocEditSearch(); }
+  });
+
+  document.getElementById('locEditUseCurrent')?.addEventListener('click', () => {
+    if (!navigator.geolocation) { alert('この端末は位置情報に対応していません'); return; }
+    navigator.geolocation.getCurrentPosition(
+      (pos) => placeLocEditMarker(pos.coords.latitude, pos.coords.longitude, { recenter: true }),
+      (err) => alert(`位置取得失敗: ${err.message}`),
+      { enableHighAccuracy: true, timeout: 10_000 },
+    );
+  });
+
+  document.getElementById('locEditFetchPlaceBtn')?.addEventListener('click', () => fetchLocEditPlaceSuggestions());
+
+  document.getElementById('locEditApply')?.addEventListener('click', async () => {
+    const lat = Number(document.getElementById('locEditLat')?.value);
+    const lng = Number(document.getElementById('locEditLon')?.value);
+    if (!isFinite(lat) || !isFinite(lng)) { alert('緯度 / 経度が不正です'); return; }
+    const place_name = (document.getElementById('locEditPlaceName')?.value || '').trim() || null;
+    const place_id = locEditState.current?.place_id || null;
+    const fn = locEditState.current?.onApply;
+    if (!fn) { closeLocationEditModal(); return; }
+    try {
+      await fn({ lat, lon: lng, place_name, place_id });
+      closeLocationEditModal();
+    } catch (e) {
+      alert(`保存エラー: ${e.message}`);
+    }
+  });
+
+  ['locEditLat', 'locEditLon'].forEach((id) => {
+    document.getElementById(id)?.addEventListener('change', () => {
+      const lat = Number(document.getElementById('locEditLat')?.value);
+      const lng = Number(document.getElementById('locEditLon')?.value);
+      if (isFinite(lat) && isFinite(lng)) placeLocEditMarker(lat, lng, { recenter: true });
+    });
+  });
+}
+wireLocationEditModal();

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -4174,15 +4174,23 @@ async function openAiSettings() {
         $('mapsApiKeyStatus').textContent = `取得失敗: ${e.message}`;
       }
     }
-    // Tracks 間引き距離
+    // Tracks 間引き距離 + ポリライン表示
     if ($('tracksDecimateMeters')) {
       try {
         const ts = await api('/api/tracks/settings');
-        $('tracksDecimateMeters').value = String(ts.decimate_meters ?? 2);
-        $('tracksDecimateStatus').textContent = `現在: ${ts.decimate_meters}m`;
+        $('tracksDecimateMeters').value = String(ts.decimate_meters ?? 0);
+        $('tracksDecimateStatus').textContent = ts.decimate_meters > 0
+          ? `現在: ${ts.decimate_meters}m`
+          : `現在: 全点 (間引きなし)`;
       } catch (e) {
         $('tracksDecimateStatus').textContent = `取得失敗: ${e.message}`;
       }
+    }
+    if ($('tracksShowPolyline')) {
+      try {
+        const ts = await api('/api/tracks/settings');
+        $('tracksShowPolyline').checked = !!ts.show_polyline;
+      } catch { /* swallow */ }
     }
     // Electron 配下のときだけ「デスクトップアプリ」セクションを出す。
     // window.memoria は preload.ts (contextBridge) が expose する。
@@ -4510,22 +4518,35 @@ async function saveAiSettings() {
         return;
       }
     }
-    // Tracks 間引き距離
+    // Tracks 間引き距離 + ポリライン表示
     const dmRaw = $('tracksDecimateMeters')?.value;
+    const showPolyline = !!$('tracksShowPolyline')?.checked;
+    const tracksPatch = {};
     if (dmRaw !== undefined && dmRaw !== '') {
       const v = Number(dmRaw);
       if (Number.isFinite(v) && v >= 0 && v <= 1000) {
-        try {
-          await api('/api/tracks/settings', {
-            method: 'PATCH',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ decimate_meters: v }),
-          });
-          tracksState.decimateMeters = v; // すぐ map にも反映
-        } catch (e) {
-          alert(`間引き距離保存失敗: ${e.message}`);
-          return;
+        tracksPatch.decimate_meters = v;
+      }
+    }
+    if ($('tracksShowPolyline')) {
+      tracksPatch.show_polyline = showPolyline;
+    }
+    if (Object.keys(tracksPatch).length > 0) {
+      try {
+        await api('/api/tracks/settings', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(tracksPatch),
+        });
+        if (tracksPatch.decimate_meters !== undefined) {
+          tracksState.decimateMeters = tracksPatch.decimate_meters; // 即時反映
         }
+        if (tracksPatch.show_polyline !== undefined) {
+          tracksState.showPolyline = tracksPatch.show_polyline;
+        }
+      } catch (e) {
+        alert(`Tracks 設定保存失敗: ${e.message}`);
+        return;
       }
     }
     alert('保存しました。次回のジョブから反映されます。');
@@ -4882,10 +4903,11 @@ async function loadTracks() {
     const [{ apiKey, hasKey }, { days }, ts] = await Promise.all([
       api('/api/maps/config'),
       api('/api/locations/days?limit=180'),
-      api('/api/tracks/settings').catch(() => ({ decimate_meters: 2 })),
+      api('/api/tracks/settings').catch(() => ({ decimate_meters: 0, show_polyline: false })),
     ]);
     tracksState.apiKey = apiKey;
-    tracksState.decimateMeters = Number(ts.decimate_meters ?? 2);
+    tracksState.decimateMeters = Number(ts.decimate_meters ?? 0);
+    tracksState.showPolyline = !!ts.show_polyline;
     $('tracksMissingKey').classList.toggle('hidden', !!hasKey);
     renderTracksDaysList(days);
     if (hasKey) {
@@ -5028,8 +5050,9 @@ function handleLivePoint(point) {
         zIndex: 5,
       }));
     }
-    // 直前との区間に専用色 polyline を追加 (drawTracks で全描き直しせず差分のみ)
-    if (window.google?.maps && tracksState.polylines) {
+    // 直前との区間に専用色 polyline を追加 (drawTracks で全描き直しせず差分のみ).
+    // 既定 (点のみ表示) では skip.
+    if (tracksState.showPolyline && window.google?.maps && tracksState.polylines) {
       const cat = seg.category;
       tracksState.polylines.push(new google.maps.Polyline({
         path: [{ lat: prev.lat, lng: prev.lon }, { lat: cur.lat, lng: cur.lon }],
@@ -5384,8 +5407,9 @@ function drawTracks(points) {
   const { cats, walkMeters, walkSec, transitMeters, transitSec, stillMeters, stillSec } = classifyAll(points);
 
   // 区間ごとに polyline を 1 本ずつ描画 (cats[i] = points[i-1] → points[i] の category).
-  // 64 点でも polyline 63 本程度なので Maps の負荷的には許容.
-  if (points.length >= 2) {
+  // 既定では「点のみ表示」 (tracksState.showPolyline=false) で線を描かない.
+  // 設定 UI の "ポリライン表示" を ON にすると区間色分けが復活する.
+  if (tracksState.showPolyline && points.length >= 2) {
     for (let i = 1; i < points.length; i++) {
       const cat = cats[i] || 'still';
       tracksState.polylines.push(new google.maps.Polyline({

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -9,7 +9,7 @@
   <title>Memoria</title>
   <link rel="manifest" href="manifest.webmanifest" />
   <link rel="apple-touch-icon" href="icon-192.svg" />
-  <link rel="stylesheet" href="style.css?v=20260503b" />
+  <link rel="stylesheet" href="style.css?v=20260503c" />
 </head>
 <body>
   <header class="topbar">
@@ -1139,6 +1139,6 @@ bogus-priv</code></pre>
       <button id="aiSettingsSave">保存</button>
     </div>
   </div>
-  <script src="app.js?v=20260503b"></script>
+  <script src="app.js?v=20260503c"></script>
 </body>
 </html>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -781,10 +781,11 @@ bogus-priv</code></pre>
                 <button type="button" id="mealModalLocHere" class="ghost" title="現在地から取得">📍 現在地</button>
                 <button type="button" id="mealModalLocClear" class="ghost" title="場所を削除">∅ クリア</button>
                 <button type="button" id="mealModalMapToggle" class="ghost" title="地図を表示 / 非表示">🗺 地図</button>
+                <button type="button" id="mealModalLocPick" class="ghost" title="検索 + ピン留め + 施設名取得">📌 詳細編集</button>
                 <a id="mealModalMapOpen" href="#" target="_blank" rel="noopener" class="ghost meal-modal-map-link" title="Google Maps で開く" hidden>↗ Maps で開く</a>
               </div>
               <div id="mealModalMap" class="meal-modal-map hidden"></div>
-              <span class="meal-modal-hint muted">地図をクリック / タップで座標を取得。 空欄なら EXIF / GPS 軌跡から推定</span>
+              <span class="meal-modal-hint muted">地図クリック or 「📌 詳細編集」 で検索 + ピン留め + 施設名取得。 空欄なら EXIF / GPS 軌跡から推定。</span>
             </div>
 
             <label class="meal-modal-row">
@@ -803,6 +804,62 @@ bogus-priv</code></pre>
             <span class="grow"></span>
             <button type="button" id="mealModalCancel" class="ghost">キャンセル</button>
             <button type="button" id="mealModalSubmit">登録</button>
+          </footer>
+        </div>
+      </dialog>
+
+      <!-- ── 場所編集ダイアログ — 軌跡 / 食事 / その他で再利用される共通 modal -->
+      <dialog id="locationEditModal" class="loc-edit-modal" aria-labelledby="locationEditTitle">
+        <div class="loc-edit-card">
+          <header class="loc-edit-head">
+            <h3 id="locationEditTitle">場所を編集</h3>
+            <span id="locEditSubtitle" class="loc-edit-subtitle muted"></span>
+            <button type="button" id="locEditClose" class="loc-edit-x" aria-label="閉じる">×</button>
+          </header>
+
+          <div class="loc-edit-search">
+            <input id="locEditSearchInput" type="search"
+              placeholder="お店 / 住所で検索 (例: スターバックス 渋谷)"
+              autocomplete="off" />
+            <button type="button" id="locEditSearchBtn" class="ghost" title="検索">🔎</button>
+          </div>
+          <ul id="locEditSearchResults" class="loc-edit-search-results" hidden></ul>
+
+          <div id="locEditMap" class="loc-edit-map"></div>
+          <div id="locEditMapMissing" class="loc-edit-map-missing hidden">
+            Google Maps API key 未設定。 ⚙ 設定 → AI / 連携 で <code>maps_api_key</code> を入れてください。
+          </div>
+
+          <div class="loc-edit-pin">
+            <div class="loc-edit-pin-row">
+              <label class="loc-edit-pin-coord">緯度
+                <input id="locEditLat" type="number" step="any" placeholder="35.6812" />
+              </label>
+              <label class="loc-edit-pin-coord">経度
+                <input id="locEditLon" type="number" step="any" placeholder="139.7671" />
+              </label>
+              <button type="button" id="locEditUseCurrent" class="ghost" title="現在地から取得">📍 現在地</button>
+            </div>
+            <div class="loc-edit-pin-row">
+              <label class="loc-edit-pin-name">施設名 / ラベル
+                <input id="locEditPlaceName" type="text" placeholder="(自動取得 or 手入力)" />
+              </label>
+              <button type="button" id="locEditFetchPlaceBtn" class="ghost"
+                title="ピンの位置から Google Places の名前を取得">📥 ここの施設名を取得</button>
+            </div>
+            <div id="locEditPlaceSuggest" class="loc-edit-suggest" hidden>
+              <span class="loc-edit-suggest-label">候補:</span>
+              <span id="locEditPlaceSuggestList"></span>
+            </div>
+            <div id="locEditPinHint" class="loc-edit-hint muted">
+              地図をクリック / タップでピンを置いてください。 場所名 (Google) は「📥 取得」で取込み。
+            </div>
+          </div>
+
+          <footer class="loc-edit-actions">
+            <button type="button" id="locEditCancel" class="ghost">キャンセル</button>
+            <span class="grow"></span>
+            <button type="button" id="locEditApply">📌 ここに修正</button>
           </footer>
         </div>
       </dialog>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -19,6 +19,10 @@
     <div id="queueBadge" class="queue-badge hidden" title="作業中ジョブ数">作業中 <span id="queueCount">0</span></div>
     <div class="topbar-controls">
       <button id="howToBookmarkBtn" class="ghost topbar-howto" title="ブックマークの追加方法" hidden>💡 やり方</button>
+      <button id="legatusBadge" class="ghost topbar-legatus" type="button" title="Legatus 接続状態" hidden>
+        <span class="legatus-dot" data-state="unknown">●</span>
+        <span class="legatus-label">Legatus</span>
+      </button>
       <button id="aiSettingsBtn" class="ghost topbar-settings" title="設定">⚙ 設定</button>
     </div>
   </header>
@@ -488,6 +492,14 @@
           を入れるか、 環境変数 <code>GOOGLE_MAPS_API_KEY</code> を設定してください。
         </div>
         <div id="tracksMap" class="tracks-map"></div>
+        <div class="tracks-recent">
+          <div class="tracks-recent-head">
+            <h4>📍 GPS ログ (最新 50 件)</h4>
+            <span id="tracksRecentCount" class="muted"></span>
+            <button id="tracksRecentRefresh" class="ghost" title="再読込">↻</button>
+          </div>
+          <ul id="tracksRecentList" class="tracks-recent-list"></ul>
+        </div>
         <div class="tracks-days">
           <h4>記録のある日</h4>
           <ul id="tracksDays" class="tracks-days-list"></ul>
@@ -958,107 +970,170 @@ bogus-priv</code></pre>
 
   <div id="aiSettingsPanel" class="ai-settings hidden">
     <div class="ai-settings-head">
-      <h3>AI モデル / プロバイダ設定</h3>
+      <h3>設定</h3>
       <button id="aiSettingsClose" class="ghost">×</button>
     </div>
-    <p class="ai-settings-help">タスクごとに使う LLM プロバイダを選びます。Claude CLI / Gemini CLI / Codex CLI / OpenAI API を切り替え可能。Tools (WebSearch 等) が必要なタスクで非対応プロバイダを選ぶと、そのタスクは Tools なしで動きます。</p>
-    <div id="aiTaskRows"></div>
-    <h4>CLI バイナリパス (PATH に通っていない場合のみ指定)</h4>
-    <label>claude: <input id="aiBinClaude" type="text" placeholder="claude" /></label>
-    <label>gemini: <input id="aiBinGemini" type="text" placeholder="gemini" /></label>
-    <label>codex:  <input id="aiBinCodex"  type="text" placeholder="codex" /></label>
-    <h4>🐚 Bash (Windows のみ)</h4>
-    <p class="ai-settings-help">Claude CLI は内部で bash を呼び出します。Windows でデスクトップアプリから動かすときだけ git-bash の絶対パスを指定してください (例: <code>C:\Program Files\Git\bin\bash.exe</code>)。空欄なら環境変数 <code>CLAUDE_CODE_GIT_BASH_PATH</code> を尊重します。</p>
-    <label>git-bash path: <input id="aiGitBashPath" type="text" placeholder="C:\\Program Files\\Git\\bin\\bash.exe" /></label>
-    <h4>OpenAI API</h4>
-    <label>API Key (gpt 系を使う場合): <input id="aiOpenaiKey" type="password" placeholder="sk-..." /></label>
-    <span id="aiOpenaiKeyStatus" class="ai-keystatus"></span>
-    <label>デフォルトモデル: <input id="aiOpenaiModel" type="text" placeholder="gpt-4o-mini" /></label>
-    <h4>📤 エクスポート / 📥 インポート</h4>
-    <p class="ai-settings-help">ブックマークを JSON で書き出し / 取り込み (URL 重複はスキップ)。エクスポートはチェックを入れたカードのみ。</p>
-    <div class="ai-settings-actions">
-      <button id="exportBtn" class="ghost" title="選択中をエクスポート">Export</button>
-      <label class="ghost file-btn">
-        Import<input id="importInput" type="file" accept="application/json" hidden />
-      </label>
-    </div>
+    <nav class="settings-tabs" role="tablist">
+      <button type="button" class="settings-tab active" data-stab="ai" role="tab">🤖 AI / モデル</button>
+      <button type="button" class="settings-tab" data-stab="api" role="tab">🔌 連携 / API key</button>
+      <button type="button" class="settings-tab" data-stab="notif" role="tab">🔔 通知 / 端末</button>
+      <button type="button" class="settings-tab" data-stab="profile" role="tab">🧍 プロフィール</button>
+      <button type="button" class="settings-tab" data-stab="data" role="tab">📦 データ / Hub</button>
+      <button type="button" class="settings-tab" data-stab="runtime" role="tab">🛠 ランタイム</button>
+    </nav>
 
-    <h4>📝 日記の常設メモ</h4>
-    <p class="ai-settings-help">日記生成時に毎回プロンプトに添える「常設メモ」。プロジェクトの背景・自分の役割・生成ルール (例: <code>Memoria は LUDIARS の個人ツール。曖昧な作業は推測で断定して書く</code>) などを書いておくと、毎日の日記の作業内容 / ハイライトに反映されます。空欄なら何も追加しません。</p>
-    <textarea id="aiDiaryGlobalMemo" rows="6" placeholder="例: 自分の役割は LUDIARS の AI/フルスタック開発。Memoria, Synergos, Cernere を主軸に動く。日記は事実+推測で書き、断定口調を維持。"></textarea>
+    <!-- ── 🤖 AI / モデル ── -->
+    <section class="settings-tab-body" data-stab="ai">
+      <p class="ai-settings-help">タスクごとに使う LLM プロバイダを選びます。Claude CLI / Gemini CLI / Codex CLI / OpenAI API を切り替え可能。Tools (WebSearch 等) が必要なタスクで非対応プロバイダを選ぶと、そのタスクは Tools なしで動きます。</p>
+      <div id="aiTaskRows"></div>
+      <h4>CLI バイナリパス (PATH に通っていない場合のみ指定)</h4>
+      <label>claude: <input id="aiBinClaude" type="text" placeholder="claude" /></label>
+      <label>gemini: <input id="aiBinGemini" type="text" placeholder="gemini" /></label>
+      <label>codex:  <input id="aiBinCodex"  type="text" placeholder="codex" /></label>
+      <h4>🐚 Bash (Windows のみ)</h4>
+      <p class="ai-settings-help">Claude CLI は内部で bash を呼び出します。Windows でデスクトップアプリから動かすときだけ git-bash の絶対パスを指定してください (例: <code>C:\Program Files\Git\bin\bash.exe</code>)。空欄なら環境変数 <code>CLAUDE_CODE_GIT_BASH_PATH</code> を尊重します。</p>
+      <label>git-bash path: <input id="aiGitBashPath" type="text" placeholder="C:\\Program Files\\Git\\bin\\bash.exe" /></label>
+      <h4>📝 日記の常設メモ</h4>
+      <p class="ai-settings-help">日記生成時に毎回プロンプトに添える「常設メモ」。プロジェクトの背景・自分の役割・生成ルール (例: <code>Memoria は LUDIARS の個人ツール。曖昧な作業は推測で断定して書く</code>) などを書いておくと、毎日の日記の作業内容 / ハイライトに反映されます。空欄なら何も追加しません。</p>
+      <textarea id="aiDiaryGlobalMemo" rows="6" placeholder="例: 自分の役割は LUDIARS の AI/フルスタック開発。Memoria, Synergos, Cernere を主軸に動く。日記は事実+推測で書き、断定口調を維持。"></textarea>
+    </section>
 
-    <h4 id="aiDesktopHead" hidden>🖥 デスクトップアプリ</h4>
-    <div id="aiDesktopSection" hidden>
-      <p class="ai-settings-help">この Memoria は Electron デスクトップアプリの中で動いています。 ウィンドウの × はトレイ最小化、 サーバは常駐し続けます (Chrome 拡張 / モバイル PWA からのアクセスは継続)。 完全終了はトレイ右クリック → 「Memoria を終了」。</p>
-      <label class="check-inline">
-        <input id="aiAutoLaunch" type="checkbox" />
-        ログイン時に自動起動 (バックグラウンドでサーバが立ち上がる)
-      </label>
-      <p class="ai-settings-help" style="margin-top:6px">
-        ON にすると <code>--hidden</code> フラグでウィンドウなし起動 → トレイアイコンだけ表示されます。 普段は OS スタートアップに登録するこの方式で十分。 「ログアウト中も動かしたい」 ような用途は将来 Windows サービス化を検討します (別 PR)。
+    <!-- ── 🔌 連携 / API key ── -->
+    <section class="settings-tab-body hidden" data-stab="api">
+      <h4>🤖 OpenAI API</h4>
+      <label>API Key (gpt 系を使う場合): <input id="aiOpenaiKey" type="password" placeholder="sk-..." autocomplete="off" /></label>
+      <span id="aiOpenaiKeyStatus" class="ai-keystatus"></span>
+      <label>デフォルトモデル: <input id="aiOpenaiModel" type="text" placeholder="gpt-4o-mini" /></label>
+
+      <h4>📍 Legatus 連携 (GPS / 位置情報リレー)</h4>
+      <p class="ai-settings-help">
+        この PC 上の <strong>Legatus</strong> (loopback 17320) と WebSocket で接続し、 OwnTracks の MQTT 受信状態 / Memoria 向け relay の成否を live で表示します。 Legatus が落ちている場合 🔴 disconnected。
       </p>
-    </div>
+      <div id="legatusStatusBox" class="legatus-status-box">
+        <div class="legatus-row"><span class="legatus-key">接続</span><span id="legatusConnState" class="legatus-val">checking…</span></div>
+        <div class="legatus-row"><span class="legatus-key">MQTT</span><span id="legatusMqttState" class="legatus-val">—</span></div>
+        <div class="legatus-row"><span class="legatus-key">直近 GPS</span><span id="legatusLastEvent" class="legatus-val">—</span></div>
+        <div class="legatus-row"><span class="legatus-key">buffer pending</span><span id="legatusBufferPending" class="legatus-val">—</span></div>
+        <div class="legatus-row"><span class="legatus-key">relay 24h</span><span id="legatusRelayStats" class="legatus-val">—</span></div>
+        <div class="legatus-row"><span class="legatus-key">最終受信ログ</span><span id="legatusEventTail" class="legatus-val legatus-tail">—</span></div>
+      </div>
 
-    <h4>🧹 メンテナンス</h4>
-    <p class="ai-settings-help">過去のアクセス記録に出てきたドメインのうち、まだドメイン辞書に登録されていないものを fetch + 分類キューに積みます。 force にすると既存行も再分類します (user_edited 列は保護)。</p>
-    <div class="ai-settings-actions">
-      <button id="recatalogAllBtn">アクセス記録から全ドメインを走査</button>
-      <button id="recatalogAllForceBtn" class="ghost" title="既存の辞書行も含めて全部再分類する">force 再分類</button>
-    </div>
-    <div id="recatalogAllStatus" class="multi-status"></div>
-
-    <h4>📱 通知 (WebPush)</h4>
-    <p class="ai-settings-help">
-      日記生成完了などをこの端末に通知します。
-      iOS は <strong>「ホーム画面に追加」 して PWA として開いた状態</strong>でないと
-      通知許可ダイアログが出ません (16.4+ の仕様)。
-    </p>
-    <div class="ai-settings-actions">
-      <button id="pushSubscribeBtn">この端末で通知を有効化</button>
-      <button id="pushTestBtn" class="ghost">テスト送信</button>
-    </div>
-    <div id="pushStatus" class="multi-status"></div>
-    <ul id="pushDevicesList" class="multi-servers"></ul>
-
-    <h4>🧍 プロファイル (適正カロリー計算用)</h4>
-    <p class="ai-settings-help">日記のカロリーバランス分析で使用。 未設定だと分析されません。</p>
-    <div class="user-profile-grid">
-      <label>年齢 <input id="userAge" type="number" min="1" max="120" /></label>
-      <label>性別
-        <select id="userSex">
-          <option value="">(未選択)</option>
-          <option value="male">男性</option>
-          <option value="female">女性</option>
-        </select>
+      <h4>📐 GPS ノイズ間引き距離</h4>
+      <p class="ai-settings-help">
+        Tracks ページの map と「GPS ログ最新 50 件」 list でこの距離以内の連続点を間引きます。 単位は m。 GPS の数 m ジッタを除外して実移動だけ表示するためのもの (徒歩 / 交通機関の判定にも影響)。 既定 2m、 0 で間引き OFF、 大きいほど点が減って軌跡が荒くなる。
+      </p>
+      <label>
+        間引き距離 (m):
+        <input id="tracksDecimateMeters" type="number" min="0" max="1000" step="0.5" placeholder="2" />
       </label>
-      <label>体重 (kg) <input id="userWeightKg" type="number" min="20" max="300" step="0.1" /></label>
-      <label>身長 (cm) <input id="userHeightCm" type="number" min="100" max="250" step="0.1" /></label>
-      <label>活動レベル
-        <select id="userActivityLevel">
-          <option value="sedentary">座りがち (×1.2)</option>
-          <option value="light">軽運動 (×1.375)</option>
-          <option value="moderate" selected>中運動 (×1.55)</option>
-          <option value="active">活発 (×1.725)</option>
-          <option value="very_active">非常に活発 (×1.9)</option>
-        </select>
-      </label>
-    </div>
+      <span id="tracksDecimateStatus" class="ai-keystatus"></span>
 
-    <h4>🛠 ランタイム情報 (読み取り専用)</h4>
-    <p class="ai-settings-help">これらは起動時に決まる値で、変更には再起動が必要です。デスクトップアプリから自動で渡されます。</p>
-    <div id="aiRuntimeInfo" class="ai-runtime-info"></div>
-    <div class="ai-settings-actions">
+      <h4>🗺 Google Maps API key</h4>
+      <p class="ai-settings-help">
+        軌跡 / 食事メモ等の地図表示に使用。 Google Cloud Console で <strong>Maps JavaScript API</strong> を有効化し、 発行した key の HTTP referrer 制限 (例: <code>http://localhost:5180/*</code>) と API 制限を必ず設定してください (Maps JS は HTML に embed されるため公開鍵)。
+      </p>
+      <label>API key:
+        <input id="mapsApiKey" type="password" placeholder="AIzaSy..." autocomplete="off" />
+      </label>
+      <span id="mapsApiKeyStatus" class="ai-keystatus"></span>
+      <p class="ai-settings-help">優先順: <code>app_settings.maps.api_key</code> &gt; 環境変数 <code>GOOGLE_MAPS_API_KEY</code>。 ここで保存すれば DB 側に書かれ、 再起動不要で反映。</p>
+    </section>
+
+    <!-- ── 🔔 通知 / 端末 ── -->
+    <section class="settings-tab-body hidden" data-stab="notif">
+      <h4 id="aiDesktopHead" hidden>🖥 デスクトップアプリ</h4>
+      <div id="aiDesktopSection" hidden>
+        <p class="ai-settings-help">この Memoria は Electron デスクトップアプリの中で動いています。 ウィンドウの × はトレイ最小化、 サーバは常駐し続けます (Chrome 拡張 / モバイル PWA からのアクセスは継続)。 完全終了はトレイ右クリック → 「Memoria を終了」。</p>
+        <label class="check-inline">
+          <input id="aiAutoLaunch" type="checkbox" />
+          ログイン時に自動起動 (バックグラウンドでサーバが立ち上がる)
+        </label>
+        <p class="ai-settings-help" style="margin-top:6px">
+          ON にすると <code>--hidden</code> フラグでウィンドウなし起動 → トレイアイコンだけ表示されます。 普段は OS スタートアップに登録するこの方式で十分。 「ログアウト中も動かしたい」 ような用途は将来 Windows サービス化を検討します (別 PR)。
+        </p>
+      </div>
+      <h4>📱 通知 (WebPush)</h4>
+      <p class="ai-settings-help">
+        日記生成完了などをこの端末に通知します。
+        iOS は <strong>「ホーム画面に追加」 して PWA として開いた状態</strong>でないと
+        通知許可ダイアログが出ません (16.4+ の仕様)。
+      </p>
+      <div class="ai-settings-actions">
+        <button id="pushSubscribeBtn">この端末で通知を有効化</button>
+        <button id="pushTestBtn" class="ghost">テスト送信</button>
+      </div>
+      <div id="pushStatus" class="multi-status"></div>
+      <ul id="pushDevicesList" class="multi-servers"></ul>
+    </section>
+
+    <!-- ── 🧍 プロフィール ── -->
+    <section class="settings-tab-body hidden" data-stab="profile">
+      <h4>🧍 プロファイル (適正カロリー計算用)</h4>
+      <p class="ai-settings-help">日記のカロリーバランス分析で使用。 未設定だと分析されません。</p>
+      <div class="user-profile-grid">
+        <label>年齢 <input id="userAge" type="number" min="1" max="120" /></label>
+        <label>性別
+          <select id="userSex">
+            <option value="">(未選択)</option>
+            <option value="male">男性</option>
+            <option value="female">女性</option>
+          </select>
+        </label>
+        <label>体重 (kg) <input id="userWeightKg" type="number" min="20" max="300" step="0.1" /></label>
+        <label>身長 (cm) <input id="userHeightCm" type="number" min="100" max="250" step="0.1" /></label>
+        <label>活動レベル
+          <select id="userActivityLevel">
+            <option value="sedentary">座りがち (×1.2)</option>
+            <option value="light">軽運動 (×1.375)</option>
+            <option value="moderate" selected>中運動 (×1.55)</option>
+            <option value="active">活発 (×1.725)</option>
+            <option value="very_active">非常に活発 (×1.9)</option>
+          </select>
+        </label>
+      </div>
+    </section>
+
+    <!-- ── 📦 データ / Hub ── -->
+    <section class="settings-tab-body hidden" data-stab="data">
+      <h4>📤 エクスポート / 📥 インポート</h4>
+      <p class="ai-settings-help">ブックマークを JSON で書き出し / 取り込み (URL 重複はスキップ)。エクスポートはチェックを入れたカードのみ。</p>
+      <div class="ai-settings-actions">
+        <button id="exportBtn" class="ghost" title="選択中をエクスポート">Export</button>
+        <label class="ghost file-btn">
+          Import<input id="importInput" type="file" accept="application/json" hidden />
+        </label>
+      </div>
+
+      <h4>🧹 メンテナンス</h4>
+      <p class="ai-settings-help">過去のアクセス記録に出てきたドメインのうち、まだドメイン辞書に登録されていないものを fetch + 分類キューに積みます。 force にすると既存行も再分類します (user_edited 列は保護)。</p>
+      <div class="ai-settings-actions">
+        <button id="recatalogAllBtn">アクセス記録から全ドメインを走査</button>
+        <button id="recatalogAllForceBtn" class="ghost" title="既存の辞書行も含めて全部再分類する">force 再分類</button>
+      </div>
+      <div id="recatalogAllStatus" class="multi-status"></div>
+
+      <h4>🌐 マルチサーバ (Memoria Hub)</h4>
+      <p class="ai-settings-help">辞書 / ディグ / ブックマークを共有できるハブを複数登録できます。各エントリは独立した Cernere ログインを持ち、左の topbar スイッチで個別 ON/OFF (複数同時 ON 可)。</p>
+      <ul id="multiServersList" class="multi-servers"></ul>
+      <div class="multi-add-row">
+        <input id="multiAddLabel" type="text" placeholder="ラベル (例: 社内ハブ)" />
+        <input id="multiAddUrl" type="text" placeholder="https://memoria-hub.example.com" />
+        <button id="multiAddBtn">＋ 追加</button>
+      </div>
+      <div id="multiStatus" class="multi-status"></div>
+    </section>
+
+    <!-- ── 🛠 ランタイム ── -->
+    <section class="settings-tab-body hidden" data-stab="runtime">
+      <h4>🛠 ランタイム情報 (読み取り専用)</h4>
+      <p class="ai-settings-help">これらは起動時に決まる値で、変更には再起動が必要です。デスクトップアプリから自動で渡されます。</p>
+      <div id="aiRuntimeInfo" class="ai-runtime-info"></div>
+    </section>
+
+    <!-- ── 共通 footer (どの tab でも見える) ── -->
+    <div class="ai-settings-actions settings-footer">
       <button id="aiSettingsSave">保存</button>
     </div>
-    <h4>🌐 マルチサーバ (Memoria Hub)</h4>
-    <p class="ai-settings-help">辞書 / ディグ / ブックマークを共有できるハブを複数登録できます。各エントリは独立した Cernere ログインを持ち、左の topbar スイッチで個別 ON/OFF (複数同時 ON 可)。</p>
-    <ul id="multiServersList" class="multi-servers"></ul>
-    <div class="multi-add-row">
-      <input id="multiAddLabel" type="text" placeholder="ラベル (例: 社内ハブ)" />
-      <input id="multiAddUrl" type="text" placeholder="https://memoria-hub.example.com" />
-      <button id="multiAddBtn">＋ 追加</button>
-    </div>
-    <div id="multiStatus" class="multi-status"></div>
   </div>
   <script src="app.js"></script>
 </body>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -1018,15 +1018,19 @@ bogus-priv</code></pre>
         <div class="legatus-row"><span class="legatus-key">最終受信ログ</span><span id="legatusEventTail" class="legatus-val legatus-tail">—</span></div>
       </div>
 
-      <h4>📐 GPS ノイズ間引き距離</h4>
+      <h4>📐 軌跡描画</h4>
       <p class="ai-settings-help">
-        Tracks ページの map と「GPS ログ最新 50 件」 list でこの距離以内の連続点を間引きます。 単位は m。 GPS の数 m ジッタを除外して実移動だけ表示するためのもの (徒歩 / 交通機関の判定にも影響)。 既定 2m、 0 で間引き OFF、 大きいほど点が減って軌跡が荒くなる。
+        Tracks ページの map に GPS 点をどう描くかの設定. 既定は「全点を点 marker のみ」で描画 (ポリライン無し / 間引き無し). 軌跡を線で繋ぎたい時は下のチェックを ON、 ジッタを減らしたい時は間引き距離を上げる.
       </p>
       <label>
         間引き距離 (m):
-        <input id="tracksDecimateMeters" type="number" min="0" max="1000" step="0.5" placeholder="2" />
+        <input id="tracksDecimateMeters" type="number" min="0" max="1000" step="0.5" placeholder="0" />
       </label>
       <span id="tracksDecimateStatus" class="ai-keystatus"></span>
+      <label class="tracks-toggle-row">
+        <input id="tracksShowPolyline" type="checkbox" />
+        ポリライン表示 (区間色分け線). 既定 OFF (= 点 marker のみ).
+      </label>
 
       <h4>🗺 Google Maps API key</h4>
       <p class="ai-settings-help">

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -9,7 +9,7 @@
   <title>Memoria</title>
   <link rel="manifest" href="manifest.webmanifest" />
   <link rel="apple-touch-icon" href="icon-192.svg" />
-  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="style.css?v=20260503b" />
 </head>
 <body>
   <header class="topbar">
@@ -1139,6 +1139,6 @@ bogus-priv</code></pre>
       <button id="aiSettingsSave">保存</button>
     </div>
   </div>
-  <script src="app.js"></script>
+  <script src="app.js?v=20260503b"></script>
 </body>
 </html>

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -1929,6 +1929,92 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 }
 .ai-settings-head #aiSettingsClose:hover { background: #f0f2f7; color: var(--text); }
 .ai-settings-help { font-size: 11px; color: var(--muted); margin: 8px 0 16px; line-height: 1.5; }
+
+/* ── settings tabs (内部タブ) ─────────────────────── */
+.settings-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
+  border-bottom: 1px solid var(--border);
+  margin: 12px 0 14px;
+  padding-bottom: 0;
+}
+.settings-tab {
+  padding: 6px 10px;
+  font-size: 12px;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--muted);
+  cursor: pointer;
+  border-radius: 0;
+  white-space: nowrap;
+  transform: translateY(1px);
+}
+.settings-tab:hover { color: var(--text); background: rgba(0,0,0,0.03); }
+.settings-tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+  font-weight: 600;
+  background: transparent;
+}
+.settings-tab-body { animation: settingsTabFade .12s ease-out; }
+.settings-tab-body.hidden { display: none; }
+@keyframes settingsTabFade {
+  from { opacity: 0; transform: translateY(2px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.settings-footer {
+  position: sticky;
+  bottom: -18px;
+  margin: 18px -22px -18px;
+  padding: 12px 22px;
+  background: var(--panel);
+  border-top: 1px solid var(--border);
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  z-index: 1;
+}
+
+/* ── Legatus 接続バッジ (topbar) ─────────────────────── */
+.topbar-legatus {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  padding: 4px 10px;
+}
+.legatus-dot {
+  font-size: 10px;
+  line-height: 1;
+}
+.legatus-dot[data-state="connected"]   { color: #16a34a; }
+.legatus-dot[data-state="stale"]       { color: #f59e0b; }
+.legatus-dot[data-state="disconnected"]{ color: #dc2626; }
+.legatus-dot[data-state="unknown"]     { color: var(--muted); }
+.legatus-label { color: var(--muted); }
+
+/* ── Legatus 詳細 status box (設定モーダル内) ─────────── */
+.legatus-status-box {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  padding: 8px 12px;
+  margin: 6px 0 14px;
+  font-size: 12px;
+}
+.legatus-row {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: 8px;
+  padding: 3px 0;
+  border-bottom: 1px solid rgba(0,0,0,0.04);
+}
+.legatus-row:last-child { border-bottom: none; }
+.legatus-key { color: var(--muted); font-size: 11px; }
+.legatus-val { color: var(--text); font-family: ui-monospace, monospace; font-size: 11px; word-break: break-all; }
+.legatus-val.legatus-tail { color: var(--muted); white-space: pre-wrap; }
 .ai-settings h4 { margin: 14px 0 6px; font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; }
 .ai-task-row {
   display: grid;
@@ -2951,6 +3037,76 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   border-radius: 6px;
   background: var(--bg);
 }
+/* ── tracks 最新 GPS ログ ─────────────────────── */
+.tracks-recent {
+  margin-top: 16px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  padding: 10px 12px;
+}
+.tracks-recent-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.tracks-recent-head h4 {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text);
+}
+.tracks-recent-head .muted {
+  font-size: 11px;
+}
+.tracks-recent-head button {
+  margin-left: auto;
+  font-size: 12px;
+  padding: 2px 8px;
+}
+.tracks-recent-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  max-height: 300px;
+  overflow-y: auto;
+  border-top: 1px solid var(--border);
+}
+.tracks-recent-row {
+  padding: 5px 4px;
+  border-bottom: 1px solid rgba(0,0,0,0.05);
+  cursor: pointer;
+  font-size: 12px;
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: 8px;
+  align-items: center;
+}
+.tracks-recent-row:last-child { border-bottom: none; }
+.tracks-recent-row:hover { background: rgba(59,130,246,0.06); }
+.tracks-recent-time {
+  font-family: ui-monospace, monospace;
+  color: var(--muted);
+  font-size: 11px;
+}
+.tracks-recent-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: baseline;
+  font-size: 11px;
+}
+.tracks-recent-dev {
+  background: rgba(59,130,246,0.12);
+  color: #1e40af;
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+.tracks-recent-coord code {
+  font-size: 11px;
+  color: var(--text);
+}
+
 .tracks-days {
   margin-top: 16px;
 }

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -4202,3 +4202,175 @@ dialog.meal-modal[open] {
 .ext-cfg-howto-dns { border-left: 3px solid #2a6df4; }
 
 .ext-cfg-step h5 { margin: 4px 0; font-size: 12px; color: var(--text-muted); }
+
+/* ── 場所編集ダイアログ (軌跡 / 食事 / その他共通) ─────────────── */
+dialog.loc-edit-modal {
+  border: none;
+  padding: 0;
+  background: transparent;
+  max-width: none;
+  max-height: none;
+  width: auto;
+  height: auto;
+}
+dialog.loc-edit-modal::backdrop {
+  background: rgba(0, 0, 0, 0.55);
+}
+dialog.loc-edit-modal[open] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.loc-edit-card {
+  width: min(560px, calc(100vw - 24px));
+  max-height: calc(100vh - 24px);
+  background: var(--bg-surface, #fff);
+  border-radius: 8px;
+  box-shadow: 0 10px 40px rgba(0,0,0,0.25);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.loc-edit-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+}
+.loc-edit-head h3 { margin: 0; font-size: 15px; }
+.loc-edit-subtitle { font-size: 12px; color: var(--text-muted); }
+.loc-edit-x {
+  margin-left: auto;
+  background: transparent;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+  color: var(--text-muted);
+  padding: 0 4px;
+}
+.loc-edit-x:hover { color: var(--text); background: transparent; }
+
+.loc-edit-search {
+  display: flex;
+  gap: 6px;
+  padding: 8px 14px 4px;
+}
+.loc-edit-search input {
+  flex: 1;
+  padding: 6px 10px;
+  font-size: 13px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+.loc-edit-search button { padding: 4px 10px; font-size: 13px; }
+.loc-edit-search-results {
+  list-style: none;
+  margin: 0 14px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  max-height: 160px;
+  overflow-y: auto;
+  font-size: 12px;
+  background: var(--bg-surface, #fff);
+}
+.loc-edit-search-results li {
+  padding: 6px 10px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--border);
+}
+.loc-edit-search-results li:last-child { border-bottom: none; }
+.loc-edit-search-results li:hover { background: var(--bg); }
+.loc-edit-search-result-name { font-weight: 500; }
+.loc-edit-search-result-addr { color: var(--text-muted); font-size: 11px; }
+
+.loc-edit-map {
+  width: 100%;
+  height: 320px;
+  margin: 8px 0 0;
+  background: #f4f4f4;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+.loc-edit-map-missing {
+  margin: 8px 14px 0;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: #fff7d6;
+  color: #6a4a00;
+  font-size: 12px;
+}
+
+.loc-edit-pin { padding: 10px 14px; display: flex; flex-direction: column; gap: 8px; }
+.loc-edit-pin-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: flex-end;
+}
+.loc-edit-pin-coord {
+  flex: 1 1 120px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.loc-edit-pin-coord input {
+  padding: 4px 8px;
+  font-size: 13px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+}
+.loc-edit-pin-name {
+  flex: 1 1 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.loc-edit-pin-name input {
+  padding: 4px 8px;
+  font-size: 13px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+}
+.loc-edit-suggest {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  font-size: 12px;
+}
+.loc-edit-suggest-label { color: var(--text-muted); }
+.loc-edit-suggest button {
+  padding: 2px 8px;
+  font-size: 11px;
+  border: 1px solid var(--accent, #2a6df4);
+  background: var(--bg);
+  color: var(--accent, #2a6df4);
+  border-radius: 12px;
+  cursor: pointer;
+}
+.loc-edit-suggest button:hover { background: var(--accent, #2a6df4); color: #fff; }
+.loc-edit-hint { font-size: 11px; }
+
+.loc-edit-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 10px 14px;
+  border-top: 1px solid var(--border);
+  background: var(--bg);
+}
+.loc-edit-actions .grow { flex: 1; }
+.loc-edit-actions button { font-size: 13px; padding: 6px 14px; }
+
+@media (max-width: 600px) {
+  .loc-edit-card { width: calc(100vw - 12px); max-height: calc(100vh - 12px); }
+  .loc-edit-map { height: 260px; }
+  .loc-edit-head h3 { font-size: 14px; }
+}

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -3089,6 +3089,19 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   color: var(--muted);
   font-size: 11px;
 }
+.tracks-recent-place {
+  font-size: 12px;
+  line-height: 1.3;
+  margin: 2px 0;
+}
+.tracks-recent-place strong {
+  color: var(--fg, #1f2937);
+  font-weight: 600;
+}
+.tracks-recent-place--pending {
+  font-style: italic;
+  font-size: 11px;
+}
 .tracks-recent-meta {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary

軌跡 / 食事 / その他の location 入力で再利用できる、 検索可能な full-screen ピン留めダイアログを追加。 食事モーダルから 1 つの consumer として早速使えるよう統合。

## 仕様 (user 提案準拠)

- ✅ ポップアップする <dialog> + 半透明黒 backdrop
- ✅ Google Maps を埋め込み (Maps JS API + Places lib)
- ✅ お店 / 住所の text 検索
- ✅ ピン留め → 「📌 ここに修正」 ボタン
- ✅ Geo (lat/lon) と並んで Google Maps の **施設名取得** ボタン (nearbySearch)

## 共通 API

```js
await openLocationEditModal({
  initial: { lat, lon, label?, place_id? } | null,
  title: '場所を編集',
  subtitle: '...',
  onApply: ({lat, lon, place_name, place_id}) => Promise<void>,
});
```

## 1st consumer: 食事モーダル

「場所」 行に **「📌 詳細編集」 ボタン** 追加。 既存の inline 小地図はそのまま、 加えて押すと location-modal が開きます。 onApply で:
- meal modal の lat/lon フィールドへ座標反映
- 施設名 (Google) は user note の先頭に prepend (上書きしない)

## ファイル変更

- `index.html`: <dialog id="locationEditModal"> + 食事モーダルの「📌 詳細編集」 ボタン
- `app.js`: `openLocationEditModal` / `placeLocEditMarker` / `runLocEditSearch` / `fetchLocEditPlaceSuggestions` + 結線。 `ensureGoogleMapsLoaded` に `libraries=places` を追加 (既存 tracks/meals に互換)
- `style.css`: `.loc-edit-*` 一連 (mobile 対応含む)

## Out of scope (別 PR で)

- 軌跡タブの「📌 場所を追加」 統合 — labeled waypoint テーブルが要、 別 PR
- meal モーダルの inline 小地図を完全削除して詳細編集 1 本化 — UX 後退の懸念があるので様子見

## Test plan

- [x] `node --check` pass / `npm run typecheck` clean
- [ ] 食事モーダル → 「📌 詳細編集」 → 検索 + ピン留め + 「📥 取得」 + 「📌 ここに修正」 までブラウザで一気通し
- [ ] Google Maps API key 未設定時の degradation (黄色 warning 表示)

🤖 Generated with [Claude Code](https://claude.com/claude-code)