### PR TITLE
feat(activity): paginate activity events list (latest 100 + more 100)

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -1275,7 +1275,11 @@ export function recordActivityEvent(db, { kind, occurred_at, source, ref_id, con
   return { inserted: info.changes > 0, id: info.lastInsertRowid };
 }
 
-/** 当日 (local) の活動イベントを時刻昇順で返す。 */
+/**
+ * 当日 (local) の活動イベントを時刻昇順で全件返す。
+ * 内部集計 (hourly bucket / kind 別件数) で全部欲しい時用。
+ * UI のリスト表示には activityEventsPage を使うこと。
+ */
 export function activityEventsForDate(db, dateStr) {
   return db.prepare(`
     SELECT id, kind, occurred_at, source, ref_id, content, metadata_json
@@ -1286,6 +1290,33 @@ export function activityEventsForDate(db, dateStr) {
     ...r,
     metadata: r.metadata_json ? safeParse(r.metadata_json) : null,
   }));
+}
+
+/**
+ * 当日 (local) の活動イベントを **時刻降順で** ページング取得する。
+ * UI のリスト表示 + 「more ▽」 用。 limit は 1-1000、 offset は >= 0。
+ * 戻り値: { items, total, limit, offset }
+ *   items   — 取得した行 (DESC、 最新が先頭)
+ *   total   — 当日の全件数 (offset/limit 無関係)
+ */
+export function activityEventsPage(db, dateStr, { limit = 100, offset = 0 } = {}) {
+  const safeLimit = Math.max(1, Math.min(1000, Number(limit) || 100));
+  const safeOffset = Math.max(0, Number(offset) || 0);
+  const total = db.prepare(`
+    SELECT COUNT(*) AS n FROM activity_events
+    WHERE date(occurred_at, 'localtime') = ?
+  `).get(dateStr).n;
+  const items = db.prepare(`
+    SELECT id, kind, occurred_at, source, ref_id, content, metadata_json
+    FROM activity_events
+    WHERE date(occurred_at, 'localtime') = ?
+    ORDER BY occurred_at DESC
+    LIMIT ? OFFSET ?
+  `).all(dateStr, safeLimit, safeOffset).map((r) => ({
+    ...r,
+    metadata: r.metadata_json ? safeParse(r.metadata_json) : null,
+  }));
+  return { items, total, limit: safeLimit, offset: safeOffset };
 }
 
 /** 直近 limit 件 (新しい順)。 全期間 / 任意 kind フィルタつき。 */

--- a/server/diary.js
+++ b/server/diary.js
@@ -46,7 +46,11 @@ function parseSqliteUtc(s) {
 // Anything beyond this is loaded on-demand via the per-list endpoints.
 const DIARY_LIST_INITIAL = 10;
 
-export function aggregateDay(db, dateStr, { listLimit = DIARY_LIST_INITIAL } = {}) {
+// 開発活動 (git commit / Claude Code prompt) は件数が多くなりがちなので、
+// 初期表示は別途 100 件まで。 古い側は API ページングで取得 (more ▽)。
+const ACTIVITY_LIST_INITIAL = 100;
+
+export function aggregateDay(db, dateStr, { listLimit = DIARY_LIST_INITIAL, activityLimit = ACTIVITY_LIST_INITIAL } = {}) {
   const hourlyVisits = new Array(24).fill(0);
   const domainTally = new Map();
   const domainHours = new Map(); // domain -> Set of hour buckets seen
@@ -225,9 +229,11 @@ export function aggregateDay(db, dateStr, { listLimit = DIARY_LIST_INITIAL } = {
   }
 
   // 開発活動イベント (git commit / Claude Code prompt 等)。 ブラウザ閲覧で
-  // 拾えない作業をカバーする。 list_limit でページング、 hourly bucket 別途。
+  // 拾えない作業をカバーする。 hourly + 集計は全件から、 items は最新
+  // activityLimit 件 (DESC、 新しい順) にして UI 側でページングできるよう
+  // total を渡す。
   const allActivity = activityEventsForDate(db, dateStr);
-  const activity = summarizeActivityForDate(allActivity, listLimit);
+  const activity = summarizeActivityForDate(allActivity, activityLimit);
 
   return {
     date: dateStr,
@@ -263,10 +269,15 @@ export function aggregateDay(db, dateStr, { listLimit = DIARY_LIST_INITIAL } = {
 
 /**
  * 当日分の活動イベントを集計する。
- * - hourly: kind 別の 24 時間バケット (バーグラフ用)
- * - kinds:  kind 別の総件数
- * - items:  時系列リスト (listLimit で先頭 N 件、 null なら全件 — highlights プロンプト用)
+ *
+ * - hourly: kind 別の 24 時間バケット (バーグラフ用、 全件から計算)
+ * - kinds:  kind 別の総件数 (全件から計算)
+ * - items:  **最新 listLimit 件** (DESC、 新しいが先頭)。 listLimit==null なら全件。
+ *           UI のリスト表示用、 古い側は API (`/api/activity/events?offset=...`) で
+ *           ページングする。
  * - total:  全イベント件数
+ *
+ * 入力 rows は時刻昇順 (activityEventsForDate の出力) を想定。
  */
 function summarizeActivityForDate(rows, listLimit) {
   const kinds = {};
@@ -277,7 +288,11 @@ function summarizeActivityForDate(rows, listLimit) {
     const h = parseSqliteUtc(r.occurred_at)?.getHours();
     if (Number.isFinite(h)) hourly[r.kind][h] += 1;
   }
-  const items = (listLimit == null ? rows : rows.slice(0, listLimit)).map((r) => ({
+  // 最新 listLimit 件 = rows の末尾から listLimit 件、 reverse して DESC に
+  const sliced = listLimit == null
+    ? [...rows].reverse()
+    : rows.slice(-Math.max(0, listLimit)).reverse();
+  const items = sliced.map((r) => ({
     id: r.id,
     kind: r.kind,
     occurred_at: r.occurred_at,
@@ -291,6 +306,12 @@ function summarizeActivityForDate(rows, listLimit) {
     kinds,
     hourly,
     items,
+    // UI が next page を組み立てる時の参考に渡しておく (offset = items.length が次の起点)
+    page: {
+      limit: listLimit,
+      offset: 0,
+      returned: items.length,
+    },
   };
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -60,7 +60,7 @@ import { fetchPageMetadata } from './page-metadata.js';
 import { extractWordCloud, validateWordRelevance } from './wordcloud.js';
 import { startUptimeTracking, readHeartbeat, DOWNTIME_THRESHOLD_MS } from './local/uptime.js';
 import { listServerEvents, listServerEventsForDate } from './db.js';
-import { recordActivityEvent, activityEventsForDate, listActivityEvents } from './db.js';
+import { recordActivityEvent, activityEventsForDate, listActivityEvents, activityEventsPage } from './db.js';
 import {
   aggregateDay, fetchGithubActivity, fetchGithubRange,
   generateDiary, generateWorkContent, generateHighlights,
@@ -2895,13 +2895,21 @@ app.post('/api/activity/event', async (c) => {
   }
 });
 
-// 当日の活動イベント (バーグラフ + ログ表示用)。 ?date=YYYY-MM-DD。
+// 当日の活動イベント (バーグラフ + ログ表示用、 ページング対応)。
+//   ?date=YYYY-MM-DD&limit=100&offset=0   — 当日分を時刻 DESC で paginate
+//   ?limit=200&kind=...                   — 全期間 (date 無し): listActivityEvents
+//
+// 戻り値 (date 指定時): { date, items, total, limit, offset }
+//   items は最新が先頭 (DESC)、 古い側を取りたければ offset += items.length。
+//   total は当日全件数。 limit は 1-1000、 offset は >= 0。
 app.get('/api/activity/events', (c) => {
   const date = c.req.query('date');
   if (date) {
     if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return c.json({ error: 'invalid date' }, 400);
-    const items = activityEventsForDate(db, date);
-    return c.json({ date, items, total: items.length });
+    const limit = Number(c.req.query('limit')) || 100;
+    const offset = Number(c.req.query('offset')) || 0;
+    const page = activityEventsPage(db, date, { limit, offset });
+    return c.json({ date, ...page });
   }
   const limit = Math.min(Number(c.req.query('limit')) || 200, 1000);
   const kind = c.req.query('kind') || null;

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -3063,11 +3063,11 @@ function renderDiaryActivity(activity, dateStr) {
     if (k.claude_code_prompt) parts.push(`Claude Code 指示 ${k.claude_code_prompt} 件`);
     help.textContent = parts.length ? `合計 ${total} 件 (${parts.join(' / ')})` : `合計 ${total} 件`;
   }
-  const sorted = [...items].sort((a, b) => String(a.occurred_at).localeCompare(String(b.occurred_at)));
-  const initial = sorted.slice(0, 10);
-  ul.innerHTML = initial.map(activityLi).join('');
-  if (total > initial.length) {
-    appendActivityMoreButton(ul, initial.length, total, dateStr);
+  // items はサーバから DESC (新しい順) で渡ってくる前提。 そのまま表示。
+  // 古い側を取りたい時は appendActivityMoreButton が offset = ul.children.length で paginate。
+  ul.innerHTML = items.map(activityLi).join('');
+  if (total > items.length) {
+    appendActivityMoreButton(ul, items.length, total, dateStr);
   }
 }
 
@@ -3098,14 +3098,21 @@ function activityLi(it) {
   </li>`;
 }
 
-function appendActivityMoreButton(ul, currentLen, total, dateStr) {
+/**
+ * 「more ▽」 — 古い側 100 件をページング取得して末尾に追加する。
+ * クリックごとに offset += PAGE_SIZE で次の 100 件 (より古い側) を読む。
+ * 全件読み終わったらボタンが消える。
+ */
+function appendActivityMoreButton(ul, initialLen, total, dateStr) {
+  const PAGE_SIZE = 100;
+  let displayed = initialLen;
   const li = document.createElement('li');
   li.className = 'diary-more';
-  const remaining = () => Math.max(0, total - currentLen);
+  const remaining = () => Math.max(0, total - displayed);
   function syncLabel(loading) {
     li.innerHTML = loading
       ? '読込中…'
-      : `more ▽ <span class="diary-more-count">残り ${remaining()} 件</span>`;
+      : `more ▽ <span class="diary-more-count">古い 100 件 (残り ${remaining()} 件)</span>`;
   }
   syncLabel(false);
   li.addEventListener('click', async () => {
@@ -3113,15 +3120,22 @@ function appendActivityMoreButton(ul, currentLen, total, dateStr) {
     li.dataset.busy = '1';
     syncLabel(true);
     try {
-      const r = await api(`/api/activity/events?date=${encodeURIComponent(dateStr)}`);
-      const items = (r.items || []).sort((a, b) =>
-        String(a.occurred_at).localeCompare(String(b.occurred_at)));
-      // ul の先頭 currentLen 件はそのまま、 li (more ボタン) を撤去して残りを差し込む。
-      const rest = items.slice(currentLen);
+      const url = `/api/activity/events?date=${encodeURIComponent(dateStr)}`
+        + `&limit=${PAGE_SIZE}&offset=${displayed}`;
+      const r = await api(url);
+      const items = r.items || [];   // サーバから DESC で来る (古い側)
       const frag = document.createElement('div');
-      frag.innerHTML = rest.map(activityLi).join('');
+      frag.innerHTML = items.map(activityLi).join('');
       while (frag.firstChild) ul.insertBefore(frag.firstChild, li);
-      li.remove();
+      displayed += items.length;
+      // total を最新値で更新 (新規 commit が ingest されてれば変動しうる)
+      if (typeof r.total === 'number') total = r.total;
+      if (displayed >= total || items.length === 0) {
+        li.remove();
+      } else {
+        syncLabel(false);
+        li.dataset.busy = '';
+      }
     } catch (e) {
       li.innerHTML = `<span class="error">取得失敗: ${escapeHtml(e.message)}</span>`;
       li.dataset.busy = '';


### PR DESCRIPTION
## Why

開発活動 (\`git_commit\` + \`claude_code_prompt\`) のイベント数は日々増えていく。 GitHub commit の backfill で 1 日 50+ 件、 Claude Code プロンプトを毎日数十件、 と積み上がるので、 日記詳細にすべて 1 リストで載せると重い。 ユーザ要望でページング化する。

## What

### Backend

- 新 \`activityEventsPage(db, dateStr, { limit=100, offset=0 })\` を追加
  - 当日分を **時刻 DESC** で paginate 取得
  - 戻り値: \`{ items, total, limit, offset }\` (limit は 1-1000 にクランプ)
- 既存 \`activityEventsForDate\` (全件 ASC) は **内部集計用に維持** (hourly bucket / kind 別件数で全件必要)
- \`aggregateDay\` に \`activityLimit\` (default 100) を追加。 \`metrics.activity.items\` は最新 \`activityLimit\` 件 DESC で出す
- \`/api/activity/events?date=&limit=&offset=\` がページング対応 — 戻り値に \`total\` / \`limit\` / \`offset\` を含める

### Frontend

- \`renderDiaryActivity\`: サーバから来た DESC 順をそのまま表示 (新しいが先頭)。 \`total > items.length\` の時に more ボタンを末尾に追加
- \`appendActivityMoreButton\`:
  - クリックごとに \`offset = 表示中件数\` で次の 100 件 (より古い側) をフェッチ
  - 末尾に append して連続スクロール可能
  - ラベル: \`more ▽ 古い 100 件 (残り N 件)\`
  - \`displayed >= total\` または \`items.length === 0\` で消える

## Behavior

| state | 表示 | more ボタン |
|---|---|---|
| total ≤ 100 | 全件 (DESC) | なし |
| total > 100 | 最新 100 件 | あり、 残り N 件 |
| more クリック | 100 + 100 = 200 件 | 残り (N-100) 件 |
| 全件読了 | total 件 | 消える |

## Test plan

- [ ] CI green
- [ ] 50 commits/日 × 1 週間 backfill した後、 該当日付の日記詳細を開いて活動セクションが 100 件で頭打ちになり「more ▽」 が出る
- [ ] more クリックで残り読み込み、 順序が連続して破綻しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)