### PR TITLE
chore: harden release workflow inputs and declare CI permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: lint + smoke

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -91,9 +91,11 @@ jobs:
       - name: Resolve release tag
         id: tag
         shell: bash
+        env:
+          TAG_INPUT: ${{ github.event.inputs.tag }}
         run: |
-          if [ -n "${{ github.event.inputs.tag }}" ]; then
-            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          if [ -n "$TAG_INPUT" ]; then
+            echo "tag=$TAG_INPUT" >> "$GITHUB_OUTPUT"
           else
             echo "tag=${GITHUB_REF##*/}" >> "$GITHUB_OUTPUT"
           fi
@@ -138,9 +140,11 @@ jobs:
       - name: Resolve release tag
         id: tag
         shell: bash
+        env:
+          TAG_INPUT: ${{ github.event.inputs.tag }}
         run: |
-          if [ -n "${{ github.event.inputs.tag }}" ]; then
-            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          if [ -n "$TAG_INPUT" ]; then
+            echo "tag=$TAG_INPUT" >> "$GITHUB_OUTPUT"
           else
             echo "tag=${GITHUB_REF##*/}" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## Summary
- LUDIARS-wide security audit recommendations: shell-quote tag input safely in `desktop-release.yml` (env-passthrough) and add explicit `permissions: contents: read` to `ci.yml`.
- No behavior change.

## Files
- `.github/workflows/desktop-release.yml`: pass `github.event.inputs.tag` through `env:` (lines ~96/143 in pre-fix version)
- `.github/workflows/ci.yml`: top-level `permissions: contents: read`

## Test plan
- [ ] CI green on the PR
- [ ] Manual smoke: dispatch desktop-release with a real tag after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)