### PR TITLE
Memoriaにタスク・実装自慢・MCP受信を追加

### DIFF
--- a/.claude/skills/memoria-worklog/SKILL.md
+++ b/.claude/skills/memoria-worklog/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: memoria-worklog
+description: Record concise worklogs, tasks, chat excerpts, and implementation notes into the local Memoria instance.
+---
+
+# Memoria Worklog
+
+Use this skill when the user asks Claude to record progress in Memoria, add a task, save a chat excerpt, or leave an implementation note.
+
+## Endpoint
+
+Use `MEMORIA_URL` when set. Otherwise use `http://localhost:5180`.
+
+## Actions
+
+- Worklog: send activity or chat notes to Memoria as factual summaries.
+- Task: call `POST /api/tasks` with `title`, optional `details`, optional `due_at`, and optional `share_actio`.
+- External chat: call `POST /api/external-chat/messages` with `source`, `content`, optional `role`, optional `conversation_id`, and optional `metadata`.
+- Implementation note: call `POST /api/implementation-notes` with `product`, `title`, `good_points`, `bad_points`, and `shareable`.
+
+## Rules
+
+- Keep entries concise and fact-based.
+- Do not include secrets, tokens, passwords, or private personal information.
+- Ask before marking a note or task as shareable when the user has not explicitly said to share it.

--- a/.claude/skills/memoria-worklog/SKILL.md
+++ b/.claude/skills/memoria-worklog/SKILL.md
@@ -1,25 +1,24 @@
 ---
 name: memoria-worklog
-description: Record concise worklogs, tasks, chat excerpts, and implementation notes into the local Memoria instance.
+description: Memoria に作業ログ、タスク、チャット抜粋、実装自慢を記録する。
 ---
 
 # Memoria Worklog
 
-Use this skill when the user asks Claude to record progress in Memoria, add a task, save a chat excerpt, or leave an implementation note.
+ユーザーが Memoria への記録、タスク追加、チャット内容の保存、実装自慢の作成を依頼したときに使う。
 
-## Endpoint
+## 接続先
 
-Use `MEMORIA_URL` when set. Otherwise use `http://localhost:5180`.
+`MEMORIA_URL` が設定されていればそれを使う。未設定なら `http://localhost:5180` を使う。
 
-## Actions
+## 操作
 
-- Worklog: send activity or chat notes to Memoria as factual summaries.
-- Task: call `POST /api/tasks` with `title`, optional `details`, optional `due_at`, and optional `share_actio`.
-- External chat: call `POST /api/external-chat/messages` with `source`, `content`, optional `role`, optional `conversation_id`, and optional `metadata`.
-- Implementation note: call `POST /api/implementation-notes` with `product`, `title`, `good_points`, `bad_points`, and `shareable`.
+- タスク: `POST /api/tasks` に `title`、任意の `details`、任意の `due_at`、任意の `share_actio` を送る。
+- 外部チャット: `POST /api/external-chat/messages` に `source`、`content`、任意の `role`、任意の `conversation_id`、任意の `metadata` を送る。
+- 実装自慢: `POST /api/implementation-notes` に `product`、`title`、`good_points`、`bad_points`、`shareable` を送る。
 
-## Rules
+## ルール
 
-- Keep entries concise and fact-based.
-- Do not include secrets, tokens, passwords, or private personal information.
-- Ask before marking a note or task as shareable when the user has not explicitly said to share it.
+- 記録は短く、事実ベースにする。
+- 秘密情報、トークン、パスワード、個人情報は含めない。
+- ユーザーが明示していない限り、勝手に `shareable` や `share_actio` を有効にしない。

--- a/.codex/skills/memoria-worklog/SKILL.md
+++ b/.codex/skills/memoria-worklog/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: memoria-worklog
+description: Record concise worklogs, tasks, chat excerpts, and implementation notes into the local Memoria instance.
+---
+
+# Memoria Worklog
+
+Use this skill when the user asks Codex to record progress in Memoria, add a task, save a chat excerpt, or leave an implementation note.
+
+## Endpoint
+
+Use `MEMORIA_URL` when set. Otherwise use `http://localhost:5180`.
+
+## Actions
+
+- Worklog: send activity or chat notes to Memoria as factual summaries.
+- Task: call `POST /api/tasks` with `title`, optional `details`, optional `due_at`, and optional `share_actio`.
+- External chat: call `POST /api/external-chat/messages` with `source`, `content`, optional `role`, optional `conversation_id`, and optional `metadata`.
+- Implementation note: call `POST /api/implementation-notes` with `product`, `title`, `good_points`, `bad_points`, and `shareable`.
+
+## Rules
+
+- Keep entries concise and fact-based.
+- Do not include secrets, tokens, passwords, or private personal information.
+- Ask before marking a note or task as shareable when the user has not explicitly said to share it.

--- a/.codex/skills/memoria-worklog/SKILL.md
+++ b/.codex/skills/memoria-worklog/SKILL.md
@@ -1,25 +1,24 @@
 ---
 name: memoria-worklog
-description: Record concise worklogs, tasks, chat excerpts, and implementation notes into the local Memoria instance.
+description: Memoria に作業ログ、タスク、チャット抜粋、実装自慢を記録する。
 ---
 
 # Memoria Worklog
 
-Use this skill when the user asks Codex to record progress in Memoria, add a task, save a chat excerpt, or leave an implementation note.
+ユーザーが Memoria への記録、タスク追加、チャット内容の保存、実装自慢の作成を依頼したときに使う。
 
-## Endpoint
+## 接続先
 
-Use `MEMORIA_URL` when set. Otherwise use `http://localhost:5180`.
+`MEMORIA_URL` が設定されていればそれを使う。未設定なら `http://localhost:5180` を使う。
 
-## Actions
+## 操作
 
-- Worklog: send activity or chat notes to Memoria as factual summaries.
-- Task: call `POST /api/tasks` with `title`, optional `details`, optional `due_at`, and optional `share_actio`.
-- External chat: call `POST /api/external-chat/messages` with `source`, `content`, optional `role`, optional `conversation_id`, and optional `metadata`.
-- Implementation note: call `POST /api/implementation-notes` with `product`, `title`, `good_points`, `bad_points`, and `shareable`.
+- タスク: `POST /api/tasks` に `title`、任意の `details`、任意の `due_at`、任意の `share_actio` を送る。
+- 外部チャット: `POST /api/external-chat/messages` に `source`、`content`、任意の `role`、任意の `conversation_id`、任意の `metadata` を送る。
+- 実装自慢: `POST /api/implementation-notes` に `product`、`title`、`good_points`、`bad_points`、`shareable` を送る。
 
-## Rules
+## ルール
 
-- Keep entries concise and fact-based.
-- Do not include secrets, tokens, passwords, or private personal information.
-- Ask before marking a note or task as shareable when the user has not explicitly said to share it.
+- 記録は短く、事実ベースにする。
+- 秘密情報、トークン、パスワード、個人情報は含めない。
+- ユーザーが明示していない限り、勝手に `shareable` や `share_actio` を有効にしない。

--- a/docs/db-perf-estimate.md
+++ b/docs/db-perf-estimate.md
@@ -1,0 +1,478 @@
+# Memoria DB パフォーマンス試算
+
+**測定日:** 2026-05-04
+**DB ファイル:** `data/memoria.db` (better-sqlite3, WAL モード, ジャーナル autocheckpoint 既定)
+**現在サイズ:** メイン 5.4 MB + WAL 4.0 MB ≒ 実体 6-7 MB (checkpoint 後)
+
+## 1. 結論先出し
+
+**現在の規模では SQLite の限界からは桁違いに遠い。 月次パーティションは不要。**
+ただし `activity_events` (Claude Code prompt 等) は 1 日 1500 件超のペースで増えており、
+**5-10 年スパンで 2-5 GB に達する**。 リテンション (古いデータの集計化 + 削除) を入れた方が、
+パーティションよりはるかに費用対効果が高い。
+
+懸念があるのは下記 3 点だけ:
+
+1. **`activity_events`** — 高頻度書込み、 5 年で ~2 GB
+2. **WAL の肥大化** — 既に 4 MB、 明示 checkpoint or `synchronous=NORMAL` のままで run-away するリスク
+3. **`diary_entries.metrics_json` / `dig_sessions.result_json`** — 1 行が 100 KB-1 MB クラス、 行数は少ないが個別重い
+
+---
+
+## 2. 現在の実測値
+
+### 2.1 行数とサイズ (主要テーブル)
+
+| Table | Rows | Size (bytes) | bytes/row | コメント |
+|-------|------|-------------:|----------:|----------|
+| `activity_events`  | 2,228 | 1,488,667 |   668 | git commit + Claude Code prompt の hook 受け |
+| `diary_entries`    |     7 |   898,874 | 128,410 | 1 日 1 行、 work_content / highlights / metrics_json が太い |
+| `bookmarks`        |   475 |   508,170 |  1,070 | summary + memo 含む、 HTML 本体は別ディレクトリ |
+| `page_visits`      |   931 |   168,363 |   181 | URL ごと upsert、 visit_count は inc |
+| `domain_catalog`   |   239 |   137,669 |   576 | site_name / can_do / description |
+| `dig_sessions`     |    10 |   107,253 | 10,725 | result_json が太い (sources × 8-12) |
+| `visit_events`     |   734 |    90,765 |   124 | per-event log (page_visits の生データ) |
+| `page_metadata`    |    94 |    51,610 |   549 | og_/title/summary/kind |
+| `bookmark_categories`| 2,361|    36,138 |    15 | 単純 join テーブル |
+| `server_events`    |   395 |    29,976 |    76 | start/stop/downtime/restart |
+| `gps_locations`    |    65 |    17,640 |   271 | #97 で圧縮済 (anchor + tail) |
+| `accesses`         |   607 |    15,042 |    25 | アクセスログ (短い) |
+| `meals`            |    24 |    12,418 |   517 | 写真 EXIF + 栄養素 JSON |
+| `word_clouds`      |     1 |     4,328 | 4,328 | tokens_json + extras |
+| `weekly_reports`   |     1 |     4,766 | 4,766 | 週次サマリ |
+| `dictionary_entries`|    2 |     1,945 |   972 | 用語定義 |
+| `app_settings`     |    39 |     1,142 |    29 | LLM 設定など |
+| `dictionary_links` |     1 |        29 |    29 | 用語 ↔ source |
+| `push_subscriptions`|    1 |       458 |   458 | WebPush endpoint |
+| **合計** | ~8,400 | ~3.6 MB | — | 上記 + index + freelist で実体 5.4 MB |
+
+### 2.2 直近 1 日 / 7 日の増加件数
+
+| Table | 1 日 | 7 日 | 30 日 |
+|-------|----:|----:|----:|
+| `activity_events` | **1,569** | 2,228 | 2,228 (= 全件) |
+| `gps_locations`   | 61 | 65 | 65 |
+| `server_events`   | 166 | 395 | 395 |
+| `page_visits`     | 14 | 403 | 931 |
+| `accesses`        | 1 | 60 | 607 |
+| `bookmarks`       | 1 | 15 | 475 |
+| `dig_sessions`    | 0 | 9 | 10 |
+| `diary_entries`   | 0 | 6 | 7 |
+
+> **注:** `activity_events` は Claude Code hook 起動が増えた今日 1 日で集中投入されているため、
+> 7 日と 1 日がほぼ同値になっている。 平均は **概ね 200-1500/day** のレンジ。
+
+---
+
+## 3. 成長率予測
+
+ここでは「現在のペースが今後 5-10 年続く」 ケースで試算する (ヘビーケース)。
+
+### 3.1 主要テーブルの増加率 (定常期想定)
+
+| Table | 平均 row/day | bytes/row | MB/月 | MB/年 | 5 年 | 10 年 |
+|-------|-----------:|---------:|-----:|-----:|----:|----:|
+| `activity_events` | 800 *1 | 668 | 16 MB | 195 MB | **975 MB** | **2.0 GB** |
+| `page_visits`     | 30 *2 | 181 | 0.16 | 1.9 | 9.6 MB | 19 MB |
+| `visit_events`    | 100 | 124 | 0.37 | 4.4 | 22 MB | 44 MB |
+| `accesses`        | 30 | 25 | 0.022 | 0.27 | 1.3 MB | 2.7 MB |
+| `gps_locations`   | 60 *3 | 271 | 0.49 | 5.9 | 30 MB | 59 MB |
+| `server_events`   | 50 | 76 | 0.11 | 1.4 | 6.8 MB | 14 MB |
+| `bookmarks`       | 5 | 1,070 | 0.16 | 1.9 | 9.6 MB | 19 MB |
+| `dig_sessions`    | 1 | 10,725 | 0.32 | 3.9 | 19 MB | 39 MB |
+| `diary_entries`   | 1 | 130,000 | **3.9** | **47** | **234 MB** | **468 MB** |
+| `domain_catalog`  | 0.3 | 576 | 0.005 | 0.06 | 0.3 MB | 0.6 MB |
+| `meals`           | 1 | 517 | 0.015 | 0.19 | 0.9 MB | 1.9 MB |
+| **合計** | — | — | **~22 MB/月** | **~265 MB/年** | **~1.3 GB** | **~2.7 GB** |
+
+\*1: hook が常時動く前提。 開発が落ち着けば 200-500/day に減るはず。
+\*2: 新規 URL のみ。 再訪は visit_count++ で行は増えない。
+\*3: #97 圧縮で 1 日数十行に抑えてある。 移動量次第で増減。
+
+### 3.2 ライトケース (実利用ペース)
+
+ユーザがコーディングセッション無しの日も多いと仮定 (週 3 日活動、 1 日 300 prompt):
+
+- `activity_events` 平均 ~130/day → **1.3 GB / 10 年**
+- `diary_entries` ペースは変わらず (毎日 1 行)
+- 全体 **1.5-2 GB / 10 年**
+
+---
+
+## 3a. ヘビーテーブル個別試算
+
+§3 はマクロ試算。 ここでは肥大化が懸念される **5 テーブル** を、 実測ベースで掘り下げる。
+
+### 3a.1 `activity_events` (claude_code_prompt + git_commit)
+
+**実測 (kind 別):**
+
+| kind | 行数 | content avg | metadata avg | bytes/row (推定) |
+|------|----:|----------:|-----------:|----------------:|
+| `claude_code_prompt` | 2,086 |   234 (max 240) |  111 |    470 |
+| `git_commit`         |   162 |    62 |  180 |    347 |
+
+> `claude_code_prompt` は content を 240 文字で truncate している (`server/index.js` で `slice(0, 4000)` だが
+> hook 側でさらに短く渡している) → **行サイズが想定より小さい**。 これは大きな朗報。
+
+**24 時間の hourly 分布 (実測):**
+
+```
+活動時間帯 (8-20 時) の peak: 100-104 prompts/h
+活動日合計: 800-1200 prompts/day  (5/3 実績 1080, 5/4 663+進行中)
+```
+
+**3 シナリオ別の試算:**
+
+| シナリオ | 平均 prompt/day | 行数/年 | サイズ/年 | 5 年 | 10 年 |
+|---------|---------------:|------:|--------:|----:|----:|
+| **ライト** (週 3 日 × 300/day) | 130 | 47K | 22 MB | 110 MB | 220 MB |
+| **ミドル** (週 5 日 × 600/day) | 430 | 157K | 74 MB | 369 MB | **737 MB** |
+| **ヘビー** (毎日 1000/day, 今のペース) | 1000 | 365K | 172 MB | **858 MB** | **1.7 GB** |
+
+**実用域での性能 (indexed query):**
+
+- **ライト**: 1 日分検索 = 数 ms、 全期間 COUNT = 50ms (10 年)
+- **ミドル**: 1 日分検索 = 数 ms、 全期間 COUNT = 200ms
+- **ヘビー**: **5 年目以降は indexing 補強がないと date 集計が秒台に乗る** (§6.1)
+
+**git_commit は無視してよい**: 1 日 5-20 件、 5 年でも 35K 行 / 12 MB 程度。
+
+→ **claude_code_prompt が単独で全テーブル中の最大成長源**。 ただし 240 char truncate のおかげで
+当初試算 (1KB/row) の **半分以下** に収まる。
+
+### 3a.2 `gps_locations`
+
+**圧縮効果の実測 (#97):**
+
+```
+raw samples (samples_count 合計): 1,555
+stored rows:                          65
+圧縮比:                          23.9 倍
+```
+
+**1 日の規模 (移動が多い日):**
+
+- raw OwnTracks samples: ~1,500 / day (default 30s 間隔)
+- stored: ~60 rows / day = **17 KB / day**
+
+**3 シナリオ別:**
+
+| シナリオ | raw/day | stored/day | bytes/year | 5 年 | 10 年 |
+|---------|--------:|----------:|-----------:|----:|----:|
+| 圧縮 OFF (raw 全保存) | 1,500 | 1,500 | 149 MB | 745 MB | **1.5 GB** |
+| **圧縮 ON (#97)** | 1,500 | 63 | 6.2 MB | 31 MB | 62 MB |
+| 静止が多い日 (圧縮 ON) | 800 | 30 | 3.0 MB | 15 MB | 30 MB |
+
+→ **圧縮済みなら 10 年で 60 MB**。 全く問題ない。
+→ ただし `raw_json` カラムが各行に格納されている可能性 (271 bytes/row のうち) → 確認推奨。
+   raw を捨ててよい古い行は `raw_json = NULL` で 50% 削減できる余地あり。
+
+**place_resolver 関連カラム** (`place_name` `place_address`) はテキストなので、 dwell が多い場所が
+1 行に集約されると **逆に 1 行が太くなる**。 ただし圧縮が効いているので問題化していない。
+
+### 3a.3 `visit_events` (per-event browsing log)
+
+**実測:**
+
+- 行数: 737 / avg 124 bytes/row
+- 1 日: 100-316 events (実測レンジ)
+- source: null (Legatus DNS) 689 / browser 48 → **DNS tap 由来が大半**
+
+**3 シナリオ別:**
+
+| シナリオ | events/day | bytes/year | 5 年 | 10 年 |
+|---------|----------:|-----------:|----:|----:|
+| ライト (browser のみ、 50/day) | 50 | 2.3 MB | 11 MB | 22 MB |
+| ミドル (browser + DNS 200/day) | 200 | 9.0 MB | 45 MB | 90 MB |
+| ヘビー (DNS tap fully active 500/day) | 500 | 23 MB | 113 MB | 226 MB |
+
+→ ヘビーでも 10 年 226 MB。 SQLite 余裕で扱える。
+→ ただし **page_visits に既に集約済み** なので、 **90 日超は visit_events を捨てて OK**。
+
+### 3a.4 `dig_sessions`
+
+**実測 (1 セッションあたり):**
+
+- result_json: avg **3.8 KB** (max 4.3 KB)
+- preview_json: avg 1.1 KB
+- raw_results_json: avg 1.5 KB
+- → **1 dig 合計 ~6.5 KB**
+
+**3 シナリオ別:**
+
+| シナリオ | dig/day | bytes/year | 5 年 | 10 年 |
+|---------|-------:|-----------:|----:|----:|
+| ライト (週 5 dig) | 0.7 | 1.7 MB | 8 MB | 17 MB |
+| ミドル (毎日 5 dig) | 5 | 12 MB | 59 MB | 119 MB |
+| ヘビー (毎日 20 dig) | 20 | 47 MB | 237 MB | **475 MB** |
+
+→ ヘビーケースのみ 10 年 0.5 GB。 **誤 Dig 削除を真面目にやる前提なら ミドル試算で十分**。
+→ **raw_results_json は debug 用**なので 30 日超は NULL 化して OK (40% 削減)。
+
+### 3a.5 `diary_entries` (意外な肥大化源)
+
+**実測 (1 行あたり、 7 行平均):**
+
+| カラム | avg bytes |
+|--------|----------:|
+| `work_content`        |    950 |
+| `highlights`          |    541 |
+| **`metrics_json`**    | **72,440** ← 全体の 90% |
+| `github_commits_json` |  6,067 |
+| `notes`               |     26 |
+| `summary`             | (含めていないが小さい) |
+| **1 行合計**          | **~80 KB** |
+
+> `metrics_json` が 72 KB と異常に大きい。 `server/diary.js` を確認しないと分からないが、
+> hourly bucket × 24h × 複数指標 (heartbeat / GitHub / activity) を生のままシリアライズして
+> いる可能性大。 **集計後の数字だけ残せば 5-10 KB に減らせる余地がある**。
+
+**3 シナリオ別 (現状の 80 KB/row 前提):**
+
+| シナリオ | rows/day | bytes/year | 5 年 | 10 年 |
+|---------|---------:|-----------:|----:|----:|
+| 1 日 1 行 (現状)            | 1 | 28 MB | 142 MB | 285 MB |
+| 1 日 1 行 + metrics 圧縮    | 1 |  3 MB |  17 MB |  35 MB |
+
+→ 行数は少ないが、 **1 行が太いせいで 10 年で 285 MB に到達**。
+→ `metrics_json` のスキーマ見直しが最も投資対効果が高い。
+
+### 3a.6 `page_visits` (集約テーブル、 念のため)
+
+**実測:**
+
+- 931 行 / 168 KB / 181 bytes/row
+- **upsert** なので新 URL のみ追加 (再訪は visit_count++)
+- 1 日新規 URL: 14-79 (実測)
+- max visit_count = 439 (= Gmail 等を 1 行で 439 回とカウント)
+
+**試算:** 1 日新規 50 URL × 365 日 × 5 年 = 91K 行 / 16 MB → **10 年でも 33 MB**。
+集約構造のおかげで成長率が **page_visits の visit_count に逃げる** ので、 ほぼフラット化する。
+
+→ 心配なし。
+
+### 3a.7 ヘビーテーブル合計予測 (実測 + ミドルシナリオ)
+
+| Table | 5 年 | 10 年 | %  |
+|-------|----:|----:|---:|
+| `activity_events` (claude+git, ミドル)   |  380 MB | 750 MB | 42% |
+| `gps_locations` (圧縮 ON)                |   31 MB |  62 MB |  3% |
+| `visit_events` (90 日リテンション)       |    9 MB |  18 MB |  1% |
+| `dig_sessions` (raw_json リテンション)   |   35 MB |  70 MB |  4% |
+| `diary_entries` (現状 metrics_json)      |  142 MB | 285 MB | 16% |
+| `bookmarks` 等その他                     |  300 MB | 600 MB | 34% |
+| **DB 全体合計**                          | **~900 MB** | **~1.8 GB** | 100% |
+
+→ 10 年で **1.8 GB**。 SQLite 性能限界 (50 GB+) からまだ 25 倍以上のヘッドルーム。
+
+---
+
+## 3b. もし「raw 全部保存」 にしていたらどうなるか (悪夢シナリオ)
+
+ユーザの懸念に応える形で、 **既に施されている圧縮を全部外した場合** の試算:
+
+| Table | 圧縮 OFF / リテンション無し | 5 年 | 10 年 |
+|-------|----:|----:|----:|
+| `gps_locations` raw 1500/day              | 0.4 MB/day | 730 MB | 1.5 GB |
+| `visit_events` (DNS tap full 500/day)     | 0.06 MB/day | 113 MB | 226 MB |
+| `activity_events` (truncate なし、 1KB/row, 1000/day) | 1 MB/day | 1.8 GB | **3.6 GB** |
+| `dig_sessions` (raw_json 全保存、 20/day) | 0.13 MB/day | 237 MB | 475 MB |
+| `diary_entries` (metrics 72KB/day 現状)   | 0.08 MB/day | 142 MB | 285 MB |
+| **合計**                                  | **1.7 MB/day** | **3.0 GB** | **6 GB** |
+
+→ それでも SQLite で動くサイズ。 ただし 5 年目以降は **indexing 補強なしだと
+   date 集計が秒台に乗る**。
+
+---
+
+## 3c. 月次パーティションが効く / 効かないテーブル別判定
+
+ユーザの「月次パーティション化」 案に対する個別判定:
+
+| Table | パーティション効果 | 採るべき対策 |
+|-------|------------------|------------|
+| `activity_events` | △ | **indexing + 90 日超を集計化** が遥かに有効 |
+| `gps_locations` | × | 既に圧縮済 (#97)、 古い `raw_json` を NULL 化のみ |
+| `visit_events` | △ | **90 日リテンション + 単純 DELETE** が最適 |
+| `dig_sessions` | × | 行数自体が少ない、 `raw_results_json` のみ古いものを NULL 化 |
+| `diary_entries` | × | 行数 365/year、 **`metrics_json` のスキーマ見直し**が最重要 |
+| `bookmarks` | × | upsert、 ユーザ資産そのもの — 削除候補にならない |
+
+→ **どのテーブルもパーティションより別の対策の方が効く**。
+→ 強いて言えば `activity_events` だけは将来 ATTACH 分離の余地があるが、
+   indexing + retention で 10 年 3.6 GB → 800 MB に絞れるので、
+   **個人 PC 用途では月次パーティションは過剰**。
+
+---
+
+### 4.1 理論限界 (better-sqlite3 + WAL)
+
+| 項目 | 限界 |
+|------|------|
+| ファイルサイズ | 281 TB |
+| 1 テーブルの行数 | 2^64 (実用上無制限) |
+| 1 行のサイズ | 1 GB (BLOB/TEXT) |
+| index/page サイズ | 64 KB ページ |
+
+### 4.2 実用域での性能 (better-sqlite3, 個人 PC, NVMe SSD 想定)
+
+ベンチマーク的な目安 (公式 + コミュニティ実測):
+
+| シナリオ | レイテンシ目安 |
+|---------|---------------|
+| index 付き SELECT (1 行) | < 0.1 ms (~10万 qps) |
+| index 付き範囲 SELECT (100 行) | < 1 ms |
+| 全表 COUNT (100万行) | 50-200 ms |
+| 全表 COUNT (1000万行) | 500 ms-2 s |
+| 単発 INSERT (synchronous=FULL) | 1-3 ms |
+| 単発 INSERT (synchronous=NORMAL, WAL) | 0.05-0.2 ms |
+| トランザクション内 1万 INSERT | 50-200 ms |
+
+### 4.3 Memoria での想定クエリ負荷
+
+主要なホットパスはほぼ全部 indexed:
+
+- `bookmarks` 一覧 (50 件ページング、`/api/bookmarks`): `created_at DESC LIMIT 50` → **1 ms 未満**
+- `activity_events` 当日分: `WHERE date(occurred_at,'localtime') = ?` →
+  - 行数 1500 → 数 ms
+  - 行数 1万 (8 日分) → 30-50 ms
+  - 行数 10万 → 200-500 ms 。 indexed でないので **ここが最初のボトルネック**
+- `page_visits` ドメイン別集計 (`/api/domains`): SUM with GROUP BY → **数 ms** (現サイズ)
+- 日記の dig 取得: `dig_sessions WHERE date(created_at,'localtime') = ?` → 数 ms
+
+→ **`activity_events` が 5-10 万行を超えるあたりから date 集計が秒単位になりはじめる**。
+これは概ね **1-2 年後** に到達。 ただし indexed にすればさらに 100 倍速くなる余地あり (§7.1)。
+
+---
+
+## 5. パーティションの是非
+
+### 5.1 月次パーティションの選択肢
+
+SQLite には built-in パーティショニングがない。 取りうる方法:
+
+| 方法 | メリット | デメリット |
+|------|---------|------------|
+| (a) ATTACH DATABASE で月別ファイル | ホット/コールド分離、 個別 vacuum 可 | クロスファイル JOIN 不可、 集計が UNION 地獄、 transactional 一貫性の運用負担 |
+| (b) 1 DB 内テーブルを月別に分割 (`activity_events_202605` 等) | クロステーブル UNION で集計可 | 月跨ぎの sweeper / migration / index 維持コストが累積、 schema 進化が極端に重い |
+| (c) パーティションテーブル (sqlite-vss 等の拡張) | 透過的 | 採用拡張が外部依存、 better-sqlite3 と相性問題 |
+
+### 5.2 結論: パーティションは過剰
+
+理由:
+
+1. **DB 全体が 5 年で 1-2 GB**。 SQLite が苦しむ規模は 50 GB 超えから。 50 倍のヘッドルームがある
+2. **書込み頻度のピーク (Claude Code hook = ~1500 row/min)** でも、 better-sqlite3 の WAL モードでは
+   1 トランザクションあたり 1ms 未満で捌ける。 既に POST `/api/activity/event` は durationMs 1 のログが
+   並んでいる (実測)
+3. 月別ファイルにすると、 「先月の commit + 今月の prompt をまとめて表示」 のような **作業ログタブの
+   日次グルーピング** ができなくなる。 まさに今日追加した機能と相性が悪い
+4. backup 戦略 (data/ 丸ごと) も複雑化
+
+---
+
+## 6. 代わりに採るべき対策 (推奨度順)
+
+### 6.1 ★ 推奨: indexing の補強
+
+`activity_events` の現スキーマ確認 → **`(date(occurred_at,'localtime'), kind)` 相当の generated column + index** を入れる。
+
+```sql
+ALTER TABLE activity_events ADD COLUMN occurred_date TEXT
+  GENERATED ALWAYS AS (date(occurred_at,'localtime')) VIRTUAL;
+CREATE INDEX IF NOT EXISTS idx_activity_events_date_kind
+  ON activity_events(occurred_date, kind, occurred_at DESC);
+```
+
+- 効果: `activityEventsPage(db, dateStr, { kind })` が **行数に依存しない O(log N)** になる
+- 1 日 1500 行 × 10 年 ≒ 550 万行でもページング数 ms
+
+### 6.2 ★ 推奨: WAL checkpoint の明示化
+
+```js
+// 起動時 + 1 時間に 1 回
+db.pragma('wal_checkpoint(TRUNCATE)');
+```
+
+WAL が 4 MB に膨らんでいるのは autocheckpoint が走っていない可能性。
+TRUNCATE モードで強制 checkpoint すれば WAL は数 KB に戻る。
+
+### 6.3 ☆ 中期: リテンション + 集計テーブル
+
+5 年運用後を見据えて、 **古い詳細を集計に置き換える** sweeper を入れる。
+パーティションより遥かにシンプル。
+
+```js
+// 90 日超の activity_events は、 日次集計テーブル `activity_daily` に移してから DELETE
+//   (date, kind, source) → (count, first_occurred, last_occurred, sample_content)
+// retention 適用は手動 or 月 1 cron
+```
+
+| 対象 | リテンション | 集計後の保存形式 |
+|------|------|------|
+| `activity_events` | 90-180 日 | (date, kind, repo/source, count) |
+| `visit_events` | 90 日 | 既存 `page_visits` に集約済 → 単純削除 |
+| `accesses` | 365 日 | 必要なら月次 (date, bookmark_id, count) |
+| `server_events` | 90 日 | downtime のみ保持、 start/stop は削除 |
+| `gps_locations` | 365 日 | (date, place_id, dwell_minutes) に圧縮 |
+
+10 年スパンで 2 GB → 200-300 MB に削減可能。
+
+### 6.4 ☆ 任意: VACUUM の運用
+
+```js
+db.exec('VACUUM;');  // 月 1 回手動 or 起動時、 運用負担小
+```
+
+DELETE の後に走らせるとファイルサイズが回復する。
+ただし VACUUM 中は exclusive lock がかかるので、 stop-the-world になる
+(数百 MB なら数秒、 1 GB なら 10 秒オーダー)。
+
+### 6.5 (将来) Multi-Hub への移行
+
+`docs/multi-server-architecture.md` の Local/Multi 二層化 (#34) で **Multi 側は Postgres**。
+共有データの規模が肥大したら Hub に逃がせる構造になっている。
+個人 Local DB は依然 SQLite で問題なし。
+
+---
+
+## 7. 期間別ロードマップ提案
+
+| 時期 | 対応 | 理由 |
+|-----|------|------|
+| **今すぐ (Issue 化推奨)** | indexing 補強 (§6.1) + WAL checkpoint (§6.2) | コスト数行、 効果絶大 |
+| **DB が 100 MB 超えたら** | 月 1 VACUUM + リテンション設計 (§6.3) | 100 MB が「個人 PC でも体感する」 ライン |
+| **DB が 1 GB 超えたら** | リテンション実装、 sweeper を別 cron に分離 | 検索体感が 100ms 単位になり始める |
+| **DB が 10 GB 超えたら** | activity_events を ATTACH 分離、 もしくは全面 Postgres 移行検討 | SQLite でも動くが backup / vacuum の運用負担が無視できなくなる |
+
+→ 現在のペースだと **「DB 100 MB 超え」 は約 4 ヶ月後 ≈ 2026-09**、
+**「1 GB 超え」 は約 4 年後 ≈ 2030**。 月次パーティションを今入れる理由はない。
+
+---
+
+## 8. 補遺: 計測手順 (再現用)
+
+```bash
+# 行数 + dbstat ベースサイズ (read-only で安全)
+cd E:/Document/Ars/Memoria/server
+node -e "
+import('better-sqlite3').then(({default:Database})=>{
+  const db = new Database('../data/memoria.db', { readonly: true });
+  for (const {name} of db.prepare(\"SELECT name FROM sqlite_master WHERE type='table'\").all()) {
+    const n = db.prepare('SELECT COUNT(*) AS n FROM \"'+name+'\"').get().n;
+    let bytes = null;
+    try { bytes = db.prepare('SELECT SUM(payload) AS b FROM dbstat WHERE name=?').get(name).b; } catch {}
+    console.log(name, n, bytes);
+  }
+});
+"
+
+# WAL 状態
+sqlite3 data/memoria.db 'PRAGMA wal_checkpoint(TRUNCATE);'
+```
+
+---
+
+**まとめ:** 月次パーティションの導入価値は現時点で **無し**。 代わりに indexing 補強 +
+WAL checkpoint + 1-2 年スパンでリテンション運用を整える方針が、 5-10 倍コスト効率がよい。

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -168,6 +168,93 @@ server.registerTool(
   }
 );
 
+server.registerTool(
+  'add_task',
+  {
+    title: 'Add a Memoria task',
+    description: 'Create a short todo item in Memoria. Use this when the user asks to remember a next action or task.',
+    inputSchema: {
+      title: z.string().min(1).describe('Task title'),
+      details: z.string().optional().describe('Optional details'),
+      due_at: z.string().optional().describe('Optional ISO8601 due date/time'),
+      share_actio: z.boolean().optional().describe('Whether Memoria should mark this task for Actio sharing'),
+    },
+  },
+  async ({ title, details, due_at, share_actio }) => {
+    const res = await call('/api/tasks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, details, due_at: due_at || null, share_actio: !!share_actio }),
+    });
+    return { content: [{ type: 'text', text: JSON.stringify(res.task ?? res, null, 2) }] };
+  }
+);
+
+server.registerTool(
+  'list_tasks',
+  {
+    title: 'List Memoria tasks',
+    description: 'Return recent Memoria tasks, optionally filtered by status.',
+    inputSchema: {
+      status: z.enum(['todo', 'doing', 'done']).optional(),
+      limit: z.number().int().positive().max(100).optional(),
+    },
+  },
+  async ({ status, limit }) => {
+    const qs = new URLSearchParams();
+    if (status) qs.set('status', status);
+    if (limit) qs.set('limit', String(limit));
+    const res = await call(`/api/tasks?${qs.toString()}`);
+    return { content: [{ type: 'text', text: JSON.stringify(res.items ?? [], null, 2) }] };
+  }
+);
+
+server.registerTool(
+  'record_chat_message',
+  {
+    title: 'Record an external chat message',
+    description: 'Store a message from web Claude, web Gemini, or another chat client into Memoria.',
+    inputSchema: {
+      source: z.string().min(1).describe('Source name, e.g. claude-web or gemini-web'),
+      content: z.string().min(1).describe('Message text'),
+      role: z.string().optional().describe('Optional role such as user or assistant'),
+      conversation_id: z.string().optional().describe('Optional external conversation id'),
+      metadata: z.record(z.unknown()).optional().describe('Optional metadata object'),
+    },
+  },
+  async ({ source, content, role, conversation_id, metadata }) => {
+    const res = await call('/api/external-chat/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ source, content, role, conversation_id, metadata }),
+    });
+    return { content: [{ type: 'text', text: JSON.stringify(res, null, 2) }] };
+  }
+);
+
+server.registerTool(
+  'add_implementation_note',
+  {
+    title: 'Add an implementation note',
+    description: 'Record good points and tradeoffs for a development product.',
+    inputSchema: {
+      product: z.string().min(1),
+      title: z.string().min(1),
+      good_points: z.string().optional(),
+      bad_points: z.string().optional(),
+      shareable: z.boolean().optional(),
+    },
+  },
+  async ({ product, title, good_points, bad_points, shareable }) => {
+    const res = await call('/api/implementation-notes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ product, title, good_points, bad_points, shareable: !!shareable }),
+    });
+    return { content: [{ type: 'text', text: JSON.stringify(res.note ?? res, null, 2) }] };
+  }
+);
+
 // ── resources ────────────────────────────────────────────────────────────
 
 server.registerResource(

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -177,7 +177,7 @@ server.registerTool(
       title: z.string().min(1).describe('Task title'),
       details: z.string().optional().describe('Optional details'),
       due_at: z.string().optional().describe('Optional ISO8601 due date/time'),
-      share_actio: z.boolean().optional().describe('Whether Memoria should mark this task for Actio sharing'),
+      share_actio: z.boolean().optional().describe('Actio へシェアする対象として扱うか'),
     },
   },
   async ({ title, details, due_at, share_actio }) => {
@@ -235,8 +235,8 @@ server.registerTool(
 server.registerTool(
   'add_implementation_note',
   {
-    title: 'Add an implementation note',
-    description: 'Record good points and tradeoffs for a development product.',
+    title: '実装自慢を追加する',
+    description: '自分の開発プロダクトについて、良かった点や悪かった点を Memoria に記録します。',
     inputSchema: {
       product: z.string().min(1),
       title: z.string().min(1),

--- a/server/db.js
+++ b/server/db.js
@@ -344,6 +344,26 @@ export function openDb(dbPath) {
     CREATE INDEX IF NOT EXISTS idx_tasks_due
       ON tasks(due_at);
 
+    CREATE TABLE IF NOT EXISTS work_locations (
+      id             INTEGER PRIMARY KEY AUTOINCREMENT,
+      name           TEXT NOT NULL,
+      address        TEXT,
+      latitude       REAL,
+      longitude      REAL,
+      description    TEXT,
+      url            TEXT,
+      tags           TEXT,
+      shareable      INTEGER NOT NULL DEFAULT 0,
+      shared_at      TEXT,
+      shared_origin  TEXT,
+      owner_user_id  TEXT,
+      owner_user_name TEXT,
+      created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at     TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_work_locations_created
+      ON work_locations(created_at DESC);
+
     CREATE TABLE IF NOT EXISTS external_chat_messages (
       id             INTEGER PRIMARY KEY AUTOINCREMENT,
       source         TEXT NOT NULL,
@@ -2730,6 +2750,72 @@ export function updateImplementationNote(db, id, patch) {
 
 export function deleteImplementationNote(db, id) {
   db.prepare(`DELETE FROM implementation_notes WHERE id = ?`).run(id);
+}
+
+// ---- work locations -------------------------------------------------------
+
+export function listWorkLocations(db, { limit = 200, offset = 0 } = {}) {
+  return db.prepare(`
+    SELECT * FROM work_locations
+    ORDER BY created_at DESC
+    LIMIT ? OFFSET ?
+  `).all(Number(limit) || 200, Number(offset) || 0);
+}
+
+export function getWorkLocation(db, id) {
+  return db.prepare(`SELECT * FROM work_locations WHERE id = ?`).get(id);
+}
+
+export function insertWorkLocation(db, loc) {
+  const info = db.prepare(`
+    INSERT INTO work_locations
+      (name, address, latitude, longitude, description, url, tags, shareable)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    loc.name,
+    loc.address ?? null,
+    loc.latitude == null ? null : Number(loc.latitude),
+    loc.longitude == null ? null : Number(loc.longitude),
+    loc.description ?? null,
+    loc.url ?? null,
+    loc.tags ?? null,
+    loc.shareable ? 1 : 0,
+  );
+  return Number(info.lastInsertRowid);
+}
+
+export function updateWorkLocation(db, id, patch) {
+  const allowed = new Set([
+    'name', 'address', 'latitude', 'longitude', 'description', 'url', 'tags',
+    'shareable', 'shared_at', 'shared_origin',
+    'owner_user_id', 'owner_user_name',
+  ]);
+  const cols = [];
+  const args = [];
+  for (const [k, v] of Object.entries(patch)) {
+    if (!allowed.has(k)) continue;
+    cols.push(`${k} = ?`);
+    if (k === 'shareable') args.push(v ? 1 : 0);
+    else if (k === 'latitude' || k === 'longitude') args.push(v == null ? null : Number(v));
+    else args.push(v);
+  }
+  if (!cols.length) return;
+  cols.push(`updated_at = datetime('now')`);
+  args.push(id);
+  db.prepare(`UPDATE work_locations SET ${cols.join(', ')} WHERE id = ?`).run(...args);
+}
+
+export function deleteWorkLocation(db, id) {
+  db.prepare(`DELETE FROM work_locations WHERE id = ?`).run(id);
+}
+
+export function setWorkLocationOwner(db, id, { ownerUserId, ownerUserName, sharedAt, sharedOrigin }) {
+  db.prepare(`
+    UPDATE work_locations
+       SET owner_user_id = ?, owner_user_name = ?, shared_at = ?, shared_origin = ?,
+           updated_at = datetime('now')
+     WHERE id = ?
+  `).run(ownerUserId ?? null, ownerUserName ?? null, sharedAt ?? null, sharedOrigin ?? null, id);
 }
 
 // ---- tasks ----------------------------------------------------------------

--- a/server/db.js
+++ b/server/db.js
@@ -1,6 +1,6 @@
 import Database from 'better-sqlite3';
-import { mkdirSync } from 'node:fs';
-import { dirname } from 'node:path';
+import { mkdirSync, existsSync, readFileSync, writeFileSync, renameSync, unlinkSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 
 export function openDb(dbPath) {
   mkdirSync(dirname(dbPath), { recursive: true });
@@ -824,6 +824,71 @@ export function digSessionsForDate(db, dateStr) {
 
 function safeParse(s) { try { return JSON.parse(s); } catch { return null; } }
 
+// ── worklog browsing aggregations (per-date) ─────────────────────────────
+//
+// 「作業ログ」 タブの「ブラウジング」 サブビューが叩く集計群。 page_visits は
+// last_seen_at しか持たないため、 同じ URL を別日に複数回開いた場合は最後の日付
+// にしか紐付かない (visit_events は per-event で残るが、 そちらは Legatus / SNI
+// 由来のものが混じるので、 ブクマ/履歴判定としては page_visits を主軸にする)。
+
+/** 当日 last_seen_at の page_visits、 ブックマーク済みかどうかも返す */
+export function pageVisitsForDate(db, dateStr, { limit = 200 } = {}) {
+  const safeLimit = Math.max(1, Math.min(2000, Number(limit) || 200));
+  return db.prepare(`
+    SELECT v.url, v.title, v.first_seen_at, v.last_seen_at, v.visit_count,
+           CASE WHEN b.id IS NULL THEN 0 ELSE 1 END AS is_bookmarked,
+           b.id AS bookmark_id, b.title AS bookmark_title
+    FROM page_visits v
+    LEFT JOIN bookmarks b ON b.url = v.url
+    WHERE date(v.last_seen_at, 'localtime') = ?
+    ORDER BY v.last_seen_at DESC
+    LIMIT ?
+  `).all(dateStr, safeLimit);
+}
+
+/** 当日に再訪が記録されたブックマーク (page_visits とブクマ url を JOIN) */
+export function revisitedBookmarksForDate(db, dateStr, { limit = 100 } = {}) {
+  const safeLimit = Math.max(1, Math.min(500, Number(limit) || 100));
+  return db.prepare(`
+    SELECT b.id, b.url, b.title, b.summary, v.visit_count, v.last_seen_at, v.first_seen_at
+    FROM bookmarks b
+    INNER JOIN page_visits v ON v.url = b.url
+    WHERE date(v.last_seen_at, 'localtime') = ?
+    ORDER BY v.visit_count DESC, v.last_seen_at DESC
+    LIMIT ?
+  `).all(dateStr, safeLimit);
+}
+
+/** 当日のドメイン別 visit_count 合計 + ページ閲覧総数 */
+export function browsingDomainStatsForDate(db, dateStr, { limit = 30 } = {}) {
+  const safeLimit = Math.max(1, Math.min(200, Number(limit) || 30));
+  const rows = db.prepare(`
+    SELECT LOWER(SUBSTR(SUBSTR(url, INSTR(url, '://') + 3), 1,
+                        CASE WHEN INSTR(SUBSTR(url, INSTR(url, '://') + 3), '/') > 0
+                             THEN INSTR(SUBSTR(url, INSTR(url, '://') + 3), '/') - 1
+                             ELSE LENGTH(SUBSTR(url, INSTR(url, '://') + 3)) END
+                       )) AS domain,
+           COUNT(*) AS pages,
+           SUM(visit_count) AS visits
+      FROM page_visits
+     WHERE date(last_seen_at, 'localtime') = ?
+       AND domain != ''
+     GROUP BY domain
+     ORDER BY visits DESC, pages DESC
+     LIMIT ?
+  `).all(dateStr, safeLimit);
+  const totals = db.prepare(`
+    SELECT COUNT(*) AS pages, COALESCE(SUM(visit_count), 0) AS visits
+      FROM page_visits
+     WHERE date(last_seen_at, 'localtime') = ?
+  `).get(dateStr);
+  return {
+    top_domains: rows,
+    total_pages: totals.pages,
+    total_visits: totals.visits,
+  };
+}
+
 // ── share metadata --------------------------------------------------------
 //
 // Mark a local row as having been forwarded to a multi server. owner_user_id
@@ -1272,7 +1337,12 @@ export function listServerEventsForDate(db, dateStr) {
 
 // ── activity events (git commit / claude code prompt 等) ─────────────────
 
-const ACTIVITY_KINDS = new Set(['git_commit', 'claude_code_prompt']);
+const ACTIVITY_KINDS = new Set([
+  'git_commit',
+  'claude_code_prompt',
+  'gemini_prompt',
+  'codex_prompt',
+]);
 
 /**
  * 活動イベントを 1 件記録する。
@@ -1323,20 +1393,22 @@ export function activityEventsForDate(db, dateStr) {
  *   items   — 取得した行 (DESC、 最新が先頭)
  *   total   — 当日の全件数 (offset/limit 無関係)
  */
-export function activityEventsPage(db, dateStr, { limit = 100, offset = 0 } = {}) {
+export function activityEventsPage(db, dateStr, { limit = 100, offset = 0, kind = null } = {}) {
   const safeLimit = Math.max(1, Math.min(1000, Number(limit) || 100));
   const safeOffset = Math.max(0, Number(offset) || 0);
+  const kindClause = kind && ACTIVITY_KINDS.has(kind) ? 'AND kind = ?' : '';
+  const kindArgs = kindClause ? [kind] : [];
   const total = db.prepare(`
     SELECT COUNT(*) AS n FROM activity_events
-    WHERE date(occurred_at, 'localtime') = ?
-  `).get(dateStr).n;
+    WHERE date(occurred_at, 'localtime') = ? ${kindClause}
+  `).get(dateStr, ...kindArgs).n;
   const items = db.prepare(`
     SELECT id, kind, occurred_at, source, ref_id, content, metadata_json
     FROM activity_events
-    WHERE date(occurred_at, 'localtime') = ?
+    WHERE date(occurred_at, 'localtime') = ? ${kindClause}
     ORDER BY occurred_at DESC
     LIMIT ? OFFSET ?
-  `).all(dateStr, safeLimit, safeOffset).map((r) => ({
+  `).all(dateStr, ...kindArgs, safeLimit, safeOffset).map((r) => ({
     ...r,
     metadata: r.metadata_json ? safeParse(r.metadata_json) : null,
   }));
@@ -1403,13 +1475,87 @@ export function visitEventsForDate(db, dateStr) {
   `).all(dateStr);
 }
 
+// ── Diary sidecar (太い JSON 列をファイル外出し) ────────────────────────
+//
+// `metrics_json` と `github_commits_json` は 1 行 80KB に膨らむ太さなので、
+// `<dataDir>/diary/<date>.json` に逃がして DB はサマリだけ保持する。
+// データフロー:
+//   write: upsertDiary が metrics / githubCommits を受け取ったら sidecar に
+//          書き出し、 DB の `*_json` 列は NULL のままにする。
+//   read:  getDiary は DB 行を取り、 sidecar があればそこから metrics /
+//          github_commits を埋める。 sidecar が無ければ DB 列を fallback。
+//   delete: deleteDiary が sidecar も unlink する。
+// マイグレーション (migrateDiariesToSidecar) は起動時 1 回で旧データを
+// sidecar に移し、 DB 列を NULL 化する。
+//
+// dataDir は index.js から setDiaryDataDir で注入する (db.js を fs から
+// 切り離さないために、 dir 未設定時は sidecar を no-op にして DB 列のみで動く)。
+
+let DIARY_DATA_DIR = null;
+
+export function setDiaryDataDir(dir) {
+  DIARY_DATA_DIR = dir || null;
+}
+
+function diarySidecarPath(dateStr) {
+  if (!DIARY_DATA_DIR) return null;
+  return join(DIARY_DATA_DIR, 'diary', `${dateStr}.json`);
+}
+
+function readDiarySidecar(dateStr) {
+  const file = diarySidecarPath(dateStr);
+  if (!file) return null;
+  try {
+    if (!existsSync(file)) return null;
+    return JSON.parse(readFileSync(file, 'utf8'));
+  } catch { return null; }
+}
+
+function writeDiarySidecar(dateStr, partial) {
+  const file = diarySidecarPath(dateStr);
+  if (!file) return false;
+  const dir = dirname(file);
+  mkdirSync(dir, { recursive: true });
+  // Merge with any existing sidecar so partial writes don't drop other keys.
+  let cur = {};
+  if (existsSync(file)) {
+    try { cur = JSON.parse(readFileSync(file, 'utf8')) || {}; } catch {}
+  }
+  const next = { ...cur };
+  if ('metrics' in partial) next.metrics = partial.metrics;
+  if ('github_commits' in partial) next.github_commits = partial.github_commits;
+  // Atomic-ish write: tmp + rename.
+  const tmp = file + '.tmp';
+  writeFileSync(tmp, JSON.stringify(next));
+  renameSync(tmp, file);
+  return true;
+}
+
+function deleteDiarySidecar(dateStr) {
+  const file = diarySidecarPath(dateStr);
+  if (!file) return;
+  try {
+    if (existsSync(file)) unlinkSync(file);
+  } catch {}
+}
+
 export function getDiary(db, dateStr) {
   const row = db.prepare(`SELECT * FROM diary_entries WHERE date = ?`).get(dateStr);
   if (!row) return null;
+  const side = readDiarySidecar(dateStr);
+  // Sidecar wins; DB columns are kept as fallback for un-migrated rows.
+  const metrics = side && 'metrics' in side
+    ? side.metrics
+    : (row.metrics_json ? safeParse(row.metrics_json) : null);
+  const githubCommits = side && 'github_commits' in side
+    ? side.github_commits
+    : (row.github_commits_json ? safeParse(row.github_commits_json) : null);
   return {
     ...row,
-    metrics: row.metrics_json ? safeParse(row.metrics_json) : null,
-    github_commits: row.github_commits_json ? safeParse(row.github_commits_json) : null,
+    metrics_json: null,         // hide raw blob from API consumers
+    github_commits_json: null,
+    metrics,
+    github_commits: githubCommits,
   };
 }
 
@@ -1423,6 +1569,16 @@ export function listDiariesInRange(db, { start, end }) {
 }
 
 export function upsertDiary(db, { date, summary, workContent, workMinutes, highlights, notes, metrics, githubCommits, status, error }) {
+  // Persist heavy JSON to sidecar; DB columns are kept NULL going forward.
+  // (Existing rows that still have *_json values continue to be served via
+  // the fallback path in getDiary until migrateDiariesToSidecar runs.)
+  const sidecarPatch = {};
+  if (metrics !== undefined) sidecarPatch.metrics = metrics ?? null;
+  if (githubCommits !== undefined) sidecarPatch.github_commits = githubCommits ?? null;
+  if (Object.keys(sidecarPatch).length > 0) {
+    writeDiarySidecar(date, sidecarPatch);
+  }
+
   const tx = db.transaction(() => {
     const exists = db.prepare(`SELECT date FROM diary_entries WHERE date = ?`).get(date);
     if (exists) {
@@ -1433,8 +1589,6 @@ export function upsertDiary(db, { date, summary, workContent, workMinutes, highl
                work_minutes = COALESCE(?, work_minutes),
                highlights = COALESCE(?, highlights),
                notes = COALESCE(?, notes),
-               metrics_json = COALESCE(?, metrics_json),
-               github_commits_json = COALESCE(?, github_commits_json),
                status = COALESCE(?, status),
                error = ?,
                updated_at = datetime('now')
@@ -1445,8 +1599,6 @@ export function upsertDiary(db, { date, summary, workContent, workMinutes, highl
         Number.isFinite(workMinutes) ? Math.round(workMinutes) : null,
         highlights ?? null,
         notes ?? null,
-        metrics ? JSON.stringify(metrics) : null,
-        githubCommits ? JSON.stringify(githubCommits) : null,
         status ?? null,
         error ?? null,
         date,
@@ -1454,8 +1606,8 @@ export function upsertDiary(db, { date, summary, workContent, workMinutes, highl
     } else {
       db.prepare(`
         INSERT INTO diary_entries
-          (date, summary, work_content, work_minutes, highlights, notes, metrics_json, github_commits_json, status, error)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          (date, summary, work_content, work_minutes, highlights, notes, status, error)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
       `).run(
         date,
         summary ?? null,
@@ -1463,8 +1615,6 @@ export function upsertDiary(db, { date, summary, workContent, workMinutes, highl
         Number.isFinite(workMinutes) ? Math.round(workMinutes) : null,
         highlights ?? null,
         notes ?? null,
-        metrics ? JSON.stringify(metrics) : null,
-        githubCommits ? JSON.stringify(githubCommits) : null,
         status ?? 'pending',
         error ?? null,
       );
@@ -1545,6 +1695,37 @@ export function updateDiaryNotes(db, dateStr, notes) {
 
 export function deleteDiary(db, dateStr) {
   db.prepare(`DELETE FROM diary_entries WHERE date = ?`).run(dateStr);
+  deleteDiarySidecar(dateStr);
+}
+
+/**
+ * 起動時に 1 回呼ぶマイグレーション。 旧スキーマで `metrics_json` /
+ * `github_commits_json` に値があった行を sidecar ファイルに移し、 DB の
+ * 列を NULL 化する。 idempotent。
+ */
+export function migrateDiariesToSidecar(db) {
+  if (!DIARY_DATA_DIR) return { moved: 0, reason: 'no data dir' };
+  const rows = db.prepare(`
+    SELECT date, metrics_json, github_commits_json
+    FROM diary_entries
+    WHERE metrics_json IS NOT NULL OR github_commits_json IS NOT NULL
+  `).all();
+  if (!rows.length) return { moved: 0 };
+  const tx = db.transaction(() => {
+    for (const r of rows) {
+      const patch = {};
+      if (r.metrics_json) patch.metrics = safeParse(r.metrics_json);
+      if (r.github_commits_json) patch.github_commits = safeParse(r.github_commits_json);
+      writeDiarySidecar(r.date, patch);
+      db.prepare(`
+        UPDATE diary_entries
+           SET metrics_json = NULL, github_commits_json = NULL
+         WHERE date = ?
+      `).run(r.date);
+    }
+  });
+  tx();
+  return { moved: rows.length };
 }
 
 export function getDiarySettings(db) {

--- a/server/db.js
+++ b/server/db.js
@@ -446,6 +446,7 @@ export function openDb(dbPath) {
   if (!dcCols.includes('can_do'))      db.exec(`ALTER TABLE domain_catalog ADD COLUMN can_do TEXT`);
   if (!dcCols.includes('notes'))       db.exec(`ALTER TABLE domain_catalog ADD COLUMN notes TEXT`);
   if (!dcCols.includes('user_edited')) db.exec(`ALTER TABLE domain_catalog ADD COLUMN user_edited INTEGER NOT NULL DEFAULT 0`);
+  if (!dcCols.includes('domain_private')) db.exec(`ALTER TABLE domain_catalog ADD COLUMN domain_private INTEGER NOT NULL DEFAULT 0`);
 
   // Phase 1 (multi-server): ownership / share metadata on the three shareable
   // resources. NULL owner_user_id = "this is mine" on a local server.
@@ -1297,6 +1298,10 @@ export function updateDomainCatalogUser(db, domain, patch) {
       fields.push(`${k} = ?`);
       args.push(patch[k] ?? null);
     }
+  }
+  if (typeof patch.domain_private === 'boolean' || patch.domain_private === 0 || patch.domain_private === 1) {
+    fields.push(`domain_private = ?`);
+    args.push(patch.domain_private ? 1 : 0);
   }
   if (fields.length === 0) return;
   fields.push(`user_edited = 1`);

--- a/server/db.js
+++ b/server/db.js
@@ -310,6 +310,52 @@ export function openDb(dbPath) {
     );
     CREATE INDEX IF NOT EXISTS idx_meals_eaten_at ON meals(eaten_at DESC);
     CREATE INDEX IF NOT EXISTS idx_meals_ai_status ON meals(ai_status);
+
+    CREATE TABLE IF NOT EXISTS implementation_notes (
+      id            INTEGER PRIMARY KEY AUTOINCREMENT,
+      product       TEXT NOT NULL,
+      title         TEXT NOT NULL,
+      good_points   TEXT,
+      bad_points    TEXT,
+      shareable     INTEGER NOT NULL DEFAULT 0,
+      shared_at     TEXT,
+      shared_origin TEXT,
+      created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_implementation_notes_created
+      ON implementation_notes(created_at DESC);
+
+    CREATE TABLE IF NOT EXISTS tasks (
+      id            INTEGER PRIMARY KEY AUTOINCREMENT,
+      title         TEXT NOT NULL,
+      details       TEXT,
+      status        TEXT NOT NULL DEFAULT 'todo',
+      due_at        TEXT,
+      share_actio   INTEGER NOT NULL DEFAULT 0,
+      shared_at     TEXT,
+      shared_origin TEXT,
+      created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_tasks_status_created
+      ON tasks(status, created_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_tasks_due
+      ON tasks(due_at);
+
+    CREATE TABLE IF NOT EXISTS external_chat_messages (
+      id             INTEGER PRIMARY KEY AUTOINCREMENT,
+      source         TEXT NOT NULL,
+      conversation_id TEXT,
+      role           TEXT,
+      content        TEXT NOT NULL,
+      metadata_json  TEXT,
+      received_at    TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_external_chat_received
+      ON external_chat_messages(received_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_external_chat_source
+      ON external_chat_messages(source, received_at DESC);
   `);
 
   // Forward-compat: 既存 DB に列を ALTER で追加
@@ -319,6 +365,25 @@ export function openDb(dbPath) {
   }
   if (mealsCols.length > 0 && !mealsCols.includes('nutrients_json')) {
     db.exec(`ALTER TABLE meals ADD COLUMN nutrients_json TEXT`);
+  }
+
+  const implCols = db.prepare(`PRAGMA table_info(implementation_notes)`).all().map(c => c.name);
+  for (const col of ['shared_at', 'shared_origin']) {
+    if (implCols.length > 0 && !implCols.includes(col)) {
+      db.exec(`ALTER TABLE implementation_notes ADD COLUMN ${col} TEXT`);
+    }
+  }
+
+  const taskCols = db.prepare(`PRAGMA table_info(tasks)`).all().map(c => c.name);
+  for (const [col, ddl] of [
+    ['due_at', 'TEXT'],
+    ['share_actio', 'INTEGER NOT NULL DEFAULT 0'],
+    ['shared_at', 'TEXT'],
+    ['shared_origin', 'TEXT'],
+  ]) {
+    if (taskCols.length > 0 && !taskCols.includes(col)) {
+      db.exec(`ALTER TABLE tasks ADD COLUMN ${col} ${ddl}`);
+    }
   }
 
   // Forward-compat: ensure newer columns exist on older word_clouds tables.
@@ -2588,6 +2653,151 @@ export function listMealsForDate(db, dateStr) {
 // dig graph / wordcloud などで「もう出さなくていい」 単語を蓄積する。
 // 表示側 (app.js) で随時 filter するのと、 サーバ抽出側で除外するのと
 // 両方で参照する想定 (今は表示側 filter のみで運用)。
+
+// ---- implementation notes -------------------------------------------------
+
+export function listImplementationNotes(db, { limit = 100, offset = 0, shareable = null } = {}) {
+  const where = [];
+  const args = [];
+  if (shareable != null) {
+    where.push('shareable = ?');
+    args.push(shareable ? 1 : 0);
+  }
+  args.push(limit, offset);
+  return db.prepare(`
+    SELECT * FROM implementation_notes
+    ${where.length ? 'WHERE ' + where.join(' AND ') : ''}
+    ORDER BY created_at DESC
+    LIMIT ? OFFSET ?
+  `).all(...args);
+}
+
+export function getImplementationNote(db, id) {
+  return db.prepare(`SELECT * FROM implementation_notes WHERE id = ?`).get(id);
+}
+
+export function insertImplementationNote(db, note) {
+  const info = db.prepare(`
+    INSERT INTO implementation_notes (product, title, good_points, bad_points, shareable)
+    VALUES (?, ?, ?, ?, ?)
+  `).run(
+    note.product,
+    note.title,
+    note.good_points ?? null,
+    note.bad_points ?? null,
+    note.shareable ? 1 : 0,
+  );
+  return Number(info.lastInsertRowid);
+}
+
+export function updateImplementationNote(db, id, patch) {
+  const allowed = new Set(['product', 'title', 'good_points', 'bad_points', 'shareable', 'shared_at', 'shared_origin']);
+  const cols = [];
+  const args = [];
+  for (const [k, v] of Object.entries(patch)) {
+    if (!allowed.has(k)) continue;
+    cols.push(`${k} = ?`);
+    args.push(k === 'shareable' ? (v ? 1 : 0) : v);
+  }
+  if (!cols.length) return;
+  cols.push(`updated_at = datetime('now')`);
+  args.push(id);
+  db.prepare(`UPDATE implementation_notes SET ${cols.join(', ')} WHERE id = ?`).run(...args);
+}
+
+export function deleteImplementationNote(db, id) {
+  db.prepare(`DELETE FROM implementation_notes WHERE id = ?`).run(id);
+}
+
+// ---- tasks ----------------------------------------------------------------
+
+export function listTasks(db, { status = null, limit = 100, offset = 0 } = {}) {
+  const where = [];
+  const args = [];
+  if (status) {
+    where.push('status = ?');
+    args.push(status);
+  }
+  args.push(limit, offset);
+  return db.prepare(`
+    SELECT * FROM tasks
+    ${where.length ? 'WHERE ' + where.join(' AND ') : ''}
+    ORDER BY
+      CASE status WHEN 'todo' THEN 0 WHEN 'doing' THEN 1 WHEN 'done' THEN 2 ELSE 3 END,
+      COALESCE(due_at, '9999-12-31') ASC,
+      created_at DESC
+    LIMIT ? OFFSET ?
+  `).all(...args);
+}
+
+export function getTask(db, id) {
+  return db.prepare(`SELECT * FROM tasks WHERE id = ?`).get(id);
+}
+
+export function insertTask(db, task) {
+  const info = db.prepare(`
+    INSERT INTO tasks (title, details, status, due_at, share_actio)
+    VALUES (?, ?, ?, ?, ?)
+  `).run(
+    task.title,
+    task.details ?? null,
+    task.status || 'todo',
+    task.due_at ?? null,
+    task.share_actio ? 1 : 0,
+  );
+  return Number(info.lastInsertRowid);
+}
+
+export function updateTask(db, id, patch) {
+  const allowed = new Set(['title', 'details', 'status', 'due_at', 'share_actio', 'shared_at', 'shared_origin']);
+  const cols = [];
+  const args = [];
+  for (const [k, v] of Object.entries(patch)) {
+    if (!allowed.has(k)) continue;
+    cols.push(`${k} = ?`);
+    args.push(k === 'share_actio' ? (v ? 1 : 0) : v);
+  }
+  if (!cols.length) return;
+  cols.push(`updated_at = datetime('now')`);
+  args.push(id);
+  db.prepare(`UPDATE tasks SET ${cols.join(', ')} WHERE id = ?`).run(...args);
+}
+
+export function deleteTask(db, id) {
+  db.prepare(`DELETE FROM tasks WHERE id = ?`).run(id);
+}
+
+// ---- external chat messages ----------------------------------------------
+
+export function insertExternalChatMessage(db, msg) {
+  const info = db.prepare(`
+    INSERT INTO external_chat_messages (source, conversation_id, role, content, metadata_json)
+    VALUES (?, ?, ?, ?, ?)
+  `).run(
+    msg.source,
+    msg.conversation_id ?? null,
+    msg.role ?? null,
+    msg.content,
+    msg.metadata ? JSON.stringify(msg.metadata) : null,
+  );
+  return Number(info.lastInsertRowid);
+}
+
+export function listExternalChatMessages(db, { source = null, limit = 100, offset = 0 } = {}) {
+  const where = [];
+  const args = [];
+  if (source) {
+    where.push('source = ?');
+    args.push(source);
+  }
+  args.push(limit, offset);
+  return db.prepare(`
+    SELECT * FROM external_chat_messages
+    ${where.length ? 'WHERE ' + where.join(' AND ') : ''}
+    ORDER BY received_at DESC
+    LIMIT ? OFFSET ?
+  `).all(...args);
+}
 
 export function ensureUserStopwordsTable(db) {
   db.exec(`

--- a/server/db.js
+++ b/server/db.js
@@ -331,6 +331,7 @@ export function openDb(dbPath) {
       title         TEXT NOT NULL,
       details       TEXT,
       status        TEXT NOT NULL DEFAULT 'todo',
+      creator_type  TEXT NOT NULL DEFAULT 'human',
       due_at        TEXT,
       share_actio   INTEGER NOT NULL DEFAULT 0,
       shared_at     TEXT,
@@ -373,10 +374,17 @@ export function openDb(dbPath) {
       db.exec(`ALTER TABLE implementation_notes ADD COLUMN ${col} TEXT`);
     }
   }
+  if (implCols.length > 0 && !implCols.includes('attachment_type')) {
+    db.exec(`ALTER TABLE implementation_notes ADD COLUMN attachment_type TEXT`);
+  }
+  if (implCols.length > 0 && !implCols.includes('attachment_value')) {
+    db.exec(`ALTER TABLE implementation_notes ADD COLUMN attachment_value TEXT`);
+  }
 
   const taskCols = db.prepare(`PRAGMA table_info(tasks)`).all().map(c => c.name);
   for (const [col, ddl] of [
     ['due_at', 'TEXT'],
+    ['creator_type', `TEXT NOT NULL DEFAULT 'human'`],
     ['share_actio', 'INTEGER NOT NULL DEFAULT 0'],
     ['shared_at', 'TEXT'],
     ['shared_origin', 'TEXT'],
@@ -1412,6 +1420,9 @@ const ACTIVITY_KINDS = new Set([
   'claude_code_prompt',
   'gemini_prompt',
   'codex_prompt',
+  'task_created',
+  'task_done',
+  'task_updated',
 ]);
 
 /**
@@ -2683,20 +2694,27 @@ export function getImplementationNote(db, id) {
 
 export function insertImplementationNote(db, note) {
   const info = db.prepare(`
-    INSERT INTO implementation_notes (product, title, good_points, bad_points, shareable)
-    VALUES (?, ?, ?, ?, ?)
+    INSERT INTO implementation_notes
+      (product, title, good_points, bad_points, attachment_type, attachment_value, shareable)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
   `).run(
-    note.product,
+    note.product ?? '',
     note.title,
     note.good_points ?? null,
     note.bad_points ?? null,
+    note.attachment_type ?? null,
+    note.attachment_value ?? null,
     note.shareable ? 1 : 0,
   );
   return Number(info.lastInsertRowid);
 }
 
 export function updateImplementationNote(db, id, patch) {
-  const allowed = new Set(['product', 'title', 'good_points', 'bad_points', 'shareable', 'shared_at', 'shared_origin']);
+  const allowed = new Set([
+    'product', 'title', 'good_points', 'bad_points',
+    'attachment_type', 'attachment_value',
+    'shareable', 'shared_at', 'shared_origin',
+  ]);
   const cols = [];
   const args = [];
   for (const [k, v] of Object.entries(patch)) {
@@ -2741,12 +2759,13 @@ export function getTask(db, id) {
 
 export function insertTask(db, task) {
   const info = db.prepare(`
-    INSERT INTO tasks (title, details, status, due_at, share_actio)
-    VALUES (?, ?, ?, ?, ?)
+    INSERT INTO tasks (title, details, status, creator_type, due_at, share_actio)
+    VALUES (?, ?, ?, ?, ?, ?)
   `).run(
     task.title,
     task.details ?? null,
     task.status || 'todo',
+    task.creator_type === 'ai' ? 'ai' : 'human',
     task.due_at ?? null,
     task.share_actio ? 1 : 0,
   );
@@ -2754,7 +2773,7 @@ export function insertTask(db, task) {
 }
 
 export function updateTask(db, id, patch) {
-  const allowed = new Set(['title', 'details', 'status', 'due_at', 'share_actio', 'shared_at', 'shared_origin']);
+  const allowed = new Set(['title', 'details', 'status', 'creator_type', 'due_at', 'share_actio', 'shared_at', 'shared_origin']);
   const cols = [];
   const args = [];
   for (const [k, v] of Object.entries(patch)) {

--- a/server/diary.js
+++ b/server/diary.js
@@ -114,8 +114,9 @@ export function aggregateDay(db, dateStr, { listLimit = DIARY_LIST_INITIAL, acti
       can_do: cat.can_do || null,
       kind: cat.kind || null,
       catalog_title: cat.title || null,
+      domain_private: !!cat.domain_private,
     } : d;
-  });
+  }).filter(d => !d.domain_private);
 
   const activeHours = hourlyVisits
     .map((n, h) => ({ hour: h, count: n }))

--- a/server/index.js
+++ b/server/index.js
@@ -90,6 +90,12 @@ import {
   insertMeal, getMeal, listMeals, countMeals, updateMeal, deleteMeal, listPendingMeals,
 } from './db.js';
 import {
+  listImplementationNotes, getImplementationNote, insertImplementationNote,
+  updateImplementationNote, deleteImplementationNote,
+  listTasks, getTask, insertTask, updateTask, deleteTask,
+  insertExternalChatMessage, listExternalChatMessages,
+} from './db.js';
+import {
   ensureUserStopwordsTable, listUserStopwords, addUserStopword, removeUserStopword,
 } from './db.js';
 import { initWebPush, getVapidPublicKey, saveSubscription, sendPushToAll } from './push.js';
@@ -101,6 +107,7 @@ import {
   readMultiServers, persistServers, upsertServer, removeServer,
   saveServerSession, clearServerSession, setActive, listConnectedActive,
   fetchMe, shareBookmark, shareDig, shareDictionary,
+  shareImplementationNote,
   multiFetch,
 } from './local/multi-client.js';
 
@@ -128,6 +135,28 @@ loadLlmConfigFromSettings(getAppSettings(db));
 initWebPush(DATA_DIR);
 const HEARTBEAT_FILE = join(DATA_DIR, 'heartbeat.json');
 startUptimeTracking({ db, dataDir: DATA_DIR, heartbeatFile: HEARTBEAT_FILE });
+
+function settingBool(settings, key, fallback = true) {
+  const v = settings[key];
+  if (v == null || v === '') return fallback;
+  return !['0', 'false', 'off', 'no'].includes(String(v).toLowerCase());
+}
+
+function privacySettings() {
+  const s = getAppSettings(db);
+  return {
+    tracks_enabled: settingBool(s, 'features.tracks.enabled', true),
+    tracks_visible: settingBool(s, 'features.tracks.visible', true),
+    meals_enabled: settingBool(s, 'features.meals.enabled', true),
+    meals_visible: settingBool(s, 'features.meals.visible', true),
+    tasks_actio_share_enabled: settingBool(s, 'features.tasks.actio_share.enabled', true),
+    actio_share_url: s['actio.share_url'] || '',
+  };
+}
+
+function featureEnabled(key) {
+  return privacySettings()[key] !== false;
+}
 const summaryQueue = new FifoQueue();
 const cloudQueue = new FifoQueue();
 const domainCatalogQueue = new FifoQueue();
@@ -721,6 +750,7 @@ function parseMealAdditionsJson(json) {
 //   eaten_at:   ISO8601 string (optional, 手動上書き)
 //   lat / lon:  number (optional, 手動上書き)
 app.post('/api/meals', async (c) => {
+  if (!featureEnabled('meals_enabled')) return c.json({ error: 'meals are disabled' }, 403);
   const form = await c.req.formData().catch(() => null);
   if (!form) return c.json({ error: 'multipart/form-data required' }, 400);
   const photo = form.get('photo');
@@ -821,6 +851,7 @@ app.post('/api/meals', async (c) => {
 //   lat / lon:    number (任意、 未指定なら GPS 軌跡から推定)
 //   user_note:    string (任意)
 app.post('/api/meals/manual', async (c) => {
+  if (!featureEnabled('meals_enabled')) return c.json({ error: 'meals are disabled' }, 403);
   const body = await c.req.json().catch(() => null);
   if (!body || typeof body !== 'object') return c.json({ error: 'json body required' }, 400);
   const description = typeof body.description === 'string' ? body.description.trim() : '';
@@ -886,6 +917,7 @@ app.post('/api/meals/manual', async (c) => {
 });
 
 app.get('/api/meals', (c) => {
+  if (!featureEnabled('meals_visible')) return c.json({ meals: [], total: 0 });
   const from = c.req.query('from') || undefined;
   const to = c.req.query('to') || undefined;
   const limit = Math.min(Number(c.req.query('limit') || 100), 500);
@@ -896,6 +928,7 @@ app.get('/api/meals', (c) => {
 });
 
 app.get('/api/meals/:id', (c) => {
+  if (!featureEnabled('meals_visible')) return c.json({ error: 'meals are hidden' }, 403);
   const id = Number(c.req.param('id'));
   const meal = getMeal(db, id);
   if (!meal) return c.json({ error: 'not found' }, 404);
@@ -903,6 +936,7 @@ app.get('/api/meals/:id', (c) => {
 });
 
 app.get('/api/meals/:id/photo', (c) => {
+  if (!featureEnabled('meals_visible')) return c.json({ error: 'meals are hidden' }, 403);
   const id = Number(c.req.param('id'));
   const meal = getMeal(db, id);
   if (!meal) return c.json({ error: 'not found' }, 404);
@@ -921,6 +955,7 @@ app.get('/api/meals/:id/photo', (c) => {
 });
 
 app.patch('/api/meals/:id', async (c) => {
+  if (!featureEnabled('meals_enabled')) return c.json({ error: 'meals are disabled' }, 403);
   const id = Number(c.req.param('id'));
   const meal = getMeal(db, id);
   if (!meal) return c.json({ error: 'not found' }, 404);
@@ -975,6 +1010,7 @@ app.patch('/api/meals/:id', async (c) => {
 });
 
 app.delete('/api/meals/:id', (c) => {
+  if (!featureEnabled('meals_enabled')) return c.json({ error: 'meals are disabled' }, 403);
   const id = Number(c.req.param('id'));
   const meal = getMeal(db, id);
   if (!meal) return c.json({ error: 'not found' }, 404);
@@ -991,6 +1027,7 @@ app.delete('/api/meals/:id', (c) => {
 });
 
 app.post('/api/meals/:id/reanalyze', (c) => {
+  if (!featureEnabled('meals_enabled')) return c.json({ error: 'meals are disabled' }, 403);
   const id = Number(c.req.param('id'));
   const meal = getMeal(db, id);
   if (!meal) return c.json({ error: 'not found' }, 404);
@@ -1021,6 +1058,7 @@ function parseAdditions(json) {
 }
 
 app.post('/api/meals/:id/additions', async (c) => {
+  if (!featureEnabled('meals_enabled')) return c.json({ error: 'meals are disabled' }, 403);
   const id = Number(c.req.param('id'));
   const meal = getMeal(db, id);
   if (!meal) return c.json({ error: 'not found' }, 404);
@@ -1057,6 +1095,7 @@ app.post('/api/meals/:id/additions', async (c) => {
 });
 
 app.patch('/api/meals/:id/additions/:idx', async (c) => {
+  if (!featureEnabled('meals_enabled')) return c.json({ error: 'meals are disabled' }, 403);
   const id = Number(c.req.param('id'));
   const idx = Number(c.req.param('idx'));
   const meal = getMeal(db, id);
@@ -1089,6 +1128,7 @@ app.patch('/api/meals/:id/additions/:idx', async (c) => {
 });
 
 app.delete('/api/meals/:id/additions/:idx', (c) => {
+  if (!featureEnabled('meals_enabled')) return c.json({ error: 'meals are disabled' }, 403);
   const id = Number(c.req.param('id'));
   const idx = Number(c.req.param('idx'));
   const meal = getMeal(db, id);
@@ -1638,6 +1678,214 @@ app.post('/api/dictionary/upsert-from-source', async (c) => {
   return c.json({ id: entryId, existed });
 });
 
+// ---- setup docs / privacy / notes / tasks / external chat -----------------
+
+const SETUP_DOCS = {
+  tailscale: {
+    title: 'Tailscale VPN setup',
+    body: '# Tailscale VPN setup\n\n1. Install Tailscale on the Memoria host and client devices.\n2. Sign in to the same tailnet.\n3. On the host, run `tailscale ip -4`.\n4. Open Memoria from clients with `http://<tailscale-ip>:5180`.\n5. For OwnTracks or Legatus, point clients at the host Tailscale IP.\n6. Keep public internet exposure off unless a protected tunnel is configured.',
+  },
+  cloudflare: {
+    title: 'Cloudflare Tunnel public setup',
+    body: '# Cloudflare Tunnel public setup\n\n1. Install `cloudflared` on the Memoria host.\n2. Run `cloudflared tunnel login` and create a tunnel.\n3. Route the hostname to `http://localhost:5180`.\n4. Protect the hostname with Cloudflare Access.\n5. Confirm the web UI and `/share` from outside the tailnet.\n6. Do not expose Memoria directly without authentication.',
+  },
+  legatus: {
+    title: 'Legatus startup',
+    body: '# Legatus startup\n\n1. Open the Legatus project next to Memoria.\n2. Enable only the ingestion modules you need.\n3. Set forward URLs such as `http://localhost:5180/api/locations/ingest` and `http://localhost:5180/api/visits/external`.\n4. Start Legatus with its documented dev or service command.\n5. Check Memoria Settings -> Integration / API key for Legatus status.',
+  },
+  sharing: {
+    title: 'Sharing settings',
+    body: '# Sharing settings\n\n1. Open Settings -> Data / Hub.\n2. Add a Memoria Hub URL and connect with Cernere.\n3. Enable only the servers you want to publish to.\n4. Share individual records from their own screens.\n5. Tasks can be shared to Actio when Settings -> Privacy enables Actio sharing and `actio.share_url` is set.\n6. Review content before sharing. Do not include secrets or private data.',
+  },
+};
+
+app.get('/api/setup-docs', (c) => {
+  return c.json({ docs: Object.entries(SETUP_DOCS).map(([key, v]) => ({ key, title: v.title })) });
+});
+
+app.get('/api/setup-docs/:key', (c) => {
+  const doc = SETUP_DOCS[c.req.param('key')];
+  if (!doc) return c.json({ error: 'not found' }, 404);
+  return c.json({ key: c.req.param('key'), ...doc });
+});
+
+app.get('/api/privacy/settings', (c) => c.json({ settings: privacySettings() }));
+
+app.patch('/api/privacy/settings', async (c) => {
+  const body = await c.req.json().catch(() => ({}));
+  const patch = {};
+  for (const [bodyKey, settingKey] of [
+    ['tracks_enabled', 'features.tracks.enabled'],
+    ['tracks_visible', 'features.tracks.visible'],
+    ['meals_enabled', 'features.meals.enabled'],
+    ['meals_visible', 'features.meals.visible'],
+    ['tasks_actio_share_enabled', 'features.tasks.actio_share.enabled'],
+  ]) {
+    if (typeof body[bodyKey] === 'boolean') patch[settingKey] = body[bodyKey] ? '1' : '0';
+  }
+  if (typeof body.actio_share_url === 'string') patch['actio.share_url'] = body.actio_share_url.trim();
+  if (Object.keys(patch).length) setAppSettings(db, patch);
+  return c.json({ settings: privacySettings() });
+});
+
+app.get('/api/implementation-notes', (c) => {
+  const limit = Math.min(Number(c.req.query('limit') || 100), 200);
+  const offset = Math.max(0, Number(c.req.query('offset') || 0));
+  const shareable = c.req.query('shareable');
+  const items = listImplementationNotes(db, {
+    limit,
+    offset,
+    shareable: shareable == null ? null : shareable === '1' || shareable === 'true',
+  });
+  return c.json({ items });
+});
+
+app.post('/api/implementation-notes', async (c) => {
+  const body = await c.req.json().catch(() => ({}));
+  const product = String(body.product || '').trim();
+  const title = String(body.title || '').trim();
+  if (!product || !title) return c.json({ error: 'product and title required' }, 400);
+  const id = insertImplementationNote(db, {
+    product,
+    title,
+    good_points: String(body.good_points || '').trim(),
+    bad_points: String(body.bad_points || '').trim(),
+    shareable: !!body.shareable,
+  });
+  return c.json({ note: getImplementationNote(db, id) }, 201);
+});
+
+app.patch('/api/implementation-notes/:id', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (!getImplementationNote(db, id)) return c.json({ error: 'not found' }, 404);
+  const body = await c.req.json().catch(() => ({}));
+  const patch = {};
+  for (const k of ['product', 'title', 'good_points', 'bad_points']) {
+    if (typeof body[k] === 'string') patch[k] = body[k].trim();
+  }
+  if (typeof body.shareable === 'boolean') patch.shareable = body.shareable;
+  updateImplementationNote(db, id, patch);
+  return c.json({ note: getImplementationNote(db, id) });
+});
+
+app.delete('/api/implementation-notes/:id', (c) => {
+  const id = Number(c.req.param('id'));
+  if (!getImplementationNote(db, id)) return c.json({ error: 'not found' }, 404);
+  deleteImplementationNote(db, id);
+  return c.json({ ok: true });
+});
+
+app.post('/api/implementation-notes/:id/share', async (c) => {
+  const id = Number(c.req.param('id'));
+  const note = getImplementationNote(db, id);
+  if (!note) return c.json({ error: 'not found' }, 404);
+  if (!note.shareable) return c.json({ error: 'note is not marked shareable' }, 409);
+  updateImplementationNote(db, id, { shared_at: new Date().toISOString(), shared_origin: 'local' });
+  return c.json({ ok: true, note: getImplementationNote(db, id) });
+});
+
+app.get('/api/tasks', (c) => {
+  const limit = Math.min(Number(c.req.query('limit') || 100), 200);
+  const offset = Math.max(0, Number(c.req.query('offset') || 0));
+  const status = c.req.query('status') || null;
+  return c.json({ items: listTasks(db, { status, limit, offset }) });
+});
+
+app.post('/api/tasks', async (c) => {
+  const body = await c.req.json().catch(() => ({}));
+  const title = String(body.title || '').trim();
+  if (!title) return c.json({ error: 'title required' }, 400);
+  const status = ['todo', 'doing', 'done'].includes(body.status) ? body.status : 'todo';
+  const id = insertTask(db, {
+    title,
+    details: String(body.details || '').trim(),
+    status,
+    due_at: body.due_at || null,
+    share_actio: !!body.share_actio,
+  });
+  return c.json({ task: getTask(db, id) }, 201);
+});
+
+app.patch('/api/tasks/:id', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (!getTask(db, id)) return c.json({ error: 'not found' }, 404);
+  const body = await c.req.json().catch(() => ({}));
+  const patch = {};
+  if (typeof body.title === 'string') patch.title = body.title.trim();
+  if (typeof body.details === 'string') patch.details = body.details.trim();
+  if (['todo', 'doing', 'done'].includes(body.status)) patch.status = body.status;
+  if (body.due_at === null || typeof body.due_at === 'string') patch.due_at = body.due_at || null;
+  if (typeof body.share_actio === 'boolean') patch.share_actio = body.share_actio;
+  updateTask(db, id, patch);
+  return c.json({ task: getTask(db, id) });
+});
+
+app.delete('/api/tasks/:id', (c) => {
+  const id = Number(c.req.param('id'));
+  if (!getTask(db, id)) return c.json({ error: 'not found' }, 404);
+  deleteTask(db, id);
+  return c.json({ ok: true });
+});
+
+async function shareTaskToActio(task) {
+  const settings = privacySettings();
+  if (!settings.tasks_actio_share_enabled) throw new Error('Actio task sharing is disabled');
+  if (!settings.actio_share_url) throw new Error('actio_share_url is not configured');
+  const res = await fetch(settings.actio_share_url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      source: 'memoria',
+      external_id: `memoria-task-${task.id}`,
+      title: task.title,
+      details: task.details || '',
+      status: task.status,
+      due_at: task.due_at || null,
+    }),
+  });
+  if (!res.ok) throw new Error(`Actio ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  return res.json().catch(() => ({}));
+}
+
+app.post('/api/tasks/:id/share/actio', async (c) => {
+  const id = Number(c.req.param('id'));
+  const task = getTask(db, id);
+  if (!task) return c.json({ error: 'not found' }, 404);
+  try {
+    const result = await shareTaskToActio(task);
+    updateTask(db, id, {
+      share_actio: 1,
+      shared_at: new Date().toISOString(),
+      shared_origin: privacySettings().actio_share_url || 'actio',
+    });
+    return c.json({ ok: true, result, task: getTask(db, id) });
+  } catch (e) {
+    return c.json({ error: e.message }, 502);
+  }
+});
+
+app.post('/api/external-chat/messages', async (c) => {
+  const body = await c.req.json().catch(() => ({}));
+  const source = String(body.source || '').trim() || 'unknown';
+  const content = String(body.content || '').trim();
+  if (!content) return c.json({ error: 'content required' }, 400);
+  const id = insertExternalChatMessage(db, {
+    source,
+    conversation_id: body.conversation_id || null,
+    role: body.role || null,
+    content,
+    metadata: body.metadata && typeof body.metadata === 'object' ? body.metadata : null,
+  });
+  return c.json({ id }, 201);
+});
+
+app.get('/api/external-chat/messages', (c) => {
+  const limit = Math.min(Number(c.req.query('limit') || 100), 200);
+  const offset = Math.max(0, Number(c.req.query('offset') || 0));
+  const source = c.req.query('source') || null;
+  return c.json({ items: listExternalChatMessages(db, { source, limit, offset }) });
+});
+
 // ---- llm config -----------------------------------------------------------
 
 app.get('/api/llm/config', (c) => {
@@ -1855,7 +2103,7 @@ async function proxyMulti(c, method) {
 app.get('/api/multi/proxy/*', (c) => proxyMulti(c, 'GET'));
 app.post('/api/multi/proxy/*', (c) => proxyMulti(c, 'POST'));
 
-// Body: { kind: 'bookmark' | 'dig' | 'dict', id }
+// Body: { kind: 'bookmark' | 'dig' | 'dict' | 'implementation_note', id }
 app.post('/api/multi/share', async (c) => {
   const body = await c.req.json().catch(() => null);
   if (!body?.kind || body.id == null) return c.json({ error: 'kind+id required' }, 400);
@@ -1884,6 +2132,14 @@ app.post('/api/multi/share', async (c) => {
       if (!e) return c.json({ error: 'not_found' }, 404);
       const r = await shareDictionary(state, e);
       markDictionaryShared(db, body.id, { sharedAt: r.shared_at, sharedOrigin: state.url });
+      return c.json({ ok: true, remote: r });
+    }
+    if (body.kind === 'implementation_note') {
+      const n = getImplementationNote(db, body.id);
+      if (!n) return c.json({ error: 'not_found' }, 404);
+      if (!n.shareable) return c.json({ error: 'note is not marked shareable' }, 409);
+      const r = await shareImplementationNote(state, n);
+      updateImplementationNote(db, body.id, { shared_at: r.shared_at, shared_origin: state.url });
       return c.json({ ok: true, remote: r });
     }
     return c.json({ error: 'unknown kind' }, 400);
@@ -3359,6 +3615,7 @@ app.delete('/api/locations/settings/key', (c) => {
  *     deviceIds[], source: { via, tool, requestId } }
  */
 app.post('/api/legatus/location-summary', async (c) => {
+  if (!featureEnabled('tracks_enabled')) return c.json({ error: 'tracks are disabled' }, 403);
   const body = await c.req.json().catch(() => null);
   if (!body || typeof body !== 'object') {
     return c.json({ error: 'json body required' }, 400);
@@ -3432,6 +3689,7 @@ app.post('/api/legatus/location-summary', async (c) => {
  *   - 簡易形式:       { lat, lon, recorded_at?, device_id?, accuracy_m?, ... }
  */
 app.post('/api/locations/ingest', async (c) => {
+  if (!featureEnabled('tracks_enabled')) return c.json({ error: 'tracks are disabled' }, 403);
   const denied = checkIngestKey(c);
   if (denied) return denied;
 
@@ -3544,6 +3802,7 @@ app.patch('/api/tracks/settings', async (c) => {
  * 多くても OK.
  */
 app.get('/api/locations/recent', (c) => {
+  if (!featureEnabled('tracks_visible')) return c.json({ points: [], decimated: 0, pool: 0 });
   const limit = Math.min(500, Math.max(1, Number(c.req.query('limit') ?? '50')));
   const settingsDecimate = Number(getAppSettings(db)['tracks.decimate_meters'] ?? '0');
   const decimateM = Math.max(0, Number(c.req.query('decimate') ?? settingsDecimate));
@@ -3592,6 +3851,7 @@ app.get('/api/locations/recent', (c) => {
  * 何も無ければ { point: null } を返す。
  */
 app.get('/api/locations/latest', (c) => {
+  if (!featureEnabled('tracks_visible')) return c.json({ point: null });
   const row = db.prepare(
     `SELECT id, user_id, device_id, recorded_at, lat, lon,
             accuracy_m, altitude_m, velocity_kmh, course_deg,
@@ -3607,6 +3867,7 @@ app.get('/api/locations/latest', (c) => {
  *   GET /api/locations?date=YYYY-MM-DD              (local TZ)
  */
 app.get('/api/locations', (c) => {
+  if (!featureEnabled('tracks_visible')) return c.json({ points: [] });
   const url = new URL(c.req.url);
   const date = url.searchParams.get('date');
   if (date) {
@@ -3627,6 +3888,7 @@ app.get('/api/locations', (c) => {
  * 位置情報を持っている日と件数。 UI の date picker 用。
  */
 app.get('/api/locations/days', (c) => {
+  if (!featureEnabled('tracks_visible')) return c.json({ days: [] });
   const limit = Math.min(Number(c.req.query('limit') ?? 365) || 365, 3650);
   const days = listGpsLocationDays(db, { limit });
   return c.json({ days });
@@ -3637,6 +3899,7 @@ app.get('/api/locations/days', (c) => {
  *   DELETE /api/locations?older_than=ISO
  */
 app.delete('/api/locations', (c) => {
+  if (!featureEnabled('tracks_enabled')) return c.json({ error: 'tracks are disabled' }, 403);
   const denied = checkIngestKey(c);
   if (denied) return denied;
   const olderThan = c.req.query('older_than');
@@ -3657,6 +3920,7 @@ app.delete('/api/locations', (c) => {
 app.get('/api/locations/resolve-debug', (c) => c.json(getResolverDebug()));
 
 app.post('/api/locations/resolve-all', async (c) => {
+  if (!featureEnabled('tracks_enabled')) return c.json({ error: 'tracks are disabled' }, 403);
   let body = {};
   try { body = await c.req.json(); } catch {}
   const limit = Math.min(500, Math.max(1, Number(body.limit ?? 100)));
@@ -3684,6 +3948,7 @@ app.post('/api/locations/resolve-all', async (c) => {
  *   body: { device_id?, threshold? }   — 省略可、 全デバイス + default 50m
  */
 app.post('/api/locations/compress', async (c) => {
+  if (!featureEnabled('tracks_enabled')) return c.json({ error: 'tracks are disabled' }, 403);
   let body = {};
   try { body = await c.req.json(); } catch {}
   const deviceId = typeof body.device_id === 'string' && body.device_id.length > 0 ? body.device_id : null;

--- a/server/index.js
+++ b/server/index.js
@@ -151,6 +151,11 @@ function privacySettings() {
     meals_visible: settingBool(s, 'features.meals.visible', true),
     tasks_actio_share_enabled: settingBool(s, 'features.tasks.actio_share.enabled', true),
     actio_share_url: s['actio.share_url'] || '',
+    tasks_reminder_enabled: settingBool(s, 'features.tasks.reminder.enabled', true),
+    tasks_reminder_hour: Number(s['features.tasks.reminder.hour'] ?? 6),
+    tasks_reminder_minute: Number(s['features.tasks.reminder.minute'] ?? 0),
+    tasks_reminder_nuntius_enabled: settingBool(s, 'features.tasks.reminder.nuntius_enabled', false),
+    tasks_reminder_nuntius_url: s['features.tasks.reminder.nuntius_url'] || '',
   };
 }
 
@@ -231,9 +236,14 @@ function maybeQueueDomain(url) {
       return;
     }
     if (result.dropRow) {
-      // 404 / DNS error / non-2xx → drop the row entirely so it can be retried later.
-      deleteDomainCatalog(db, domain);
-      console.log(`[domain-catalog] dropped ${domain}: ${result.error}`);
+      // 404 / DNS error / non-2xx → keep the row as error (registered but unclassified).
+      setDomainCatalog(db, domain, {
+        title: null,
+        description: null,
+        status: 'error',
+        error: result.error ?? 'fetch failed',
+      });
+      console.log(`[domain-catalog] fetch failed ${domain}: ${result.error}`);
       return;
     }
     if (!result.ok) {
@@ -1697,6 +1707,10 @@ const SETUP_DOCS = {
     title: 'シェアするための設定',
     body: '# シェアするための設定\n\n1. 設定 -> データ / Hub を開きます。\n2. Memoria Hub の URL を追加し、Cernere で接続します。\n3. 公開したい Hub だけを有効にします。\n4. ブックマーク、ディグ、辞書、実装自慢は各画面のシェア操作から共有します。\n5. タスクを Actio にシェアする場合は、設定 -> プライバシー / 表示 で Actio シェアを許可し、Actio シェア URL を設定します。\n6. シェア前に内容を確認し、秘密情報や個人情報を含めないでください。',
   },
+  mcp: {
+    title: 'MCPサーバの設定方法',
+    body: '# MCPサーバの設定方法\n\n## 概要\nMemoria MCP サーバ (mcp-server/index.js) を使うと、Claude Desktop や Claude Code からブックマーク検索・タスク操作・辞書参照などを直接呼び出せます。\n\n## 依存インストール\n```\ncd mcp-server && npm install\n```\n\n## MEMORIA_URL の設定\n環境変数 MEMORIA_URL で Memoria サーバの URL を指定します。\n- デフォルト: http://localhost:5180\n- Tailscale 経由の場合: http://<tailscale-ip>:5180\n- Cloudflare Tunnel 経由の場合: https://<your-tunnel-host>\n\n## Claude Desktop の設定\n%APPDATA%\\Claude\\claude_desktop_config.json (Windows) または\n~/Library/Application Support/Claude/claude_desktop_config.json (Mac) に以下を追加:\n\n{\n  "mcpServers": {\n    "memoria": {\n      "command": "node",\n      "args": ["C:/path/to/Memoria/mcp-server/index.js"],\n      "env": { "MEMORIA_URL": "http://localhost:5180" }\n    }\n  }\n}\n\n## Claude Code の設定\n.claude/settings.json または ~/.claude/settings.json に以下を追加:\n\n{\n  "mcpServers": {\n    "memoria": {\n      "command": "node",\n      "args": ["/path/to/Memoria/mcp-server/index.js"],\n      "env": { "MEMORIA_URL": "http://localhost:5180" }\n    }\n  }\n}\n\n## 動作確認\nClaude に以下を試してください:\n- add_task でタスクを追加\n- list_tasks でタスク一覧を取得\n- search_bookmarks でブックマーク検索\n- list_diary_entries で日記一覧を取得',
+  },
 };
 
 app.get('/api/setup-docs', (c) => {
@@ -1720,10 +1734,15 @@ app.patch('/api/privacy/settings', async (c) => {
     ['meals_enabled', 'features.meals.enabled'],
     ['meals_visible', 'features.meals.visible'],
     ['tasks_actio_share_enabled', 'features.tasks.actio_share.enabled'],
+    ['tasks_reminder_enabled', 'features.tasks.reminder.enabled'],
+    ['tasks_reminder_nuntius_enabled', 'features.tasks.reminder.nuntius_enabled'],
   ]) {
     if (typeof body[bodyKey] === 'boolean') patch[settingKey] = body[bodyKey] ? '1' : '0';
   }
   if (typeof body.actio_share_url === 'string') patch['actio.share_url'] = body.actio_share_url.trim();
+  if (typeof body.tasks_reminder_hour === 'number') patch['features.tasks.reminder.hour'] = String(Math.max(0, Math.min(23, Math.floor(body.tasks_reminder_hour))));
+  if (typeof body.tasks_reminder_minute === 'number') patch['features.tasks.reminder.minute'] = String(Math.max(0, Math.min(59, Math.floor(body.tasks_reminder_minute))));
+  if (typeof body.tasks_reminder_nuntius_url === 'string') patch['features.tasks.reminder.nuntius_url'] = body.tasks_reminder_nuntius_url.trim();
   if (Object.keys(patch).length) setAppSettings(db, patch);
   return c.json({ settings: privacySettings() });
 });
@@ -1742,14 +1761,17 @@ app.get('/api/implementation-notes', (c) => {
 
 app.post('/api/implementation-notes', async (c) => {
   const body = await c.req.json().catch(() => ({}));
-  const product = String(body.product || '').trim();
   const title = String(body.title || '').trim();
-  if (!product || !title) return c.json({ error: 'product and title required' }, 400);
+  if (!title) return c.json({ error: 'title required' }, 400);
+  const attachmentType = String(body.attachment_type || '').trim();
+  const attachmentValue = String(body.attachment_value || '').trim();
   const id = insertImplementationNote(db, {
-    product,
+    product: String(body.product || '').trim(),
     title,
     good_points: String(body.good_points || '').trim(),
     bad_points: String(body.bad_points || '').trim(),
+    attachment_type: attachmentType || null,
+    attachment_value: attachmentValue || null,
     shareable: !!body.shareable,
   });
   return c.json({ note: getImplementationNote(db, id) }, 201);
@@ -1760,7 +1782,7 @@ app.patch('/api/implementation-notes/:id', async (c) => {
   if (!getImplementationNote(db, id)) return c.json({ error: 'not found' }, 404);
   const body = await c.req.json().catch(() => ({}));
   const patch = {};
-  for (const k of ['product', 'title', 'good_points', 'bad_points']) {
+  for (const k of ['product', 'title', 'good_points', 'bad_points', 'attachment_type', 'attachment_value']) {
     if (typeof body[k] === 'string') patch[k] = body[k].trim();
   }
   if (typeof body.shareable === 'boolean') patch.shareable = body.shareable;
@@ -1791,6 +1813,17 @@ app.get('/api/tasks', (c) => {
   return c.json({ items: listTasks(db, { status, limit, offset }) });
 });
 
+function appendTaskDiaryLog(line) {
+  const date = formatLocalDate(new Date());
+  const row = getDiary(db, date);
+  const prev = String(row?.notes || '').trimEnd();
+  const now = new Date();
+  const hh = String(now.getHours()).padStart(2, '0');
+  const mm = String(now.getMinutes()).padStart(2, '0');
+  const next = prev ? `${prev}\n${hh}:${mm} ${line}` : `${hh}:${mm} ${line}`;
+  upsertDiary(db, { date, notes: next, status: row?.status || 'pending' });
+}
+
 app.post('/api/tasks', async (c) => {
   const body = await c.req.json().catch(() => ({}));
   const title = String(body.title || '').trim();
@@ -1800,15 +1833,19 @@ app.post('/api/tasks', async (c) => {
     title,
     details: String(body.details || '').trim(),
     status,
+    creator_type: body.creator_type === 'ai' ? 'ai' : 'human',
     due_at: body.due_at || null,
     share_actio: !!body.share_actio,
   });
-  return c.json({ task: getTask(db, id) }, 201);
+  const created = getTask(db, id);
+  appendTaskDiaryLog(`タスク発行: ${created.title}${created.due_at ? ` (期日: ${created.due_at})` : ''}`);
+  return c.json({ task: created }, 201);
 });
 
 app.patch('/api/tasks/:id', async (c) => {
   const id = Number(c.req.param('id'));
-  if (!getTask(db, id)) return c.json({ error: 'not found' }, 404);
+  const before = getTask(db, id);
+  if (!before) return c.json({ error: 'not found' }, 404);
   const body = await c.req.json().catch(() => ({}));
   const patch = {};
   if (typeof body.title === 'string') patch.title = body.title.trim();
@@ -1816,8 +1853,22 @@ app.patch('/api/tasks/:id', async (c) => {
   if (['todo', 'doing', 'done'].includes(body.status)) patch.status = body.status;
   if (body.due_at === null || typeof body.due_at === 'string') patch.due_at = body.due_at || null;
   if (typeof body.share_actio === 'boolean') patch.share_actio = body.share_actio;
+  if (before.creator_type === 'ai' && Object.hasOwn(patch, 'due_at') && patch.due_at !== before.due_at) {
+    patch.creator_type = 'human';
+  }
   updateTask(db, id, patch);
-  return c.json({ task: getTask(db, id) });
+  const after = getTask(db, id);
+  const completedNow = before.status !== 'done' && after.status === 'done';
+  if (completedNow) {
+    appendTaskDiaryLog(`タスク完了: ${after.title}`);
+  } else {
+    const changed = ['title', 'details', 'status', 'due_at', 'share_actio'].some((k) => Object.hasOwn(patch, k));
+    const isHumanChange = before.creator_type === 'human' || (before.creator_type === 'ai' && after.creator_type === 'human');
+    if (changed && isHumanChange) {
+      appendTaskDiaryLog(`タスク更新: ${after.title}${after.due_at ? ` (期日: ${after.due_at})` : ''}`);
+    }
+  }
+  return c.json({ task: after });
 });
 
 app.delete('/api/tasks/:id', (c) => {
@@ -2417,8 +2468,12 @@ app.post('/api/domains/:domain/regenerate', (c) => {
   insertDomainPending(db, d);
   domainCatalogQueue.enqueue(async () => {
     const result = await classifyDomain({ domain: d });
-    if (result.skip || result.dropRow) {
+    if (result.skip) {
       deleteDomainCatalog(db, d);
+      return;
+    }
+    if (result.dropRow) {
+      setDomainCatalog(db, d, { title: null, description: null, status: 'error', error: result.error ?? 'fetch failed' });
       return;
     }
     if (!result.ok) {
@@ -2484,8 +2539,12 @@ app.post('/api/domains/recatalog-all', async (c) => {
       insertDomainPending(db, domain);
       domainCatalogQueue.enqueue(async () => {
         const result = await classifyDomain({ domain });
-        if (result.skip || result.dropRow) {
+        if (result.skip) {
           deleteDomainCatalog(db, domain);
+          return;
+        }
+        if (result.dropRow) {
+          setDomainCatalog(db, domain, { title: null, description: null, status: 'error', error: result.error ?? 'fetch failed' });
           return;
         }
         if (!result.ok) {
@@ -3211,9 +3270,11 @@ app.get('/api/worklog/browsing', (c) => {
   const revisits = revisitedBookmarksForDate(db, date, { limit: revisitLimit });
   const stats = browsingDomainStatsForDate(db, date, { limit: domainLimit });
 
-  // Enrich visits with domain catalog so the UI can show site_name / kind
-  const domains = [...new Set(visits.map(v => extractDomainFromUrl(v.url)).filter(Boolean))];
-  const catalog = getDomainCatalogMap(db, domains);
+  // Enrich visits with domain catalog so the UI can show site_name / kind / status
+  const visitDomains = [...new Set(visits.map(v => extractDomainFromUrl(v.url)).filter(Boolean))];
+  const topDomainNames = (stats.top_domains || []).map(d => d.domain).filter(Boolean);
+  const allDomains = [...new Set([...visitDomains, ...topDomainNames])];
+  const catalog = getDomainCatalogMap(db, allDomains);
   const enrichedVisits = visits.map(v => {
     const dom = extractDomainFromUrl(v.url);
     const cat = dom ? catalog.get(dom) : null;
@@ -3222,15 +3283,20 @@ app.get('/api/worklog/browsing', (c) => {
       domain: dom,
       catalog: cat ? {
         site_name: cat.site_name, kind: cat.kind, description: cat.description,
+        status: cat.status,
       } : null,
     };
   });
+  const enrichedTopDomains = (stats.top_domains || []).map(d => ({
+    ...d,
+    catalog_status: catalog.get(d.domain)?.status ?? null,
+  }));
 
   return c.json({
     date,
     visits: enrichedVisits,
     revisits,
-    top_domains: stats.top_domains,
+    top_domains: enrichedTopDomains,
     total_pages: stats.total_pages,
     total_visits: stats.total_visits,
   });
@@ -4066,6 +4132,51 @@ wss.on('connection', (ws) => {
   // 接続直後の hello (UI 側で接続成立を確認しやすくする)
   try { ws.send(JSON.stringify({ type: 'hello', ts: Date.now() })); } catch {}
 });
+
+// Task reminder: 1分ごとに時刻チェック、当日初回のみ送信
+setInterval(async () => {
+  try {
+    const s = privacySettings();
+    if (!s.tasks_reminder_enabled) return;
+    const now = new Date();
+    if (now.getHours() !== s.tasks_reminder_hour || now.getMinutes() !== s.tasks_reminder_minute) return;
+    const today = now.toISOString().slice(0, 10);
+    const appS = getAppSettings(db);
+    if (appS['tasks.reminder.last_sent_date'] === today) return;
+
+    const tasks = [
+      ...listTasks(db, { status: 'todo', limit: 20 }),
+      ...listTasks(db, { status: 'doing', limit: 20 }),
+    ];
+    if (!tasks.length) {
+      setAppSettings(db, { 'tasks.reminder.last_sent_date': today });
+      return;
+    }
+
+    const todoCount = tasks.filter(t => t.status === 'todo').length;
+    const doingCount = tasks.filter(t => t.status === 'doing').length;
+    const preview = tasks.slice(0, 5).map(t => `・${t.title.slice(0, 50)}`).join('\n');
+    const more = tasks.length > 5 ? `\n…他 ${tasks.length - 5} 件` : '';
+    const pushBody = `todo: ${todoCount} 件, 進行中: ${doingCount} 件\n${preview}${more}`;
+
+    await sendPushToAll(db, { title: '📋 本日のタスクリマインド', body: pushBody })
+      .catch(e => console.error('[reminder] push failed:', e?.message));
+
+    if (s.tasks_reminder_nuntius_enabled && s.tasks_reminder_nuntius_url) {
+      await fetch(s.tasks_reminder_nuntius_url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: '📋 本日のタスクリマインド', body: pushBody }),
+        signal: AbortSignal.timeout(10_000),
+      }).catch(e => console.error('[reminder] nuntius failed:', e?.message));
+    }
+
+    setAppSettings(db, { 'tasks.reminder.last_sent_date': today });
+    console.log(`[reminder] sent for ${today}: ${tasks.length} task(s)`);
+  } catch (e) {
+    console.error('[reminder] unexpected error:', e?.message);
+  }
+}, 60_000).unref?.();
 
 // keep-alive: 30s ごとに ping。 Cloudflare の idle timeout (100s 程度) を超えない。
 setInterval(() => {

--- a/server/index.js
+++ b/server/index.js
@@ -48,6 +48,7 @@ import {
   addDictionaryLink, removeDictionaryLink,
   insertVisitEvent, insertExternalVisitEvent, getDiary, listDiariesInRange, upsertDiary, updateDiaryNotes,
   deleteDiary, getDiarySettings, setDiarySettings,
+  setDiaryDataDir, migrateDiariesToSidecar,
   getWeekly, listWeeklyForMonth, upsertWeekly, deleteWeekly,
   getDomainCatalog, listDomainCatalog, listDomainCatalogWithCounts, getDomainCatalogMap,
   insertDomainPending, setDomainCatalog, deleteDomainCatalog,
@@ -61,6 +62,7 @@ import { extractWordCloud, validateWordRelevance } from './wordcloud.js';
 import { startUptimeTracking, readHeartbeat, DOWNTIME_THRESHOLD_MS } from './local/uptime.js';
 import { listServerEvents, listServerEventsForDate } from './db.js';
 import { recordActivityEvent, activityEventsForDate, listActivityEvents, activityEventsPage } from './db.js';
+import { pageVisitsForDate, revisitedBookmarksForDate, browsingDomainStatsForDate } from './db.js';
 import {
   aggregateDay, fetchGithubActivity, fetchGithubRange,
   generateDiary, generateWorkContent, generateHighlights,
@@ -114,6 +116,14 @@ mkdirSync(HTML_DIR, { recursive: true });
 mkdirSync(MEAL_DIR, { recursive: true });
 const db = openDb(DB_PATH);
 ensureUserStopwordsTable(db);
+// Diary 本文の太い JSON 列 (metrics_json / github_commits_json) は
+// `<DATA_DIR>/diary/<date>.json` に切り出す。 既存行は起動時に 1 回だけ
+// 移行する (idempotent、 行数 0 なら no-op)。
+setDiaryDataDir(DATA_DIR);
+const _diaryMig = migrateDiariesToSidecar(db);
+if (_diaryMig.moved > 0) {
+  console.log(`[diary] migrated ${_diaryMig.moved} row(s) to sidecar JSON`);
+}
 loadLlmConfigFromSettings(getAppSettings(db));
 initWebPush(DATA_DIR);
 const HEARTBEAT_FILE = join(DATA_DIR, 'heartbeat.json');
@@ -2879,7 +2889,8 @@ app.post('/api/activity/event', async (c) => {
   }
   const kind = String(body.kind || '');
   if (!kind) return c.json({ error: 'kind required' }, 400);
-  if (kind !== 'git_commit' && kind !== 'claude_code_prompt') {
+  const ALLOWED_KINDS = new Set(['git_commit', 'claude_code_prompt', 'gemini_prompt', 'codex_prompt']);
+  if (!ALLOWED_KINDS.has(kind)) {
     return c.json({ error: `unknown kind: ${kind}` }, 400);
   }
   try {
@@ -2906,16 +2917,67 @@ app.post('/api/activity/event', async (c) => {
 //   total は当日全件数。 limit は 1-1000、 offset は >= 0。
 app.get('/api/activity/events', (c) => {
   const date = c.req.query('date');
+  const kind = c.req.query('kind') || null;
   if (date) {
     if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return c.json({ error: 'invalid date' }, 400);
     const limit = Number(c.req.query('limit')) || 100;
     const offset = Number(c.req.query('offset')) || 0;
-    const page = activityEventsPage(db, date, { limit, offset });
-    return c.json({ date, ...page });
+    const page = activityEventsPage(db, date, { limit, offset, kind });
+    return c.json({ date, kind, ...page });
   }
   const limit = Math.min(Number(c.req.query('limit')) || 200, 1000);
-  const kind = c.req.query('kind') || null;
   return c.json({ items: listActivityEvents(db, { limit, kind }) });
+});
+
+// ── 作業ログ (worklog) 用 集計 -------------------------------------------
+// /api/worklog/server-events?date=YYYY-MM-DD  当日のサーバ稼働イベント
+// /api/worklog/browsing?date=YYYY-MM-DD       当日のページ訪問 / 再訪 BM / ドメイン Top
+// dig は既存 /api/diary/:date/digs を再利用 (作業ログ・日記で共有)。
+
+app.get('/api/worklog/server-events', (c) => {
+  const date = c.req.query('date');
+  if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return c.json({ error: 'invalid date' }, 400);
+  }
+  return c.json({ date, items: listServerEventsForDate(db, date) });
+});
+
+app.get('/api/worklog/browsing', (c) => {
+  const date = c.req.query('date');
+  if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return c.json({ error: 'invalid date' }, 400);
+  }
+  const visitLimit = Math.min(Number(c.req.query('visit_limit')) || 200, 2000);
+  const revisitLimit = Math.min(Number(c.req.query('revisit_limit')) || 100, 500);
+  const domainLimit = Math.min(Number(c.req.query('domain_limit')) || 30, 200);
+
+  const visits = pageVisitsForDate(db, date, { limit: visitLimit });
+  const revisits = revisitedBookmarksForDate(db, date, { limit: revisitLimit });
+  const stats = browsingDomainStatsForDate(db, date, { limit: domainLimit });
+
+  // Enrich visits with domain catalog so the UI can show site_name / kind
+  const domains = [...new Set(visits.map(v => extractDomainFromUrl(v.url)).filter(Boolean))];
+  const catalog = getDomainCatalogMap(db, domains);
+  const enrichedVisits = visits.map(v => {
+    const dom = extractDomainFromUrl(v.url);
+    const cat = dom ? catalog.get(dom) : null;
+    return {
+      ...v,
+      domain: dom,
+      catalog: cat ? {
+        site_name: cat.site_name, kind: cat.kind, description: cat.description,
+      } : null,
+    };
+  });
+
+  return c.json({
+    date,
+    visits: enrichedVisits,
+    revisits,
+    top_domains: stats.top_domains,
+    total_pages: stats.total_pages,
+    total_visits: stats.total_visits,
+  });
 });
 
 // Paginated dig list for the diary panel.

--- a/server/index.js
+++ b/server/index.js
@@ -1839,6 +1839,11 @@ app.post('/api/tasks', async (c) => {
   });
   const created = getTask(db, id);
   appendTaskDiaryLog(`タスク発行: ${created.title}${created.due_at ? ` (期日: ${created.due_at})` : ''}`);
+  recordActivityEvent(db, {
+    kind: 'task_created',
+    content: created.title,
+    metadata: created.due_at ? { due_at: created.due_at } : undefined,
+  });
   return c.json({ task: created }, 201);
 });
 
@@ -1861,11 +1866,17 @@ app.patch('/api/tasks/:id', async (c) => {
   const completedNow = before.status !== 'done' && after.status === 'done';
   if (completedNow) {
     appendTaskDiaryLog(`タスク完了: ${after.title}`);
+    recordActivityEvent(db, { kind: 'task_done', content: after.title });
   } else {
     const changed = ['title', 'details', 'status', 'due_at', 'share_actio'].some((k) => Object.hasOwn(patch, k));
     const isHumanChange = before.creator_type === 'human' || (before.creator_type === 'ai' && after.creator_type === 'human');
     if (changed && isHumanChange) {
       appendTaskDiaryLog(`タスク更新: ${after.title}${after.due_at ? ` (期日: ${after.due_at})` : ''}`);
+      recordActivityEvent(db, {
+        kind: 'task_updated',
+        content: after.title,
+        metadata: patch.status ? { status: after.status } : undefined,
+      });
     }
   }
   return c.json({ task: after });

--- a/server/index.js
+++ b/server/index.js
@@ -1682,20 +1682,20 @@ app.post('/api/dictionary/upsert-from-source', async (c) => {
 
 const SETUP_DOCS = {
   tailscale: {
-    title: 'Tailscale VPN setup',
-    body: '# Tailscale VPN setup\n\n1. Install Tailscale on the Memoria host and client devices.\n2. Sign in to the same tailnet.\n3. On the host, run `tailscale ip -4`.\n4. Open Memoria from clients with `http://<tailscale-ip>:5180`.\n5. For OwnTracks or Legatus, point clients at the host Tailscale IP.\n6. Keep public internet exposure off unless a protected tunnel is configured.',
+    title: 'Tailscale を使用した VPN 構築方法',
+    body: '# Tailscale を使用した VPN 構築方法\n\n1. Memoria を動かす PC と、接続したい端末に Tailscale をインストールします。\n2. すべて同じ tailnet にログインします。\n3. Memoria 側の PC で `tailscale ip -4` を実行し、Tailscale IP を確認します。\n4. 端末側から `http://<tailscale-ip>:5180` を開きます。\n5. OwnTracks や Legatus を使う場合も、接続先はこの Tailscale IP にします。\n6. 外部公開が必要ない場合は、インターネットへ直接公開しないでください。',
   },
   cloudflare: {
-    title: 'Cloudflare Tunnel public setup',
-    body: '# Cloudflare Tunnel public setup\n\n1. Install `cloudflared` on the Memoria host.\n2. Run `cloudflared tunnel login` and create a tunnel.\n3. Route the hostname to `http://localhost:5180`.\n4. Protect the hostname with Cloudflare Access.\n5. Confirm the web UI and `/share` from outside the tailnet.\n6. Do not expose Memoria directly without authentication.',
+    title: 'Cloudflare Tunnel を使用した公開方法',
+    body: '# Cloudflare Tunnel を使用した公開方法\n\n1. Memoria を動かす PC に `cloudflared` をインストールします。\n2. `cloudflared tunnel login` を実行し、Tunnel を作成します。\n3. 公開ホスト名の転送先を `http://localhost:5180` に設定します。\n4. 個人データを扱うため、Cloudflare Access などで認証を必ず設定します。\n5. tailnet 外のネットワークから Web UI と `/share` が動くことを確認します。\n6. 認証なしで Memoria を直接公開しないでください。',
   },
   legatus: {
-    title: 'Legatus startup',
-    body: '# Legatus startup\n\n1. Open the Legatus project next to Memoria.\n2. Enable only the ingestion modules you need.\n3. Set forward URLs such as `http://localhost:5180/api/locations/ingest` and `http://localhost:5180/api/visits/external`.\n4. Start Legatus with its documented dev or service command.\n5. Check Memoria Settings -> Integration / API key for Legatus status.',
+    title: 'Legatus の起動方法',
+    body: '# Legatus の起動方法\n\n1. Memoria と同じ PC、または到達可能な PC で Legatus プロジェクトを開きます。\n2. 必要な取込モジュールだけを有効にします。GPS / DNS / SNI などは明示的に ON にしてください。\n3. 転送先 URL に `http://localhost:5180/api/locations/ingest` や `http://localhost:5180/api/visits/external` を設定します。\n4. Legatus 側の README に従って dev 起動またはサービス起動します。\n5. Memoria の 設定 -> 連携 / API key で Legatus の接続状態を確認します。',
   },
   sharing: {
-    title: 'Sharing settings',
-    body: '# Sharing settings\n\n1. Open Settings -> Data / Hub.\n2. Add a Memoria Hub URL and connect with Cernere.\n3. Enable only the servers you want to publish to.\n4. Share individual records from their own screens.\n5. Tasks can be shared to Actio when Settings -> Privacy enables Actio sharing and `actio.share_url` is set.\n6. Review content before sharing. Do not include secrets or private data.',
+    title: 'シェアするための設定',
+    body: '# シェアするための設定\n\n1. 設定 -> データ / Hub を開きます。\n2. Memoria Hub の URL を追加し、Cernere で接続します。\n3. 公開したい Hub だけを有効にします。\n4. ブックマーク、ディグ、辞書、実装自慢は各画面のシェア操作から共有します。\n5. タスクを Actio にシェアする場合は、設定 -> プライバシー / 表示 で Actio シェアを許可し、Actio シェア URL を設定します。\n6. シェア前に内容を確認し、秘密情報や個人情報を含めないでください。',
   },
 };
 

--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,7 @@ import { WebSocketServer } from 'ws';
 import { mkdirSync, writeFileSync, readFileSync, unlinkSync, existsSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
 import {
   openDb,
   insertBookmark,
@@ -94,6 +95,8 @@ import {
   updateImplementationNote, deleteImplementationNote,
   listTasks, getTask, insertTask, updateTask, deleteTask,
   insertExternalChatMessage, listExternalChatMessages,
+  listWorkLocations, getWorkLocation, insertWorkLocation,
+  updateWorkLocation, deleteWorkLocation, setWorkLocationOwner,
 } from './db.js';
 import {
   ensureUserStopwordsTable, listUserStopwords, addUserStopword, removeUserStopword,
@@ -107,7 +110,7 @@ import {
   readMultiServers, persistServers, upsertServer, removeServer,
   saveServerSession, clearServerSession, setActive, listConnectedActive,
   fetchMe, shareBookmark, shareDig, shareDictionary,
-  shareImplementationNote,
+  shareImplementationNote, shareWorkLocation,
   multiFetch,
 } from './local/multi-client.js';
 
@@ -156,7 +159,42 @@ function privacySettings() {
     tasks_reminder_minute: Number(s['features.tasks.reminder.minute'] ?? 0),
     tasks_reminder_nuntius_enabled: settingBool(s, 'features.tasks.reminder.nuntius_enabled', false),
     tasks_reminder_nuntius_url: s['features.tasks.reminder.nuntius_url'] || '',
+    mcp_autostart_enabled: settingBool(s, 'features.mcp.autostart.enabled', false),
   };
+}
+
+let mcpChild = null;
+function mcpServerDir() {
+  return resolve(__dirname, '..', 'mcp-server');
+}
+function startMcpServer() {
+  if (mcpChild) return;
+  if (!existsSync(mcpServerDir())) return;
+  const env = {
+    ...process.env,
+    MEMORIA_URL: process.env.MEMORIA_URL || `http://127.0.0.1:${PORT}`,
+  };
+  const child = spawn(process.execPath, ['index.js'], {
+    cwd: mcpServerDir(),
+    env,
+    stdio: ['ignore', 'ignore', 'inherit'],
+    detached: false,
+  });
+  child.on('exit', () => { if (mcpChild?.pid === child.pid) mcpChild = null; });
+  child.on('error', (e) => console.error('[mcp] spawn failed:', e.message));
+  mcpChild = child;
+  console.log(`[mcp] started pid=${child.pid}`);
+}
+function stopMcpServer() {
+  if (!mcpChild) return;
+  try { mcpChild.kill('SIGTERM'); } catch {}
+  mcpChild = null;
+  console.log('[mcp] stopped');
+}
+function syncMcpAutostart() {
+  const s = privacySettings();
+  if (s.mcp_autostart_enabled) startMcpServer();
+  else stopMcpServer();
 }
 
 function featureEnabled(key) {
@@ -1736,6 +1774,7 @@ app.patch('/api/privacy/settings', async (c) => {
     ['tasks_actio_share_enabled', 'features.tasks.actio_share.enabled'],
     ['tasks_reminder_enabled', 'features.tasks.reminder.enabled'],
     ['tasks_reminder_nuntius_enabled', 'features.tasks.reminder.nuntius_enabled'],
+    ['mcp_autostart_enabled', 'features.mcp.autostart.enabled'],
   ]) {
     if (typeof body[bodyKey] === 'boolean') patch[settingKey] = body[bodyKey] ? '1' : '0';
   }
@@ -1744,6 +1783,7 @@ app.patch('/api/privacy/settings', async (c) => {
   if (typeof body.tasks_reminder_minute === 'number') patch['features.tasks.reminder.minute'] = String(Math.max(0, Math.min(59, Math.floor(body.tasks_reminder_minute))));
   if (typeof body.tasks_reminder_nuntius_url === 'string') patch['features.tasks.reminder.nuntius_url'] = body.tasks_reminder_nuntius_url.trim();
   if (Object.keys(patch).length) setAppSettings(db, patch);
+  if (Object.prototype.hasOwnProperty.call(body, 'mcp_autostart_enabled')) syncMcpAutostart();
   return c.json({ settings: privacySettings() });
 });
 
@@ -1886,6 +1926,59 @@ app.delete('/api/tasks/:id', (c) => {
   const id = Number(c.req.param('id'));
   if (!getTask(db, id)) return c.json({ error: 'not found' }, 404);
   deleteTask(db, id);
+  return c.json({ ok: true });
+});
+
+// ---- work locations -------------------------------------------------------
+
+app.get('/api/work-locations', (c) => {
+  const limit = Math.min(Number(c.req.query('limit') || 200), 500);
+  const offset = Math.max(0, Number(c.req.query('offset') || 0));
+  return c.json({ items: listWorkLocations(db, { limit, offset }) });
+});
+
+app.post('/api/work-locations', async (c) => {
+  const body = await c.req.json().catch(() => ({}));
+  const name = String(body.name || '').trim();
+  if (!name) return c.json({ error: 'name required' }, 400);
+  const id = insertWorkLocation(db, {
+    name,
+    address: typeof body.address === 'string' ? body.address.trim() : null,
+    latitude: body.latitude == null || body.latitude === '' ? null : Number(body.latitude),
+    longitude: body.longitude == null || body.longitude === '' ? null : Number(body.longitude),
+    description: typeof body.description === 'string' ? body.description.trim() : null,
+    url: typeof body.url === 'string' ? body.url.trim() : null,
+    tags: typeof body.tags === 'string' ? body.tags.trim() : null,
+    shareable: !!body.shareable,
+  });
+  return c.json({ location: getWorkLocation(db, id) }, 201);
+});
+
+app.patch('/api/work-locations/:id', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (!getWorkLocation(db, id)) return c.json({ error: 'not found' }, 404);
+  const body = await c.req.json().catch(() => ({}));
+  const patch = {};
+  if (typeof body.name === 'string') patch.name = body.name.trim();
+  if (typeof body.address === 'string' || body.address === null) patch.address = body.address;
+  if (body.latitude === null || body.latitude === '' || body.latitude === undefined) {
+    if ('latitude' in body) patch.latitude = null;
+  } else patch.latitude = Number(body.latitude);
+  if (body.longitude === null || body.longitude === '' || body.longitude === undefined) {
+    if ('longitude' in body) patch.longitude = null;
+  } else patch.longitude = Number(body.longitude);
+  if (typeof body.description === 'string' || body.description === null) patch.description = body.description;
+  if (typeof body.url === 'string' || body.url === null) patch.url = body.url;
+  if (typeof body.tags === 'string' || body.tags === null) patch.tags = body.tags;
+  if (typeof body.shareable === 'boolean') patch.shareable = body.shareable;
+  updateWorkLocation(db, id, patch);
+  return c.json({ location: getWorkLocation(db, id) });
+});
+
+app.delete('/api/work-locations/:id', (c) => {
+  const id = Number(c.req.param('id'));
+  if (!getWorkLocation(db, id)) return c.json({ error: 'not found' }, 404);
+  deleteWorkLocation(db, id);
   return c.json({ ok: true });
 });
 
@@ -2204,6 +2297,14 @@ app.post('/api/multi/share', async (c) => {
       updateImplementationNote(db, body.id, { shared_at: r.shared_at, shared_origin: state.url });
       return c.json({ ok: true, remote: r });
     }
+    if (body.kind === 'work_location') {
+      const w = getWorkLocation(db, body.id);
+      if (!w) return c.json({ error: 'not_found' }, 404);
+      if (!w.shareable) return c.json({ error: 'location is not marked shareable' }, 409);
+      const r = await shareWorkLocation(state, w);
+      updateWorkLocation(db, body.id, { shared_at: r.shared_at, shared_origin: state.url });
+      return c.json({ ok: true, remote: r });
+    }
     return c.json({ error: 'unknown kind' }, 400);
   } catch (e) {
     console.error('[multi/share]', e);
@@ -2211,7 +2312,7 @@ app.post('/api/multi/share', async (c) => {
   }
 });
 
-// Body: { kind: 'bookmark' | 'dig' | 'dict', remote_id }
+// Body: { kind: 'bookmark' | 'dig' | 'dict' | 'implementation_note' | 'work_location', remote_id }
 //
 // Pulls a single resource from the connected Hub and writes it into the
 // local SQLite. owner_user_id / owner_user_name are populated from the
@@ -2302,6 +2403,43 @@ app.post('/api/multi/download', async (c) => {
         sharedOrigin: state.url,
       });
       return c.json({ ok: true, id });
+    }
+    if (body.kind === 'implementation_note') {
+      const remote = await multiFetch(state,`/api/shared/implementation-notes/${body.remote_id}`);
+      const id = insertImplementationNote(db, {
+        product: remote.product || '',
+        title: remote.title,
+        good_points: remote.good_points,
+        bad_points: remote.bad_points,
+        attachment_type: remote.attachment_type,
+        attachment_value: remote.attachment_value,
+        shareable: 0,
+      });
+      updateImplementationNote(db, id, {
+        shared_at: remote.shared_at,
+        shared_origin: state.url,
+      });
+      return c.json({ ok: true, id, owner: remote.owner_user_name });
+    }
+    if (body.kind === 'work_location') {
+      const remote = await multiFetch(state,`/api/shared/work-locations/${body.remote_id}`);
+      const id = insertWorkLocation(db, {
+        name: remote.name,
+        address: remote.address,
+        latitude: remote.latitude,
+        longitude: remote.longitude,
+        description: remote.description,
+        url: remote.url,
+        tags: remote.tags,
+        shareable: 0,
+      });
+      setWorkLocationOwner(db, id, {
+        ownerUserId: remote.owner_user_id,
+        ownerUserName: remote.owner_user_name,
+        sharedAt: remote.shared_at,
+        sharedOrigin: state.url,
+      });
+      return c.json({ ok: true, id, owner: remote.owner_user_name });
     }
     return c.json({ error: 'unknown kind' }, 400);
   } catch (e) {
@@ -4143,6 +4281,11 @@ wss.on('connection', (ws) => {
   // 接続直後の hello (UI 側で接続成立を確認しやすくする)
   try { ws.send(JSON.stringify({ type: 'hello', ts: Date.now() })); } catch {}
 });
+
+syncMcpAutostart();
+process.on('exit', () => stopMcpServer());
+process.on('SIGINT', () => { stopMcpServer(); process.exit(0); });
+process.on('SIGTERM', () => { stopMcpServer(); process.exit(0); });
 
 // Task reminder: 1分ごとに時刻チェック、当日初回のみ送信
 setInterval(async () => {

--- a/server/index.js
+++ b/server/index.js
@@ -110,7 +110,7 @@ import {
   readMultiServers, persistServers, upsertServer, removeServer,
   saveServerSession, clearServerSession, setActive, listConnectedActive,
   fetchMe, shareBookmark, shareDig, shareDictionary,
-  shareImplementationNote, shareWorkLocation,
+  shareImplementationNote, shareWorkLocation, shareWorkplacePresence,
   multiFetch,
 } from './local/multi-client.js';
 
@@ -160,6 +160,9 @@ function privacySettings() {
     tasks_reminder_nuntius_enabled: settingBool(s, 'features.tasks.reminder.nuntius_enabled', false),
     tasks_reminder_nuntius_url: s['features.tasks.reminder.nuntius_url'] || '',
     mcp_autostart_enabled: settingBool(s, 'features.mcp.autostart.enabled', false),
+    workplace_geo_enabled: settingBool(s, 'features.workplace.geo.enabled', true),
+    workplace_auto_share_enabled: settingBool(s, 'features.workplace.share.enabled', false),
+    workplace_match_radius_m: Number(s['features.workplace.match.radius_m'] ?? 150),
   };
 }
 
@@ -1775,6 +1778,8 @@ app.patch('/api/privacy/settings', async (c) => {
     ['tasks_reminder_enabled', 'features.tasks.reminder.enabled'],
     ['tasks_reminder_nuntius_enabled', 'features.tasks.reminder.nuntius_enabled'],
     ['mcp_autostart_enabled', 'features.mcp.autostart.enabled'],
+    ['workplace_geo_enabled', 'features.workplace.geo.enabled'],
+    ['workplace_auto_share_enabled', 'features.workplace.share.enabled'],
   ]) {
     if (typeof body[bodyKey] === 'boolean') patch[settingKey] = body[bodyKey] ? '1' : '0';
   }
@@ -1782,6 +1787,7 @@ app.patch('/api/privacy/settings', async (c) => {
   if (typeof body.tasks_reminder_hour === 'number') patch['features.tasks.reminder.hour'] = String(Math.max(0, Math.min(23, Math.floor(body.tasks_reminder_hour))));
   if (typeof body.tasks_reminder_minute === 'number') patch['features.tasks.reminder.minute'] = String(Math.max(0, Math.min(59, Math.floor(body.tasks_reminder_minute))));
   if (typeof body.tasks_reminder_nuntius_url === 'string') patch['features.tasks.reminder.nuntius_url'] = body.tasks_reminder_nuntius_url.trim();
+  if (typeof body.workplace_match_radius_m === 'number') patch['features.workplace.match.radius_m'] = String(Math.max(20, Math.min(2000, Math.floor(body.workplace_match_radius_m))));
   if (Object.keys(patch).length) setAppSettings(db, patch);
   if (Object.prototype.hasOwnProperty.call(body, 'mcp_autostart_enabled')) syncMcpAutostart();
   return c.json({ settings: privacySettings() });
@@ -1980,6 +1986,151 @@ app.delete('/api/work-locations/:id', (c) => {
   if (!getWorkLocation(db, id)) return c.json({ error: 'not found' }, 404);
   deleteWorkLocation(db, id);
   return c.json({ ok: true });
+});
+
+// ── Place API: reverse geocode a lat/lng to {name, address}
+//
+// Default provider: OpenStreetMap Nominatim (free, no API key, but
+// rate-limited and User-Agent required). Switchable via
+// `places.api.url` setting.
+app.post('/api/work-locations/resolve-place', async (c) => {
+  const body = await c.req.json().catch(() => ({}));
+  const lat = Number(body.latitude);
+  const lng = Number(body.longitude);
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+    return c.json({ error: 'latitude+longitude required' }, 400);
+  }
+  const settings = getAppSettings(db);
+  const baseUrl = (settings['places.api.url'] || 'https://nominatim.openstreetmap.org/reverse').replace(/\/+$/, '');
+  const ua = settings['places.api.ua'] || 'Memoria/0.2 (workplace resolver)';
+  const url = `${baseUrl}?format=jsonv2&zoom=18&addressdetails=1&lat=${encodeURIComponent(lat)}&lon=${encodeURIComponent(lng)}`;
+  try {
+    const res = await fetch(url, {
+      headers: { 'User-Agent': ua, 'Accept': 'application/json', 'Accept-Language': 'ja,en;q=0.5' },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return c.json({ error: `place api ${res.status}` }, 502);
+    const json = await res.json();
+    const a = json.address || {};
+    const name = json.name || a.amenity || a.shop || a.office || a.building
+      || a.tourism || a.leisure || a.public_building || a.road
+      || (json.display_name || '').split(',')[0] || '';
+    return c.json({
+      name: String(name).trim().slice(0, 120),
+      address: String(json.display_name || '').slice(0, 240),
+      latitude: Number(json.lat ?? lat),
+      longitude: Number(json.lon ?? lng),
+      raw: { osm_id: json.osm_id, type: json.type, category: json.category },
+    });
+  } catch (e) {
+    return c.json({ error: `place api: ${e.message}` }, 502);
+  }
+});
+
+// Haversine distance in meters between two {lat,lng} points.
+function _haversineMeters(a, b) {
+  const R = 6_371_000;
+  const toRad = (d) => (d * Math.PI) / 180;
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+  const s = Math.sin(dLat / 2) ** 2
+    + Math.cos(toRad(a.lat)) * Math.cos(toRad(b.lat)) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(s));
+}
+
+// ── Checkin: GPS coords → match nearest local work_location → broadcast
+// to Hub if user opted-in and the workplace changed since last checkin.
+app.post('/api/work-locations/checkin', async (c) => {
+  const body = await c.req.json().catch(() => ({}));
+  const lat = Number(body.latitude);
+  const lng = Number(body.longitude);
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+    return c.json({ error: 'latitude+longitude required' }, 400);
+  }
+  const settings = privacySettings();
+  if (!settings.workplace_geo_enabled) {
+    return c.json({ error: 'workplace_geo disabled' }, 403);
+  }
+  const radius = Math.max(20, Math.min(2000, Number(settings.workplace_match_radius_m) || 150));
+
+  // Find nearest workplace within radius.
+  const all = listWorkLocations(db, { limit: 500 });
+  let matched = null;
+  let matchedDist = Infinity;
+  for (const w of all) {
+    if (!Number.isFinite(w.latitude) || !Number.isFinite(w.longitude)) continue;
+    const d = _haversineMeters({ lat, lng }, { lat: w.latitude, lng: w.longitude });
+    if (d <= radius && d < matchedDist) {
+      matched = w;
+      matchedDist = d;
+    }
+  }
+
+  const appS = getAppSettings(db);
+  const lastId = appS['workplace.current.id'] ? Number(appS['workplace.current.id']) : null;
+  const now = new Date().toISOString();
+  const result = {
+    matched: !!matched,
+    workplace: matched || null,
+    distance_m: matched ? Math.round(matchedDist) : null,
+    changed: false,
+    broadcast: null,
+  };
+
+  if (matched) {
+    if (lastId !== matched.id) {
+      result.changed = true;
+      setAppSettings(db, {
+        'workplace.current.id': String(matched.id),
+        'workplace.current.at': now,
+      });
+
+      // Optional broadcast to Hub.
+      if (settings.workplace_auto_share_enabled) {
+        try {
+          const state = readMultiState(db);
+          if (isConnected(state)) {
+            const r = await shareWorkplacePresence(state, {
+              workplace_name: matched.name,
+              address: matched.address,
+              latitude: matched.latitude,
+              longitude: matched.longitude,
+              kind: 'enter',
+            });
+            result.broadcast = { ok: true, id: r.id, occurred_at: r.occurred_at };
+          } else {
+            result.broadcast = { ok: false, error: 'not_connected' };
+          }
+        } catch (e) {
+          console.error('[workplace/checkin] broadcast failed', e);
+          result.broadcast = { ok: false, error: e.message };
+        }
+      }
+    }
+  } else if (lastId) {
+    // We left the previously matched workplace.
+    result.changed = true;
+    const prev = getWorkLocation(db, lastId);
+    setAppSettings(db, { 'workplace.current.id': '', 'workplace.current.at': now });
+    if (prev && settings.workplace_auto_share_enabled) {
+      try {
+        const state = readMultiState(db);
+        if (isConnected(state)) {
+          await shareWorkplacePresence(state, {
+            workplace_name: prev.name,
+            address: prev.address,
+            latitude: prev.latitude,
+            longitude: prev.longitude,
+            kind: 'leave',
+          });
+          result.broadcast = { ok: true, kind: 'leave' };
+        }
+      } catch (e) {
+        console.error('[workplace/checkin] leave broadcast failed', e);
+      }
+    }
+  }
+  return c.json(result);
 });
 
 async function shareTaskToActio(task) {

--- a/server/llm.js
+++ b/server/llm.js
@@ -52,6 +52,7 @@ export const PROVIDERS = {
     defaultBin: 'codex',
     supportsTools: false,
     supportsModel: true,
+    jsonOutput: true,
   },
   openai: {
     label: 'OpenAI API',
@@ -144,20 +145,44 @@ export async function runLlm({ task, prompt, tools, timeoutMs = 180_000 }) {
   }
   // CLI providers
   const bin = cfg.bins[provider] || p.defaultBin;
-  const args = ['-p'];
   const modelToUse = taskCfg.model || TASK_DEFAULT_MODELS[task] || '';
-  if (modelToUse && p.supportsModel) args.push('--model', modelToUse);
-  if (tools && p.supportsTools) args.push('--allowedTools', tools.join(','));
+  const args = buildCliArgs({
+    provider,
+    model: modelToUse,
+    tools,
+    supportsModel: p.supportsModel,
+    supportsTools: p.supportsTools,
+  });
   // Pass CLAUDE_CODE_GIT_BASH_PATH to the Claude CLI on Windows. Configured
   // via settings → runtime.git_bash_path; falls back to the parent env.
   const env = { ...process.env };
   if (provider === 'claude' && cfg.git_bash_path) {
     env.CLAUDE_CODE_GIT_BASH_PATH = cfg.git_bash_path;
   }
-  return runCli({ bin, args, prompt, timeoutMs, env, label: provider });
+  return runCli({ bin, args, prompt, timeoutMs, env, label: provider, jsonOutput: !!p.jsonOutput });
 }
 
-function runCli({ bin, args, prompt, timeoutMs, env, label }) {
+function buildCliArgs({ provider, model, tools, supportsModel, supportsTools }) {
+  if (provider === 'codex') {
+    const args = [
+      'exec',
+      '--json',
+      '--color', 'never',
+      '--ask-for-approval', 'never',
+      '--sandbox', 'workspace-write',
+    ];
+    if (model && supportsModel) args.push('--model', model);
+    args.push('-');
+    return args;
+  }
+
+  const args = ['-p'];
+  if (model && supportsModel) args.push('--model', model);
+  if (tools && supportsTools) args.push('--allowedTools', tools.join(','));
+  return args;
+}
+
+function runCli({ bin, args, prompt, timeoutMs, env, label, jsonOutput = false }) {
   return new Promise((resolve, reject) => {
     let child;
     try {
@@ -177,10 +202,52 @@ function runCli({ bin, args, prompt, timeoutMs, env, label }) {
     child.on('close', code => {
       clearTimeout(timer);
       if (code !== 0) reject(new Error(`${label} CLI exited ${code}: ${stderr.slice(0, 400)}`));
-      else resolve(stdout);
+      else resolve(jsonOutput ? extractCodexLastMessage(stdout) : stdout);
     });
     child.stdin.end(prompt, 'utf8');
   });
+}
+
+function extractCodexLastMessage(raw) {
+  let lastText = '';
+  const lines = raw.split(/\r?\n/).filter(l => l.trim());
+  for (const line of lines) {
+    let obj;
+    try { obj = JSON.parse(line); } catch { continue; }
+    const text = extractTextFromCodexEvent(obj);
+    if (text) lastText = text;
+  }
+  return lastText || raw;
+}
+
+function extractTextFromCodexEvent(obj) {
+  if (!obj || typeof obj !== 'object') return '';
+  const candidates = [
+    obj.message,
+    obj.text,
+    obj.delta,
+    obj.payload?.message,
+    obj.payload?.text,
+    obj.payload?.delta,
+    obj.payload,
+  ];
+  for (const candidate of candidates) {
+    const text = extractContentText(candidate);
+    if (text) return text;
+  }
+  return '';
+}
+
+function extractContentText(value) {
+  if (!value) return '';
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) return value.map(extractContentText).filter(Boolean).join('\n');
+  if (typeof value !== 'object') return '';
+  if (value.role && value.role !== 'assistant') return '';
+  if (typeof value.content === 'string') return value.content;
+  if (Array.isArray(value.content)) return extractContentText(value.content);
+  if (typeof value.text === 'string') return value.text;
+  return '';
 }
 
 async function runOpenAi({ apiKey, model, prompt, timeoutMs }) {

--- a/server/local/multi-client.js
+++ b/server/local/multi-client.js
@@ -215,10 +215,27 @@ export async function shareImplementationNote(state, n) {
   return multiFetch(state, '/api/shared/implementation-notes', {
     method: 'POST',
     body: JSON.stringify({
-      product: n.product,
+      product: n.product || '',
       title: n.title,
       good_points: n.good_points || null,
       bad_points: n.bad_points || null,
+      attachment_type: n.attachment_type || null,
+      attachment_value: n.attachment_value || null,
+    }),
+  });
+}
+
+export async function shareWorkLocation(state, w) {
+  return multiFetch(state, '/api/shared/work-locations', {
+    method: 'POST',
+    body: JSON.stringify({
+      name: w.name,
+      address: w.address || null,
+      latitude: w.latitude == null ? null : Number(w.latitude),
+      longitude: w.longitude == null ? null : Number(w.longitude),
+      description: w.description || null,
+      url: w.url || null,
+      tags: w.tags || null,
     }),
   });
 }

--- a/server/local/multi-client.js
+++ b/server/local/multi-client.js
@@ -211,6 +211,18 @@ export async function shareDictionary(state, e) {
   });
 }
 
+export async function shareImplementationNote(state, n) {
+  return multiFetch(state, '/api/shared/implementation-notes', {
+    method: 'POST',
+    body: JSON.stringify({
+      product: n.product,
+      title: n.title,
+      good_points: n.good_points || null,
+      bad_points: n.bad_points || null,
+    }),
+  });
+}
+
 export async function fetchMe(state) {
   return multiFetch(state, '/api/me');
 }

--- a/server/local/multi-client.js
+++ b/server/local/multi-client.js
@@ -240,6 +240,19 @@ export async function shareWorkLocation(state, w) {
   });
 }
 
+export async function shareWorkplacePresence(state, presence) {
+  return multiFetch(state, '/api/shared/workplace-presence', {
+    method: 'POST',
+    body: JSON.stringify({
+      workplace_name: presence.workplace_name,
+      address: presence.address || null,
+      latitude: presence.latitude == null ? null : Number(presence.latitude),
+      longitude: presence.longitude == null ? null : Number(presence.longitude),
+      kind: presence.kind === 'leave' ? 'leave' : 'enter',
+    }),
+  });
+}
+
 export async function fetchMe(state) {
   return multiFetch(state, '/api/me');
 }

--- a/server/multi/db.js
+++ b/server/multi/db.js
@@ -88,6 +88,17 @@ export async function getSharedDictionary(id) {
   return r.rows[0] || null;
 }
 
+export async function getSharedImplementationNote(id) {
+  const r = await query(
+    `SELECT id, product, title, good_points, bad_points,
+            owner_user_id, owner_user_name, shared_at, shared_origin
+       FROM implementation_notes
+       WHERE id = $1 AND hidden_at IS NULL`,
+    [id],
+  );
+  return r.rows[0] || null;
+}
+
 export async function insertSharedBookmark({ url, title, summary, memo, categories, ownerUserId, ownerUserName, sharedOrigin }) {
   const r = await query(
     `INSERT INTO bookmarks (url, title, summary, memo, owner_user_id, owner_user_name, shared_origin)
@@ -217,12 +228,57 @@ export async function deleteSharedDictionary(id, { actingUserId, role }) {
   return { ok: true };
 }
 
+export async function listSharedImplementationNotes({ limit = 50, before = null } = {}) {
+  const args = [];
+  let where = 'WHERE hidden_at IS NULL';
+  if (before) { args.push(before); where += ` AND shared_at < $${args.length}`; }
+  args.push(limit);
+  const r = await query(
+    `SELECT id, product, title, good_points, bad_points,
+            owner_user_id, owner_user_name, shared_at, shared_origin
+       FROM implementation_notes
+       ${where}
+       ORDER BY shared_at DESC
+       LIMIT $${args.length}`,
+    args,
+  );
+  return r.rows;
+}
+
+export async function insertSharedImplementationNote({ product, title, goodPoints, badPoints, ownerUserId, ownerUserName, sharedOrigin }) {
+  const r = await query(
+    `INSERT INTO implementation_notes
+       (product, title, good_points, bad_points, owner_user_id, owner_user_name, shared_origin)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     RETURNING id, shared_at`,
+    [product, title, goodPoints ?? null, badPoints ?? null, ownerUserId, ownerUserName, sharedOrigin ?? null],
+  );
+  return { id: r.rows[0].id, shared_at: r.rows[0].shared_at };
+}
+
+export async function deleteSharedImplementationNote(id, { actingUserId, role }) {
+  const r = await query('SELECT owner_user_id FROM implementation_notes WHERE id = $1', [id]);
+  if (!r.rowCount) return { ok: false, error: 'not_found' };
+  const owner = r.rows[0].owner_user_id;
+  if (owner !== actingUserId && role !== 'admin' && role !== 'moderator') {
+    return { ok: false, error: 'forbidden' };
+  }
+  await query('DELETE FROM implementation_notes WHERE id = $1', [id]);
+  await query(
+    `INSERT INTO share_log (resource_kind, resource_id, action, acting_user_id)
+       VALUES ('implementation_note', $1, 'delete', $2)`,
+    [id, actingUserId],
+  );
+  return { ok: true };
+}
+
 // ── moderation ─────────────────────────────────────────────────────────────
 
 const TABLE_BY_KIND = {
   bookmark: 'bookmarks',
   dig: 'dig_sessions',
   dict: 'dictionary_entries',
+  implementation_note: 'implementation_notes',
 };
 
 function tableForKind(kind) {
@@ -282,6 +338,8 @@ export async function listHidden({ limit = 100 } = {}) {
      ${sql('dig', 'dig_sessions', 'query')}
      UNION ALL
      ${sql('dict', 'dictionary_entries', 'term')}
+     UNION ALL
+     ${sql('implementation_note', 'implementation_notes', 'title')}
      ORDER BY hidden_at DESC
      LIMIT $1`,
     [limit],

--- a/server/multi/db.js
+++ b/server/multi/db.js
@@ -329,6 +329,49 @@ export async function deleteSharedWorkLocation(id, { actingUserId, role }) {
   return { ok: true };
 }
 
+// ── workplace presence ─────────────────────────────────────────────────────
+
+export async function insertWorkplacePresence({ userId, userName, workplaceName, address, latitude, longitude, kind, sharedOrigin }) {
+  const k = kind === 'leave' ? 'leave' : 'enter';
+  const r = await query(
+    `INSERT INTO workplace_presence
+       (user_id, user_name, workplace_name, address, latitude, longitude, kind, shared_origin)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     RETURNING id, occurred_at`,
+    [userId, userName, workplaceName, address ?? null, latitude ?? null, longitude ?? null, k, sharedOrigin ?? null],
+  );
+  return { id: r.rows[0].id, occurred_at: r.rows[0].occurred_at };
+}
+
+export async function listRecentWorkplacePresence({ limit = 50, sinceHours = 24 } = {}) {
+  const since = Math.max(1, Math.min(24 * 30, Number(sinceHours) || 24));
+  const lim = Math.max(1, Math.min(500, Number(limit) || 50));
+  const r = await query(
+    `SELECT id, user_id, user_name, workplace_name, address, latitude, longitude, kind, occurred_at
+       FROM workplace_presence
+       WHERE occurred_at >= now() - ($1 || ' hours')::interval
+       ORDER BY occurred_at DESC
+       LIMIT $2`,
+    [String(since), lim],
+  );
+  return r.rows;
+}
+
+// Latest presence per user (for "who is where right now" view).
+export async function listCurrentWorkplacePresence({ limit = 100 } = {}) {
+  const lim = Math.max(1, Math.min(500, Number(limit) || 100));
+  const r = await query(
+    `SELECT DISTINCT ON (user_id)
+            user_id, user_name, workplace_name, address, latitude, longitude, kind, occurred_at
+       FROM workplace_presence
+       WHERE occurred_at >= now() - interval '24 hours'
+       ORDER BY user_id, occurred_at DESC
+       LIMIT $1`,
+    [lim],
+  );
+  return r.rows.filter(row => row.kind === 'enter');
+}
+
 // ── moderation ─────────────────────────────────────────────────────────────
 
 const TABLE_BY_KIND = {

--- a/server/multi/db.js
+++ b/server/multi/db.js
@@ -90,7 +90,7 @@ export async function getSharedDictionary(id) {
 
 export async function getSharedImplementationNote(id) {
   const r = await query(
-    `SELECT id, product, title, good_points, bad_points,
+    `SELECT id, product, title, good_points, bad_points, attachment_type, attachment_value,
             owner_user_id, owner_user_name, shared_at, shared_origin
        FROM implementation_notes
        WHERE id = $1 AND hidden_at IS NULL`,
@@ -234,7 +234,7 @@ export async function listSharedImplementationNotes({ limit = 50, before = null 
   if (before) { args.push(before); where += ` AND shared_at < $${args.length}`; }
   args.push(limit);
   const r = await query(
-    `SELECT id, product, title, good_points, bad_points,
+    `SELECT id, product, title, good_points, bad_points, attachment_type, attachment_value,
             owner_user_id, owner_user_name, shared_at, shared_origin
        FROM implementation_notes
        ${where}
@@ -245,13 +245,13 @@ export async function listSharedImplementationNotes({ limit = 50, before = null 
   return r.rows;
 }
 
-export async function insertSharedImplementationNote({ product, title, goodPoints, badPoints, ownerUserId, ownerUserName, sharedOrigin }) {
+export async function insertSharedImplementationNote({ product, title, goodPoints, badPoints, attachmentType, attachmentValue, ownerUserId, ownerUserName, sharedOrigin }) {
   const r = await query(
     `INSERT INTO implementation_notes
-       (product, title, good_points, bad_points, owner_user_id, owner_user_name, shared_origin)
-     VALUES ($1, $2, $3, $4, $5, $6, $7)
+       (product, title, good_points, bad_points, attachment_type, attachment_value, owner_user_id, owner_user_name, shared_origin)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
      RETURNING id, shared_at`,
-    [product, title, goodPoints ?? null, badPoints ?? null, ownerUserId, ownerUserName, sharedOrigin ?? null],
+    [product ?? '', title, goodPoints ?? null, badPoints ?? null, attachmentType ?? null, attachmentValue ?? null, ownerUserId, ownerUserName, sharedOrigin ?? null],
   );
   return { id: r.rows[0].id, shared_at: r.rows[0].shared_at };
 }
@@ -272,6 +272,63 @@ export async function deleteSharedImplementationNote(id, { actingUserId, role })
   return { ok: true };
 }
 
+// ── work locations ─────────────────────────────────────────────────────────
+
+export async function listSharedWorkLocations({ limit = 100, before = null } = {}) {
+  const args = [];
+  let where = 'WHERE hidden_at IS NULL';
+  if (before) { args.push(before); where += ` AND shared_at < $${args.length}`; }
+  args.push(limit);
+  const r = await query(
+    `SELECT id, name, address, latitude, longitude, description, url, tags,
+            owner_user_id, owner_user_name, shared_at, shared_origin
+       FROM work_locations
+       ${where}
+       ORDER BY shared_at DESC
+       LIMIT $${args.length}`,
+    args,
+  );
+  return r.rows;
+}
+
+export async function getSharedWorkLocation(id) {
+  const r = await query(
+    `SELECT id, name, address, latitude, longitude, description, url, tags,
+            owner_user_id, owner_user_name, shared_at, shared_origin
+       FROM work_locations
+       WHERE id = $1 AND hidden_at IS NULL`,
+    [id],
+  );
+  return r.rowCount ? r.rows[0] : null;
+}
+
+export async function insertSharedWorkLocation({ name, address, latitude, longitude, description, url, tags, ownerUserId, ownerUserName, sharedOrigin }) {
+  const r = await query(
+    `INSERT INTO work_locations
+       (name, address, latitude, longitude, description, url, tags, owner_user_id, owner_user_name, shared_origin)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+     RETURNING id, shared_at`,
+    [name, address ?? null, latitude ?? null, longitude ?? null, description ?? null, url ?? null, tags ?? null, ownerUserId, ownerUserName, sharedOrigin ?? null],
+  );
+  return { id: r.rows[0].id, shared_at: r.rows[0].shared_at };
+}
+
+export async function deleteSharedWorkLocation(id, { actingUserId, role }) {
+  const r = await query('SELECT owner_user_id FROM work_locations WHERE id = $1', [id]);
+  if (!r.rowCount) return { ok: false, error: 'not_found' };
+  const owner = r.rows[0].owner_user_id;
+  if (owner !== actingUserId && role !== 'admin' && role !== 'moderator') {
+    return { ok: false, error: 'forbidden' };
+  }
+  await query('DELETE FROM work_locations WHERE id = $1', [id]);
+  await query(
+    `INSERT INTO share_log (resource_kind, resource_id, action, acting_user_id)
+       VALUES ('work_location', $1, 'delete', $2)`,
+    [id, actingUserId],
+  );
+  return { ok: true };
+}
+
 // ── moderation ─────────────────────────────────────────────────────────────
 
 const TABLE_BY_KIND = {
@@ -279,6 +336,7 @@ const TABLE_BY_KIND = {
   dig: 'dig_sessions',
   dict: 'dictionary_entries',
   implementation_note: 'implementation_notes',
+  work_location: 'work_locations',
 };
 
 function tableForKind(kind) {
@@ -340,6 +398,8 @@ export async function listHidden({ limit = 100 } = {}) {
      ${sql('dict', 'dictionary_entries', 'term')}
      UNION ALL
      ${sql('implementation_note', 'implementation_notes', 'title')}
+     UNION ALL
+     ${sql('work_location', 'work_locations', 'name')}
      ORDER BY hidden_at DESC
      LIMIT $1`,
     [limit],

--- a/server/multi/index.js
+++ b/server/multi/index.js
@@ -35,6 +35,7 @@ import {
   listSharedWorkLocations, insertSharedWorkLocation, deleteSharedWorkLocation,
   getSharedBookmark, getSharedDig, getSharedDictionary,
   getSharedImplementationNote, getSharedWorkLocation,
+  insertWorkplacePresence, listRecentWorkplacePresence, listCurrentWorkplacePresence,
   hideShared, unhideShared, listHidden, listShareLog,
   recordShareEvent,
 } from './db.js';
@@ -361,6 +362,50 @@ app.delete('/api/shared/work-locations/:id', async (c) => {
   const r = await deleteSharedWorkLocation(id, { actingUserId: u.userId, role: u.role });
   if (!r.ok) return c.json({ error: r.error }, r.error === 'not_found' ? 404 : 403);
   return c.json({ ok: true });
+});
+
+// ── /api/shared/workplace-presence ─────────────────────────────────────────
+//
+// Ephemeral "I am at <place>" stream for the team. POST when a user enters
+// or leaves a workplace; GET to see the current state of the team.
+
+app.post('/api/shared/workplace-presence', async (c) => {
+  const u = await authedUser(c);
+  if (!u) return c.json({ error: 'unauthorized' }, 401);
+  const body = await c.req.json().catch(() => null);
+  if (!body?.workplace_name) return c.json({ error: 'workplace_name required' }, 400);
+  const r = await insertWorkplacePresence({
+    userId: u.userId,
+    userName: u.displayName,
+    workplaceName: body.workplace_name,
+    address: body.address ?? null,
+    latitude: body.latitude == null ? null : Number(body.latitude),
+    longitude: body.longitude == null ? null : Number(body.longitude),
+    kind: body.kind === 'leave' ? 'leave' : 'enter',
+    sharedOrigin: c.req.header('x-memoria-origin') || null,
+  });
+  await recordShareEvent({
+    kind: 'workplace_presence', id: r.id, action: 'share',
+    actingUserId: u.userId, details: { workplace_name: body.workplace_name, kind: body.kind || 'enter' },
+  });
+  return c.json(r, 201);
+});
+
+app.get('/api/shared/workplace-presence', async (c) => {
+  const u = await authedUser(c);
+  if (!u) return c.json({ error: 'unauthorized' }, 401);
+  const limit = Math.min(Number(c.req.query('limit') || 50), 500);
+  const sinceHours = Math.min(Number(c.req.query('since_hours') || 24), 24 * 30);
+  const items = await listRecentWorkplacePresence({ limit, sinceHours });
+  return c.json({ items });
+});
+
+app.get('/api/shared/workplace-presence/current', async (c) => {
+  const u = await authedUser(c);
+  if (!u) return c.json({ error: 'unauthorized' }, 401);
+  const limit = Math.min(Number(c.req.query('limit') || 100), 500);
+  const items = await listCurrentWorkplacePresence({ limit });
+  return c.json({ items });
 });
 
 // ── /api/shared/moderation/* (admin / moderator only) ──────────────────────

--- a/server/multi/index.js
+++ b/server/multi/index.js
@@ -32,8 +32,9 @@ import {
   listSharedDigs, insertSharedDig, deleteSharedDig,
   listSharedDictionary, insertSharedDictionary, deleteSharedDictionary,
   listSharedImplementationNotes, insertSharedImplementationNote, deleteSharedImplementationNote,
+  listSharedWorkLocations, insertSharedWorkLocation, deleteSharedWorkLocation,
   getSharedBookmark, getSharedDig, getSharedDictionary,
-  getSharedImplementationNote,
+  getSharedImplementationNote, getSharedWorkLocation,
   hideShared, unhideShared, listHidden, listShareLog,
   recordShareEvent,
 } from './db.js';
@@ -286,6 +287,8 @@ app.post('/api/shared/implementation-notes', async (c) => {
     title: body.title,
     goodPoints: body.good_points,
     badPoints: body.bad_points,
+    attachmentType: body.attachment_type,
+    attachmentValue: body.attachment_value,
     ownerUserId: u.userId,
     ownerUserName: u.displayName,
     sharedOrigin: c.req.header('x-memoria-origin') || null,
@@ -308,6 +311,54 @@ app.delete('/api/shared/implementation-notes/:id', async (c) => {
   if (!u) return c.json({ error: 'unauthorized' }, 401);
   const id = Number(c.req.param('id'));
   const r = await deleteSharedImplementationNote(id, { actingUserId: u.userId, role: u.role });
+  if (!r.ok) return c.json({ error: r.error }, r.error === 'not_found' ? 404 : 403);
+  return c.json({ ok: true });
+});
+
+// ── /api/shared/work-locations ─────────────────────────────────────────────
+
+app.get('/api/shared/work-locations', async (c) => {
+  const limit = Math.min(Number(c.req.query('limit') || 100), 500);
+  const before = c.req.query('before') || null;
+  const items = await listSharedWorkLocations({ limit, before });
+  return c.json({ items });
+});
+
+app.post('/api/shared/work-locations', async (c) => {
+  const u = await authedUser(c);
+  if (!u) return c.json({ error: 'unauthorized' }, 401);
+  const body = await c.req.json().catch(() => null);
+  if (!body?.name) return c.json({ error: 'name required' }, 400);
+  const r = await insertSharedWorkLocation({
+    name: body.name,
+    address: body.address,
+    latitude: body.latitude == null ? null : Number(body.latitude),
+    longitude: body.longitude == null ? null : Number(body.longitude),
+    description: body.description,
+    url: body.url,
+    tags: body.tags,
+    ownerUserId: u.userId,
+    ownerUserName: u.displayName,
+    sharedOrigin: c.req.header('x-memoria-origin') || null,
+  });
+  await recordShareEvent({
+    kind: 'work_location', id: r.id, action: 'share',
+    actingUserId: u.userId, details: { name: body.name },
+  });
+  return c.json(r, 201);
+});
+
+app.get('/api/shared/work-locations/:id', async (c) => {
+  const r = await getSharedWorkLocation(Number(c.req.param('id')));
+  if (!r) return c.json({ error: 'not_found' }, 404);
+  return c.json(r);
+});
+
+app.delete('/api/shared/work-locations/:id', async (c) => {
+  const u = await authedUser(c);
+  if (!u) return c.json({ error: 'unauthorized' }, 401);
+  const id = Number(c.req.param('id'));
+  const r = await deleteSharedWorkLocation(id, { actingUserId: u.userId, role: u.role });
   if (!r.ok) return c.json({ error: r.error }, r.error === 'not_found' ? 404 : 403);
   return c.json({ ok: true });
 });

--- a/server/multi/index.js
+++ b/server/multi/index.js
@@ -31,7 +31,9 @@ import {
   listSharedBookmarks, insertSharedBookmark, deleteSharedBookmark,
   listSharedDigs, insertSharedDig, deleteSharedDig,
   listSharedDictionary, insertSharedDictionary, deleteSharedDictionary,
+  listSharedImplementationNotes, insertSharedImplementationNote, deleteSharedImplementationNote,
   getSharedBookmark, getSharedDig, getSharedDictionary,
+  getSharedImplementationNote,
   hideShared, unhideShared, listHidden, listShareLog,
   recordShareEvent,
 } from './db.js';
@@ -261,6 +263,51 @@ app.delete('/api/shared/dictionary/:id', async (c) => {
   if (!u) return c.json({ error: 'unauthorized' }, 401);
   const id = Number(c.req.param('id'));
   const r = await deleteSharedDictionary(id, { actingUserId: u.userId, role: u.role });
+  if (!r.ok) return c.json({ error: r.error }, r.error === 'not_found' ? 404 : 403);
+  return c.json({ ok: true });
+});
+
+// ── /api/shared/implementation-notes ───────────────────────────────────────
+
+app.get('/api/shared/implementation-notes', async (c) => {
+  const limit = Math.min(Number(c.req.query('limit') || 50), 200);
+  const before = c.req.query('before') || null;
+  const items = await listSharedImplementationNotes({ limit, before });
+  return c.json({ items });
+});
+
+app.post('/api/shared/implementation-notes', async (c) => {
+  const u = await authedUser(c);
+  if (!u) return c.json({ error: 'unauthorized' }, 401);
+  const body = await c.req.json().catch(() => null);
+  if (!body?.product || !body?.title) return c.json({ error: 'product+title required' }, 400);
+  const r = await insertSharedImplementationNote({
+    product: body.product,
+    title: body.title,
+    goodPoints: body.good_points,
+    badPoints: body.bad_points,
+    ownerUserId: u.userId,
+    ownerUserName: u.displayName,
+    sharedOrigin: c.req.header('x-memoria-origin') || null,
+  });
+  await recordShareEvent({
+    kind: 'implementation_note', id: r.id, action: 'share',
+    actingUserId: u.userId, details: { product: body.product, title: body.title },
+  });
+  return c.json(r, 201);
+});
+
+app.get('/api/shared/implementation-notes/:id', async (c) => {
+  const r = await getSharedImplementationNote(Number(c.req.param('id')));
+  if (!r) return c.json({ error: 'not_found' }, 404);
+  return c.json(r);
+});
+
+app.delete('/api/shared/implementation-notes/:id', async (c) => {
+  const u = await authedUser(c);
+  if (!u) return c.json({ error: 'unauthorized' }, 401);
+  const id = Number(c.req.param('id'));
+  const r = await deleteSharedImplementationNote(id, { actingUserId: u.userId, role: u.role });
   if (!r.ok) return c.json({ error: r.error }, r.error === 'not_found' ? 404 : 403);
   return c.json({ ok: true });
 });

--- a/server/multi/migrations/002_implementation_notes.sql
+++ b/server/multi/migrations/002_implementation_notes.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS implementation_notes (
+  id                BIGSERIAL PRIMARY KEY,
+  product           TEXT NOT NULL,
+  title             TEXT NOT NULL,
+  good_points       TEXT,
+  bad_points        TEXT,
+  owner_user_id     TEXT NOT NULL,
+  owner_user_name   TEXT NOT NULL,
+  shared_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  shared_origin     TEXT,
+  hidden_at         TIMESTAMPTZ,
+  hidden_by         TEXT,
+  hidden_reason     TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_impl_notes_owner
+  ON implementation_notes(owner_user_id);
+CREATE INDEX IF NOT EXISTS idx_impl_notes_shared
+  ON implementation_notes(shared_at DESC);

--- a/server/multi/migrations/004_work_locations.sql
+++ b/server/multi/migrations/004_work_locations.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS work_locations (
+  id                BIGSERIAL PRIMARY KEY,
+  name              TEXT NOT NULL,
+  address           TEXT,
+  latitude          DOUBLE PRECISION,
+  longitude         DOUBLE PRECISION,
+  description       TEXT,
+  url               TEXT,
+  tags              TEXT,
+  owner_user_id     TEXT NOT NULL,
+  owner_user_name   TEXT NOT NULL,
+  shared_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  shared_origin     TEXT,
+  hidden_at         TIMESTAMPTZ,
+  hidden_by         TEXT,
+  hidden_reason     TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_work_locations_owner
+  ON work_locations(owner_user_id);
+CREATE INDEX IF NOT EXISTS idx_work_locations_shared
+  ON work_locations(shared_at DESC);

--- a/server/multi/migrations/005_workplace_presence.sql
+++ b/server/multi/migrations/005_workplace_presence.sql
@@ -1,0 +1,21 @@
+-- Workplace presence: ephemeral "I am working at X right now" events.
+-- Separate from work_locations (which is the persistent catalog) so the
+-- presence stream can be queried for "who is where" without polluting
+-- the curated locations list.
+CREATE TABLE IF NOT EXISTS workplace_presence (
+  id                BIGSERIAL PRIMARY KEY,
+  user_id           TEXT NOT NULL,
+  user_name         TEXT NOT NULL,
+  workplace_name    TEXT NOT NULL,
+  address           TEXT,
+  latitude          DOUBLE PRECISION,
+  longitude         DOUBLE PRECISION,
+  kind              TEXT NOT NULL DEFAULT 'enter', -- 'enter' | 'leave'
+  shared_origin     TEXT,
+  occurred_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_workplace_presence_user
+  ON workplace_presence(user_id, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_workplace_presence_recent
+  ON workplace_presence(occurred_at DESC);

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -4774,14 +4774,23 @@ function ensureMemoriaFeatureViews() {
       <div class="simple-panel">
         <div class="simple-panel-head">
           <h2>🗺️ 作業場所</h2>
-          <button id="workplaceNewBtn" type="button">+ 場所を追加</button>
+          <div style="display:flex;gap:6px;flex-wrap:wrap">
+            <button id="workplaceCheckinBtn" type="button" class="ghost">📍 ここで作業中</button>
+            <button id="workplaceFromGpsBtn" type="button" class="ghost">📍 現在地から登録</button>
+            <button id="workplaceNewBtn" type="button">+ 場所を追加</button>
+          </div>
         </div>
-        <p class="diary-settings-help">よく作業するカフェ・コワーキング・図書館などをまとめ、Hub にシェアしてチームでナレッジ共有できます。</p>
+        <p class="diary-settings-help">よく作業するカフェ・コワーキング・図書館などをまとめ、Hub にシェアしてチームでナレッジ共有できます。GPS と Place API (OpenStreetMap Nominatim) で現在地を取得して登録/チェックインできます。</p>
+        <div id="workplaceCurrentBanner" class="muted" style="margin:6px 0 10px"></div>
         <div id="workplaceList" class="simple-list"></div>
         <section id="workplaceEditorModal" class="dict-detail modal-panel hidden foundation-form">
           <button type="button" class="modal-close" id="workplaceEditorClose" aria-label="close">×</button>
           <h3 id="workplaceEditorHeading">作業場所を追加</h3>
           <input type="hidden" id="workplaceEditorId" />
+          <div class="simple-actions" style="justify-content:flex-start">
+            <button type="button" class="ghost" id="workplaceEditorGpsBtn">📍 現在地を取得</button>
+            <span id="workplaceEditorGpsStatus" class="muted" style="font-size:11px"></span>
+          </div>
           <label class="simple-field">
             <span>名前</span>
             <input id="workplaceEditorName" type="text" placeholder="例: WeWork 六本木" />
@@ -4866,7 +4875,14 @@ function ensureMemoriaFeatureViews() {
       <label>Nuntius URL: <input id="taskReminderNuntiusUrl" type="text" placeholder="https://nuntius.example.com/notify" /></label>
       <h4 style="margin-top:12px">MCP サーバ</h4>
       <label class="check-inline"><input id="mcpAutostartEnabled" type="checkbox" /> Memoria 起動時に MCP サーバを同時起動する (任意)</label>
-      <p class="diary-settings-help" style="margin-top:6px">iOS で受け取る場合はホーム画面に追加 + 通知を許可してください。</p>`;
+      <h4 style="margin-top:12px">作業場所 (GPS / Hub 共有)</h4>
+      <label class="check-inline"><input id="workplaceGeoEnabled" type="checkbox" /> GPS で現在地を取得して作業場所をマッチする</label>
+      <label class="check-inline"><input id="workplaceAutoShareEnabled" type="checkbox" /> 作業場所が切り替わったとき Hub に共有する (オプトイン)</label>
+      <label style="display:flex;align-items:center;gap:6px;margin-bottom:6px">マッチ半径:
+        <input id="workplaceMatchRadiusM" type="number" min="20" max="2000" step="10" style="width:80px" />
+        m
+      </label>
+      <p class="diary-settings-help" style="margin-top:6px">iOS で受け取る場合はホーム画面に追加 + 通知を許可してください。GPS 共有は Hub 接続済みのときのみ動作します。</p>`;
     footer.parentNode.insertBefore(sec, footer);
   }
   if (footer && !$('setupDocsBody')) {
@@ -5081,6 +5097,10 @@ async function loadPrivacySettings() {
   if ($('taskReminderNuntiusEnabled')) $('taskReminderNuntiusEnabled').checked = !!s.tasks_reminder_nuntius_enabled;
   if ($('taskReminderNuntiusUrl')) $('taskReminderNuntiusUrl').value = s.tasks_reminder_nuntius_url || '';
   if ($('mcpAutostartEnabled')) $('mcpAutostartEnabled').checked = !!s.mcp_autostart_enabled;
+  if ($('workplaceGeoEnabled')) $('workplaceGeoEnabled').checked = !!s.workplace_geo_enabled;
+  if ($('workplaceAutoShareEnabled')) $('workplaceAutoShareEnabled').checked = !!s.workplace_auto_share_enabled;
+  if ($('workplaceMatchRadiusM')) $('workplaceMatchRadiusM').value = s.workplace_match_radius_m ?? 150;
+  configureWorkplaceCheckin(!!s.workplace_geo_enabled);
   if (s.tasks_reminder_enabled) {
     scheduleLocalTaskReminder(s.tasks_reminder_hour ?? 6, s.tasks_reminder_minute ?? 0);
   }
@@ -5105,12 +5125,16 @@ async function savePrivacySettings() {
       tasks_reminder_nuntius_enabled: !!($('taskReminderNuntiusEnabled')?.checked),
       tasks_reminder_nuntius_url: $('taskReminderNuntiusUrl')?.value.trim() || '',
       mcp_autostart_enabled: !!($('mcpAutostartEnabled')?.checked),
+      workplace_geo_enabled: !!($('workplaceGeoEnabled')?.checked),
+      workplace_auto_share_enabled: !!($('workplaceAutoShareEnabled')?.checked),
+      workplace_match_radius_m: Number($('workplaceMatchRadiusM')?.value ?? 150),
     }),
   });
   const s = r.settings || {};
   if (s.tasks_reminder_enabled) {
     scheduleLocalTaskReminder(s.tasks_reminder_hour ?? 6, s.tasks_reminder_minute ?? 0);
   }
+  configureWorkplaceCheckin(!!s.workplace_geo_enabled);
   applyFeatureVisibility(s);
 }
 
@@ -5674,6 +5698,125 @@ function closeWorkplaceEditor() {
   hideModal('workplaceEditorModal');
 }
 
+// ── GPS / Place API helpers ────────────────────────────────────────────────
+
+function getCurrentPositionPromise(opts = {}) {
+  return new Promise((resolve, reject) => {
+    if (!('geolocation' in navigator)) {
+      reject(new Error('このブラウザは Geolocation に対応していません'));
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(
+      (pos) => resolve(pos.coords),
+      (err) => reject(new Error(err.message || 'GPS 取得失敗')),
+      { enableHighAccuracy: true, timeout: 12000, maximumAge: 30000, ...opts },
+    );
+  });
+}
+
+async function resolvePlaceForCoords(coords) {
+  return api('/api/work-locations/resolve-place', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ latitude: coords.latitude, longitude: coords.longitude }),
+  });
+}
+
+async function fillEditorFromCurrentLocation() {
+  const status = $('workplaceEditorGpsStatus');
+  if (status) status.textContent = 'GPS 取得中…';
+  try {
+    const coords = await getCurrentPositionPromise();
+    if (status) status.textContent = '逆ジオコーディング中…';
+    const place = await resolvePlaceForCoords(coords).catch(() => null);
+    if ($('workplaceEditorLat')) $('workplaceEditorLat').value = coords.latitude.toFixed(6);
+    if ($('workplaceEditorLng')) $('workplaceEditorLng').value = coords.longitude.toFixed(6);
+    if (place?.name && !$('workplaceEditorName').value) {
+      $('workplaceEditorName').value = place.name;
+    }
+    if (place?.address && !$('workplaceEditorAddress').value) {
+      $('workplaceEditorAddress').value = place.address;
+    }
+    if (status) status.textContent = place?.name ? `取得: ${place.name}` : '座標のみ取得';
+  } catch (e) {
+    if (status) status.textContent = `失敗: ${e.message}`;
+    else alert(`GPS 取得失敗: ${e.message}`);
+  }
+}
+
+async function openEditorFromCurrentGps() {
+  openWorkplaceEditor(null);
+  await fillEditorFromCurrentLocation();
+}
+
+let _workplaceCheckinTimer = null;
+let _workplaceGeoEnabled = false;
+const WORKPLACE_CHECKIN_INTERVAL_MS = 5 * 60 * 1000;
+
+async function _silentCheckin() {
+  if (!_workplaceGeoEnabled) return;
+  if (document.visibilityState !== 'visible') return;
+  try {
+    const coords = await getCurrentPositionPromise({ timeout: 8000, maximumAge: 60000 });
+    const r = await api('/api/work-locations/checkin', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ latitude: coords.latitude, longitude: coords.longitude }),
+    });
+    const banner = $('workplaceCurrentBanner');
+    if (banner && r.matched) {
+      const broadcast = r.changed && r.broadcast?.ok ? ' ・ Hub に共有しました' : '';
+      banner.textContent = `📍 ${r.workplace.name}${broadcast}`;
+    }
+  } catch (e) {
+    // 静かに失敗 (バッテリ最適化で deny されるなど)。手動ボタンでは表示する。
+    console.debug('[workplace] silent checkin skipped:', e.message);
+  }
+}
+
+function configureWorkplaceCheckin(enabled) {
+  _workplaceGeoEnabled = !!enabled;
+  if (_workplaceCheckinTimer) {
+    clearInterval(_workplaceCheckinTimer);
+    _workplaceCheckinTimer = null;
+  }
+  if (_workplaceGeoEnabled) {
+    _workplaceCheckinTimer = setInterval(_silentCheckin, WORKPLACE_CHECKIN_INTERVAL_MS);
+    // visibility change で復帰時にも 1 回トリガー
+    document.addEventListener('visibilitychange', _onWorkplaceVisibility);
+  } else {
+    document.removeEventListener('visibilitychange', _onWorkplaceVisibility);
+  }
+}
+
+function _onWorkplaceVisibility() {
+  if (document.visibilityState === 'visible') _silentCheckin();
+}
+
+async function workplaceCheckinNow() {
+  const banner = $('workplaceCurrentBanner');
+  if (banner) banner.textContent = 'GPS 取得中…';
+  try {
+    const coords = await getCurrentPositionPromise();
+    const r = await api('/api/work-locations/checkin', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ latitude: coords.latitude, longitude: coords.longitude }),
+    });
+    if (banner) {
+      if (r.matched) {
+        const dist = r.distance_m != null ? ` (${r.distance_m}m)` : '';
+        const broadcast = r.broadcast?.ok ? ' ・ Hub に共有済み' : (r.changed && r.broadcast?.error ? ` ・ Hub 共有失敗: ${r.broadcast.error}` : '');
+        banner.textContent = `📍 ${r.workplace.name}${dist}${broadcast}`;
+      } else {
+        banner.textContent = '近くに登録済みの作業場所がありません。「現在地から登録」で追加できます。';
+      }
+    }
+  } catch (e) {
+    if (banner) banner.textContent = `チェックイン失敗: ${e.message}`;
+  }
+}
+
 async function saveWorkLocationFromForm() {
   const name = $('workplaceEditorName')?.value.trim();
   if (!name) { alert('名前を入力してください'); return; }
@@ -6002,6 +6145,9 @@ ensureMemoriaFeatureViews = function () {
   if ($('workplaceEditorClose')) $('workplaceEditorClose').onclick = closeWorkplaceEditor;
   if ($('workplaceEditorCancelBtn')) $('workplaceEditorCancelBtn').onclick = closeWorkplaceEditor;
   if ($('workplaceEditorSaveBtn')) $('workplaceEditorSaveBtn').onclick = saveWorkLocationFromForm;
+  if ($('workplaceEditorGpsBtn')) $('workplaceEditorGpsBtn').onclick = fillEditorFromCurrentLocation;
+  if ($('workplaceFromGpsBtn')) $('workplaceFromGpsBtn').onclick = openEditorFromCurrentGps;
+  if ($('workplaceCheckinBtn')) $('workplaceCheckinBtn').onclick = workplaceCheckinNow;
   document.querySelectorAll('#tasksMenu [data-task-menu]').forEach((btn) => {
     btn.onclick = () => {
       state.taskMenu = btn.dataset.taskMenu;

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -2234,10 +2234,36 @@ function renderDomainList() {
         <span>${escapeHtml(e.domain)}</span>
         <span>本日 ${e.visits_today} / 週 ${e.visits_week}</span>
       </div>
+      <label class="domain-private-toggle" title="ON にすると日記のドメイン欄には表示しません。アクセス履歴や傾向には残ります。">
+        <input type="checkbox" data-domain-private="${escapeHtml(e.domain)}" ${e.domain_private ? 'checked' : ''} />
+        private
+      </label>
     </li>`;
   }).join('');
   ul.querySelectorAll('.dict-item').forEach(li => {
     li.addEventListener('click', () => loadDomainEntry(li.dataset.domain));
+  });
+  ul.querySelectorAll('input[data-domain-private]').forEach(cb => {
+    cb.addEventListener('click', (ev) => ev.stopPropagation());
+    cb.addEventListener('change', async (ev) => {
+      ev.stopPropagation();
+      const domain = cb.dataset.domainPrivate;
+      const checked = cb.checked;
+      try {
+        await api(`/api/domains/${encodeURIComponent(domain)}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ domain_private: checked }),
+        });
+        const row = state.domainEntries.find(x => x.domain === domain);
+        if (row) row.domain_private = checked ? 1 : 0;
+        if (state.domainDetail?.domain === domain) state.domainDetail.domain_private = checked ? 1 : 0;
+        flashToast(checked ? '日記では非表示にしました' : '日記に表示するようにしました');
+      } catch (e) {
+        cb.checked = !checked;
+        alert(`private 更新失敗: ${e.message}`);
+      }
+    });
   });
 }
 

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -4781,12 +4781,166 @@ function ensureMemoriaFeatureViews() {
     footer.parentNode.insertBefore(sec, footer);
   }
 
-  if ($('taskNewBtn')) $('taskNewBtn').onclick = () => $('taskForm')?.classList.remove('hidden');
+  upgradeTaskFormMarkup();
+  upgradeImplementationFormMarkup();
+  setupTaskFormKeyboard();
+  setupImplementationFormKeyboard();
+
+  if ($('taskNewBtn')) $('taskNewBtn').onclick = () => {
+    $('taskForm')?.classList.remove('hidden');
+    $('taskTitle')?.focus();
+  };
   if ($('taskCancelBtn')) $('taskCancelBtn').onclick = () => $('taskForm')?.classList.add('hidden');
   if ($('taskAddBtn')) $('taskAddBtn').onclick = addTaskFromForm;
-  if ($('implNewBtn')) $('implNewBtn').onclick = () => $('implForm')?.classList.remove('hidden');
+  if ($('implNewBtn')) $('implNewBtn').onclick = () => {
+    $('implForm')?.classList.remove('hidden');
+    $('implProduct')?.focus();
+  };
   if ($('implCancelBtn')) $('implCancelBtn').onclick = () => $('implForm')?.classList.add('hidden');
   if ($('implAddBtn')) $('implAddBtn').onclick = addImplementationNoteFromForm;
+}
+
+function localDatetimeValue(date) {
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+function dueShortcutValue(kind) {
+  const d = new Date();
+  if (kind === 'tomorrow') d.setDate(d.getDate() + 1);
+  if (kind === 'saturday') {
+    const day = d.getDay();
+    const delta = day <= 6 ? 6 - day : 6;
+    d.setDate(d.getDate() + delta);
+  }
+  d.setHours(23, 59, 0, 0);
+  return localDatetimeValue(d);
+}
+
+function upgradeTaskFormMarkup() {
+  const form = $('taskForm');
+  if (!form || form.dataset.upgraded === '1') return;
+  form.dataset.upgraded = '1';
+  form.innerHTML = `
+    <label class="simple-field">
+      <span>タスク名</span>
+      <input id="taskTitle" type="text" placeholder="直近やること" />
+    </label>
+    <label class="simple-field">
+      <span>期日</span>
+      <input id="taskDue" type="datetime-local" />
+    </label>
+    <div class="task-due-shortcuts" aria-label="期日のショートカット">
+      <button type="button" class="ghost" data-task-due-shortcut="today">今日</button>
+      <button type="button" class="ghost" data-task-due-shortcut="tomorrow">明日</button>
+      <button type="button" class="ghost" data-task-due-shortcut="saturday">今週中(土曜締め)</button>
+    </div>
+    <label class="simple-check-row">
+      <input id="taskShareActio" type="checkbox" tabindex="-1" />
+      <span>Actio にシェアする</span>
+    </label>
+    <label class="simple-field">
+      <span>メモ</span>
+      <textarea id="taskDetails" rows="6" placeholder="タスク内容のメモ"></textarea>
+    </label>
+    <div class="simple-actions">
+      <button id="taskAddBtn">追加</button>
+      <button id="taskCancelBtn" type="button" class="ghost">キャンセル</button>
+    </div>`;
+  form.querySelectorAll('[data-task-due-shortcut]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      $('taskDue').value = dueShortcutValue(btn.dataset.taskDueShortcut);
+      $('taskDetails')?.focus();
+    });
+  });
+}
+
+function setupTaskFormKeyboard() {
+  const title = $('taskTitle');
+  const due = $('taskDue');
+  const details = $('taskDetails');
+  const add = $('taskAddBtn');
+  if (title) title.onkeydown = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      due?.focus();
+    }
+  };
+  if (due) due.onkeydown = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      details?.focus();
+    }
+  };
+  if (details) details.onkeydown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      add?.focus();
+    }
+  };
+}
+
+function upgradeImplementationFormMarkup() {
+  const form = $('implForm');
+  if (!form || form.dataset.upgraded === '1') return;
+  form.dataset.upgraded = '1';
+  form.innerHTML = `
+    <label class="simple-field">
+      <span>プロダクト名</span>
+      <input id="implProduct" type="text" placeholder="Memoria" />
+    </label>
+    <label class="simple-field">
+      <span>タイトル</span>
+      <input id="implTitle" type="text" placeholder="短いタイトル" />
+    </label>
+    <label class="simple-field">
+      <span>良かった点</span>
+      <textarea id="implGood" rows="5" placeholder="実装して良かった点"></textarea>
+    </label>
+    <label class="simple-field">
+      <span>悪かった点 / トレードオフ</span>
+      <textarea id="implBad" rows="4" placeholder="悪かった点、迷った点、次に直したい点"></textarea>
+    </label>
+    <label class="simple-check-row">
+      <input id="implShareable" type="checkbox" tabindex="-1" />
+      <span>シェア可能にする</span>
+    </label>
+    <div class="simple-actions">
+      <button id="implAddBtn">追加</button>
+      <button id="implCancelBtn" type="button" class="ghost">キャンセル</button>
+    </div>`;
+}
+
+function setupImplementationFormKeyboard() {
+  const product = $('implProduct');
+  const title = $('implTitle');
+  const good = $('implGood');
+  const bad = $('implBad');
+  const add = $('implAddBtn');
+  if (product) product.onkeydown = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      title?.focus();
+    }
+  };
+  if (title) title.onkeydown = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      good?.focus();
+    }
+  };
+  if (good) good.onkeydown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      bad?.focus();
+    }
+  };
+  if (bad) bad.onkeydown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      add?.focus();
+    }
+  };
 }
 
 async function loadPrivacySettings() {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -3479,19 +3479,34 @@ function renderTrendKeywords(items) {
 function renderTrendWorkHours(items) {
   const el = $('trendWorkHours');
   if (!el) return;
-  // items: [{date: 'YYYY-MM-DD', minutes: number|null}]
-  // null = no diary generated for that day → drop from the line, don't draw 0.
   const present = (items || []).filter(d => Number.isFinite(d.minutes));
   if (!present.length) {
     el.innerHTML = '<div class="queue-empty">作業時間が記録された日記がまだありません</div>';
     return;
   }
-  const data = present.map(d => ({ date: d.date, value: d.minutes / 60, raw: d.minutes }));
-  el.innerHTML = renderLineChartSvg(data, {
-    yLabel: (v) => `${v.toFixed(1)}h`,
-    pointLabel: (d) => `${d.date} : ${(d.value).toFixed(1)} 時間 (${d.raw} 分)`,
+  el.innerHTML = svgHorizontalBar(
+    present,
+    (d) => String(d.date || '').slice(5),
+    (d) => Number(d.minutes || 0),
+    '',
+    {
+      valueLabel: (v) => `${(v / 60).toFixed(1)}h`,
+    }
+  );
+}
+
+function applyTaskDueShortcutToEditor(kind) {
+  const due = $('taskEditorDue');
+  if (!due) return;
+  if (kind === 'weekend') kind = 'saturday';
+  due.value = dueShortcutValue(kind);
+  $('taskEditorDetails')?.focus();
+}
+
+function wireTaskEditorDueShortcuts() {
+  document.querySelectorAll('[data-task-editor-due-shortcut]').forEach((btn) => {
+    btn.addEventListener('click', () => applyTaskDueShortcutToEditor(btn.dataset.taskEditorDueShortcut));
   });
-  attachLineChartTooltip(el);
 }
 
 function renderTrendGpsWalking(items) {
@@ -4106,13 +4121,18 @@ function hideModal(panelId) {
   // If neither panel is open after this hide, drop the backdrop too.
   const dictOpen = !$('dictDetail').classList.contains('hidden');
   const domOpen  = !$('domainDetail').classList.contains('hidden');
-  $('modalBackdrop').hidden = !(dictOpen || domOpen);
+  const taskOpen = $('taskEditorModal') ? !$('taskEditorModal').classList.contains('hidden') : false;
+  const implOpen = $('implEditorModal') ? !$('implEditorModal').classList.contains('hidden') : false;
+  $('modalBackdrop').hidden = !(dictOpen || domOpen || taskOpen || implOpen);
 }
 function closeAllModals() {
   state.dictDetail = null;
   state.domainDetail = null;
+  state.taskDetail = null;
   hideModal('dictDetail');
   hideModal('domainDetail');
+  hideModal('taskEditorModal');
+  hideModal('implEditorModal');
 }
 $('dictDetailClose')?.addEventListener('click', () => {
   state.dictDetail = null;
@@ -5295,7 +5315,7 @@ loadImplementationNotes = async function () {
     return;
   }
   list.innerHTML = items.map(n => `
-    <div class="simple-item" data-id="${n.id}">
+    <div class="simple-item" data-id="${n.id}" data-impl-open="${n.id}">
       <div class="simple-item-head"><strong>${escapeHtml(n.title)}</strong></div>
       <h4>良かった点</h4><p>${escapeHtml(n.good_points || '')}</p>
       <h4>悪かった点 / トレードオフ</h4><p>${escapeHtml(n.bad_points || '')}</p>
@@ -5307,7 +5327,8 @@ loadImplementationNotes = async function () {
       </div>
     </div>`).join('');
   list.querySelectorAll('[data-impl-share]').forEach(btn => {
-    btn.addEventListener('click', async () => {
+    btn.addEventListener('click', async (ev) => {
+      ev.stopPropagation();
       try {
         await api('/api/multi/share', {
           method: 'POST',
@@ -5321,34 +5342,48 @@ loadImplementationNotes = async function () {
     });
   });
   list.querySelectorAll('[data-impl-delete]').forEach(btn => {
-    btn.addEventListener('click', async () => {
+    btn.addEventListener('click', async (ev) => {
+      ev.stopPropagation();
       await api(`/api/implementation-notes/${btn.dataset.implDelete}`, { method: 'DELETE' });
       loadImplementationNotes();
+    });
+  });
+  list.querySelectorAll('[data-impl-open]').forEach(el => {
+    el.addEventListener('click', (ev) => {
+      if (ev.target.closest('button,a,input,select,textarea')) return;
+      const id = Number(el.dataset.implOpen || 0);
+      const note = items.find((n) => n.id === id);
+      if (note) openImplEditor(note);
     });
   });
 };
 
 addImplementationNoteFromForm = async function () {
-  const title = $('implTitle')?.value.trim();
+  const title = $('implEditorTitle')?.value.trim();
   if (!title) return;
-  await api('/api/implementation-notes', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      title,
-      good_points: $('implGood')?.value.trim() || '',
-      bad_points: $('implBad')?.value.trim() || '',
-      attachment_type: $('implAttachmentType')?.value || '',
-      attachment_value: $('implAttachmentValue')?.value.trim() || '',
-      shareable: !!$('implShareable')?.checked,
-    }),
-  });
-  for (const id of ['implTitle', 'implGood', 'implBad', 'implAttachmentType', 'implAttachmentValue']) {
-    const el = $(id);
-    if (el) el.value = '';
+  const noteId = Number($('implEditorNoteId')?.value || 0);
+  const payload = {
+    title,
+    good_points: $('implEditorGood')?.value.trim() || '',
+    bad_points: $('implEditorBad')?.value.trim() || '',
+    attachment_type: $('implEditorAttachmentType')?.value || '',
+    attachment_value: $('implEditorAttachmentValue')?.value.trim() || '',
+    shareable: !!$('implEditorShareable')?.checked,
+  };
+  if (noteId) {
+    await api(`/api/implementation-notes/${noteId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  } else {
+    await api('/api/implementation-notes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
   }
-  $('implShareable').checked = false;
-  $('implForm')?.classList.add('hidden');
+  closeImplEditor();
   loadImplementationNotes();
 };
 
@@ -5448,7 +5483,7 @@ function taskCardHtml(t) {
     ? '<button class="ghost" disabled>Done</button>'
     : `<button class="ghost" data-task-done="${t.id}">Done</button>`;
   return `
-    <article class="task-card" data-task-open="${t.id}">
+    <article class="task-card" data-task-open="${t.id}" data-task-drag="${t.id}" draggable="${t.status === 'done' ? 'false' : 'true'}">
       <div class="task-card-head">
         <strong>${escapeHtml(t.title)}</strong>
         ${aiBadge}
@@ -5464,64 +5499,44 @@ function taskCardHtml(t) {
 }
 
 function renderTaskDetail() {
-  const panel = $('taskDetailPanel');
-  if (!panel) return;
-  const t = state.taskDetail;
-  if (!t) {
-    panel.classList.add('hidden');
-    panel.innerHTML = '';
-    return;
-  }
-  panel.classList.remove('hidden');
-  panel.innerHTML = `
-    <div class="task-detail-head">
-      <h3>タスク詳細</h3>
-      <span class="task-origin ${t.creator_type === 'ai' ? 'ai' : 'human'}">${t.creator_type === 'ai' ? 'AI作成' : '人間作成'}</span>
-    </div>
-    <label class="simple-field">
-      <span>タスク内容</span>
-      <input id="taskDetailTitle" type="text" value="${escapeHtml(t.title || '')}" />
-    </label>
-    <label class="simple-field">
-      <span>期日</span>
-      <input id="taskDetailDue" type="datetime-local" value="${escapeHtml((t.due_at || '').slice(0, 16))}" />
-    </label>
-    <label class="simple-field">
-      <span>ステータス</span>
-      <select id="taskDetailStatus">
-        ${['todo', 'doing', 'done'].map((s) => `<option value="${s}" ${t.status === s ? 'selected' : ''}>${s.toUpperCase()}</option>`).join('')}
-      </select>
-    </label>
-    <label class="simple-field">
-      <span>メモ</span>
-      <textarea id="taskDetailMemo" rows="5">${escapeHtml(t.details || '')}</textarea>
-    </label>
-    <div class="simple-actions">
-      <button id="taskDetailSaveBtn">保存</button>
-      <button id="taskDetailCloseBtn" class="ghost" type="button">閉じる</button>
-    </div>
-  `;
-  $('taskDetailCloseBtn').onclick = () => {
-    state.taskDetail = null;
-    renderTaskDetail();
-  };
-  $('taskDetailSaveBtn').onclick = async () => {
-    try {
-      await api(`/api/tasks/${t.id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          title: $('taskDetailTitle').value.trim(),
-          due_at: $('taskDetailDue').value || null,
-          status: $('taskDetailStatus').value,
-          details: $('taskDetailMemo').value.trim(),
-        }),
-      });
-      await loadTasks();
-    } catch (e) {
-      alert(e.message);
-    }
-  };
+  // Task detail is edited in a modal dialog.
+}
+
+function openTaskEditor(task = null) {
+  const isEdit = !!task;
+  if (!$('taskEditorModal')) return;
+  $('taskEditorHeading').textContent = isEdit ? 'タスクを変更' : 'タスクを追加';
+  $('taskEditorTitle').value = task?.title || '';
+  $('taskEditorDue').value = task?.due_at ? String(task.due_at).slice(0, 16) : '';
+  $('taskEditorStatus').value = task?.status || 'todo';
+  $('taskEditorDetails').value = task?.details || '';
+  $('taskEditorShareActio').checked = !!task?.share_actio;
+  $('taskEditorTaskId').value = task?.id ? String(task.id) : '';
+  showModal('taskEditorModal');
+  $('taskEditorTitle').focus();
+}
+
+function closeTaskEditor() {
+  hideModal('taskEditorModal');
+}
+
+function openImplEditor(note = null) {
+  const isEdit = !!note;
+  if (!$('implEditorModal')) return;
+  $('implEditorHeading').textContent = isEdit ? '実装自慢を変更' : '実装自慢を追加';
+  $('implEditorNoteId').value = note?.id ? String(note.id) : '';
+  $('implEditorTitle').value = note?.title || '';
+  $('implEditorGood').value = note?.good_points || '';
+  $('implEditorBad').value = note?.bad_points || '';
+  $('implEditorAttachmentType').value = note?.attachment_type || '';
+  $('implEditorAttachmentValue').value = note?.attachment_value || '';
+  $('implEditorShareable').checked = !!note?.shareable;
+  showModal('implEditorModal');
+  $('implEditorTitle').focus();
+}
+
+function closeImplEditor() {
+  hideModal('implEditorModal');
 }
 
 function renderTaskBoard() {
@@ -5545,7 +5560,7 @@ function renderTaskBoard() {
       const id = Number(el.dataset.taskOpen);
       if (ev.target.closest('button')) return;
       state.taskDetail = state.taskItems.find((t) => t.id === id) || null;
-      renderTaskDetail();
+      openTaskEditor(state.taskDetail);
     });
   });
   document.querySelectorAll('[data-task-done]').forEach((btn) => {
@@ -5579,6 +5594,39 @@ function renderTaskBoard() {
       await loadTasks();
     });
   });
+  document.querySelectorAll('[data-task-drag]').forEach((el) => {
+    el.addEventListener('dragstart', (ev) => {
+      const id = el.dataset.taskDrag;
+      if (!id) return;
+      ev.dataTransfer?.setData('text/plain', id);
+      ev.dataTransfer.effectAllowed = 'move';
+      document.body.classList.add('task-dragging');
+    });
+    el.addEventListener('dragend', () => {
+      document.body.classList.remove('task-dragging');
+    });
+  });
+  const doneDrop = $('taskDoneDrop');
+  if (doneDrop) {
+    doneDrop.ondragover = (ev) => {
+      ev.preventDefault();
+      doneDrop.classList.add('drag-over');
+    };
+    doneDrop.ondragleave = () => doneDrop.classList.remove('drag-over');
+    doneDrop.ondrop = async (ev) => {
+      ev.preventDefault();
+      doneDrop.classList.remove('drag-over');
+      document.body.classList.remove('task-dragging');
+      const id = Number(ev.dataTransfer?.getData('text/plain') || 0);
+      if (!id) return;
+      await api(`/api/tasks/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'done' }),
+      });
+      await loadTasks();
+    };
+  }
 }
 
 function decorateTaskAndImplTabs() {
@@ -5623,6 +5671,9 @@ ensureMemoriaFeatureViews = function () {
           <aside id="tasksMenu" class="tasks-menu">
             <button type="button" data-task-menu="todo" class="active">TODO</button>
             <button type="button" data-task-menu="done">完了済み</button>
+            <div id="taskDoneDrop" class="task-done-drop" title="タスクをここにドロップで完了">
+              完了
+            </div>
           </aside>
           <section class="tasks-pane">
             <h3>今日が期限 / 期限切れ</h3>
@@ -5633,8 +5684,92 @@ ensureMemoriaFeatureViews = function () {
             <div id="tasksFuture" class="simple-list"></div>
           </section>
         </div>
-        <section id="taskDetailPanel" class="task-detail-panel hidden"></section>
+        <section id="taskEditorModal" class="dict-detail modal-panel hidden foundation-form">
+          <button type="button" class="modal-close" id="taskEditorClose" aria-label="close">×</button>
+          <h3 id="taskEditorHeading">タスクを追加</h3>
+          <input type="hidden" id="taskEditorTaskId" />
+          <label class="simple-field">
+            <span>タスク内容</span>
+            <input id="taskEditorTitle" type="text" />
+          </label>
+          <label class="simple-field">
+            <span>期日</span>
+            <input id="taskEditorDue" type="datetime-local" />
+          </label>
+          <div class="task-due-shortcuts" aria-label="期日のショートカット">
+            <button type="button" class="ghost" data-task-editor-due-shortcut="today">今日</button>
+            <button type="button" class="ghost" data-task-editor-due-shortcut="tomorrow">明日</button>
+            <button type="button" class="ghost" data-task-editor-due-shortcut="weekend">今週末</button>
+          </div>
+          <label class="simple-field">
+            <span>ステータス</span>
+            <select id="taskEditorStatus">
+              <option value="todo">TODO</option>
+              <option value="doing">DOING</option>
+              <option value="done">DONE</option>
+            </select>
+          </label>
+          <label class="simple-check-row">
+            <input id="taskEditorShareActio" type="checkbox" />
+            <span>Actio にシェアする</span>
+          </label>
+          <label class="simple-field">
+            <span>メモ</span>
+            <textarea id="taskEditorDetails" rows="6"></textarea>
+          </label>
+          <div class="simple-actions">
+            <button id="taskEditorSaveBtn">保存</button>
+            <button id="taskEditorCancelBtn" type="button" class="ghost">キャンセル</button>
+          </div>
+        </section>
       </div>`;
+  }
+  const implView = $('implView');
+  if (implView && !$('implEditorModal')) {
+    const panel = implView.querySelector('.simple-panel') || implView;
+    const modal = document.createElement('section');
+    modal.id = 'implEditorModal';
+    modal.className = 'dict-detail modal-panel hidden foundation-form';
+    modal.innerHTML = `
+      <button type="button" class="modal-close" id="implEditorClose" aria-label="close">×</button>
+      <h3 id="implEditorHeading">実装自慢を追加</h3>
+      <input type="hidden" id="implEditorNoteId" />
+      <label class="simple-field">
+        <span>ドヤポイント</span>
+        <input id="implEditorTitle" type="text" />
+      </label>
+      <label class="simple-field">
+        <span>良かった点</span>
+        <textarea id="implEditorGood" rows="5"></textarea>
+      </label>
+      <label class="simple-field">
+        <span>悪かった点 / トレードオフ</span>
+        <textarea id="implEditorBad" rows="4"></textarea>
+      </label>
+      <label class="simple-field">
+        <span>添付するもの</span>
+        <select id="implEditorAttachmentType">
+          <option value="">なし</option>
+          <option value="github">GitHub のプロダクト</option>
+          <option value="screenshot">スクリーンキャプチャ</option>
+          <option value="video">動画</option>
+          <option value="code">コードスニペット</option>
+          <option value="other">その他</option>
+        </select>
+      </label>
+      <label class="simple-field">
+        <span>添付内容</span>
+        <textarea id="implEditorAttachmentValue" rows="4"></textarea>
+      </label>
+      <label class="simple-check-row">
+        <input id="implEditorShareable" type="checkbox" />
+        <span>シェア可能にする</span>
+      </label>
+      <div class="simple-actions">
+        <button id="implEditorSaveBtn">保存</button>
+        <button id="implEditorCancelBtn" type="button" class="ghost">キャンセル</button>
+      </div>`;
+    panel.appendChild(modal);
   }
   decorateTaskAndImplTabs();
   upgradeTaskFormMarkup();
@@ -5642,17 +5777,18 @@ ensureMemoriaFeatureViews = function () {
   setupTaskFormKeyboard();
   setupImplementationFormKeyboard();
   if ($('taskNewBtn')) $('taskNewBtn').onclick = () => {
-    $('taskForm')?.classList.remove('hidden');
-    $('taskTitle')?.focus();
+    openTaskEditor(null);
   };
-  if ($('taskCancelBtn')) $('taskCancelBtn').onclick = () => $('taskForm')?.classList.add('hidden');
-  if ($('taskAddBtn')) $('taskAddBtn').onclick = addTaskFromForm;
+  if ($('taskEditorClose')) $('taskEditorClose').onclick = closeTaskEditor;
+  if ($('taskEditorCancelBtn')) $('taskEditorCancelBtn').onclick = closeTaskEditor;
+  if ($('taskEditorSaveBtn')) $('taskEditorSaveBtn').onclick = addTaskFromForm;
+  wireTaskEditorDueShortcuts();
   if ($('implNewBtn')) $('implNewBtn').onclick = () => {
-    $('implForm')?.classList.remove('hidden');
-    $('implTitle')?.focus();
+    openImplEditor(null);
   };
-  if ($('implCancelBtn')) $('implCancelBtn').onclick = () => $('implForm')?.classList.add('hidden');
-  if ($('implAddBtn')) $('implAddBtn').onclick = addImplementationNoteFromForm;
+  if ($('implEditorClose')) $('implEditorClose').onclick = closeImplEditor;
+  if ($('implEditorCancelBtn')) $('implEditorCancelBtn').onclick = closeImplEditor;
+  if ($('implEditorSaveBtn')) $('implEditorSaveBtn').onclick = addImplementationNoteFromForm;
   document.querySelectorAll('#tasksMenu [data-task-menu]').forEach((btn) => {
     btn.onclick = () => {
       state.taskMenu = btn.dataset.taskMenu;
@@ -5673,22 +5809,36 @@ loadTasks = async function () {
 };
 
 addTaskFromForm = async function () {
-  const title = $('taskTitle')?.value.trim();
+  const title = $('taskEditorTitle')?.value.trim();
   if (!title) return;
-  await api('/api/tasks', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      title,
-      details: $('taskDetails')?.value.trim() || '',
-      due_at: $('taskDue')?.value || null,
-      share_actio: !!$('taskShareActio')?.checked,
-      creator_type: 'human',
-    }),
-  });
-  $('taskTitle').value = '';
-  $('taskDetails').value = '';
-  $('taskForm')?.classList.add('hidden');
+  const editId = Number($('taskEditorTaskId')?.value || 0);
+  if (editId) {
+    await api(`/api/tasks/${editId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title,
+        details: $('taskEditorDetails')?.value.trim() || '',
+        due_at: $('taskEditorDue')?.value || null,
+        status: $('taskEditorStatus')?.value || 'todo',
+        share_actio: !!$('taskEditorShareActio')?.checked,
+      }),
+    });
+  } else {
+    await api('/api/tasks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title,
+        details: $('taskEditorDetails')?.value.trim() || '',
+        due_at: $('taskEditorDue')?.value || null,
+        status: $('taskEditorStatus')?.value || 'todo',
+        share_actio: !!$('taskEditorShareActio')?.checked,
+        creator_type: 'human',
+      }),
+    });
+  }
+  closeTaskEditor();
   await loadTasks();
 };
 

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -616,6 +616,8 @@ function switchTab(tab) {
   $('diaryView').classList.toggle('hidden', tab !== 'diary');
   $('tracksView')?.classList.toggle('hidden', tab !== 'tracks');
   $('mealsView')?.classList.toggle('hidden', tab !== 'meals');
+  $('tasksView')?.classList.toggle('hidden', tab !== 'tasks');
+  $('implView')?.classList.toggle('hidden', tab !== 'impl');
   $('externalView')?.classList.toggle('hidden', tab !== 'external');
   $('multiView')?.classList.toggle('hidden', tab !== 'multi');
   if (tab === 'queue') renderQueue();
@@ -628,6 +630,8 @@ function switchTab(tab) {
   if (tab === 'diary') loadDiary();
   if (tab === 'tracks') loadTracks();
   if (tab === 'meals') loadMeals();
+  if (tab === 'tasks') loadTasks();
+  if (tab === 'impl') loadImplementationNotes();
   if (tab === 'external') loadExternalConfig();
   if (tab === 'multi') loadMulti();
   bumpTabUsage(tab);
@@ -4548,6 +4552,7 @@ async function saveAiSettings() {
         return;
       }
     }
+    await savePrivacySettings();
     alert('保存しました。次回のジョブから反映されます。');
     $('aiSettingsPanel').classList.add('hidden');
   } catch (e) {
@@ -4569,6 +4574,8 @@ document.addEventListener('click', (ev) => {
     sec.classList.toggle('hidden', sec.dataset.stab !== stab);
   });
   // タブを切り替えたら panel を上にリセット (各タブの先頭から見たい)
+  if (stab === 'privacy') loadPrivacySettings().catch(console.warn);
+  if (stab === 'setup') loadSetupDocs().catch(console.warn);
   panel.scrollTop = 0;
 });
 
@@ -4636,6 +4643,296 @@ function renderEvents(items) {
 }
 
 document.getElementById('eventsRefresh')?.addEventListener('click', loadEvents);
+
+// ---- Tasks / implementation notes / setup docs / privacy ------------------
+
+function ensureMemoriaFeatureViews() {
+  const tabs = document.querySelector('.tabs-scroll');
+  if (tabs && !document.querySelector('.tab[data-tab="tasks"]')) {
+    for (const spec of [
+      ['tasks', 'Tasks'],
+      ['impl', 'Implementation Notes'],
+    ]) {
+      const b = document.createElement('button');
+      b.className = 'tab';
+      b.dataset.tab = spec[0];
+      b.innerHTML = `<span class="tab-label" data-full="${spec[1]}" data-short="${spec[1]}">${spec[1]}</span>`;
+      b.addEventListener('click', () => switchTab(spec[0]));
+      tabs.appendChild(b);
+    }
+  }
+  const content = document.querySelector('.content');
+  if (content && !$('tasksView')) {
+    const div = document.createElement('div');
+    div.id = 'tasksView';
+    div.className = 'hidden';
+    div.innerHTML = `
+      <div class="simple-panel">
+        <h2>Tasks</h2>
+        <div class="simple-form">
+          <input id="taskTitle" type="text" placeholder="Next task" />
+          <input id="taskDue" type="datetime-local" />
+          <label class="check-inline"><input id="taskShareActio" type="checkbox" /> Share to Actio</label>
+          <textarea id="taskDetails" rows="3" placeholder="Details"></textarea>
+          <button id="taskAddBtn">Add task</button>
+        </div>
+        <div id="tasksList" class="simple-list"></div>
+      </div>`;
+    content.appendChild(div);
+  }
+  if (content && !$('implView')) {
+    const div = document.createElement('div');
+    div.id = 'implView';
+    div.className = 'hidden';
+    div.innerHTML = `
+      <div class="simple-panel">
+        <h2>Implementation Notes</h2>
+        <div class="simple-form">
+          <input id="implProduct" type="text" placeholder="Product name" />
+          <input id="implTitle" type="text" placeholder="Short title" />
+          <textarea id="implGood" rows="4" placeholder="Good points"></textarea>
+          <textarea id="implBad" rows="3" placeholder="Bad points / tradeoffs"></textarea>
+          <label class="check-inline"><input id="implShareable" type="checkbox" /> Shareable</label>
+          <button id="implAddBtn">Add note</button>
+        </div>
+        <div id="implList" class="simple-list"></div>
+      </div>`;
+    content.appendChild(div);
+  }
+
+  const settingsTabs = document.querySelector('.settings-tabs');
+  const footer = document.querySelector('.settings-footer');
+  if (settingsTabs && !document.querySelector('.settings-tab[data-stab="privacy"]')) {
+    for (const spec of [
+      ['privacy', 'Privacy / visibility'],
+      ['setup', 'Setup docs'],
+    ]) {
+      const b = document.createElement('button');
+      b.type = 'button';
+      b.className = 'settings-tab';
+      b.dataset.stab = spec[0];
+      b.setAttribute('role', 'tab');
+      b.textContent = spec[1];
+      settingsTabs.appendChild(b);
+    }
+  }
+  if (footer && !$('privacySettingsBody')) {
+    const sec = document.createElement('section');
+    sec.id = 'privacySettingsBody';
+    sec.className = 'settings-tab-body hidden';
+    sec.dataset.stab = 'privacy';
+    sec.innerHTML = `
+      <h4>Privacy / visibility</h4>
+      <label class="check-inline"><input id="tracksEnabled" type="checkbox" /> Collect tracks</label>
+      <label class="check-inline"><input id="tracksVisible" type="checkbox" /> Show tracks tab and data</label>
+      <label class="check-inline"><input id="mealsEnabled" type="checkbox" /> Collect meals</label>
+      <label class="check-inline"><input id="mealsVisible" type="checkbox" /> Show meals tab and data</label>
+      <label class="check-inline"><input id="tasksActioShareEnabled" type="checkbox" /> Allow task sharing to Actio</label>
+      <label>Actio share URL: <input id="actioShareUrl" type="text" placeholder="http://localhost:.../api/tasks/import" /></label>`;
+    footer.parentNode.insertBefore(sec, footer);
+  }
+  if (footer && !$('setupDocsBody')) {
+    const sec = document.createElement('section');
+    sec.id = 'setupDocsBody';
+    sec.className = 'settings-tab-body hidden';
+    sec.dataset.stab = 'setup';
+    sec.innerHTML = `
+      <h4>Setup docs</h4>
+      <div id="setupDocsList" class="setup-docs-list"></div>
+      <pre id="setupDocBody" class="setup-doc-body"></pre>`;
+    footer.parentNode.insertBefore(sec, footer);
+  }
+
+  if ($('taskAddBtn')) $('taskAddBtn').onclick = addTaskFromForm;
+  if ($('implAddBtn')) $('implAddBtn').onclick = addImplementationNoteFromForm;
+}
+
+async function loadPrivacySettings() {
+  ensureMemoriaFeatureViews();
+  const r = await api('/api/privacy/settings');
+  const s = r.settings || {};
+  if ($('tracksEnabled')) $('tracksEnabled').checked = !!s.tracks_enabled;
+  if ($('tracksVisible')) $('tracksVisible').checked = !!s.tracks_visible;
+  if ($('mealsEnabled')) $('mealsEnabled').checked = !!s.meals_enabled;
+  if ($('mealsVisible')) $('mealsVisible').checked = !!s.meals_visible;
+  if ($('tasksActioShareEnabled')) $('tasksActioShareEnabled').checked = !!s.tasks_actio_share_enabled;
+  if ($('actioShareUrl')) $('actioShareUrl').value = s.actio_share_url || '';
+  applyFeatureVisibility(s);
+}
+
+async function savePrivacySettings() {
+  if (!$('tracksEnabled')) return;
+  const r = await api('/api/privacy/settings', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      tracks_enabled: $('tracksEnabled').checked,
+      tracks_visible: $('tracksVisible').checked,
+      meals_enabled: $('mealsEnabled').checked,
+      meals_visible: $('mealsVisible').checked,
+      tasks_actio_share_enabled: $('tasksActioShareEnabled').checked,
+      actio_share_url: $('actioShareUrl').value.trim(),
+    }),
+  });
+  applyFeatureVisibility(r.settings || {});
+}
+
+function applyFeatureVisibility(s) {
+  const tracksTab = document.querySelector('.tab[data-tab="tracks"]');
+  const mealsTab = document.querySelector('.tab[data-tab="meals"]');
+  if (tracksTab) tracksTab.hidden = s.tracks_visible === false;
+  if (mealsTab) mealsTab.hidden = s.meals_visible === false;
+  if (state.tab === 'tracks' && s.tracks_visible === false) switchTab('bookmarks');
+  if (state.tab === 'meals' && s.meals_visible === false) switchTab('bookmarks');
+  reflowTabsForViewport();
+}
+
+async function loadSetupDocs() {
+  ensureMemoriaFeatureViews();
+  const root = $('setupDocsList');
+  if (!root) return;
+  const r = await api('/api/setup-docs');
+  root.innerHTML = (r.docs || []).map(d => `<button class="ghost" data-doc="${escapeHtml(d.key)}">${escapeHtml(d.title)}</button>`).join('');
+  root.querySelectorAll('button[data-doc]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const doc = await api(`/api/setup-docs/${encodeURIComponent(btn.dataset.doc)}`);
+      $('setupDocBody').textContent = doc.body || '';
+    });
+  });
+  if ((r.docs || [])[0]) root.querySelector('button[data-doc]')?.click();
+}
+
+async function loadTasks() {
+  ensureMemoriaFeatureViews();
+  const r = await api('/api/tasks');
+  const items = r.items || [];
+  const list = $('tasksList');
+  if (!list) return;
+  if (!items.length) {
+    list.innerHTML = '<div class="queue-empty">No tasks.</div>';
+    return;
+  }
+  list.innerHTML = items.map(t => `
+    <div class="simple-item" data-id="${t.id}">
+      <div class="simple-item-head">
+        <strong>${escapeHtml(t.title)}</strong>
+        <select data-task-status="${t.id}">
+          ${['todo','doing','done'].map(s => `<option value="${s}" ${t.status === s ? 'selected' : ''}>${s}</option>`).join('')}
+        </select>
+      </div>
+      <div class="muted">${escapeHtml(t.due_at || '')}</div>
+      <p>${escapeHtml(t.details || '')}</p>
+      <div class="simple-actions">
+        <button class="ghost" data-task-share="${t.id}">Share Actio</button>
+        <button class="danger" data-task-delete="${t.id}">Delete</button>
+      </div>
+    </div>`).join('');
+  list.querySelectorAll('[data-task-status]').forEach(sel => {
+    sel.addEventListener('change', async () => {
+      await api(`/api/tasks/${sel.dataset.taskStatus}`, {
+        method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: sel.value }),
+      });
+      loadTasks();
+    });
+  });
+  list.querySelectorAll('[data-task-share]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      try { await api(`/api/tasks/${btn.dataset.taskShare}/share/actio`, { method: 'POST' }); showShareToast('Shared to Actio'); }
+      catch (e) { alert(e.message); }
+      loadTasks();
+    });
+  });
+  list.querySelectorAll('[data-task-delete]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      await api(`/api/tasks/${btn.dataset.taskDelete}`, { method: 'DELETE' });
+      loadTasks();
+    });
+  });
+}
+
+async function addTaskFromForm() {
+  const title = $('taskTitle')?.value.trim();
+  if (!title) return;
+  await api('/api/tasks', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      title,
+      details: $('taskDetails')?.value.trim() || '',
+      due_at: $('taskDue')?.value || null,
+      share_actio: !!$('taskShareActio')?.checked,
+    }),
+  });
+  $('taskTitle').value = '';
+  $('taskDetails').value = '';
+  loadTasks();
+}
+
+async function loadImplementationNotes() {
+  ensureMemoriaFeatureViews();
+  const r = await api('/api/implementation-notes');
+  const list = $('implList');
+  const items = r.items || [];
+  if (!list) return;
+  if (!items.length) {
+    list.innerHTML = '<div class="queue-empty">No implementation notes.</div>';
+    return;
+  }
+  list.innerHTML = items.map(n => `
+    <div class="simple-item" data-id="${n.id}">
+      <div class="simple-item-head"><strong>${escapeHtml(n.product)}: ${escapeHtml(n.title)}</strong></div>
+      <h4>Good</h4><p>${escapeHtml(n.good_points || '')}</p>
+      <h4>Bad / tradeoffs</h4><p>${escapeHtml(n.bad_points || '')}</p>
+      <div class="simple-actions">
+        <span class="muted">${n.shareable ? 'Shareable' : 'Private'}</span>
+        <button class="ghost" data-impl-share="${n.id}">Share</button>
+        <button class="danger" data-impl-delete="${n.id}">Delete</button>
+      </div>
+    </div>`).join('');
+  list.querySelectorAll('[data-impl-share]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      try {
+        await api('/api/multi/share', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ kind: 'implementation_note', id: Number(btn.dataset.implShare) }),
+        });
+        showShareToast('Shared implementation note');
+      }
+      catch (e) { alert(e.message); }
+      loadImplementationNotes();
+    });
+  });
+  list.querySelectorAll('[data-impl-delete]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      await api(`/api/implementation-notes/${btn.dataset.implDelete}`, { method: 'DELETE' });
+      loadImplementationNotes();
+    });
+  });
+}
+
+async function addImplementationNoteFromForm() {
+  const product = $('implProduct')?.value.trim();
+  const title = $('implTitle')?.value.trim();
+  if (!product || !title) return;
+  await api('/api/implementation-notes', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      product,
+      title,
+      good_points: $('implGood')?.value.trim() || '',
+      bad_points: $('implBad')?.value.trim() || '',
+      shareable: !!$('implShareable')?.checked,
+    }),
+  });
+  for (const id of ['implProduct', 'implTitle', 'implGood', 'implBad']) $(id).value = '';
+  loadImplementationNotes();
+}
+
+ensureMemoriaFeatureViews();
+loadPrivacySettings().catch(console.warn);
 
 // ── Worklog tab (作業ログ) ─────────────────────────────────────────────
 //

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -618,6 +618,8 @@ function switchTab(tab) {
   $('mealsView')?.classList.toggle('hidden', tab !== 'meals');
   $('tasksView')?.classList.toggle('hidden', tab !== 'tasks');
   $('implView')?.classList.toggle('hidden', tab !== 'impl');
+  $('workplaceView')?.classList.toggle('hidden', tab !== 'workplace');
+  if (tab === 'workplace') loadWorkLocations().catch(console.warn);
   $('externalView')?.classList.toggle('hidden', tab !== 'external');
   $('multiView')?.classList.toggle('hidden', tab !== 'multi');
   if (tab === 'queue') renderQueue();
@@ -3484,13 +3486,17 @@ function renderTrendWorkHours(items) {
     el.innerHTML = '<div class="queue-empty">作業時間が記録された日記がまだありません</div>';
     return;
   }
+  const presentHours = present.map((d) => ({
+    ...d,
+    hours: Number(d.minutes || 0) / 60,
+  }));
   el.innerHTML = svgHorizontalBar(
-    present,
+    presentHours,
     (d) => String(d.date || '').slice(5),
-    (d) => Number(d.minutes || 0),
-    '',
+    (d) => Number(d.hours || 0),
+    '時間',
     {
-      valueLabel: (v) => `${(v / 60).toFixed(1)}h`,
+      valueLabel: (v) => `${v.toFixed(1)} 時間`,
     }
   );
 }
@@ -4123,7 +4129,8 @@ function hideModal(panelId) {
   const domOpen  = !$('domainDetail').classList.contains('hidden');
   const taskOpen = $('taskEditorModal') ? !$('taskEditorModal').classList.contains('hidden') : false;
   const implOpen = $('implEditorModal') ? !$('implEditorModal').classList.contains('hidden') : false;
-  $('modalBackdrop').hidden = !(dictOpen || domOpen || taskOpen || implOpen);
+  const workOpen = $('workplaceEditorModal') ? !$('workplaceEditorModal').classList.contains('hidden') : false;
+  $('modalBackdrop').hidden = !(dictOpen || domOpen || taskOpen || implOpen || workOpen);
 }
 function closeAllModals() {
   state.dictDetail = null;
@@ -4133,6 +4140,7 @@ function closeAllModals() {
   hideModal('domainDetail');
   hideModal('taskEditorModal');
   hideModal('implEditorModal');
+  hideModal('workplaceEditorModal');
 }
 $('dictDetailClose')?.addEventListener('click', () => {
   state.dictDetail = null;
@@ -4698,6 +4706,7 @@ function ensureMemoriaFeatureViews() {
     for (const spec of [
       ['tasks', 'タスク'],
       ['impl', '実装自慢'],
+      ['workplace', '作業場所'],
     ]) {
       const b = document.createElement('button');
       b.className = 'tab';
@@ -4757,6 +4766,64 @@ function ensureMemoriaFeatureViews() {
       </div>`;
     content.appendChild(div);
   }
+  if (content && !$('workplaceView')) {
+    const div = document.createElement('div');
+    div.id = 'workplaceView';
+    div.className = 'hidden';
+    div.innerHTML = `
+      <div class="simple-panel">
+        <div class="simple-panel-head">
+          <h2>🗺️ 作業場所</h2>
+          <button id="workplaceNewBtn" type="button">+ 場所を追加</button>
+        </div>
+        <p class="diary-settings-help">よく作業するカフェ・コワーキング・図書館などをまとめ、Hub にシェアしてチームでナレッジ共有できます。</p>
+        <div id="workplaceList" class="simple-list"></div>
+        <section id="workplaceEditorModal" class="dict-detail modal-panel hidden foundation-form">
+          <button type="button" class="modal-close" id="workplaceEditorClose" aria-label="close">×</button>
+          <h3 id="workplaceEditorHeading">作業場所を追加</h3>
+          <input type="hidden" id="workplaceEditorId" />
+          <label class="simple-field">
+            <span>名前</span>
+            <input id="workplaceEditorName" type="text" placeholder="例: WeWork 六本木" />
+          </label>
+          <label class="simple-field">
+            <span>住所</span>
+            <input id="workplaceEditorAddress" type="text" placeholder="例: 東京都港区六本木..." />
+          </label>
+          <div class="simple-field-row">
+            <label class="simple-field">
+              <span>緯度 (任意)</span>
+              <input id="workplaceEditorLat" type="number" step="0.000001" />
+            </label>
+            <label class="simple-field">
+              <span>経度 (任意)</span>
+              <input id="workplaceEditorLng" type="number" step="0.000001" />
+            </label>
+          </div>
+          <label class="simple-field">
+            <span>URL (任意)</span>
+            <input id="workplaceEditorUrl" type="text" placeholder="https://..." />
+          </label>
+          <label class="simple-field">
+            <span>タグ (カンマ区切り)</span>
+            <input id="workplaceEditorTags" type="text" placeholder="wifi, 電源, 静か" />
+          </label>
+          <label class="simple-field">
+            <span>説明 / メモ</span>
+            <textarea id="workplaceEditorDescription" rows="6" placeholder="営業時間・wifi・電源・席数・雰囲気など"></textarea>
+          </label>
+          <label class="simple-check-row">
+            <input id="workplaceEditorShareable" type="checkbox" />
+            <span>シェア可能にする</span>
+          </label>
+          <div class="simple-actions">
+            <button id="workplaceEditorSaveBtn">保存</button>
+            <button id="workplaceEditorCancelBtn" type="button" class="ghost">キャンセル</button>
+          </div>
+        </section>
+      </div>`;
+    content.appendChild(div);
+  }
 
   const settingsTabs = document.querySelector('.settings-tabs');
   const footer = document.querySelector('.settings-footer');
@@ -4797,6 +4864,8 @@ function ensureMemoriaFeatureViews() {
       </label>
       <label class="check-inline"><input id="taskReminderNuntiusEnabled" type="checkbox" /> Nuntius にも送る</label>
       <label>Nuntius URL: <input id="taskReminderNuntiusUrl" type="text" placeholder="https://nuntius.example.com/notify" /></label>
+      <h4 style="margin-top:12px">MCP サーバ</h4>
+      <label class="check-inline"><input id="mcpAutostartEnabled" type="checkbox" /> Memoria 起動時に MCP サーバを同時起動する (任意)</label>
       <p class="diary-settings-help" style="margin-top:6px">iOS で受け取る場合はホーム画面に追加 + 通知を許可してください。</p>`;
     footer.parentNode.insertBefore(sec, footer);
   }
@@ -5011,6 +5080,7 @@ async function loadPrivacySettings() {
   if ($('taskReminderMinute')) $('taskReminderMinute').value = s.tasks_reminder_minute ?? 0;
   if ($('taskReminderNuntiusEnabled')) $('taskReminderNuntiusEnabled').checked = !!s.tasks_reminder_nuntius_enabled;
   if ($('taskReminderNuntiusUrl')) $('taskReminderNuntiusUrl').value = s.tasks_reminder_nuntius_url || '';
+  if ($('mcpAutostartEnabled')) $('mcpAutostartEnabled').checked = !!s.mcp_autostart_enabled;
   if (s.tasks_reminder_enabled) {
     scheduleLocalTaskReminder(s.tasks_reminder_hour ?? 6, s.tasks_reminder_minute ?? 0);
   }
@@ -5034,6 +5104,7 @@ async function savePrivacySettings() {
       tasks_reminder_minute: Number($('taskReminderMinute')?.value ?? 0),
       tasks_reminder_nuntius_enabled: !!($('taskReminderNuntiusEnabled')?.checked),
       tasks_reminder_nuntius_url: $('taskReminderNuntiusUrl')?.value.trim() || '',
+      mcp_autostart_enabled: !!($('mcpAutostartEnabled')?.checked),
     }),
   });
   const s = r.settings || {};
@@ -5502,6 +5573,144 @@ function renderTaskDetail() {
   // Task detail is edited in a modal dialog.
 }
 
+// ---- work locations -------------------------------------------------------
+
+let _workplaceItems = [];
+
+async function loadWorkLocations() {
+  ensureMemoriaFeatureViews();
+  const list = $('workplaceList');
+  if (!list) return;
+  try {
+    const r = await api('/api/work-locations');
+    _workplaceItems = r.items || [];
+  } catch (e) {
+    list.innerHTML = `<div class="queue-empty">読み込み失敗: ${escapeHtml(e.message)}</div>`;
+    return;
+  }
+  if (!_workplaceItems.length) {
+    list.innerHTML = '<div class="queue-empty">まだ登録された場所がありません。「+ 場所を追加」から登録できます。</div>';
+    return;
+  }
+  list.innerHTML = _workplaceItems.map(w => {
+    const owner = w.owner_user_name ? `<span class="muted">by ${escapeHtml(w.owner_user_name)}</span>` : '';
+    const tags = (w.tags || '').split(',').map(s => s.trim()).filter(Boolean)
+      .map(t => `<span class="wl-meta">${escapeHtml(t)}</span>`).join(' ');
+    const link = w.url ? `<a href="${escapeHtml(w.url)}" target="_blank" rel="noopener">${escapeHtml(w.url)}</a>` : '';
+    const coord = (Number.isFinite(w.latitude) && Number.isFinite(w.longitude))
+      ? `<span class="muted">${w.latitude.toFixed(4)}, ${w.longitude.toFixed(4)}</span>` : '';
+    const sharedTag = w.shared_at
+      ? `シェア済み: ${escapeHtml(fmtDate(w.shared_at))}`
+      : (w.shareable ? 'シェア可能' : '非公開');
+    const isOwned = !w.owner_user_id;
+    return `
+      <div class="simple-item" data-id="${w.id}" data-workplace-open="${w.id}">
+        <div class="simple-item-head">
+          <strong>${escapeHtml(w.name)}</strong>
+          ${owner}
+        </div>
+        <div class="muted">${escapeHtml(w.address || '')}</div>
+        <div>${tags} ${coord}</div>
+        <p>${escapeHtml(w.description || '')}</p>
+        ${link ? `<div>${link}</div>` : ''}
+        <div class="simple-actions">
+          <span class="muted">${sharedTag}</span>
+          ${isOwned ? `<button class="ghost" data-workplace-share="${w.id}" ${w.shared_at ? 'disabled' : ''}>シェア</button>` : ''}
+          <button class="danger" data-workplace-delete="${w.id}">削除</button>
+        </div>
+      </div>`;
+  }).join('');
+
+  list.querySelectorAll('[data-workplace-open]').forEach(el => {
+    el.addEventListener('click', (ev) => {
+      if (ev.target.closest('button,a,input,select,textarea')) return;
+      const id = Number(el.dataset.workplaceOpen || 0);
+      const w = _workplaceItems.find(x => x.id === id);
+      if (w) openWorkplaceEditor(w);
+    });
+  });
+  list.querySelectorAll('[data-workplace-share]').forEach(btn => {
+    btn.addEventListener('click', async (ev) => {
+      ev.stopPropagation();
+      try {
+        await api('/api/multi/share', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ kind: 'work_location', id: Number(btn.dataset.workplaceShare) }),
+        });
+        showShareToast('作業場所をシェアしました');
+      } catch (e) { alert(e.message); }
+      loadWorkLocations();
+    });
+  });
+  list.querySelectorAll('[data-workplace-delete]').forEach(btn => {
+    btn.addEventListener('click', async (ev) => {
+      ev.stopPropagation();
+      if (!confirm('この場所を削除しますか?')) return;
+      await api(`/api/work-locations/${btn.dataset.workplaceDelete}`, { method: 'DELETE' });
+      loadWorkLocations();
+    });
+  });
+}
+
+function openWorkplaceEditor(w = null) {
+  const isEdit = !!w;
+  if (!$('workplaceEditorModal')) return;
+  $('workplaceEditorHeading').textContent = isEdit ? '作業場所を変更' : '作業場所を追加';
+  $('workplaceEditorId').value = w?.id ? String(w.id) : '';
+  $('workplaceEditorName').value = w?.name || '';
+  $('workplaceEditorAddress').value = w?.address || '';
+  $('workplaceEditorLat').value = w?.latitude == null ? '' : w.latitude;
+  $('workplaceEditorLng').value = w?.longitude == null ? '' : w.longitude;
+  $('workplaceEditorUrl').value = w?.url || '';
+  $('workplaceEditorTags').value = w?.tags || '';
+  $('workplaceEditorDescription').value = w?.description || '';
+  $('workplaceEditorShareable').checked = !!w?.shareable;
+  showModal('workplaceEditorModal');
+  $('workplaceEditorName').focus();
+}
+
+function closeWorkplaceEditor() {
+  hideModal('workplaceEditorModal');
+}
+
+async function saveWorkLocationFromForm() {
+  const name = $('workplaceEditorName')?.value.trim();
+  if (!name) { alert('名前を入力してください'); return; }
+  const editId = Number($('workplaceEditorId')?.value || 0);
+  const latStr = $('workplaceEditorLat')?.value;
+  const lngStr = $('workplaceEditorLng')?.value;
+  const payload = {
+    name,
+    address: $('workplaceEditorAddress')?.value.trim() || null,
+    latitude: latStr === '' || latStr == null ? null : Number(latStr),
+    longitude: lngStr === '' || lngStr == null ? null : Number(lngStr),
+    url: $('workplaceEditorUrl')?.value.trim() || null,
+    tags: $('workplaceEditorTags')?.value.trim() || null,
+    description: $('workplaceEditorDescription')?.value.trim() || null,
+    shareable: !!$('workplaceEditorShareable')?.checked,
+  };
+  try {
+    if (editId) {
+      await api(`/api/work-locations/${editId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+    } else {
+      await api('/api/work-locations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+    }
+    closeWorkplaceEditor();
+    await loadWorkLocations();
+  } catch (e) {
+    alert(`保存に失敗しました: ${e.message}`);
+  }
+}
+
 function openTaskEditor(task = null) {
   const isEdit = !!task;
   if (!$('taskEditorModal')) return;
@@ -5789,6 +5998,10 @@ ensureMemoriaFeatureViews = function () {
   if ($('implEditorClose')) $('implEditorClose').onclick = closeImplEditor;
   if ($('implEditorCancelBtn')) $('implEditorCancelBtn').onclick = closeImplEditor;
   if ($('implEditorSaveBtn')) $('implEditorSaveBtn').onclick = addImplementationNoteFromForm;
+  if ($('workplaceNewBtn')) $('workplaceNewBtn').onclick = () => openWorkplaceEditor(null);
+  if ($('workplaceEditorClose')) $('workplaceEditorClose').onclick = closeWorkplaceEditor;
+  if ($('workplaceEditorCancelBtn')) $('workplaceEditorCancelBtn').onclick = closeWorkplaceEditor;
+  if ($('workplaceEditorSaveBtn')) $('workplaceEditorSaveBtn').onclick = saveWorkLocationFromForm;
   document.querySelectorAll('#tasksMenu [data-task-menu]').forEach((btn) => {
     btn.onclick = () => {
       state.taskMenu = btn.dataset.taskMenu;
@@ -5911,7 +6124,11 @@ async function loadWorklog() {
   if (sub === 'schedule') return loadWorklogSchedule(date);
   if (sub === 'browsing') return loadWorklogBrowsing(date);
   if (sub === 'dig') return loadWorklogDig(date);
-  if (WL_KIND_BY_SUB[sub]) return loadWorklogActivity(date, sub);
+  if (WL_KIND_BY_SUB[sub]) {
+    await loadWorklogActivity(date, sub);
+    if (sub === 'gemini') await loadGeminiWebResearchLogs(date);
+    return;
+  }
 }
 
 async function loadWorklogSchedule(date) {
@@ -6062,6 +6279,70 @@ function renderWorklogPrompts(items, listEl, summaryEl, sub) {
       ${content ? `<div class="wl-content truncate" title="${escapeHtml(content)}">${escapeHtml(content)}</div>` : ''}
     </li>`;
   }).join('');
+}
+
+async function loadGeminiWebResearchLogs(date) {
+  const listEl = $('wlGeminiWebList');
+  const emptyEl = $('wlGeminiWebEmpty');
+  if (!listEl || !emptyEl) return;
+  try {
+    const r = await api('/api/external-chat/messages?source=gemini-web&limit=200');
+    const items = (r.items || []).filter((it) => String(it.received_at || '').startsWith(date));
+    if (!items.length) {
+      listEl.innerHTML = '';
+      emptyEl.classList.remove('hidden');
+      return;
+    }
+    emptyEl.classList.add('hidden');
+    listEl.innerHTML = items.map((it) => {
+      let meta = {};
+      try { meta = it.metadata_json ? JSON.parse(it.metadata_json) : (it.metadata || {}); } catch {}
+      const title = meta.title || '(no title)';
+      const url = meta.url || '';
+      const t = String(it.received_at || '').slice(11, 19);
+      return `<li>
+        <div class="wl-row1">
+          <span class="wl-time">${escapeHtml(t)}</span>
+          ${url ? `<a class="wl-source" href="${escapeHtml(url)}" target="_blank" rel="noopener">link</a>` : ''}
+        </div>
+        <div class="wl-content"><strong>${escapeHtml(title)}</strong></div>
+        <div class="wl-content">${escapeHtml(it.content || '')}</div>
+      </li>`;
+    }).join('');
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+async function saveGeminiWebResearchLog() {
+  const title = $('wlGeminiWebTitle')?.value.trim() || '';
+  const url = $('wlGeminiWebUrl')?.value.trim() || '';
+  const content = $('wlGeminiWebContent')?.value.trim() || '';
+  if (!content) return;
+  await api('/api/external-chat/messages', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      source: 'gemini-web',
+      role: 'assistant',
+      content,
+      metadata: { title, url, kind: 'research' },
+    }),
+  });
+  await api('/api/activity/event', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      kind: 'gemini_prompt',
+      source: 'gemini-web',
+      content: title || content.slice(0, 120),
+      metadata: { via: 'manual-research-log', url },
+    }),
+  }).catch(() => {});
+  $('wlGeminiWebTitle').value = '';
+  $('wlGeminiWebUrl').value = '';
+  $('wlGeminiWebContent').value = '';
+  await loadGeminiWebResearchLogs(state.worklog.date);
 }
 
 async function loadWorklogBrowsing(date) {
@@ -6241,6 +6522,21 @@ $('wlDate')?.addEventListener('change', (e) => {
   }
 });
 $('wlRefresh')?.addEventListener('click', () => loadWorklog());
+$('wlGeminiWebSaveBtn')?.addEventListener('click', () => {
+  saveGeminiWebResearchLog().catch((e) => {
+    console.error(e);
+    alert(`Gemini Web 調査ログの保存に失敗しました: ${e.message}`);
+  });
+});
+$('wlGeminiWebContent')?.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+    e.preventDefault();
+    saveGeminiWebResearchLog().catch((err) => {
+      console.error(err);
+      alert(`Gemini Web 調査ログの保存に失敗しました: ${err.message}`);
+    });
+  }
+});
 
 // ── 🌐 Multi (Memoria Hub) browse ─────────────────────────────────────────
 state.multiSubtab = 'bookmarks';

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -447,6 +447,7 @@ async function refreshVisitsBadge() {
   try {
     const r = await api('/api/visits/unsaved/count');
     const badge = $('tabVisitsCount');
+    if (!badge) return;
     if (r.count > 0) {
       badge.classList.remove('hidden');
       badge.textContent = r.count;
@@ -606,27 +607,25 @@ function switchTab(tab) {
   if (layout) layout.dataset.activeTab = tab;
   $('bookmarksView').classList.toggle('hidden', tab !== 'bookmarks');
   $('queueView').classList.toggle('hidden', tab !== 'queue');
-  $('visitsView').classList.toggle('hidden', tab !== 'visits');
+  $('worklogView')?.classList.toggle('hidden', tab !== 'worklog');
   $('trendsView').classList.toggle('hidden', tab !== 'trends');
   $('recommendView').classList.toggle('hidden', tab !== 'recommend');
   $('digView').classList.toggle('hidden', tab !== 'dig');
   $('dictView').classList.toggle('hidden', tab !== 'dict');
   $('domainView').classList.toggle('hidden', tab !== 'domain');
   $('diaryView').classList.toggle('hidden', tab !== 'diary');
-  $('eventsView').classList.toggle('hidden', tab !== 'events');
   $('tracksView')?.classList.toggle('hidden', tab !== 'tracks');
   $('mealsView')?.classList.toggle('hidden', tab !== 'meals');
   $('externalView')?.classList.toggle('hidden', tab !== 'external');
   $('multiView')?.classList.toggle('hidden', tab !== 'multi');
   if (tab === 'queue') renderQueue();
-  if (tab === 'visits') loadVisits();
+  if (tab === 'worklog') loadWorklog();
   if (tab === 'trends') loadTrends();
   if (tab === 'recommend') loadRecommendations();
   if (tab === 'dig') loadDigHistory();
   if (tab === 'dict') loadDictionary();
   if (tab === 'domain') loadDomainCatalog();
   if (tab === 'diary') loadDiary();
-  if (tab === 'events') loadEvents();
   if (tab === 'tracks') loadTracks();
   if (tab === 'meals') loadMeals();
   if (tab === 'external') loadExternalConfig();
@@ -4637,6 +4636,356 @@ function renderEvents(items) {
 }
 
 document.getElementById('eventsRefresh')?.addEventListener('click', loadEvents);
+
+// ── Worklog tab (作業ログ) ─────────────────────────────────────────────
+//
+// Sub-tabs: schedule / github / claude / gemini / codex / browsing / dig.
+// All views share `state.worklog.date` (YYYY-MM-DD, local). The day navigator
+// shifts ±1 day; the date input lets users jump to any day.
+
+state.worklog = { date: localDateStr(new Date()), sub: 'schedule' };
+
+function localDateStr(d) {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+function shiftWorklogDate(deltaDays) {
+  const [y, m, d] = state.worklog.date.split('-').map(Number);
+  const dt = new Date(y, m - 1, d);
+  dt.setDate(dt.getDate() + deltaDays);
+  state.worklog.date = localDateStr(dt);
+  syncWorklogDateInput();
+  loadWorklog();
+}
+function syncWorklogDateInput() {
+  const input = $('wlDate');
+  if (input) input.value = state.worklog.date;
+}
+
+const WL_SUB_VIEWS = {
+  schedule: 'wlScheduleView',
+  github: 'wlGithubView',
+  claude: 'wlClaudeView',
+  gemini: 'wlGeminiView',
+  codex: 'wlCodexView',
+  browsing: 'wlBrowsingView',
+  dig: 'wlDigView',
+};
+
+const WL_KIND_BY_SUB = {
+  github: 'git_commit',
+  claude: 'claude_code_prompt',
+  gemini: 'gemini_prompt',
+  codex: 'codex_prompt',
+};
+
+function switchWorklogSub(sub) {
+  if (!WL_SUB_VIEWS[sub]) return;
+  state.worklog.sub = sub;
+  document.querySelectorAll('.wl-subtab').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.sub === sub);
+  });
+  for (const [key, viewId] of Object.entries(WL_SUB_VIEWS)) {
+    const view = $(viewId);
+    if (view) view.classList.toggle('hidden', key !== sub);
+  }
+  loadWorklog();
+}
+
+async function loadWorklog() {
+  syncWorklogDateInput();
+  const date = state.worklog.date;
+  const sub = state.worklog.sub;
+  if (sub === 'schedule') return loadWorklogSchedule(date);
+  if (sub === 'browsing') return loadWorklogBrowsing(date);
+  if (sub === 'dig') return loadWorklogDig(date);
+  if (WL_KIND_BY_SUB[sub]) return loadWorklogActivity(date, sub);
+}
+
+async function loadWorklogSchedule(date) {
+  try {
+    const [evs, ut] = await Promise.all([
+      api(`/api/worklog/server-events?date=${encodeURIComponent(date)}`),
+      api('/api/uptime'),
+    ]);
+    renderWorklogUptime(ut);
+    renderWorklogSchedule(evs.items || []);
+  } catch (e) { console.error(e); }
+}
+
+function renderWorklogUptime(u) {
+  const el = $('wlUptimeStatus');
+  if (!el) return;
+  if (!u?.heartbeat) { el.innerHTML = '<span style="color:var(--muted)">heartbeat 情報なし</span>'; return; }
+  const h = u.heartbeat;
+  const startedAt = h.server_started_at ? new Date(h.server_started_at) : null;
+  const lastHb = h.last_heartbeat_at ? new Date(h.last_heartbeat_at) : null;
+  const upMs = startedAt ? Date.now() - startedAt.getTime() : 0;
+  el.innerHTML = `
+    <span><b>稼働中</b> · 起動 ${startedAt ? startedAt.toLocaleString() : '?'} (${fmtElapsed(upMs)})</span>
+    <span style="margin-left:12px;color:var(--muted)">last heartbeat ${lastHb ? lastHb.toLocaleTimeString() : '?'}</span>
+  `;
+}
+
+function renderWorklogSchedule(items) {
+  const list = $('wlScheduleList');
+  const empty = $('wlScheduleEmpty');
+  if (!list || !empty) return;
+  if (!items.length) {
+    list.innerHTML = '';
+    empty.classList.remove('hidden');
+    setWorklogSummary('この日のサーバ稼働イベントなし');
+    return;
+  }
+  empty.classList.add('hidden');
+  list.innerHTML = items.map(e => {
+    const label = EVENT_LABELS[e.type] || e.type;
+    const occ = (e.occurred_at || '').replace('T', ' ').slice(0, 19);
+    const dur = e.duration_ms ? ` · ${Math.round(e.duration_ms / 1000)}秒` : '';
+    const ended = e.ended_at ? ` → ${e.ended_at.replace('T',' ').slice(0,19)}` : '';
+    const det = e.details ? `<div class="ev-det">${escapeHtml(JSON.stringify(e.details))}</div>` : '';
+    return `<li class="ev-row ev-${e.type}">
+      <span class="ev-tag">${label}</span>
+      <span class="ev-time">${escapeHtml(occ)}${ended}${dur}</span>
+      ${det}
+    </li>`;
+  }).join('');
+  const counts = items.reduce((acc, e) => {
+    acc[e.type] = (acc[e.type] || 0) + 1;
+    return acc;
+  }, {});
+  const summary = Object.entries(counts).map(([k, v]) => `${EVENT_LABELS[k] || k} ${v}`).join(' / ');
+  setWorklogSummary(`${items.length} 件 · ${summary}`);
+}
+
+async function loadWorklogActivity(date, sub) {
+  const kind = WL_KIND_BY_SUB[sub];
+  const view = WL_SUB_VIEWS[sub];
+  const summaryEl = $(`${view}`)?.querySelector('.wl-summary-row');
+  const listEl = view === 'wlGithubView' ? $('wlGithubList')
+    : view === 'wlClaudeView' ? $('wlClaudeList')
+    : view === 'wlGeminiView' ? $('wlGeminiList')
+    : $('wlCodexList');
+  const emptyEl = view === 'wlGithubView' ? $('wlGithubEmpty')
+    : view === 'wlClaudeView' ? $('wlClaudeEmpty')
+    : view === 'wlGeminiView' ? $('wlGeminiEmpty')
+    : $('wlCodexEmpty');
+  if (!listEl || !emptyEl) return;
+  try {
+    const r = await api(`/api/activity/events?date=${encodeURIComponent(date)}&kind=${encodeURIComponent(kind)}&limit=500`);
+    const items = r.items || [];
+    if (!items.length) {
+      listEl.innerHTML = '';
+      emptyEl.classList.remove('hidden');
+      if (summaryEl) summaryEl.innerHTML = '';
+      setWorklogSummary(`${labelForSub(sub)}: 0 件`);
+      return;
+    }
+    emptyEl.classList.add('hidden');
+    if (sub === 'github') renderWorklogGithub(items, listEl, summaryEl);
+    else renderWorklogPrompts(items, listEl, summaryEl, sub);
+    setWorklogSummary(`${labelForSub(sub)}: ${r.total} 件`);
+  } catch (e) { console.error(e); }
+}
+
+function labelForSub(sub) {
+  return ({ schedule: '予定', github: 'GitHub', claude: 'Claude Code', gemini: 'Gemini', codex: 'Codex', browsing: 'ブラウジング', dig: 'ディグ' })[sub] || sub;
+}
+
+function renderWorklogGithub(items, listEl, summaryEl) {
+  // Group by repo (= source field) with a header summary row.
+  const byRepo = new Map();
+  for (const it of items) {
+    const repo = it.source || '(unknown)';
+    if (!byRepo.has(repo)) byRepo.set(repo, []);
+    byRepo.get(repo).push(it);
+  }
+  const sortedRepos = [...byRepo.entries()].sort((a, b) => b[1].length - a[1].length);
+  if (summaryEl) {
+    summaryEl.innerHTML = sortedRepos.map(([repo, list]) =>
+      `<strong>${escapeHtml(repo)}</strong>${list.length}`
+    ).join(' / ');
+  }
+  listEl.innerHTML = sortedRepos.map(([repo, list]) => {
+    const rows = list.map(it => {
+      const t = (it.occurred_at || '').replace('T', ' ').slice(0, 19);
+      const sha = (it.ref_id || '').slice(0, 7);
+      const meta = it.metadata || {};
+      const branch = meta.branch ? ` [${escapeHtml(meta.branch)}]` : '';
+      const author = meta.author ? ` · ${escapeHtml(meta.author)}` : '';
+      const content = it.content || '';
+      return `<li>
+        <div class="wl-row1">
+          <span class="wl-time">${escapeHtml(t)}</span>
+          <span class="wl-source">${escapeHtml(sha)}${branch}</span>
+          <span class="wl-meta">${author}</span>
+        </div>
+        <div class="wl-content">${escapeHtml(content)}</div>
+      </li>`;
+    }).join('');
+    return `<li class="wl-repo-group" style="background:transparent;border:none;padding:0;gap:4px">
+      <div class="wl-row1"><strong>${escapeHtml(repo)}</strong> <span class="wl-meta">${list.length} commits</span></div>
+      <ul class="wl-list" style="margin-left:8px">${rows}</ul>
+    </li>`;
+  }).join('');
+}
+
+function renderWorklogPrompts(items, listEl, summaryEl, sub) {
+  if (summaryEl) {
+    summaryEl.innerHTML = `<strong>${escapeHtml(labelForSub(sub))}</strong>${items.length} prompts`;
+  }
+  listEl.innerHTML = items.map(it => {
+    const t = (it.occurred_at || '').replace('T', ' ').slice(0, 19);
+    const meta = it.metadata || {};
+    const cwd = meta.cwd ? `${escapeHtml(meta.cwd)}` : '';
+    const branch = meta.branch ? ` · ${escapeHtml(meta.branch)}` : '';
+    const source = it.source ? `<span class="wl-source">${escapeHtml(it.source)}</span>` : '';
+    const content = (it.content || '').trim();
+    return `<li>
+      <div class="wl-row1">
+        <span class="wl-time">${escapeHtml(t)}</span>
+        ${source}
+        <span class="wl-meta">${cwd}${branch}</span>
+      </div>
+      ${content ? `<div class="wl-content truncate" title="${escapeHtml(content)}">${escapeHtml(content)}</div>` : ''}
+    </li>`;
+  }).join('');
+}
+
+async function loadWorklogBrowsing(date) {
+  try {
+    const r = await api(`/api/worklog/browsing?date=${encodeURIComponent(date)}`);
+    renderWorklogBrowsing(r);
+  } catch (e) { console.error(e); }
+}
+
+function renderWorklogBrowsing(r) {
+  const visits = r.visits || [];
+  const revisits = r.revisits || [];
+  const domains = r.top_domains || [];
+  $('wlVisitsCount').textContent = visits.length;
+  $('wlRevisitsCount').textContent = revisits.length;
+  $('wlDomainsCount').textContent = domains.length;
+
+  const summaryEl = $('wlBrowsingSummary');
+  summaryEl.innerHTML = `<strong>ページ閲覧</strong>${r.total_pages || 0} ページ / ${r.total_visits || 0} 回 · <strong>再訪 BM</strong>${revisits.length} · <strong>ドメイン</strong>${domains.length}`;
+  setWorklogSummary(`${r.total_pages || 0} ページ / ${r.total_visits || 0} 回 · 再訪 ${revisits.length} · ドメイン ${domains.length}`);
+
+  // Visits list (chronological, 最新が先頭)
+  const visitsList = $('wlVisitsList');
+  const visitsEmpty = $('wlVisitsEmpty');
+  if (!visits.length) {
+    visitsList.innerHTML = '';
+    visitsEmpty.classList.remove('hidden');
+  } else {
+    visitsEmpty.classList.add('hidden');
+    visitsList.innerHTML = visits.map(v => {
+      const t = (v.last_seen_at || '').slice(11, 19);
+      const bm = v.is_bookmarked ? '<span class="wl-source">★ BM</span>' : '';
+      const dom = v.domain ? `<span class="wl-meta">${escapeHtml(v.domain)}</span>` : '';
+      const cnt = v.visit_count > 1 ? `<span class="wl-meta">×${v.visit_count}</span>` : '';
+      return `<li>
+        <div class="wl-row1">
+          <span class="wl-time">${escapeHtml(t)}</span>
+          ${bm}${dom}${cnt}
+        </div>
+        <div class="wl-content"><a href="${escapeHtml(v.url)}" target="_blank" rel="noopener">${escapeHtml(v.title || v.url)}</a></div>
+      </li>`;
+    }).join('');
+  }
+
+  // Revisits list
+  const reList = $('wlRevisitsList');
+  const reEmpty = $('wlRevisitsEmpty');
+  if (!revisits.length) {
+    reList.innerHTML = '';
+    reEmpty.classList.remove('hidden');
+  } else {
+    reEmpty.classList.add('hidden');
+    reList.innerHTML = revisits.map(b => {
+      const cnt = `<span class="wl-meta">×${b.visit_count}</span>`;
+      const t = (b.last_seen_at || '').slice(11, 19);
+      return `<li>
+        <div class="wl-row1">
+          <span class="wl-time">${escapeHtml(t)}</span>${cnt}
+        </div>
+        <div class="wl-content"><a href="${escapeHtml(b.url)}" target="_blank" rel="noopener">${escapeHtml(b.title || b.url)}</a></div>
+      </li>`;
+    }).join('');
+  }
+
+  // Top domains
+  const domList = $('wlDomainsList');
+  domList.innerHTML = domains.map(d => `
+    <li>
+      <span class="wl-dom-name">${escapeHtml(d.domain)}</span>
+      <span class="wl-dom-count">${d.pages} ページ / ${d.visits} 回</span>
+    </li>
+  `).join('');
+}
+
+async function loadWorklogDig(date) {
+  try {
+    const r = await api(`/api/diary/${encodeURIComponent(date)}/digs?limit=200`);
+    renderWorklogDig(r);
+  } catch (e) { console.error(e); }
+}
+
+function renderWorklogDig(r) {
+  const items = r.items || [];
+  const list = $('wlDigList');
+  const empty = $('wlDigEmpty');
+  const summaryEl = $('wlDigSummary');
+  if (summaryEl) summaryEl.innerHTML = `<strong>ディグ</strong>${r.total || items.length} セッション`;
+  setWorklogSummary(`ディグ ${r.total || items.length} 件`);
+  if (!items.length) {
+    list.innerHTML = '';
+    empty.classList.remove('hidden');
+    return;
+  }
+  empty.classList.add('hidden');
+  list.innerHTML = items.map(d => {
+    const t = (d.created_at || '').replace('T', ' ').slice(0, 19);
+    const status = d.status ? `<span class="wl-source">${escapeHtml(d.status)}</span>` : '';
+    const summary = d.summary ? `<div class="wl-content truncate">${escapeHtml(d.summary)}</div>` : '';
+    const sources = d.source_count ? `<span class="wl-meta">${d.source_count} sources</span>` : '';
+    return `<li>
+      <div class="wl-row1">
+        <span class="wl-time">${escapeHtml(t)}</span>
+        ${status}${sources}
+      </div>
+      <div class="wl-content"><strong>${escapeHtml(d.query || '')}</strong></div>
+      ${summary}
+    </li>`;
+  }).join('');
+}
+
+function setWorklogSummary(text) {
+  const el = $('wlSummary');
+  if (el) el.textContent = `${state.worklog.date} · ${text}`;
+}
+
+// Worklog event listeners
+document.querySelectorAll('.wl-subtab').forEach(btn => {
+  btn.addEventListener('click', () => switchWorklogSub(btn.dataset.sub));
+});
+$('wlPrevDay')?.addEventListener('click', () => shiftWorklogDate(-1));
+$('wlNextDay')?.addEventListener('click', () => shiftWorklogDate(1));
+$('wlToday')?.addEventListener('click', () => {
+  state.worklog.date = localDateStr(new Date());
+  syncWorklogDateInput();
+  loadWorklog();
+});
+$('wlDate')?.addEventListener('change', (e) => {
+  const v = e.target.value;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(v)) {
+    state.worklog.date = v;
+    loadWorklog();
+  }
+});
+$('wlRefresh')?.addEventListener('click', () => loadWorklog());
 
 // ── 🌐 Multi (Memoria Hub) browse ─────────────────────────────────────────
 state.multiSubtab = 'bookmarks';

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -4650,8 +4650,8 @@ function ensureMemoriaFeatureViews() {
   const tabs = document.querySelector('.tabs-scroll');
   if (tabs && !document.querySelector('.tab[data-tab="tasks"]')) {
     for (const spec of [
-      ['tasks', 'Tasks'],
-      ['impl', 'Implementation Notes'],
+      ['tasks', 'タスク'],
+      ['impl', '実装自慢'],
     ]) {
       const b = document.createElement('button');
       b.className = 'tab';
@@ -4668,13 +4668,19 @@ function ensureMemoriaFeatureViews() {
     div.className = 'hidden';
     div.innerHTML = `
       <div class="simple-panel">
-        <h2>Tasks</h2>
-        <div class="simple-form">
-          <input id="taskTitle" type="text" placeholder="Next task" />
+        <div class="simple-panel-head">
+          <h2>タスク</h2>
+          <button id="taskNewBtn" type="button">+ タスクを追加</button>
+        </div>
+        <div id="taskForm" class="simple-form hidden">
+          <input id="taskTitle" type="text" placeholder="直近やること" />
           <input id="taskDue" type="datetime-local" />
-          <label class="check-inline"><input id="taskShareActio" type="checkbox" /> Share to Actio</label>
-          <textarea id="taskDetails" rows="3" placeholder="Details"></textarea>
-          <button id="taskAddBtn">Add task</button>
+          <label class="check-inline"><input id="taskShareActio" type="checkbox" /> Actio にシェアする</label>
+          <textarea id="taskDetails" rows="3" placeholder="詳細メモ"></textarea>
+          <div class="simple-actions">
+            <button id="taskAddBtn">追加</button>
+            <button id="taskCancelBtn" type="button" class="ghost">キャンセル</button>
+          </div>
         </div>
         <div id="tasksList" class="simple-list"></div>
       </div>`;
@@ -4686,14 +4692,20 @@ function ensureMemoriaFeatureViews() {
     div.className = 'hidden';
     div.innerHTML = `
       <div class="simple-panel">
-        <h2>Implementation Notes</h2>
-        <div class="simple-form">
-          <input id="implProduct" type="text" placeholder="Product name" />
-          <input id="implTitle" type="text" placeholder="Short title" />
-          <textarea id="implGood" rows="4" placeholder="Good points"></textarea>
-          <textarea id="implBad" rows="3" placeholder="Bad points / tradeoffs"></textarea>
-          <label class="check-inline"><input id="implShareable" type="checkbox" /> Shareable</label>
-          <button id="implAddBtn">Add note</button>
+        <div class="simple-panel-head">
+          <h2>実装自慢</h2>
+          <button id="implNewBtn" type="button">+ ノートを追加</button>
+        </div>
+        <div id="implForm" class="simple-form hidden">
+          <input id="implProduct" type="text" placeholder="プロダクト名" />
+          <input id="implTitle" type="text" placeholder="短いタイトル" />
+          <textarea id="implGood" rows="4" placeholder="良かった点"></textarea>
+          <textarea id="implBad" rows="3" placeholder="悪かった点 / トレードオフ"></textarea>
+          <label class="check-inline"><input id="implShareable" type="checkbox" /> シェア可能にする</label>
+          <div class="simple-actions">
+            <button id="implAddBtn">追加</button>
+            <button id="implCancelBtn" type="button" class="ghost">キャンセル</button>
+          </div>
         </div>
         <div id="implList" class="simple-list"></div>
       </div>`;
@@ -4704,8 +4716,8 @@ function ensureMemoriaFeatureViews() {
   const footer = document.querySelector('.settings-footer');
   if (settingsTabs && !document.querySelector('.settings-tab[data-stab="privacy"]')) {
     for (const spec of [
-      ['privacy', 'Privacy / visibility'],
-      ['setup', 'Setup docs'],
+      ['privacy', 'プライバシー / 表示'],
+      ['setup', 'セットアップ手順'],
     ]) {
       const b = document.createElement('button');
       b.type = 'button';
@@ -4722,13 +4734,13 @@ function ensureMemoriaFeatureViews() {
     sec.className = 'settings-tab-body hidden';
     sec.dataset.stab = 'privacy';
     sec.innerHTML = `
-      <h4>Privacy / visibility</h4>
-      <label class="check-inline"><input id="tracksEnabled" type="checkbox" /> Collect tracks</label>
-      <label class="check-inline"><input id="tracksVisible" type="checkbox" /> Show tracks tab and data</label>
-      <label class="check-inline"><input id="mealsEnabled" type="checkbox" /> Collect meals</label>
-      <label class="check-inline"><input id="mealsVisible" type="checkbox" /> Show meals tab and data</label>
-      <label class="check-inline"><input id="tasksActioShareEnabled" type="checkbox" /> Allow task sharing to Actio</label>
-      <label>Actio share URL: <input id="actioShareUrl" type="text" placeholder="http://localhost:.../api/tasks/import" /></label>`;
+      <h4>プライバシー / 表示</h4>
+      <label class="check-inline"><input id="tracksEnabled" type="checkbox" /> 軌跡を記録する</label>
+      <label class="check-inline"><input id="tracksVisible" type="checkbox" /> 軌跡タブとデータを表示する</label>
+      <label class="check-inline"><input id="mealsEnabled" type="checkbox" /> 食事を記録する</label>
+      <label class="check-inline"><input id="mealsVisible" type="checkbox" /> 食事タブとデータを表示する</label>
+      <label class="check-inline"><input id="tasksActioShareEnabled" type="checkbox" /> タスクの Actio シェアを許可する</label>
+      <label>Actio シェア URL: <input id="actioShareUrl" type="text" placeholder="http://localhost:.../api/tasks/import" /></label>`;
     footer.parentNode.insertBefore(sec, footer);
   }
   if (footer && !$('setupDocsBody')) {
@@ -4737,13 +4749,17 @@ function ensureMemoriaFeatureViews() {
     sec.className = 'settings-tab-body hidden';
     sec.dataset.stab = 'setup';
     sec.innerHTML = `
-      <h4>Setup docs</h4>
+      <h4>セットアップ手順</h4>
       <div id="setupDocsList" class="setup-docs-list"></div>
       <pre id="setupDocBody" class="setup-doc-body"></pre>`;
     footer.parentNode.insertBefore(sec, footer);
   }
 
+  if ($('taskNewBtn')) $('taskNewBtn').onclick = () => $('taskForm')?.classList.remove('hidden');
+  if ($('taskCancelBtn')) $('taskCancelBtn').onclick = () => $('taskForm')?.classList.add('hidden');
   if ($('taskAddBtn')) $('taskAddBtn').onclick = addTaskFromForm;
+  if ($('implNewBtn')) $('implNewBtn').onclick = () => $('implForm')?.classList.remove('hidden');
+  if ($('implCancelBtn')) $('implCancelBtn').onclick = () => $('implForm')?.classList.add('hidden');
   if ($('implAddBtn')) $('implAddBtn').onclick = addImplementationNoteFromForm;
 }
 
@@ -4809,7 +4825,7 @@ async function loadTasks() {
   const list = $('tasksList');
   if (!list) return;
   if (!items.length) {
-    list.innerHTML = '<div class="queue-empty">No tasks.</div>';
+    list.innerHTML = '<div class="queue-empty">タスクはまだありません。</div>';
     return;
   }
   list.innerHTML = items.map(t => `
@@ -4823,8 +4839,8 @@ async function loadTasks() {
       <div class="muted">${escapeHtml(t.due_at || '')}</div>
       <p>${escapeHtml(t.details || '')}</p>
       <div class="simple-actions">
-        <button class="ghost" data-task-share="${t.id}">Share Actio</button>
-        <button class="danger" data-task-delete="${t.id}">Delete</button>
+        <button class="ghost" data-task-share="${t.id}">Actio にシェア</button>
+        <button class="danger" data-task-delete="${t.id}">削除</button>
       </div>
     </div>`).join('');
   list.querySelectorAll('[data-task-status]').forEach(sel => {
@@ -4838,7 +4854,7 @@ async function loadTasks() {
   });
   list.querySelectorAll('[data-task-share]').forEach(btn => {
     btn.addEventListener('click', async () => {
-      try { await api(`/api/tasks/${btn.dataset.taskShare}/share/actio`, { method: 'POST' }); showShareToast('Shared to Actio'); }
+      try { await api(`/api/tasks/${btn.dataset.taskShare}/share/actio`, { method: 'POST' }); showShareToast('Actio にシェアしました'); }
       catch (e) { alert(e.message); }
       loadTasks();
     });
@@ -4866,6 +4882,7 @@ async function addTaskFromForm() {
   });
   $('taskTitle').value = '';
   $('taskDetails').value = '';
+  $('taskForm')?.classList.add('hidden');
   loadTasks();
 }
 
@@ -4876,18 +4893,18 @@ async function loadImplementationNotes() {
   const items = r.items || [];
   if (!list) return;
   if (!items.length) {
-    list.innerHTML = '<div class="queue-empty">No implementation notes.</div>';
+    list.innerHTML = '<div class="queue-empty">実装自慢はまだありません。</div>';
     return;
   }
   list.innerHTML = items.map(n => `
     <div class="simple-item" data-id="${n.id}">
       <div class="simple-item-head"><strong>${escapeHtml(n.product)}: ${escapeHtml(n.title)}</strong></div>
-      <h4>Good</h4><p>${escapeHtml(n.good_points || '')}</p>
-      <h4>Bad / tradeoffs</h4><p>${escapeHtml(n.bad_points || '')}</p>
+      <h4>良かった点</h4><p>${escapeHtml(n.good_points || '')}</p>
+      <h4>悪かった点 / トレードオフ</h4><p>${escapeHtml(n.bad_points || '')}</p>
       <div class="simple-actions">
-        <span class="muted">${n.shareable ? 'Shareable' : 'Private'}</span>
-        <button class="ghost" data-impl-share="${n.id}">Share</button>
-        <button class="danger" data-impl-delete="${n.id}">Delete</button>
+        <span class="muted">${n.shared_at ? `シェア済み: ${escapeHtml(fmtDate(n.shared_at))}` : (n.shareable ? 'シェア可能' : '非公開')}</span>
+        <button class="ghost" data-impl-share="${n.id}" ${n.shared_at ? 'disabled' : ''}>シェア</button>
+        <button class="danger" data-impl-delete="${n.id}">削除</button>
       </div>
     </div>`).join('');
   list.querySelectorAll('[data-impl-share]').forEach(btn => {
@@ -4898,7 +4915,7 @@ async function loadImplementationNotes() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ kind: 'implementation_note', id: Number(btn.dataset.implShare) }),
         });
-        showShareToast('Shared implementation note');
+        showShareToast('実装自慢をシェアしました');
       }
       catch (e) { alert(e.message); }
       loadImplementationNotes();
@@ -4928,6 +4945,7 @@ async function addImplementationNoteFromForm() {
     }),
   });
   for (const id of ['implProduct', 'implTitle', 'implGood', 'implBad']) $(id).value = '';
+  $('implForm')?.classList.add('hidden');
   loadImplementationNotes();
 }
 

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -4766,7 +4766,18 @@ function ensureMemoriaFeatureViews() {
       <label class="check-inline"><input id="mealsEnabled" type="checkbox" /> 食事を記録する</label>
       <label class="check-inline"><input id="mealsVisible" type="checkbox" /> 食事タブとデータを表示する</label>
       <label class="check-inline"><input id="tasksActioShareEnabled" type="checkbox" /> タスクの Actio シェアを許可する</label>
-      <label>Actio シェア URL: <input id="actioShareUrl" type="text" placeholder="http://localhost:.../api/tasks/import" /></label>`;
+      <label>Actio シェア URL: <input id="actioShareUrl" type="text" placeholder="http://localhost:.../api/tasks/import" /></label>
+      <h4 style="margin-top:12px">タスクリマインド</h4>
+      <label class="check-inline"><input id="taskReminderEnabled" type="checkbox" /> 毎朝タスクリマインドを送る</label>
+      <label style="display:flex;align-items:center;gap:6px;margin-bottom:6px">リマインド時刻:
+        <input id="taskReminderHour" type="number" min="0" max="23" style="width:52px" />
+        時
+        <input id="taskReminderMinute" type="number" min="0" max="59" style="width:52px" />
+        分
+      </label>
+      <label class="check-inline"><input id="taskReminderNuntiusEnabled" type="checkbox" /> Nuntius にも送る</label>
+      <label>Nuntius URL: <input id="taskReminderNuntiusUrl" type="text" placeholder="https://nuntius.example.com/notify" /></label>
+      <p class="diary-settings-help" style="margin-top:6px">iOS で受け取る場合はホーム画面に追加 + 通知を許可してください。</p>`;
     footer.parentNode.insertBefore(sec, footer);
   }
   if (footer && !$('setupDocsBody')) {
@@ -4880,7 +4891,7 @@ function setupTaskFormKeyboard() {
   };
 }
 
-function upgradeImplementationFormMarkup() {
+upgradeImplementationFormMarkup = function () {
   const form = $('implForm');
   if (!form || form.dataset.upgraded === '1') return;
   form.dataset.upgraded = '1';
@@ -4909,9 +4920,9 @@ function upgradeImplementationFormMarkup() {
       <button id="implAddBtn">追加</button>
       <button id="implCancelBtn" type="button" class="ghost">キャンセル</button>
     </div>`;
-}
+};
 
-function setupImplementationFormKeyboard() {
+setupImplementationFormKeyboard = function () {
   const product = $('implProduct');
   const title = $('implTitle');
   const good = $('implGood');
@@ -4943,6 +4954,28 @@ function setupImplementationFormKeyboard() {
   };
 }
 
+let _localReminderTimer = null;
+function scheduleLocalTaskReminder(hour, minute) {
+  if (!('Notification' in window) || Notification.permission !== 'granted') return;
+  if (_localReminderTimer) { clearTimeout(_localReminderTimer); _localReminderTimer = null; }
+  const now = new Date();
+  const next = new Date(now);
+  next.setHours(hour, minute, 0, 0);
+  if (next <= now) next.setDate(next.getDate() + 1);
+  _localReminderTimer = setTimeout(async () => {
+    _localReminderTimer = null;
+    try {
+      const { items = [] } = await api('/api/tasks');
+      const pending = items.filter(t => t.status === 'todo' || t.status === 'doing');
+      if (pending.length) {
+        const body = pending.slice(0, 3).map(t => `・${t.title}`).join('\n');
+        new Notification('📋 本日のタスクリマインド', { body, icon: '/icon-192.png' });
+      }
+    } catch {}
+    scheduleLocalTaskReminder(hour, minute);
+  }, next.getTime() - now.getTime());
+}
+
 async function loadPrivacySettings() {
   ensureMemoriaFeatureViews();
   const r = await api('/api/privacy/settings');
@@ -4953,6 +4986,14 @@ async function loadPrivacySettings() {
   if ($('mealsVisible')) $('mealsVisible').checked = !!s.meals_visible;
   if ($('tasksActioShareEnabled')) $('tasksActioShareEnabled').checked = !!s.tasks_actio_share_enabled;
   if ($('actioShareUrl')) $('actioShareUrl').value = s.actio_share_url || '';
+  if ($('taskReminderEnabled')) $('taskReminderEnabled').checked = !!s.tasks_reminder_enabled;
+  if ($('taskReminderHour')) $('taskReminderHour').value = s.tasks_reminder_hour ?? 6;
+  if ($('taskReminderMinute')) $('taskReminderMinute').value = s.tasks_reminder_minute ?? 0;
+  if ($('taskReminderNuntiusEnabled')) $('taskReminderNuntiusEnabled').checked = !!s.tasks_reminder_nuntius_enabled;
+  if ($('taskReminderNuntiusUrl')) $('taskReminderNuntiusUrl').value = s.tasks_reminder_nuntius_url || '';
+  if (s.tasks_reminder_enabled) {
+    scheduleLocalTaskReminder(s.tasks_reminder_hour ?? 6, s.tasks_reminder_minute ?? 0);
+  }
   applyFeatureVisibility(s);
 }
 
@@ -4968,9 +5009,18 @@ async function savePrivacySettings() {
       meals_visible: $('mealsVisible').checked,
       tasks_actio_share_enabled: $('tasksActioShareEnabled').checked,
       actio_share_url: $('actioShareUrl').value.trim(),
+      tasks_reminder_enabled: !!($('taskReminderEnabled')?.checked),
+      tasks_reminder_hour: Number($('taskReminderHour')?.value ?? 6),
+      tasks_reminder_minute: Number($('taskReminderMinute')?.value ?? 0),
+      tasks_reminder_nuntius_enabled: !!($('taskReminderNuntiusEnabled')?.checked),
+      tasks_reminder_nuntius_url: $('taskReminderNuntiusUrl')?.value.trim() || '',
     }),
   });
-  applyFeatureVisibility(r.settings || {});
+  const s = r.settings || {};
+  if (s.tasks_reminder_enabled) {
+    scheduleLocalTaskReminder(s.tasks_reminder_hour ?? 6, s.tasks_reminder_minute ?? 0);
+  }
+  applyFeatureVisibility(s);
 }
 
 function applyFeatureVisibility(s) {
@@ -5129,6 +5179,521 @@ async function addImplementationNoteFromForm() {
   loadImplementationNotes();
 }
 
+function implementationAttachmentLabel(type) {
+  return ({
+    github: 'GitHub のプロダクト',
+    screenshot: 'スクリーンキャプチャ',
+    video: '動画',
+    code: 'コードスニペット',
+    other: 'その他',
+  })[type] || '';
+}
+
+function renderImplementationAttachment(note) {
+  const type = note.attachment_type || '';
+  const value = note.attachment_value || '';
+  if (!type || !value) return '';
+  const label = implementationAttachmentLabel(type) || '添付';
+  if (type === 'code') {
+    return `<div class="impl-attachment"><div class="muted">${escapeHtml(label)}</div><pre><code>${escapeHtml(value)}</code></pre></div>`;
+  }
+  if (/^https?:\/\//i.test(value)) {
+    return `<div class="impl-attachment"><div class="muted">${escapeHtml(label)}</div><a href="${escapeHtml(value)}" target="_blank" rel="noopener">${escapeHtml(value)}</a></div>`;
+  }
+  return `<div class="impl-attachment"><div class="muted">${escapeHtml(label)}</div><p>${escapeHtml(value)}</p></div>`;
+}
+
+upgradeImplementationFormMarkup = function () {
+  const form = $('implForm');
+  if (!form || form.dataset.upgraded === '2') return;
+  form.dataset.upgraded = '2';
+  form.innerHTML = `
+    <label class="simple-field">
+      <span>ドヤポイント</span>
+      <input id="implTitle" type="text" placeholder="ここを作り込んだ、ここが気持ちいい" />
+    </label>
+    <label class="simple-field">
+      <span>良かった点</span>
+      <textarea id="implGood" rows="5" placeholder="設計、実装、体験で良かった点"></textarea>
+    </label>
+    <label class="simple-field">
+      <span>悪かった点 / トレードオフ</span>
+      <textarea id="implBad" rows="4" placeholder="迷った点、直したい点、次に改善する点"></textarea>
+    </label>
+    <label class="simple-field">
+      <span>添付するもの</span>
+      <select id="implAttachmentType">
+        <option value="">なし</option>
+        <option value="github">GitHub のプロダクト</option>
+        <option value="screenshot">スクリーンキャプチャ</option>
+        <option value="video">動画</option>
+        <option value="code">コードスニペット</option>
+        <option value="other">その他</option>
+      </select>
+    </label>
+    <label class="simple-field">
+      <span>添付内容</span>
+      <textarea id="implAttachmentValue" rows="4" placeholder="URL、画像や動画のパス、コードなどを 1 つだけ記入"></textarea>
+    </label>
+    <label class="simple-check-row">
+      <input id="implShareable" type="checkbox" tabindex="-1" />
+      <span>シェア可能にする</span>
+    </label>
+    <div class="simple-actions">
+      <button id="implAddBtn">追加</button>
+      <button id="implCancelBtn" type="button" class="ghost">キャンセル</button>
+    </div>`;
+};
+
+setupImplementationFormKeyboard = function () {
+  const title = $('implTitle');
+  const good = $('implGood');
+  const bad = $('implBad');
+  const attachmentType = $('implAttachmentType');
+  const attachmentValue = $('implAttachmentValue');
+  const add = $('implAddBtn');
+  if (title) title.onkeydown = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      good?.focus();
+    }
+  };
+  if (good) good.onkeydown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      bad?.focus();
+    }
+  };
+  if (bad) bad.onkeydown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      attachmentType?.focus();
+    }
+  };
+  if (attachmentType) attachmentType.onkeydown = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      attachmentValue?.focus();
+    }
+  };
+  if (attachmentValue) attachmentValue.onkeydown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      add?.focus();
+    }
+  };
+};
+
+loadImplementationNotes = async function () {
+  ensureMemoriaFeatureViews();
+  const r = await api('/api/implementation-notes');
+  const list = $('implList');
+  const items = r.items || [];
+  if (!list) return;
+  if (!items.length) {
+    list.innerHTML = '<div class="queue-empty">実装自慢はまだありません。</div>';
+    return;
+  }
+  list.innerHTML = items.map(n => `
+    <div class="simple-item" data-id="${n.id}">
+      <div class="simple-item-head"><strong>${escapeHtml(n.title)}</strong></div>
+      <h4>良かった点</h4><p>${escapeHtml(n.good_points || '')}</p>
+      <h4>悪かった点 / トレードオフ</h4><p>${escapeHtml(n.bad_points || '')}</p>
+      ${renderImplementationAttachment(n)}
+      <div class="simple-actions">
+        <span class="muted">${n.shared_at ? `シェア済み: ${escapeHtml(fmtDate(n.shared_at))}` : (n.shareable ? 'シェア可能' : '非公開')}</span>
+        <button class="ghost" data-impl-share="${n.id}" ${n.shared_at ? 'disabled' : ''}>シェア</button>
+        <button class="danger" data-impl-delete="${n.id}">削除</button>
+      </div>
+    </div>`).join('');
+  list.querySelectorAll('[data-impl-share]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      try {
+        await api('/api/multi/share', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ kind: 'implementation_note', id: Number(btn.dataset.implShare) }),
+        });
+        showShareToast('実装自慢をシェアしました');
+      }
+      catch (e) { alert(e.message); }
+      loadImplementationNotes();
+    });
+  });
+  list.querySelectorAll('[data-impl-delete]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      await api(`/api/implementation-notes/${btn.dataset.implDelete}`, { method: 'DELETE' });
+      loadImplementationNotes();
+    });
+  });
+};
+
+addImplementationNoteFromForm = async function () {
+  const title = $('implTitle')?.value.trim();
+  if (!title) return;
+  await api('/api/implementation-notes', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      title,
+      good_points: $('implGood')?.value.trim() || '',
+      bad_points: $('implBad')?.value.trim() || '',
+      attachment_type: $('implAttachmentType')?.value || '',
+      attachment_value: $('implAttachmentValue')?.value.trim() || '',
+      shareable: !!$('implShareable')?.checked,
+    }),
+  });
+  for (const id of ['implTitle', 'implGood', 'implBad', 'implAttachmentType', 'implAttachmentValue']) {
+    const el = $(id);
+    if (el) el.value = '';
+  }
+  $('implShareable').checked = false;
+  $('implForm')?.classList.add('hidden');
+  loadImplementationNotes();
+};
+
+renderDomainList = function () {
+  const ul = $('domainList');
+  if (!state.domainEntries.length) {
+    ul.innerHTML = '<li class="dict-empty">ドメイン辞書はまだ空です。アクセス履歴の生成によって自動で追加されます。</li>';
+    return;
+  }
+  ul.innerHTML = state.domainEntries.map(e => {
+    const desc = (e.description || '').trim();
+    const can = (e.can_do || '').trim();
+    const body = desc + (desc && can ? '\n\n' : '') + (can ? `できること:\n${can}` : '');
+    return `
+    <li class="dict-item ${state.domainDetail?.domain === e.domain ? 'selected' : ''}" data-domain="${escapeHtml(e.domain)}">
+      <div class="dict-term">${escapeHtml(e.site_name || e.domain)}</div>
+      <div class="dict-snippet">${escapeHtml(body.slice(0, 320))}</div>
+      <div class="dict-meta">
+        <span>${escapeHtml(e.domain)}</span>
+        <span>本日 ${e.visits_today} / 週 ${e.visits_week}</span>
+      </div>
+    </li>`;
+  }).join('');
+  ul.querySelectorAll('.dict-item').forEach(li => {
+    li.addEventListener('click', () => loadDomainEntry(li.dataset.domain));
+  });
+};
+
+renderDomainDetail = function () {
+  const e = state.domainDetail;
+  const panel = $('domainDetail');
+  if (!e) { hideModal('domainDetail'); return; }
+  showModal('domainDetail');
+  $('domainKey').value = e.domain;
+  $('domainSiteName').value = e.site_name || '';
+  $('domainDesc').value = e.description || '';
+  $('domainCanDo').value = e.can_do || '';
+  $('domainKind').value = e.kind || '';
+  $('domainNotes').value = e.notes || '';
+  $('domainStats').innerHTML = `
+    <span class="domain-stat"><b>${e.visits_today ?? 0}</b><br>本日</span>
+    <span class="domain-stat"><b>${e.visits_week ?? 0}</b><br>過去7日</span>
+    <span class="domain-stat"><b>${e.visits_total ?? 0}</b><br>累計</span>
+    <span class="domain-stat"><b>${e.user_edited ? '✓' : '-'}</b><br>編集済み</span>
+    <span class="domain-stat"><b>${escapeHtml(e.status || '')}</b><br>状態</span>
+    <label class="domain-private-detail">
+      <input id="domainPrivateCheck" type="checkbox" ${e.domain_private ? 'checked' : ''} />
+      <span>日記では非表示</span>
+    </label>
+  `;
+  const privateCheck = $('domainPrivateCheck');
+  if (privateCheck) {
+    privateCheck.onchange = async () => {
+      const checked = privateCheck.checked;
+      try {
+        await api(`/api/domains/${encodeURIComponent(e.domain)}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ domain_private: checked }),
+        });
+        e.domain_private = checked ? 1 : 0;
+        const row = state.domainEntries.find(x => x.domain === e.domain);
+        if (row) row.domain_private = e.domain_private;
+        flashToast(checked ? '日記では非表示にしました' : '日記に表示するようにしました');
+      } catch (err) {
+        privateCheck.checked = !checked;
+        alert(`private 更新失敗: ${err.message}`);
+      }
+    };
+  }
+};
+
+state.taskMenu = 'todo';
+state.taskItems = [];
+state.taskDetail = null;
+
+function taskDatePartition(task) {
+  if (!task.due_at) return 'middle';
+  const due = new Date(task.due_at);
+  if (Number.isNaN(due.getTime())) return 'middle';
+  const today = new Date();
+  today.setHours(23, 59, 59, 999);
+  return due.getTime() > today.getTime() ? 'right' : 'middle';
+}
+
+function formatTaskDue(dueAt) {
+  if (!dueAt) return '期日未設定';
+  const d = new Date(dueAt);
+  if (Number.isNaN(d.getTime())) return dueAt;
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function taskCardHtml(t) {
+  const aiBadge = t.creator_type === 'ai' ? '<span class="task-origin ai">AI</span>' : '<span class="task-origin human">人間</span>';
+  const doneBtn = t.status === 'done'
+    ? '<button class="ghost" disabled>Done</button>'
+    : `<button class="ghost" data-task-done="${t.id}">Done</button>`;
+  return `
+    <article class="task-card" data-task-open="${t.id}">
+      <div class="task-card-head">
+        <strong>${escapeHtml(t.title)}</strong>
+        ${aiBadge}
+      </div>
+      <div class="muted">期日: ${escapeHtml(formatTaskDue(t.due_at))}</div>
+      <p>${escapeHtml(t.details || '')}</p>
+      <div class="simple-actions">
+        ${doneBtn}
+        <button class="ghost" data-task-share="${t.id}">Actioにシェア</button>
+        <button class="danger" data-task-delete="${t.id}">削除</button>
+      </div>
+    </article>`;
+}
+
+function renderTaskDetail() {
+  const panel = $('taskDetailPanel');
+  if (!panel) return;
+  const t = state.taskDetail;
+  if (!t) {
+    panel.classList.add('hidden');
+    panel.innerHTML = '';
+    return;
+  }
+  panel.classList.remove('hidden');
+  panel.innerHTML = `
+    <div class="task-detail-head">
+      <h3>タスク詳細</h3>
+      <span class="task-origin ${t.creator_type === 'ai' ? 'ai' : 'human'}">${t.creator_type === 'ai' ? 'AI作成' : '人間作成'}</span>
+    </div>
+    <label class="simple-field">
+      <span>タスク内容</span>
+      <input id="taskDetailTitle" type="text" value="${escapeHtml(t.title || '')}" />
+    </label>
+    <label class="simple-field">
+      <span>期日</span>
+      <input id="taskDetailDue" type="datetime-local" value="${escapeHtml((t.due_at || '').slice(0, 16))}" />
+    </label>
+    <label class="simple-field">
+      <span>ステータス</span>
+      <select id="taskDetailStatus">
+        ${['todo', 'doing', 'done'].map((s) => `<option value="${s}" ${t.status === s ? 'selected' : ''}>${s.toUpperCase()}</option>`).join('')}
+      </select>
+    </label>
+    <label class="simple-field">
+      <span>メモ</span>
+      <textarea id="taskDetailMemo" rows="5">${escapeHtml(t.details || '')}</textarea>
+    </label>
+    <div class="simple-actions">
+      <button id="taskDetailSaveBtn">保存</button>
+      <button id="taskDetailCloseBtn" class="ghost" type="button">閉じる</button>
+    </div>
+  `;
+  $('taskDetailCloseBtn').onclick = () => {
+    state.taskDetail = null;
+    renderTaskDetail();
+  };
+  $('taskDetailSaveBtn').onclick = async () => {
+    try {
+      await api(`/api/tasks/${t.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: $('taskDetailTitle').value.trim(),
+          due_at: $('taskDetailDue').value || null,
+          status: $('taskDetailStatus').value,
+          details: $('taskDetailMemo').value.trim(),
+        }),
+      });
+      await loadTasks();
+    } catch (e) {
+      alert(e.message);
+    }
+  };
+}
+
+function renderTaskBoard() {
+  const menu = $('tasksMenu');
+  const middle = $('tasksDueNow');
+  const right = $('tasksFuture');
+  if (!menu || !middle || !right) return;
+  menu.querySelectorAll('[data-task-menu]').forEach((btn) => {
+    btn.classList.toggle('active', btn.dataset.taskMenu === state.taskMenu);
+  });
+  const base = state.taskMenu === 'done'
+    ? state.taskItems.filter((t) => t.status === 'done')
+    : state.taskItems.filter((t) => t.status !== 'done');
+  const middleItems = base.filter((t) => taskDatePartition(t) === 'middle');
+  const rightItems = base.filter((t) => taskDatePartition(t) === 'right');
+  middle.innerHTML = middleItems.length ? middleItems.map(taskCardHtml).join('') : '<div class="queue-empty">対象タスクなし</div>';
+  right.innerHTML = rightItems.length ? rightItems.map(taskCardHtml).join('') : '<div class="queue-empty">対象タスクなし</div>';
+
+  document.querySelectorAll('[data-task-open]').forEach((el) => {
+    el.addEventListener('click', (ev) => {
+      const id = Number(el.dataset.taskOpen);
+      if (ev.target.closest('button')) return;
+      state.taskDetail = state.taskItems.find((t) => t.id === id) || null;
+      renderTaskDetail();
+    });
+  });
+  document.querySelectorAll('[data-task-done]').forEach((btn) => {
+    btn.addEventListener('click', async (ev) => {
+      ev.stopPropagation();
+      await api(`/api/tasks/${btn.dataset.taskDone}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'done' }),
+      });
+      await loadTasks();
+    });
+  });
+  document.querySelectorAll('[data-task-share]').forEach((btn) => {
+    btn.addEventListener('click', async (ev) => {
+      ev.stopPropagation();
+      try {
+        await api(`/api/tasks/${btn.dataset.taskShare}/share/actio`, { method: 'POST' });
+        showShareToast('Actio にシェアしました');
+      } catch (e) {
+        alert(e.message);
+      }
+      await loadTasks();
+    });
+  });
+  document.querySelectorAll('[data-task-delete]').forEach((btn) => {
+    btn.addEventListener('click', async (ev) => {
+      ev.stopPropagation();
+      await api(`/api/tasks/${btn.dataset.taskDelete}`, { method: 'DELETE' });
+      if (state.taskDetail?.id === Number(btn.dataset.taskDelete)) state.taskDetail = null;
+      await loadTasks();
+    });
+  });
+}
+
+function decorateTaskAndImplTabs() {
+  const taskTab = document.querySelector('.tab[data-tab="tasks"]');
+  const implTab = document.querySelector('.tab[data-tab="impl"]');
+  if (taskTab) {
+    const label = taskTab.querySelector('.tab-label');
+    if (label) {
+      label.textContent = '📝 タスク';
+      label.dataset.full = '📝 タスク';
+      label.dataset.short = '📝 タスク';
+    }
+    if (!isNarrowViewport()) taskTab.style.order = '-20';
+    else taskTab.style.order = '';
+  }
+  if (implTab) {
+    const label = implTab.querySelector('.tab-label');
+    if (label) {
+      label.textContent = '✨ 実装自慢';
+      label.dataset.full = '✨ 実装自慢';
+      label.dataset.short = '✨ 実装自慢';
+    }
+    if (!isNarrowViewport()) implTab.style.order = '-19';
+    else implTab.style.order = '';
+  }
+}
+
+const baseEnsureMemoriaFeatureViews = ensureMemoriaFeatureViews;
+ensureMemoriaFeatureViews = function () {
+  baseEnsureMemoriaFeatureViews();
+  const tasksView = $('tasksView');
+  if (tasksView && tasksView.dataset.v2 !== '1') {
+    tasksView.dataset.v2 = '1';
+    tasksView.innerHTML = `
+      <div class="simple-panel">
+        <div class="simple-panel-head">
+          <h2>📝 タスク</h2>
+          <button id="taskNewBtn" type="button">+ 追加</button>
+        </div>
+        <div id="taskForm" class="simple-form hidden"></div>
+        <div class="tasks-three-pane">
+          <aside id="tasksMenu" class="tasks-menu">
+            <button type="button" data-task-menu="todo" class="active">TODO</button>
+            <button type="button" data-task-menu="done">完了済み</button>
+          </aside>
+          <section class="tasks-pane">
+            <h3>今日が期限 / 期限切れ</h3>
+            <div id="tasksDueNow" class="simple-list"></div>
+          </section>
+          <section class="tasks-pane">
+            <h3>未来のタスク</h3>
+            <div id="tasksFuture" class="simple-list"></div>
+          </section>
+        </div>
+        <section id="taskDetailPanel" class="task-detail-panel hidden"></section>
+      </div>`;
+  }
+  decorateTaskAndImplTabs();
+  upgradeTaskFormMarkup();
+  upgradeImplementationFormMarkup();
+  setupTaskFormKeyboard();
+  setupImplementationFormKeyboard();
+  if ($('taskNewBtn')) $('taskNewBtn').onclick = () => {
+    $('taskForm')?.classList.remove('hidden');
+    $('taskTitle')?.focus();
+  };
+  if ($('taskCancelBtn')) $('taskCancelBtn').onclick = () => $('taskForm')?.classList.add('hidden');
+  if ($('taskAddBtn')) $('taskAddBtn').onclick = addTaskFromForm;
+  if ($('implNewBtn')) $('implNewBtn').onclick = () => {
+    $('implForm')?.classList.remove('hidden');
+    $('implTitle')?.focus();
+  };
+  if ($('implCancelBtn')) $('implCancelBtn').onclick = () => $('implForm')?.classList.add('hidden');
+  if ($('implAddBtn')) $('implAddBtn').onclick = addImplementationNoteFromForm;
+  document.querySelectorAll('#tasksMenu [data-task-menu]').forEach((btn) => {
+    btn.onclick = () => {
+      state.taskMenu = btn.dataset.taskMenu;
+      renderTaskBoard();
+    };
+  });
+};
+
+loadTasks = async function () {
+  ensureMemoriaFeatureViews();
+  const r = await api('/api/tasks');
+  state.taskItems = r.items || [];
+  if (state.taskDetail?.id) {
+    state.taskDetail = state.taskItems.find((t) => t.id === state.taskDetail.id) || null;
+  }
+  renderTaskBoard();
+  renderTaskDetail();
+};
+
+addTaskFromForm = async function () {
+  const title = $('taskTitle')?.value.trim();
+  if (!title) return;
+  await api('/api/tasks', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      title,
+      details: $('taskDetails')?.value.trim() || '',
+      due_at: $('taskDue')?.value || null,
+      share_actio: !!$('taskShareActio')?.checked,
+      creator_type: 'human',
+    }),
+  });
+  $('taskTitle').value = '';
+  $('taskDetails').value = '';
+  $('taskForm')?.classList.add('hidden');
+  await loadTasks();
+};
+
+window.addEventListener('resize', decorateTaskAndImplTabs);
+
 ensureMemoriaFeatureViews();
 loadPrivacySettings().catch(console.warn);
 
@@ -5145,7 +5710,7 @@ function localDateStr(d) {
   const m = String(d.getMonth() + 1).padStart(2, '0');
   const day = String(d.getDate()).padStart(2, '0');
   return `${y}-${m}-${day}`;
-}
+};
 function shiftWorklogDate(deltaDays) {
   const [y, m, d] = state.worklog.date.split('-').map(Number);
   const dt = new Date(y, m - 1, d);
@@ -5381,14 +5946,36 @@ function renderWorklogBrowsing(r) {
       const bm = v.is_bookmarked ? '<span class="wl-source">★ BM</span>' : '';
       const dom = v.domain ? `<span class="wl-meta">${escapeHtml(v.domain)}</span>` : '';
       const cnt = v.visit_count > 1 ? `<span class="wl-meta">×${v.visit_count}</span>` : '';
+      const unregistered = v.domain && !v.catalog
+        ? `<button class="wl-reg-btn" data-domain="${escapeHtml(v.domain)}">登録</button>`
+        : '';
       return `<li>
         <div class="wl-row1">
           <span class="wl-time">${escapeHtml(t)}</span>
-          ${bm}${dom}${cnt}
+          ${bm}${dom}${cnt}${unregistered}
         </div>
         <div class="wl-content"><a href="${escapeHtml(v.url)}" target="_blank" rel="noopener">${escapeHtml(v.title || v.url)}</a></div>
       </li>`;
     }).join('');
+    visitsList.querySelectorAll('.wl-reg-btn').forEach(btn => {
+      btn.addEventListener('click', async () => {
+        const domain = btn.dataset.domain;
+        if (!domain) return;
+        const origText = btn.textContent;
+        btn.disabled = true;
+        btn.textContent = '登録中…';
+        try {
+          await api(`/api/domains/${encodeURIComponent(domain)}/regenerate`, { method: 'POST' });
+          switchTab('domain');
+          await new Promise(r => setTimeout(r, 0));
+          loadDomainEntry(domain).catch(() => {});
+        } catch (err) {
+          btn.disabled = false;
+          btn.textContent = origText;
+          alert(`登録に失敗しました: ${err.message}`);
+        }
+      });
+    });
   }
 
   // Revisits list
@@ -5413,12 +6000,35 @@ function renderWorklogBrowsing(r) {
 
   // Top domains
   const domList = $('wlDomainsList');
-  domList.innerHTML = domains.map(d => `
-    <li>
+  domList.innerHTML = domains.map(d => {
+    const unreg = d.catalog_status == null
+      ? `<button class="wl-reg-btn" data-domain="${escapeHtml(d.domain)}">未登録</button>`
+      : '';
+    return `<li>
       <span class="wl-dom-name">${escapeHtml(d.domain)}</span>
       <span class="wl-dom-count">${d.pages} ページ / ${d.visits} 回</span>
-    </li>
-  `).join('');
+      ${unreg}
+    </li>`;
+  }).join('');
+  domList.querySelectorAll('.wl-reg-btn').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const domain = btn.dataset.domain;
+      if (!domain) return;
+      const origText = btn.textContent;
+      btn.disabled = true;
+      btn.textContent = '登録中…';
+      try {
+        await api(`/api/domains/${encodeURIComponent(domain)}/regenerate`, { method: 'POST' });
+        switchTab('domain');
+        await new Promise(r => setTimeout(r, 0));
+        loadDomainEntry(domain).catch(() => {});
+      } catch (err) {
+        btn.disabled = false;
+        btn.textContent = origText;
+        alert(`登録に失敗しました: ${err.message}`);
+      }
+    });
+  });
 }
 
 async function loadWorklogDig(date) {

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -82,12 +82,8 @@
             <span class="tab-label" data-full="⚙ 作業キュー" data-short="⚙ キュー">⚙ 作業キュー</span>
             <span id="tabQueueCount" class="tab-count hidden">0</span>
           </button>
-          <button class="tab" data-tab="events">
-            <span class="tab-label" data-full="📋 予定" data-short="📋 予定">📋 予定</span>
-          </button>
-          <button class="tab" data-tab="visits">
-            <span class="tab-label" data-full="🕘 アクセス履歴" data-short="🕘 履歴">🕘 アクセス履歴</span>
-            <span id="tabVisitsCount" class="tab-count hidden">0</span>
+          <button class="tab" data-tab="worklog">
+            <span class="tab-label" data-full="📝 作業ログ" data-short="📝 ログ">📝 作業ログ</span>
           </button>
           <button class="tab" data-tab="trends">
             <span class="tab-label" data-full="📊 傾向" data-short="📊 傾向">📊 傾向</span>
@@ -155,31 +151,6 @@
             </div>
           </div>
         </div>
-      </div>
-
-      <div id="visitsView" class="hidden">
-        <div class="visits-bar">
-          <span>ブラウザで開いた URL の履歴。各ドメインの説明は裏で Sonnet が分類して付与しています。</span>
-          <span class="grow"></span>
-          <select id="visitsRange">
-            <option value="today">今日のみ</option>
-            <option value="7" selected>過去 7 日</option>
-            <option value="30">過去 30 日</option>
-            <option value="90">過去 90 日</option>
-          </select>
-          <button id="visitsRefresh" class="ghost">更新</button>
-        </div>
-        <div class="visits-actions">
-          <label class="check-inline">
-            <input type="checkbox" id="visitsAll" /> 全選択
-          </label>
-          <span id="visitsSelCount">0</span> 件選択中
-          <button id="visitsBookmark">選択をブックマークに保存</button>
-          <button id="visitsDelete" class="ghost">選択を履歴から削除</button>
-        </div>
-        <ul id="visitsList" class="visits-list"></ul>
-        <div id="visitsEmpty" class="queue-empty hidden">本日の未保存履歴はありません。</div>
-        <ul id="visitsResults" class="visits-results"></ul>
       </div>
 
       <div id="trendsView" class="hidden">
@@ -451,12 +422,93 @@
         <div id="queueHistory" class="queue-history-list"></div>
       </div>
 
-      <div id="eventsView" class="hidden">
-        <div class="events-bar">
-          <div id="uptimeStatus" class="uptime-status"></div>
-          <button id="eventsRefresh" class="ghost">更新</button>
+      <div id="worklogView" class="hidden">
+        <div class="worklog-daynav">
+          <button id="wlPrevDay" class="ghost" title="前日">◀</button>
+          <input id="wlDate" type="date" />
+          <button id="wlNextDay" class="ghost" title="翌日">▶</button>
+          <button id="wlToday" class="ghost">今日</button>
+          <span class="grow"></span>
+          <span id="wlSummary" class="worklog-summary"></span>
+          <button id="wlRefresh" class="ghost">更新</button>
         </div>
-        <ul id="eventsList" class="events-list"></ul>
+        <nav class="worklog-subtabs" id="worklogSubtabs">
+          <button class="wl-subtab active" data-sub="schedule">📋 予定</button>
+          <button class="wl-subtab" data-sub="github">🐙 GitHub</button>
+          <button class="wl-subtab" data-sub="claude">🤖 Claude Code</button>
+          <button class="wl-subtab" data-sub="gemini">💎 Gemini</button>
+          <button class="wl-subtab" data-sub="codex">📜 Codex</button>
+          <button class="wl-subtab" data-sub="browsing">🌐 ブラウジング</button>
+          <button class="wl-subtab" data-sub="dig">🔎 ディグ</button>
+        </nav>
+
+        <section id="wlScheduleView" class="wl-sub">
+          <div id="wlUptimeStatus" class="uptime-status"></div>
+          <ul id="wlScheduleList" class="events-list"></ul>
+          <div id="wlScheduleEmpty" class="queue-empty hidden">この日のイベントはありません。</div>
+        </section>
+
+        <section id="wlGithubView" class="wl-sub hidden">
+          <div class="wl-summary-row" id="wlGithubSummary"></div>
+          <ul id="wlGithubList" class="wl-list"></ul>
+          <div id="wlGithubEmpty" class="queue-empty hidden">この日の git commit はありません。</div>
+        </section>
+
+        <section id="wlClaudeView" class="wl-sub hidden">
+          <div class="wl-summary-row" id="wlClaudeSummary"></div>
+          <ul id="wlClaudeList" class="wl-list"></ul>
+          <div id="wlClaudeEmpty" class="queue-empty hidden">この日の Claude Code prompt はありません。</div>
+        </section>
+
+        <section id="wlGeminiView" class="wl-sub hidden">
+          <div class="wl-summary-row" id="wlGeminiSummary"></div>
+          <ul id="wlGeminiList" class="wl-list"></ul>
+          <div id="wlGeminiEmpty" class="queue-empty hidden">この日の Gemini prompt はありません。 (gemini hook 未設定の場合は記録されません)</div>
+        </section>
+
+        <section id="wlCodexView" class="wl-sub hidden">
+          <div class="wl-summary-row" id="wlCodexSummary"></div>
+          <ul id="wlCodexList" class="wl-list"></ul>
+          <div id="wlCodexEmpty" class="queue-empty hidden">この日の Codex prompt はありません。 (codex hook 未設定の場合は記録されません)</div>
+        </section>
+
+        <section id="wlBrowsingView" class="wl-sub hidden">
+          <div class="wl-summary-row" id="wlBrowsingSummary"></div>
+          <div class="wl-browsing-grid">
+            <div class="wl-browsing-col">
+              <h4>当日訪問ページ <span id="wlVisitsCount" class="wl-count">0</span></h4>
+              <ul id="wlVisitsList" class="wl-list"></ul>
+              <div id="wlVisitsEmpty" class="queue-empty hidden">この日のページ閲覧履歴はありません。</div>
+            </div>
+            <div class="wl-browsing-col">
+              <h4>再訪したブックマーク <span id="wlRevisitsCount" class="wl-count">0</span></h4>
+              <ul id="wlRevisitsList" class="wl-list"></ul>
+              <div id="wlRevisitsEmpty" class="queue-empty hidden">この日の再訪ブックマークはありません。</div>
+              <h4 class="wl-h-sub">上位ドメイン <span id="wlDomainsCount" class="wl-count">0</span></h4>
+              <ul id="wlDomainsList" class="wl-domains-list"></ul>
+            </div>
+          </div>
+        </section>
+
+        <!-- 旧アクセス履歴ビュー (visitsView) は廃止された。
+             既存 listener 互換のため hidden の placeholder DOM を残す。 -->
+        <div id="visitsView" class="hidden" aria-hidden="true">
+          <select id="visitsRange"><option value="7" selected>7</option></select>
+          <button id="visitsRefresh"></button>
+          <input type="checkbox" id="visitsAll" />
+          <span id="visitsSelCount">0</span>
+          <button id="visitsBookmark"></button>
+          <button id="visitsDelete"></button>
+          <ul id="visitsList"></ul>
+          <div id="visitsEmpty"></div>
+          <ul id="visitsResults"></ul>
+        </div>
+
+        <section id="wlDigView" class="wl-sub hidden">
+          <div class="wl-summary-row" id="wlDigSummary"></div>
+          <ul id="wlDigList" class="wl-list"></ul>
+          <div id="wlDigEmpty" class="queue-empty hidden">この日のディグはありません。</div>
+        </section>
       </div>
 
       <div id="tracksView" class="hidden">

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -4543,3 +4543,173 @@ dialog.loc-edit-modal[open] {
   .loc-edit-map { height: 260px; }
   .loc-edit-head h3 { font-size: 14px; }
 }
+
+/* ── Worklog tab ───────────────────────────────────────────────────────── */
+
+.worklog-daynav {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+.worklog-daynav input[type="date"] {
+  padding: 4px 6px;
+  font-size: 14px;
+  background: var(--card);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+.worklog-daynav .grow { flex: 1; min-width: 8px; }
+.worklog-summary {
+  font-size: 12px;
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 60vw;
+}
+
+.worklog-subtabs {
+  display: flex;
+  gap: 4px;
+  padding: 8px 12px 0 12px;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--border);
+  scrollbar-width: thin;
+}
+.wl-subtab {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-bottom: none;
+  border-radius: 6px 6px 0 0;
+  padding: 6px 12px;
+  font-size: 13px;
+  color: var(--muted);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.wl-subtab:hover { color: var(--text); background: var(--card); }
+.wl-subtab.active {
+  color: var(--text);
+  background: var(--card);
+  border-color: var(--accent);
+  border-bottom: 1px solid var(--card);
+  margin-bottom: -1px;
+}
+
+.wl-sub { padding: 12px; }
+.wl-sub.hidden { display: none; }
+
+.wl-summary-row {
+  font-size: 13px;
+  color: var(--muted);
+  margin-bottom: 8px;
+  padding: 6px 8px;
+  background: var(--card);
+  border-radius: 4px;
+  border: 1px solid var(--border);
+}
+.wl-summary-row strong { color: var(--text); margin-right: 6px; }
+
+.wl-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.wl-list li {
+  padding: 8px 10px;
+  border-radius: 4px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  font-size: 13px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.wl-list li .wl-row1 {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.wl-list li .wl-time {
+  color: var(--muted);
+  font-size: 11px;
+  font-family: ui-monospace, monospace;
+  white-space: nowrap;
+}
+.wl-list li .wl-source {
+  color: var(--accent);
+  font-size: 11px;
+  white-space: nowrap;
+}
+.wl-list li .wl-content {
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.4;
+}
+.wl-list li .wl-content.truncate {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.wl-list li a { color: var(--accent); text-decoration: none; }
+.wl-list li a:hover { text-decoration: underline; }
+.wl-meta {
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.wl-count {
+  font-size: 11px;
+  color: var(--muted);
+  margin-left: 6px;
+}
+.wl-h-sub { margin-top: 16px; }
+
+.wl-browsing-grid {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 16px;
+}
+.wl-browsing-col h4 {
+  margin: 0 0 8px 0;
+  font-size: 13px;
+  color: var(--muted);
+  font-weight: 600;
+}
+.wl-domains-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.wl-domains-list li {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 4px 8px;
+  font-size: 13px;
+  border-bottom: 1px dashed var(--border);
+}
+.wl-domains-list li .wl-dom-name { flex: 1; word-break: break-all; }
+.wl-domains-list li .wl-dom-count {
+  color: var(--muted);
+  font-size: 11px;
+  font-family: ui-monospace, monospace;
+  white-space: nowrap;
+}
+
+@media (max-width: 760px) {
+  .wl-browsing-grid { grid-template-columns: 1fr; }
+  .worklog-summary { max-width: 100%; flex-basis: 100%; }
+}

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -3966,6 +3966,14 @@ dialog.meal-modal[open] {
   overflow: auto;
   max-height: 48vh;
 }
+.domain-private-toggle {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--muted);
+}
 
 @media (max-width: 480px) {
   .meal-modal-map {

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -1396,8 +1396,9 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 .modal-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(0, 0, 0, 0.55);
   z-index: 90;
+  backdrop-filter: blur(1px);
 }
 .modal-backdrop[hidden] { display: none; }
 .modal-panel {
@@ -1419,6 +1420,7 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   box-shadow: 0 12px 48px rgba(0,0,0,0.2);
 }
 .modal-panel.ext-setup { background: var(--panel) !important; }
+.modal-panel#taskEditorModal { z-index: 110; }
 .modal-close {
   /* 右上ピン留めの×。 スマホでも押しやすいよう 44x44 を確保。 */
   position: absolute;
@@ -3941,6 +3943,48 @@ dialog.meal-modal[open] {
 .simple-field > span {
   font-weight: 600;
 }
+.foundation-form {
+  display: grid;
+  gap: 10px;
+}
+.foundation-form .simple-field {
+  gap: 6px;
+}
+.foundation-form .simple-field > span {
+  font-size: 12px;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+}
+.foundation-form input[type="text"],
+.foundation-form input[type="datetime-local"],
+.foundation-form textarea,
+.foundation-form select {
+  width: 100%;
+  box-sizing: border-box;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-size: 14px;
+  color: var(--text);
+}
+.foundation-form textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+.foundation-form input:focus,
+.foundation-form textarea:focus,
+.foundation-form select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+.foundation-form .simple-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
 .simple-check-row {
   display: grid;
   grid-template-columns: 18px 1fr;
@@ -3975,14 +4019,16 @@ dialog.meal-modal[open] {
 }
 .tasks-three-pane {
   display: grid;
-  grid-template-columns: 180px 1fr 1fr;
+  grid-template-columns: 20% 40% 40%;
   gap: 12px;
   align-items: start;
   margin-bottom: 12px;
+  width: 100%;
 }
 .tasks-menu {
   display: grid;
   gap: 8px;
+  margin-right: 8px;
 }
 .tasks-menu button {
   text-align: left;
@@ -3991,6 +4037,7 @@ dialog.meal-modal[open] {
   border-radius: 8px;
   background: var(--panel);
   cursor: pointer;
+  color: var(--text);
 }
 .tasks-menu button.active {
   background: var(--accent-bg);
@@ -3998,15 +4045,53 @@ dialog.meal-modal[open] {
   color: var(--accent);
   font-weight: 600;
 }
+.tasks-menu button:not(.active) {
+  color: var(--text);
+  background: #fff;
+}
+.task-done-drop {
+  display: none;
+  margin-top: 4px;
+  padding: 14px 10px;
+  border: 2px dashed var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  background: #fff;
+  text-align: center;
+  font-weight: 600;
+}
+.task-done-drop.drag-over {
+  border-color: var(--accent);
+  background: var(--accent-bg);
+  color: var(--accent);
+}
+@media (min-width: 761px) {
+  body.task-dragging .task-done-drop {
+    display: block;
+    border-color: var(--accent);
+    background: var(--accent-bg);
+    color: var(--accent);
+  }
+}
 .tasks-pane h3 {
   margin: 0 0 8px;
   font-size: 13px;
 }
+.tasks-pane:first-of-type {
+  margin-left: 8px;
+}
 .task-card {
+  background: var(--panel);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 10px;
-  background: var(--surface);
+  border-radius: 10px;
+  padding: 12px 14px;
+  box-shadow: var(--shadow);
+  transition: border-color 80ms, transform 80ms, box-shadow 80ms;
+}
+.task-card:hover {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.08);
 }
 .task-card-head {
   display: flex;

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -3912,6 +3912,16 @@ dialog.meal-modal[open] {
   margin: 0 0 12px;
   font-size: 20px;
 }
+.simple-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.simple-panel-head h2 {
+  margin: 0;
+}
 .simple-form {
   display: grid;
   gap: 8px;

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -1408,6 +1408,7 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   width: min(680px, 92vw);
   max-height: 88vh;
   overflow-y: auto;
+  resize: none;
   z-index: 100;
   /* 説明テキストが白背景で読める。 後ろのバックドロップ (alpha 0.4) を
    * 透かさないよう !important で確実に opaque にする。 */
@@ -1867,6 +1868,9 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   padding: 16px;
   box-shadow: 0 8px 32px rgba(0,0,0,0.15);
   width: 380px;
+  max-height: 80vh;
+  overflow-y: auto;
+  resize: none;
   z-index: 50;
 }
 .diary-settings h4 { margin: 0 0 8px; }
@@ -1900,6 +1904,7 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   width: 560px;
   max-height: 80vh;
   overflow-y: auto;
+  resize: none;
   z-index: 100;
 }
 .ai-settings-head {
@@ -3968,6 +3973,83 @@ dialog.meal-modal[open] {
   display: grid;
   gap: 10px;
 }
+.tasks-three-pane {
+  display: grid;
+  grid-template-columns: 180px 1fr 1fr;
+  gap: 12px;
+  align-items: start;
+  margin-bottom: 12px;
+}
+.tasks-menu {
+  display: grid;
+  gap: 8px;
+}
+.tasks-menu button {
+  text-align: left;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel);
+  cursor: pointer;
+}
+.tasks-menu button.active {
+  background: var(--accent-bg);
+  border-color: var(--accent);
+  color: var(--accent);
+  font-weight: 600;
+}
+.tasks-pane h3 {
+  margin: 0 0 8px;
+  font-size: 13px;
+}
+.task-card {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px;
+  background: var(--surface);
+}
+.task-card-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+.task-origin {
+  display: inline-flex;
+  align-items: center;
+  height: 20px;
+  padding: 0 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  border: 1px solid var(--border);
+  color: var(--muted);
+}
+.task-origin.ai {
+  border-color: #c37a00;
+  color: #9a6000;
+  background: #fff3df;
+}
+.task-origin.human {
+  border-color: #1f56c0;
+  color: #1f56c0;
+  background: #eaf1ff;
+}
+.task-detail-panel {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  padding: 12px;
+}
+.task-detail-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+.task-detail-head h3 {
+  margin: 0;
+  font-size: 15px;
+}
 .simple-item {
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -4005,8 +4087,43 @@ dialog.meal-modal[open] {
   font-size: 12px;
   color: var(--muted);
 }
+.domain-private-detail {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  align-self: stretch;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 13px;
+  color: var(--text);
+}
+.domain-private-detail input {
+  margin: 0;
+}
+.impl-attachment {
+  display: grid;
+  gap: 6px;
+  margin: 8px 0 12px;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel);
+}
+.impl-attachment pre {
+  margin: 0;
+  max-height: 240px;
+  overflow: auto;
+  white-space: pre-wrap;
+}
+.impl-attachment p {
+  margin: 0;
+}
 
 @media (max-width: 480px) {
+  .tasks-three-pane {
+    grid-template-columns: 1fr;
+  }
   .meal-modal-map {
     height: 200px;
   }
@@ -4811,6 +4928,21 @@ dialog.loc-edit-modal[open] {
   font-size: 11px;
   font-family: ui-monospace, monospace;
   white-space: nowrap;
+}
+.wl-reg-btn {
+  font-size: 10px;
+  padding: 1px 6px;
+  border: 1px solid var(--accent);
+  border-radius: 3px;
+  background: transparent;
+  color: var(--accent);
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.wl-reg-btn:hover {
+  background: var(--accent);
+  color: #fff;
 }
 
 @media (max-width: 760px) {

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -3902,6 +3902,61 @@ dialog.meal-modal[open] {
 }
 .meal-loc-map-link:hover { text-decoration: underline; }
 
+/* Simple feature panes injected by app.js for tasks / implementation notes. */
+.simple-panel {
+  padding: 16px;
+  max-width: 960px;
+  margin: 0 auto;
+}
+.simple-panel h2 {
+  margin: 0 0 12px;
+  font-size: 20px;
+}
+.simple-form {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+.simple-form input,
+.simple-form textarea,
+.setup-doc-body {
+  width: 100%;
+  box-sizing: border-box;
+}
+.simple-list {
+  display: grid;
+  gap: 10px;
+}
+.simple-item {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+  background: var(--surface);
+}
+.simple-item-head,
+.simple-actions,
+.setup-docs-list {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.simple-item-head {
+  justify-content: space-between;
+}
+.simple-item p {
+  white-space: pre-wrap;
+}
+.setup-doc-body {
+  margin-top: 10px;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  white-space: pre-wrap;
+  overflow: auto;
+  max-height: 48vh;
+}
+
 @media (max-width: 480px) {
   .meal-modal-map {
     height: 200px;

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -3927,11 +3927,42 @@ dialog.meal-modal[open] {
   gap: 8px;
   margin-bottom: 14px;
 }
+.simple-field {
+  display: grid;
+  gap: 4px;
+  font-size: 13px;
+  color: var(--text);
+}
+.simple-field > span {
+  font-weight: 600;
+}
+.simple-check-row {
+  display: grid;
+  grid-template-columns: 18px 1fr;
+  gap: 8px;
+  align-items: center;
+  width: fit-content;
+  font-size: 13px;
+}
+.simple-check-row input {
+  margin: 0;
+}
+.task-due-shortcuts {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
 .simple-form input,
 .simple-form textarea,
 .setup-doc-body {
   width: 100%;
   box-sizing: border-box;
+}
+.simple-form textarea {
+  min-height: 120px;
+}
+#taskDetails {
+  min-height: 160px;
 }
 .simple-list {
   display: grid;

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -3985,6 +3985,14 @@ dialog.meal-modal[open] {
   gap: 8px;
   margin-top: 4px;
 }
+.simple-field-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+@media (max-width: 480px) {
+  .simple-field-row { grid-template-columns: 1fr; }
+}
 .simple-check-row {
   display: grid;
   grid-template-columns: 18px 1fr;
@@ -4876,6 +4884,30 @@ dialog.loc-edit-modal[open] {
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 60vw;
+}
+.wl-gemini-web-box {
+  margin-top: 12px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--panel);
+  display: grid;
+  gap: 8px;
+}
+.wl-gemini-web-box h4 {
+  margin: 0;
+  font-size: 13px;
+}
+.wl-gemini-web-box label {
+  display: grid;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.wl-gemini-web-box input,
+.wl-gemini-web-box textarea {
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .worklog-subtabs {


### PR DESCRIPTION
## 概要
- セットアップ手順、プライバシー/表示設定、タスク、実装自慢の UI/API を追加
- 軌跡/食事の opt-out と、ドメイン private ルールによる日記表示除外を追加
- MCP からタスク追加・外部チャット受信・実装自慢追加ができる tool を追加
- Claude/Codex 向け skill をプロジェクトルートに追加

## 確認
- node --check server/index.js
- node --check server/db.js
- node --check server/diary.js
- node --check server/public/app.js
- node --check mcp-server/index.js
- node --check server/multi/index.js
- node --check server/multi/db.js
- 一時データディレクトリで追加 API の smoke test