### PR TITLE
feat: track git commits + Claude Code prompts as activity events

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -132,6 +132,32 @@ export function openDb(dbPath) {
     CREATE INDEX IF NOT EXISTS idx_visit_events_domain
       ON visit_events(domain);
 
+    -- 開発系の活動イベント (git commit / Claude Code prompt 等) を時系列で保存。
+    -- ブラウザ閲覧 (visit_events) では拾えない作業 (スマホ開発、 ターミナル作業
+    -- 中心の日) を可視化し、 仕事時間推定の根拠にする。
+    -- kind: 'git_commit' | 'claude_code_prompt' (将来追加可能)
+    -- source: kind 別の文脈 (リポ名 / セッション ID 等)
+    -- ref_id: 一意性のあるキー (commit sha / prompt UUID) — 重複登録防止
+    -- content: 短い本文 (commit message 1 行目 / プロンプト先頭〜200 文字)
+    -- metadata_json: JSON で kind 別の追加情報 (branch, author, model, cwd 等)
+    CREATE TABLE IF NOT EXISTS activity_events (
+      id            INTEGER PRIMARY KEY AUTOINCREMENT,
+      kind          TEXT NOT NULL,
+      occurred_at   TEXT NOT NULL,
+      source        TEXT,
+      ref_id        TEXT,
+      content       TEXT,
+      metadata_json TEXT,
+      ingested_at   TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_activity_events_at
+      ON activity_events(occurred_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_activity_events_kind_at
+      ON activity_events(kind, occurred_at DESC);
+    -- 同一 ref_id (sha 等) の重複登録を防ぐ — kind+ref_id の組で一意。
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_activity_events_ref
+      ON activity_events(kind, ref_id) WHERE ref_id IS NOT NULL;
+
     CREATE TABLE IF NOT EXISTS diary_entries (
       date                  TEXT PRIMARY KEY,
       summary               TEXT,
@@ -1202,6 +1228,69 @@ export function listServerEventsForDate(db, dateStr) {
     ORDER BY occurred_at ASC
   `).all(dateStr, dateStr).map(r => ({
     ...r, details: r.details_json ? safeParse(r.details_json) : null,
+  }));
+}
+
+// ── activity events (git commit / claude code prompt 等) ─────────────────
+
+const ACTIVITY_KINDS = new Set(['git_commit', 'claude_code_prompt']);
+
+/**
+ * 活動イベントを 1 件記録する。
+ * kind+ref_id の重複は INSERT OR IGNORE で吸収 (同じ commit sha / prompt id が
+ * 二度送られても重複しない)。 戻り値は inserted=true|false + id。
+ */
+export function recordActivityEvent(db, { kind, occurred_at, source, ref_id, content, metadata }) {
+  if (!ACTIVITY_KINDS.has(kind)) {
+    throw new Error(`unknown activity kind: ${kind}`);
+  }
+  const ts = occurred_at || new Date().toISOString();
+  const info = db.prepare(`
+    INSERT OR IGNORE INTO activity_events
+      (kind, occurred_at, source, ref_id, content, metadata_json)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run(
+    kind,
+    ts,
+    source ?? null,
+    ref_id ?? null,
+    content ?? null,
+    metadata ? JSON.stringify(metadata) : null,
+  );
+  return { inserted: info.changes > 0, id: info.lastInsertRowid };
+}
+
+/** 当日 (local) の活動イベントを時刻昇順で返す。 */
+export function activityEventsForDate(db, dateStr) {
+  return db.prepare(`
+    SELECT id, kind, occurred_at, source, ref_id, content, metadata_json
+    FROM activity_events
+    WHERE date(occurred_at, 'localtime') = ?
+    ORDER BY occurred_at ASC
+  `).all(dateStr).map((r) => ({
+    ...r,
+    metadata: r.metadata_json ? safeParse(r.metadata_json) : null,
+  }));
+}
+
+/** 直近 limit 件 (新しい順)。 全期間 / 任意 kind フィルタつき。 */
+export function listActivityEvents(db, { limit = 200, kind = null } = {}) {
+  const args = [];
+  let where = '';
+  if (kind && ACTIVITY_KINDS.has(kind)) {
+    where = 'WHERE kind = ?';
+    args.push(kind);
+  }
+  args.push(Number(limit) || 200);
+  return db.prepare(`
+    SELECT id, kind, occurred_at, source, ref_id, content, metadata_json, ingested_at
+    FROM activity_events
+    ${where}
+    ORDER BY occurred_at DESC
+    LIMIT ?
+  `).all(...args).map((r) => ({
+    ...r,
+    metadata: r.metadata_json ? safeParse(r.metadata_json) : null,
   }));
 }
 

--- a/server/diary.js
+++ b/server/diary.js
@@ -4,7 +4,7 @@
 // Hourly buckets, top domains, and active hours are computed locally;
 // claude is asked only to narrate.
 
-import { visitEventsForDate, getDiary, getDomainCatalogMap, digSessionsForDate, listServerEventsForDate, listGpsLocationsForDate, listMealsForDate, getAppSettings } from './db.js';
+import { visitEventsForDate, getDiary, getDomainCatalogMap, digSessionsForDate, listServerEventsForDate, listGpsLocationsForDate, listMealsForDate, getAppSettings, activityEventsForDate } from './db.js';
 import { runLlm } from './llm.js';
 
 // Downtimes >5 min make it into the diary; shorter gaps are treated as
@@ -224,6 +224,11 @@ export function aggregateDay(db, dateStr, { listLimit = DIARY_LIST_INITIAL } = {
     }
   }
 
+  // 開発活動イベント (git commit / Claude Code prompt 等)。 ブラウザ閲覧で
+  // 拾えない作業をカバーする。 list_limit でページング、 hourly bucket 別途。
+  const allActivity = activityEventsForDate(db, dateStr);
+  const activity = summarizeActivityForDate(allActivity, listLimit);
+
   return {
     date: dateStr,
     total_events: totalEvents,
@@ -247,10 +252,45 @@ export function aggregateDay(db, dateStr, { listLimit = DIARY_LIST_INITIAL } = {
       intake: meals.length > 0 ? mealsCalories : null,
       gpsDistanceM: gps?.distance_m ?? 0,
     }),
+    activity,
     sources: {
       visit_events: events.length,
       page_visits: pageVisitsContribution,
+      activity_events: allActivity.length,
     },
+  };
+}
+
+/**
+ * 当日分の活動イベントを集計する。
+ * - hourly: kind 別の 24 時間バケット (バーグラフ用)
+ * - kinds:  kind 別の総件数
+ * - items:  時系列リスト (listLimit で先頭 N 件、 null なら全件 — highlights プロンプト用)
+ * - total:  全イベント件数
+ */
+function summarizeActivityForDate(rows, listLimit) {
+  const kinds = {};
+  const hourly = {};
+  for (const r of rows) {
+    kinds[r.kind] = (kinds[r.kind] || 0) + 1;
+    if (!hourly[r.kind]) hourly[r.kind] = new Array(24).fill(0);
+    const h = parseSqliteUtc(r.occurred_at)?.getHours();
+    if (Number.isFinite(h)) hourly[r.kind][h] += 1;
+  }
+  const items = (listLimit == null ? rows : rows.slice(0, listLimit)).map((r) => ({
+    id: r.id,
+    kind: r.kind,
+    occurred_at: r.occurred_at,
+    source: r.source,
+    ref_id: r.ref_id,
+    content: r.content,
+    metadata: r.metadata,
+  }));
+  return {
+    total: rows.length,
+    kinds,
+    hourly,
+    items,
   };
 }
 
@@ -639,9 +679,10 @@ export function summarizeGithubByRepo(github) {
   return { repos, total: commits.length };
 }
 
-const WORK_CONTENT_PROMPT = ({ dateStr, urlList, totalEvents, totalDomains }) => [
+const WORK_CONTENT_PROMPT = ({ dateStr, urlList, activityList, totalEvents, totalDomains, activityCounts }) => [
   `あなたは ${dateStr} の「作業内容」セクションを書きます。`,
-  'ブラウザ閲覧履歴 (URL + 時刻) を読み、**大まかな時間帯**で何をしていたかを 1 文でまとめ、',
+  'ブラウザ閲覧履歴 (URL + 時刻) と開発活動 (git commit / Claude Code への指示) を両方読み、',
+  '**大まかな時間帯**で何をしていたかを 1 文でまとめ、',
   'その下に主な作業を箇条書きで添えてください。細かい行動を全部書く必要はありません。',
   '',
   '出力フォーマット (markdown のみ。前置き・コードフェンス禁止):',
@@ -682,15 +723,23 @@ const WORK_CONTENT_PROMPT = ({ dateStr, urlList, totalEvents, totalDomains }) =>
   '  単純な開始〜終了の wall clock ではなく、移動・休憩・離席・SNS 流し見等は除く。',
   '- ブラウザのタブが開きっぱなしでもアクセス記録に動きがない時間は作業していないとみなす。',
   '- 「記録なし」のブロックは 0 分。',
+  '- **重要**: 開発活動 (git commit / Claude Code への指示) は強い作業シグナル。',
+  '  ブラウザ履歴が空でも、 commit / 指示が連続している時間帯は作業していたとみなす。',
+  '  特にスマホ開発・ターミナル中心の作業日はブラウザ履歴がほぼ無いので、',
+  '  開発活動を主たる根拠にして時間帯を組み立てる。',
   '- 24 時間 (1440 分) を超えてはいけない。実態として 12 時間を超えるのは長時間集中日のみ。',
-  '- 推定材料が足りない (例: 1 件しかアクセスがない) 場合は WORK_MINUTES: 0 と書く。',
+  '- 推定材料が足りない (例: 1 件しかアクセスがない、 開発活動も 0) 場合は WORK_MINUTES: 0 と書く。',
   '',
   `日付: ${dateStr}`,
   `総アクセス: ${totalEvents}`,
   `ユニークドメイン: ${totalDomains}`,
+  `開発活動: ${activityCounts || '(なし)'}`,
   '',
   'URL 履歴 (時刻 + URL):',
-  urlList,
+  urlList || '(ブラウザ閲覧記録なし)',
+  '',
+  '開発活動 (時刻 + イベント):',
+  activityList || '(なし)',
 ].join('\n');
 
 /**
@@ -802,6 +851,32 @@ function formatMealsBlock(metrics) {
   return lines.join('\n');
 }
 
+function formatActivityBlock(activity) {
+  if (!activity || !activity.total) return '(なし)';
+  const lines = [];
+  const counts = formatActivityCounts(activity);
+  if (counts) lines.push(`- 合計: ${counts}`);
+  // 最大 30 件まで時刻昇順で並べる (highlights プロンプトのサイズ管理)。
+  const sorted = [...(activity.items || [])].sort((a, b) => {
+    const at = parseSqliteUtc(a.occurred_at)?.getTime() || 0;
+    const bt = parseSqliteUtc(b.occurred_at)?.getTime() || 0;
+    return at - bt;
+  }).slice(0, 30);
+  for (const it of sorted) {
+    const t = formatLocalHm(it.occurred_at);
+    const tag = it.kind === 'git_commit' ? 'git'
+      : it.kind === 'claude_code_prompt' ? 'cc'
+      : it.kind;
+    const src = it.source ? ` ${it.source}:` : '';
+    const content = (it.content || '').replace(/\s+/g, ' ').slice(0, 140);
+    lines.push(`- ${t} [${tag}]${src} ${content}`.trim());
+  }
+  if ((activity.items || []).length > 30) {
+    lines.push(`- … ほか ${activity.items.length - 30} 件`);
+  }
+  return lines.join('\n');
+}
+
 function formatLocalHm(iso) {
   if (!iso) return '';
   const d = new Date(iso);
@@ -827,6 +902,9 @@ const HIGHLIGHTS_PROMPT = ({ dateStr, workContent, githubByRepo, bookmarkSummary
   githubByRepo.repos.length
     ? githubByRepo.repos.map(r => `- ${r.repo}: ${r.count} commits`).join('\n')
     : '(なし)',
+  '',
+  '## 入力 3b: ローカル開発活動 (git commit + Claude Code 指示)',
+  formatActivityBlock(metrics.activity),
   '',
   '## 入力 4: 当日のディグ調査 (検索 + 取得した情報源)',
   (digs && digs.length > 0)
@@ -1003,19 +1081,65 @@ function appendMemoAndImprove(prompt, { globalMemo, improve } = {}) {
  * the day's focused work minutes (tail line `WORK_MINUTES: <int>`). Returns
  * `{ content, workMinutes }` — content is the markdown shown to the user
  * (tail stripped), workMinutes feeds the trends chart.
+ *
+ * URL 履歴に加えて開発活動 (git commit / Claude Code prompt) も
+ * 時系列で渡し、 ブラウザ履歴が薄い日 (スマホ開発等) でも作業時間が
+ * 適切に推定されるようにする。
  */
 export async function generateWorkContent({ db, dateStr, metrics, globalMemo, improve, timeoutMs = 180_000 }) {
   const urlList = buildUrlList(db, dateStr);
-  if (!urlList.trim()) return { content: '', workMinutes: null };
+  const activityList = buildActivityList(metrics.activity);
+  // どちらか片方でもシグナルがあれば走らせる (スマホ開発日などは URL が空でも commit がある)。
+  if (!urlList.trim() && !activityList.trim()) return { content: '', workMinutes: null };
+  const activityCounts = formatActivityCounts(metrics.activity);
   const base = WORK_CONTENT_PROMPT({
     dateStr,
     urlList,
+    activityList,
     totalEvents: metrics.total_events,
     totalDomains: metrics.unique_domains,
+    activityCounts,
   });
   const prompt = appendMemoAndImprove(base, { globalMemo, improve });
   const raw = await runLlm({ task: 'diary_work', prompt, timeoutMs });
   return extractWorkMinutes(raw);
+}
+
+/**
+ * Sonnet プロンプトに渡す活動タイムラインを組み立てる。
+ * 形式: "HH:MM [git/cc] <短い content>" を時刻昇順で並べる。
+ * 上限 800 行 (URL 側と揃える) でトリム — 直近側を残す。
+ */
+function buildActivityList(activity) {
+  if (!activity || !activity.items || activity.items.length === 0) return '';
+  // items は listLimit 切り取り済 (frontend 用) なので、 prompt 用には全件欲しい。
+  // ただし aggregateDay の listLimit=null 経路 (highlights 用) でないと不足する場合あり。
+  // 妥協: items を時刻昇順にし直し、 そのまま渡す。
+  const sorted = [...activity.items].sort((a, b) => {
+    const at = parseSqliteUtc(a.occurred_at)?.getTime() || 0;
+    const bt = parseSqliteUtc(b.occurred_at)?.getTime() || 0;
+    return at - bt;
+  });
+  const lines = sorted.map((it) => {
+    const d = parseSqliteUtc(it.occurred_at);
+    const hh = d ? String(d.getHours()).padStart(2, '0') : '??';
+    const mm = d ? String(d.getMinutes()).padStart(2, '0') : '??';
+    const tag = it.kind === 'git_commit' ? 'git'
+      : it.kind === 'claude_code_prompt' ? 'cc'
+      : it.kind;
+    const src = it.source ? ` ${it.source}:` : '';
+    const content = (it.content || '').replace(/\s+/g, ' ').slice(0, 160);
+    return `${hh}:${mm} [${tag}]${src} ${content}`.trim();
+  });
+  return lines.slice(-800).join('\n');
+}
+
+function formatActivityCounts(activity) {
+  if (!activity || !activity.total) return null;
+  const parts = [];
+  if (activity.kinds.git_commit) parts.push(`git commit ${activity.kinds.git_commit} 件`);
+  if (activity.kinds.claude_code_prompt) parts.push(`Claude Code 指示 ${activity.kinds.claude_code_prompt} 件`);
+  return parts.join(' / ') || `${activity.total} 件`;
 }
 
 /** Stage 3: Opus 1M (default) integrates work content + bookmark count + commits + dig into highlights. */
@@ -1054,7 +1178,7 @@ export async function generateDiary({ db, dateStr, metrics, github, notes }) {
   });
 
   // Combined summary for legacy display.
-  const summary = composeSummary({ workContent, githubByRepo, highlights, digs });
+  const summary = composeSummary({ workContent, githubByRepo, highlights, digs, activity: metrics.activity });
   return { workContent, workMinutes, githubByRepo, highlights, summary, digs };
 }
 
@@ -1072,7 +1196,7 @@ function buildBookmarkSummary(metrics) {
   };
 }
 
-function composeSummary({ workContent, githubByRepo, highlights, digs }) {
+function composeSummary({ workContent, githubByRepo, highlights, digs, activity }) {
   const parts = [];
   if (workContent) parts.push(`## 作業内容\n${workContent.trim()}`);
   if (digs && digs.length > 0) {
@@ -1087,6 +1211,29 @@ function composeSummary({ workContent, githubByRepo, highlights, digs }) {
       .map(r => `- ${r.repo}: ${r.count} commits`)
       .join('\n');
     parts.push(`## GitHub commits (${githubByRepo.total} 件)\n${repoLines}`);
+  }
+  if (activity && activity.total > 0) {
+    const counts = formatActivityCounts(activity);
+    const head = counts ? `合計: ${counts}` : `合計: ${activity.total} 件`;
+    // 先頭から最大 10 件をサマリに出す (フル一覧は activity 個別パネルで)。
+    const sorted = [...(activity.items || [])].sort((a, b) => {
+      const at = parseSqliteUtc(a.occurred_at)?.getTime() || 0;
+      const bt = parseSqliteUtc(b.occurred_at)?.getTime() || 0;
+      return at - bt;
+    }).slice(0, 10);
+    const lines = sorted.map((it) => {
+      const t = formatLocalHm(it.occurred_at);
+      const tag = it.kind === 'git_commit' ? 'git'
+        : it.kind === 'claude_code_prompt' ? 'cc'
+        : it.kind;
+      const src = it.source ? ` ${it.source}:` : '';
+      const content = (it.content || '').replace(/\s+/g, ' ').slice(0, 120);
+      return `- ${t} [${tag}]${src} ${content}`.trim();
+    });
+    const tail = (activity.items || []).length > 10
+      ? `\n- … ほか ${activity.items.length - 10} 件`
+      : '';
+    parts.push(`## 開発活動\n${head}\n${lines.join('\n')}${tail}`);
   }
   if (highlights) parts.push(`## ハイライト\n${highlights.trim()}`);
   return parts.join('\n\n');

--- a/server/hooks/claude-code-prompt.mjs
+++ b/server/hooks/claude-code-prompt.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+// Claude Code UserPromptSubmit hook → Memoria activity event.
+//
+// stdin から hook payload (session_id / prompt / cwd ... の JSON) を読み、
+// `claude_code_prompt` イベントとして Memoria の /api/activity/event に POST する。
+//
+// 設計方針:
+//   - **絶対にプロンプト処理を妨げない**。 ネットワーク失敗 / parse 失敗 / JSON
+//     不正は全部握りつぶして exit 0。 stdout も汚さない。
+//   - 1 秒タイムアウト。 Memoria が落ちてれば即諦める。
+//   - prompt 先頭 240 文字だけ送る (個人情報の漏洩面を最小化)。
+//
+// settings.json 設定例:
+//   "UserPromptSubmit": [{
+//     "hooks": [{
+//       "type": "command",
+//       "command": "node \"<path>/server/hooks/claude-code-prompt.mjs\"",
+//       "async": true,
+//       "timeout": 2
+//     }]
+//   }]
+//
+// 環境変数:
+//   MEMORIA_URL — base URL (default http://localhost:5180)
+
+const MEMORIA_URL = process.env.MEMORIA_URL || 'http://localhost:5180';
+const TIMEOUT_MS = 1000;
+const CONTENT_MAX = 240;
+
+let buf = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (c) => { buf += c; });
+process.stdin.on('end', async () => {
+  try {
+    const payload = JSON.parse(buf || '{}');
+    const prompt = typeof payload.prompt === 'string' ? payload.prompt : '';
+    const body = {
+      kind: 'claude_code_prompt',
+      ref_id: payload.session_id ? `${payload.session_id}:${Date.now()}` : null,
+      source: payload.cwd || null,
+      content: prompt.slice(0, CONTENT_MAX),
+      occurred_at: new Date().toISOString(),
+      metadata: {
+        cwd: payload.cwd || null,
+        session_id: payload.session_id || null,
+        prompt_length: prompt.length,
+      },
+    };
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), TIMEOUT_MS);
+    try {
+      await fetch(`${MEMORIA_URL}/api/activity/event`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+        signal: ac.signal,
+      });
+    } catch {
+      // ignore — server down / timeout
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch {
+    // ignore — stdin not JSON / unreadable
+  }
+  // 必ず exit 0 (プロンプト処理を妨げない)
+  process.exit(0);
+});
+process.stdin.on('error', () => process.exit(0));

--- a/server/index.js
+++ b/server/index.js
@@ -60,6 +60,7 @@ import { fetchPageMetadata } from './page-metadata.js';
 import { extractWordCloud, validateWordRelevance } from './wordcloud.js';
 import { startUptimeTracking, readHeartbeat, DOWNTIME_THRESHOLD_MS } from './local/uptime.js';
 import { listServerEvents, listServerEventsForDate } from './db.js';
+import { recordActivityEvent, activityEventsForDate, listActivityEvents } from './db.js';
 import {
   aggregateDay, fetchGithubActivity, fetchGithubRange,
   generateDiary, generateWorkContent, generateHighlights,
@@ -2683,6 +2684,7 @@ function enqueueDiaryStages(dateStr, opts = {}) {
         githubByRepo: ctx.githubByRepo,
         highlights: ctx.highlights,
         digs,
+        activity: ctx.metrics?.activity,
       });
       upsertDiary(db, {
         date: dateStr,
@@ -2713,7 +2715,7 @@ function enqueueDiaryStages(dateStr, opts = {}) {
 
 // Mirror of `composeSummary` from diary.js — extracted here so we can run
 // the highlights stage independently in the queue chain.
-function composeDiarySummary({ workContent, githubByRepo, highlights, digs }) {
+function composeDiarySummary({ workContent, githubByRepo, highlights, digs, activity }) {
   const parts = [];
   if (workContent) parts.push(`## 作業内容\n${workContent.trim()}`);
   if (digs && digs.length > 0) {
@@ -2726,6 +2728,24 @@ function composeDiarySummary({ workContent, githubByRepo, highlights, digs }) {
   if (githubByRepo?.repos?.length) {
     const repoLines = githubByRepo.repos.map(r => `- ${r.repo}: ${r.count} commits`).join('\n');
     parts.push(`## GitHub commits (${githubByRepo.total} 件)\n${repoLines}`);
+  }
+  if (activity && activity.total > 0) {
+    const countParts = [];
+    if (activity.kinds?.git_commit) countParts.push(`git commit ${activity.kinds.git_commit} 件`);
+    if (activity.kinds?.claude_code_prompt) countParts.push(`Claude Code 指示 ${activity.kinds.claude_code_prompt} 件`);
+    const head = countParts.length > 0 ? countParts.join(' / ') : `${activity.total} 件`;
+    const items = (activity.items || []).slice(0, 10).map((it) => {
+      const t = (it.occurred_at || '').slice(11, 16);
+      const tag = it.kind === 'git_commit' ? 'git'
+        : it.kind === 'claude_code_prompt' ? 'cc' : it.kind;
+      const src = it.source ? ` ${it.source}:` : '';
+      const content = (it.content || '').replace(/\s+/g, ' ').slice(0, 120);
+      return `- ${t} [${tag}]${src} ${content}`.trim();
+    });
+    const tail = (activity.items || []).length > 10
+      ? `\n- … ほか ${activity.items.length - 10} 件`
+      : '';
+    parts.push(`## 開発活動\n合計: ${head}\n${items.join('\n')}${tail}`);
   }
   if (highlights) parts.push(`## ハイライト\n${highlights.trim()}`);
   return parts.join('\n\n');
@@ -2831,6 +2851,61 @@ app.get('/api/diary/:date/bookmarks', (c) => {
     total: kind === 'accessed' ? r.accessed_total : r.created_total,
     offset, limit,
   });
+});
+
+// ─── activity events (git commit / claude code prompt 等) ─────────────────
+//
+// 外部のフック (グローバル git post-commit / Claude Code UserPromptSubmit hook
+// 等) からこのエンドポイントに POST してもらう。 同一 ref_id (commit sha 等) は
+// kind+ref_id の UNIQUE 制約で自動的に重複弾き。
+//
+// Body:
+//   {
+//     "kind": "git_commit" | "claude_code_prompt",
+//     "occurred_at": "YYYY-MM-DDTHH:MM:SSZ"   // 省略時は now
+//     "source": "<repo path / project name>",
+//     "ref_id": "<sha or session_id>",        // 重複弾き用、 省略可
+//     "content": "<commit msg 1 行目 / プロンプト先頭 200 文字>",
+//     "metadata": { ... }                     // 追加情報 (branch / cwd / model 等)
+//   }
+app.post('/api/activity/event', async (c) => {
+  let body;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid json' }, 400);
+  }
+  const kind = String(body.kind || '');
+  if (!kind) return c.json({ error: 'kind required' }, 400);
+  if (kind !== 'git_commit' && kind !== 'claude_code_prompt') {
+    return c.json({ error: `unknown kind: ${kind}` }, 400);
+  }
+  try {
+    const result = recordActivityEvent(db, {
+      kind,
+      occurred_at: typeof body.occurred_at === 'string' ? body.occurred_at : null,
+      source: typeof body.source === 'string' ? body.source.slice(0, 500) : null,
+      ref_id: typeof body.ref_id === 'string' ? body.ref_id.slice(0, 200) : null,
+      content: typeof body.content === 'string' ? body.content.slice(0, 4000) : null,
+      metadata: body.metadata && typeof body.metadata === 'object' ? body.metadata : null,
+    });
+    return c.json({ ok: true, id: result.id, deduped: !result.inserted });
+  } catch (e) {
+    return c.json({ error: e.message }, 400);
+  }
+});
+
+// 当日の活動イベント (バーグラフ + ログ表示用)。 ?date=YYYY-MM-DD。
+app.get('/api/activity/events', (c) => {
+  const date = c.req.query('date');
+  if (date) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return c.json({ error: 'invalid date' }, 400);
+    const items = activityEventsForDate(db, date);
+    return c.json({ date, items, total: items.length });
+  }
+  const limit = Math.min(Number(c.req.query('limit')) || 200, 1000);
+  const kind = c.req.query('kind') || null;
+  return c.json({ items: listActivityEvents(db, { limit, kind }) });
 });
 
 // Paginated dig list for the diary panel.

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -2646,7 +2646,10 @@ function renderDiaryDetail() {
   // page_visits as a fallback for events captured before visit_events existed,
   // so it's preferred over the snapshot stored at generation time.
   const metrics = d.live_metrics || d.metrics || { hourly_visits: new Array(24).fill(0), top_domains: [] };
-  $('diaryHourly').innerHTML = renderHourlyChart(metrics.hourly_visits || []);
+  // 開発活動 (git commit + Claude Code prompt) を時間帯バーに重ねる。
+  // kind 別を合算して 1 系列にして表示 (kind 別内訳はリスト側で見せる)。
+  const activityHourlyTotal = sumActivityHourly(metrics.activity);
+  $('diaryHourly').innerHTML = renderHourlyChart(metrics.hourly_visits || [], activityHourlyTotal);
   const domains = metrics.top_domains || [];
   $('diaryPie').innerHTML = renderDomainPie(domains);
   $('diaryDomains').innerHTML = domains.length === 0
@@ -2688,6 +2691,8 @@ function renderDiaryDetail() {
   renderDiaryMeals(metrics.meals || [], metrics.meals_total_calories, metrics.meals_nutrients, metrics.meals_pfc_label);
   // カロリーバランス
   renderDiaryCaloricBalance(metrics.caloric_balance);
+  // 開発活動 (git commit + Claude Code prompt) のログ — 10 件以上なら collapse。
+  renderDiaryActivity(metrics.activity, d.date);
 
   const commits = d.github_commits?.commits || [];
   if (commits.length === 0) {
@@ -2979,23 +2984,150 @@ function appendDiaryMoreButton(ul, currentLen, total, fetchPage) {
   ul.appendChild(li);
 }
 
-function renderHourlyChart(hours) {
-  const max = Math.max(1, ...hours);
+/** activity.hourly = { git_commit: [24], claude_code_prompt: [24], ... } を 1 系列に合算する。 */
+function sumActivityHourly(activity) {
+  const out = new Array(24).fill(0);
+  if (!activity || !activity.hourly) return out;
+  for (const arr of Object.values(activity.hourly)) {
+    if (!Array.isArray(arr)) continue;
+    for (let i = 0; i < 24 && i < arr.length; i++) {
+      out[i] += Number(arr[i]) || 0;
+    }
+  }
+  return out;
+}
+
+function renderHourlyChart(hours, activityHours) {
+  // visits = ブラウザ閲覧の時間帯バー (青系 .diary-bar)
+  // activityHours = git commit + Claude Code prompt 等の活動バー (橙 .diary-bar-activity)
+  // 件数オーダーが大きく異なる (visits: 100-500/h, activity: 1-20/h) ため
+  // それぞれ自分の max でスケールする — 視覚的に比較可能にしつつ両者ゼロでない時間帯を見える化。
+  const visits = hours || new Array(24).fill(0);
+  const activity = activityHours || new Array(24).fill(0);
+  const visitMax = Math.max(1, ...visits);
+  const activityMax = Math.max(1, ...activity);
   const w = 720, h = 140, padL = 30, padR = 12, padT = 12, padB = 24;
   const cw = (w - padL - padR) / 24;
+  // 1 セル幅を 2 等分して左 = visits, 右 = activity に。
+  const halfW = (cw - 4) / 2; // 4px の安全マージン
   let bars = '';
   for (let i = 0; i < 24; i++) {
-    const v = hours[i] || 0;
-    const bh = Math.round((v / max) * (h - padT - padB));
-    const x = padL + i * cw;
-    const y = h - padB - bh;
+    const v = visits[i] || 0;
+    const a = activity[i] || 0;
+    const vh = Math.round((v / visitMax) * (h - padT - padB));
+    const ah = Math.round((a / activityMax) * (h - padT - padB));
+    const xCell = padL + i * cw;
+    const xV = xCell + 1;
+    const xA = xCell + 1 + halfW + 1;
+    const yV = h - padB - vh;
+    const yA = h - padB - ah;
     bars += `
-      <rect x="${x.toFixed(1)}" y="${y.toFixed(1)}" width="${(cw - 2).toFixed(1)}" height="${bh}" class="diary-bar" />
-      <text x="${(x + cw / 2).toFixed(1)}" y="${(h - padB + 12).toFixed(1)}" class="diary-bar-label">${i}</text>
-      ${v > 0 ? `<text x="${(x + cw / 2).toFixed(1)}" y="${(y - 2).toFixed(1)}" class="diary-bar-value">${v}</text>` : ''}
+      <rect x="${xV.toFixed(1)}" y="${yV.toFixed(1)}" width="${halfW.toFixed(1)}" height="${vh}" class="diary-bar" />
+      ${a > 0 ? `<rect x="${xA.toFixed(1)}" y="${yA.toFixed(1)}" width="${halfW.toFixed(1)}" height="${ah}" class="diary-bar-activity" />` : ''}
+      <text x="${(xCell + cw / 2).toFixed(1)}" y="${(h - padB + 12).toFixed(1)}" class="diary-bar-label">${i}</text>
+      ${v > 0 ? `<text x="${(xV + halfW / 2).toFixed(1)}" y="${(yV - 2).toFixed(1)}" class="diary-bar-value">${v}</text>` : ''}
+      ${a > 0 ? `<text x="${(xA + halfW / 2).toFixed(1)}" y="${(yA - 2).toFixed(1)}" class="diary-bar-value diary-bar-value-activity">${a}</text>` : ''}
     `;
   }
-  return `<svg viewBox="0 0 ${w} ${h}" preserveAspectRatio="xMidYMid meet">${bars}</svg>`;
+  // 凡例 — 右上に小さく
+  const legend = `
+    <g class="diary-bar-legend" transform="translate(${(w - padR - 200).toFixed(1)}, 2)">
+      <rect width="10" height="10" y="2" class="diary-bar" />
+      <text x="14" y="11" class="diary-bar-legend-text">閲覧</text>
+      <rect x="60" width="10" height="10" y="2" class="diary-bar-activity" />
+      <text x="74" y="11" class="diary-bar-legend-text">開発活動 (commit/CC)</text>
+    </g>
+  `;
+  return `<svg viewBox="0 0 ${w} ${h}" preserveAspectRatio="xMidYMid meet">${legend}${bars}</svg>`;
+}
+
+/**
+ * Activity log: render up to first 10 items, append "more ▽" button if more.
+ * Click loads the rest from /api/activity/events?date=YYYY-MM-DD and replaces the list.
+ */
+function renderDiaryActivity(activity, dateStr) {
+  const ul = $('diaryActivityList');
+  const help = $('diaryActivitySummary');
+  if (!ul) return;
+  const items = activity?.items || [];
+  const total = activity?.total || items.length || 0;
+  if (total === 0) {
+    if (help) help.textContent = 'この日の活動 (git commit / Claude Code 指示) は記録されていません。';
+    ul.innerHTML = '';
+    return;
+  }
+  if (help) {
+    const parts = [];
+    const k = activity.kinds || {};
+    if (k.git_commit) parts.push(`git commit ${k.git_commit} 件`);
+    if (k.claude_code_prompt) parts.push(`Claude Code 指示 ${k.claude_code_prompt} 件`);
+    help.textContent = parts.length ? `合計 ${total} 件 (${parts.join(' / ')})` : `合計 ${total} 件`;
+  }
+  const sorted = [...items].sort((a, b) => String(a.occurred_at).localeCompare(String(b.occurred_at)));
+  const initial = sorted.slice(0, 10);
+  ul.innerHTML = initial.map(activityLi).join('');
+  if (total > initial.length) {
+    appendActivityMoreButton(ul, initial.length, total, dateStr);
+  }
+}
+
+function activityLi(it) {
+  const d = it.occurred_at ? new Date(it.occurred_at.replace(' ', 'T') + (it.occurred_at.endsWith('Z') ? '' : 'Z')) : null;
+  const t = d && !isNaN(d.getTime())
+    ? `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+    : '??:??';
+  const kindLabel = it.kind === 'git_commit' ? 'git'
+    : it.kind === 'claude_code_prompt' ? 'CC'
+    : it.kind;
+  const klass = it.kind === 'git_commit' ? 'kind-git' : it.kind === 'claude_code_prompt' ? 'kind-cc' : 'kind-other';
+  const src = it.source ? `<span class="activity-src">${escapeHtml(it.source)}</span>` : '';
+  const content = it.content
+    ? `<div class="activity-content">${escapeHtml(String(it.content).slice(0, 240))}</div>`
+    : '';
+  const ref = it.ref_id
+    ? `<span class="activity-ref">${escapeHtml(String(it.ref_id).slice(0, 12))}</span>`
+    : '';
+  return `<li class="diary-activity-item ${klass}">
+    <div class="activity-head">
+      <span class="activity-time">${t}</span>
+      <span class="activity-kind">${kindLabel}</span>
+      ${src}
+      ${ref}
+    </div>
+    ${content}
+  </li>`;
+}
+
+function appendActivityMoreButton(ul, currentLen, total, dateStr) {
+  const li = document.createElement('li');
+  li.className = 'diary-more';
+  const remaining = () => Math.max(0, total - currentLen);
+  function syncLabel(loading) {
+    li.innerHTML = loading
+      ? '読込中…'
+      : `more ▽ <span class="diary-more-count">残り ${remaining()} 件</span>`;
+  }
+  syncLabel(false);
+  li.addEventListener('click', async () => {
+    if (li.dataset.busy === '1') return;
+    li.dataset.busy = '1';
+    syncLabel(true);
+    try {
+      const r = await api(`/api/activity/events?date=${encodeURIComponent(dateStr)}`);
+      const items = (r.items || []).sort((a, b) =>
+        String(a.occurred_at).localeCompare(String(b.occurred_at)));
+      // ul の先頭 currentLen 件はそのまま、 li (more ボタン) を撤去して残りを差し込む。
+      const rest = items.slice(currentLen);
+      const frag = document.createElement('div');
+      frag.innerHTML = rest.map(activityLi).join('');
+      while (frag.firstChild) ul.insertBefore(frag.firstChild, li);
+      li.remove();
+    } catch (e) {
+      li.innerHTML = `<span class="error">取得失敗: ${escapeHtml(e.message)}</span>`;
+      li.dataset.busy = '';
+    }
+  });
+  ul.appendChild(li);
 }
 
 async function generateDiary({ improve = '' } = {}) {

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -405,6 +405,9 @@
             <div id="diaryCaloricBalance" class="diary-caloric-balance"></div>
             <h4>GitHub commits (リポ別件数)</h4>
             <ul id="diaryGithub" class="diary-github"></ul>
+            <h4>🛠 開発活動 (git commit + Claude Code 指示)</h4>
+            <p class="diary-activity-help" id="diaryActivitySummary">この日の活動はまだ記録されていません。</p>
+            <ul id="diaryActivityList" class="diary-activity-list"></ul>
             <h4>メモ・補足</h4>
             <textarea id="diaryNotes" rows="6" placeholder="補足や訂正を書くと、次の再生成で反映されます。"></textarea>
             <div class="diary-detail-actions">

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -1745,8 +1745,75 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 }
 .diary-hourly svg { width: 100%; height: 140px; display: block; }
 .diary-hourly .diary-bar { fill: var(--accent); }
+.diary-hourly .diary-bar-activity { fill: #e07b00; }
 .diary-hourly .diary-bar-label { fill: var(--muted); font-size: 10px; }
 .diary-hourly .diary-bar-value { fill: #1f56c0; font-size: 9px; }
+.diary-hourly .diary-bar-value-activity { fill: #c66800; font-size: 9px; }
+.diary-hourly .diary-bar-legend-text { fill: var(--muted); font-size: 9px; }
+
+/* 開発活動 (git commit / Claude Code prompt) のログ */
+.diary-activity-help {
+  color: var(--muted);
+  font-size: 12px;
+  margin: 4px 0 8px 0;
+}
+.diary-activity-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+}
+.diary-activity-item {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-left-width: 3px;
+  border-radius: 6px;
+  padding: 6px 10px;
+}
+.diary-activity-item.kind-git { border-left-color: #388e3c; }
+.diary-activity-item.kind-cc  { border-left-color: #e07b00; }
+.diary-activity-item.kind-other { border-left-color: var(--muted); }
+.diary-activity-item .activity-head {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+.diary-activity-item .activity-time {
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  color: var(--muted);
+  font-size: 11px;
+}
+.diary-activity-item .activity-kind {
+  font-weight: 600;
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: var(--accent-bg);
+  color: var(--accent);
+}
+.diary-activity-item.kind-git .activity-kind { background: #e8f5e9; color: #2e7d32; }
+.diary-activity-item.kind-cc  .activity-kind { background: #fff3e0; color: #c66800; }
+.diary-activity-item .activity-src {
+  color: var(--muted);
+  font-size: 11px;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+}
+.diary-activity-item .activity-ref {
+  color: var(--muted);
+  font-size: 10px;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  margin-left: auto;
+}
+.diary-activity-item .activity-content {
+  margin-top: 4px;
+  font-size: 12px;
+  line-height: 1.4;
+  word-break: break-word;
+}
 .diary-domains, .diary-github {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
## Why

スマホ開発・ターミナル中心の作業日にブラウザ閲覧履歴がほぼ無く、 Sonnet が「45 分しか働いてない」 と推定してしまう問題への対応。

## What

新テーブル \`activity_events\` に開発系イベント (git commit / Claude Code への指示) を時系列で保存し、 日記の作業時間推定 + バーグラフ + ログリスト + サマリにすべて反映する。

## Schema

\`\`\`sql
CREATE TABLE activity_events (
  id            INTEGER PRIMARY KEY AUTOINCREMENT,
  kind          TEXT NOT NULL,    -- 'git_commit' | 'claude_code_prompt'
  occurred_at   TEXT NOT NULL,
  source        TEXT,              -- repo path / project name
  ref_id        TEXT,              -- commit sha / session_id (重複弾き)
  content       TEXT,              -- commit msg 1 行目 / prompt 先頭 240
  metadata_json TEXT,
  ingested_at   TEXT NOT NULL DEFAULT (datetime('now'))
);
CREATE UNIQUE INDEX idx_activity_events_ref
  ON activity_events(kind, ref_id) WHERE ref_id IS NOT NULL;
\`\`\`

## API

- \`POST /api/activity/event\` — 外部フックから 1 件登録 (重複は INSERT OR IGNORE で吸収)
- \`GET  /api/activity/events?date=YYYY-MM-DD\` — 当日分を時系列順で返す

## diary 反映

- \`aggregateDay()\` → \`metrics.activity = { total, kinds, hourly, items }\` を出す
- \`WORK_CONTENT_PROMPT\` (Sonnet) に活動タイムラインを足す。 ブラウザ履歴が薄い日でも commit/CC 指示の連続から WORK_MINUTES を推定するよう明示
- \`HIGHLIGHTS_PROMPT\` (Opus 1M) にも開発活動ブロック追加
- \`composeSummary\` / \`composeDiarySummary\` に「開発活動」セクション追加 (合計 + 先頭 10 件 + ほか N 件)

## Frontend

- \`renderHourlyChart()\` を visit + activity の 2 系列バーに拡張 (1 セル幅を 2 等分、 各々自分の max でスケール、 凡例つき)
- 日記詳細に「🛠 開発活動」 セクション追加。 10 件超は collapse + \`more ▽\` で残りをロード (既存 \`appendDiaryMoreButton\` パターン踏襲)
- kind 別にバッジ色 + 左ボーダー (git=緑 / cc=橙)

## Hooks

- \`server/hooks/claude-code-prompt.mjs\` を新規追加 — Claude Code \`UserPromptSubmit\` hook 用。 stdin payload を読み 1 秒タイムアウトで POST、 失敗は全部握りつぶし \`exit 0\` (プロンプト処理を妨げない)

  settings.json 側:
  \`\`\`json
  {
    \"hooks\": {
      \"UserPromptSubmit\": [{
        \"hooks\": [{
          \"type\": \"command\",
          \"command\": \"node \\\"<path>/server/hooks/claude-code-prompt.mjs\\\"\",
          \"async\": true,
          \"timeout\": 2
        }]
      }]
    }
  }
  \`\`\`

- git commit hook はリポ非依存なので global git \`post-commit\` (\`~/.git-hooks/post-commit\` 等) に curl 1 行を追加する想定。 シェル例:

  \`\`\`sh
  COMMIT_SHA=\$(git rev-parse HEAD)
  COMMIT_MSG=\$(git log -1 --pretty=format:'%s')
  COMMIT_DATE=\$(git log -1 --pretty=format:'%cI')
  REPO=\$(basename \"\$(git config --get remote.origin.url 2>/dev/null || pwd)\" .git)
  BRANCH=\$(git rev-parse --abbrev-ref HEAD)
  curl --silent --max-time 1 -o /dev/null -X POST     -H 'Content-Type: application/json'     -d \"{\\\"kind\\\":\\\"git_commit\\\",\\\"ref_id\\\":\\\"\$COMMIT_SHA\\\",\\\"occurred_at\\\":\\\"\$COMMIT_DATE\\\",\\\"source\\\":\\\"\$REPO\\\",\\\"content\\\":\\\"\$COMMIT_MSG\\\",\\\"metadata\\\":{\\\"branch\\\":\\\"\$BRANCH\\\"}}\"     http://localhost:5180/api/activity/event 2>/dev/null || true
  \`\`\`

## Test plan

- [ ] CI green
- [ ] Memoria server を再起動 → activity_events テーブルが作られていること
- [ ] curl で POST → \`GET /api/activity/events?date=...\` で見える
- [ ] settings.json の hook 追加 → 数回プロンプト送信 → 日記に出る
- [ ] global git post-commit に curl 追加 → commit → 日記に出る

🤖 Generated with [Claude Code](https://claude.com/claude-code)