### PR TITLE
feat: タスクをAIエージェント (Claude/Codex/Gemini) に委託する

### DIFF
--- a/server/agent-dispatch.js
+++ b/server/agent-dispatch.js
@@ -59,22 +59,37 @@ function buildPrompt({ task, project }) {
   return lines.join('\n');
 }
 
-function buildArgs(agent) {
+// 各エージェントのデフォルトモデル (model 未指定時に使う)
+const AGENT_DEFAULT_MODEL = {
+  claude_code: 'sonnet',
+  codex:       '5.3-codex',
+  gemini:      'gemini-2.5-flash',
+};
+
+function buildArgs(agent, model) {
+  const m = (model && String(model).trim()) || AGENT_DEFAULT_MODEL[agent] || '';
   if (agent === 'codex') {
-    return [
+    const args = [
       'exec',
       '--json',
       '--color', 'never',
       '--ask-for-approval', 'never',
       '--sandbox', 'workspace-write',
-      '-',
     ];
+    if (m) args.push('--model', m);
+    args.push('-');
+    return args;
   }
   if (agent === 'gemini') {
-    return ['-p'];
+    const args = [];
+    if (m) args.push('-m', m);
+    args.push('-p');
+    return args;
   }
   // claude_code (default)
-  return ['-p', '--dangerously-skip-permissions'];
+  const args = ['-p', '--dangerously-skip-permissions'];
+  if (m) args.push('--model', m);
+  return args;
 }
 
 function binaryFor(agent, settings) {
@@ -97,7 +112,7 @@ function binaryFor(agent, settings) {
  *   gitBashPath — optional CLAUDE_CODE_GIT_BASH_PATH override
  *   timeoutMs   — kill the child after this many ms (default 30 min)
  */
-export function startAgentRun(db, { dataDir, settings, task, project, agent, gitBashPath, timeoutMs = 30 * 60 * 1000 }) {
+export function startAgentRun(db, { dataDir, settings, task, project, agent, model, gitBashPath, timeoutMs = 30 * 60 * 1000 }) {
   if (!task) throw new Error('task required');
   if (!project) throw new Error('project required');
   const a = agent || project.default_agent || 'claude_code';
@@ -112,11 +127,13 @@ export function startAgentRun(db, { dataDir, settings, task, project, agent, git
   const logFile = `run_${Date.now()}_${Math.random().toString(36).slice(2, 8)}.log`;
   const logPath = join(logDir, logFile);
   const prompt = buildPrompt({ task, project });
+  const effectiveModel = (model && String(model).trim()) || AGENT_DEFAULT_MODEL[a] || '';
 
   const runId = insertAgentRun(db, {
     task_id: task.id,
     project_id: project.id,
     agent: a,
+    model: effectiveModel || null,
     prompt,
     status: 'pending',
     log_path: logFile,
@@ -125,13 +142,13 @@ export function startAgentRun(db, { dataDir, settings, task, project, agent, git
   // Spawn after row exists so we always have a record even if spawn fails.
   let child;
   const bin = binaryFor(a, settings || {});
-  const args = buildArgs(a);
+  const args = buildArgs(a, effectiveModel);
   const env = { ...process.env };
   if (a === 'claude_code' && (gitBashPath || settings?.['runtime.git_bash_path'])) {
     env.CLAUDE_CODE_GIT_BASH_PATH = gitBashPath || settings['runtime.git_bash_path'];
   }
   const stream = createWriteStream(logPath, { flags: 'a' });
-  stream.write(`# agent: ${a}\n# bin: ${bin}\n# args: ${JSON.stringify(args)}\n# cwd: ${project.path}\n# started: ${new Date().toISOString()}\n# task: ${task.title}\n\n----- prompt -----\n${prompt}\n----- output -----\n`);
+  stream.write(`# agent: ${a}\n# model: ${effectiveModel || '(default)'}\n# bin: ${bin}\n# args: ${JSON.stringify(args)}\n# cwd: ${project.path}\n# started: ${new Date().toISOString()}\n# task: ${task.title}\n\n----- prompt -----\n${prompt}\n----- output -----\n`);
 
   try {
     child = spawn(bin, args, {
@@ -156,8 +173,8 @@ export function startAgentRun(db, { dataDir, settings, task, project, agent, git
 
   recordActivityEvent(db, {
     kind: 'task_updated',
-    content: `[AI実装開始] ${task.title} (${a})`,
-    metadata: { agent_run_id: runId, agent: a, project: project.name },
+    content: `[AI実装開始] ${task.title} (${a}${effectiveModel ? `:${effectiveModel}` : ''})`,
+    metadata: { agent_run_id: runId, agent: a, model: effectiveModel || null, project: project.name },
   });
 
   let timer = setTimeout(() => {

--- a/server/agent-dispatch.js
+++ b/server/agent-dispatch.js
@@ -1,0 +1,234 @@
+// agent-dispatch.js — Memoria task → AI agent (Claude Code / Codex / Gemini) を
+// プロジェクトディレクトリで non-interactive に走らせ、stdout/stderr を log
+// ファイルにストリーム保存しながら DB の `agent_runs` 行を更新する。
+//
+// 既存の `runLlm` (server/llm.js) は短い LLM 質問用 (タイムアウト 3 分、結果を
+// 文字列で返す) なのでこちらの長尺・1 ショット実装用とは分けて持つ。
+//
+// Usage:
+//   const runId = startAgentRun(db, { task, project, agent });
+//   // returns immediately. The child runs in the background and updates
+//   // agent_runs by id when it exits.
+
+import { spawn } from 'node:child_process';
+import { mkdirSync, createWriteStream, existsSync, readFileSync, statSync } from 'node:fs';
+import { join, isAbsolute } from 'node:path';
+import {
+  insertAgentRun, updateAgentRun, getAgentRun, getTask, recordActivityEvent,
+} from './db.js';
+
+const SUPPORTED_AGENTS = new Set(['claude_code', 'codex', 'gemini']);
+
+// Track running children by run id so cancel() can find them.
+const _running = new Map();
+
+function ensureLogDir(dataDir) {
+  const dir = join(dataDir, 'agent_logs');
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function buildPrompt({ task, project }) {
+  const rules = (project.rules || '').trim();
+  const lines = [
+    `あなたはこのプロジェクトのコードを 1 ショットで実装するエージェントです。`,
+    `止まらず最後まで実装し、完了したらサマリを 1 行出力して終了してください。`,
+    '',
+    `## プロジェクト: ${project.name}`,
+    `パス: ${project.path}`,
+    '',
+  ];
+  if (rules) {
+    lines.push('## ルール');
+    lines.push(rules);
+    lines.push('');
+  }
+  lines.push('## タスク');
+  lines.push(`タイトル: ${task.title}`);
+  if (task.due_at) lines.push(`期日: ${task.due_at}`);
+  lines.push('');
+  if (task.details) {
+    lines.push('## 詳細');
+    lines.push(task.details);
+    lines.push('');
+  }
+  lines.push('## 実行ガイド');
+  lines.push('- 不明点があればまずコードを読んで判断する (質問せず先に進む)');
+  lines.push('- ローカルテスト・型チェック・lint があれば実行する');
+  lines.push('- 完了時にやった作業の要約を 3〜5 行で出力する');
+  return lines.join('\n');
+}
+
+function buildArgs(agent) {
+  if (agent === 'codex') {
+    return [
+      'exec',
+      '--json',
+      '--color', 'never',
+      '--ask-for-approval', 'never',
+      '--sandbox', 'workspace-write',
+      '-',
+    ];
+  }
+  if (agent === 'gemini') {
+    return ['-p'];
+  }
+  // claude_code (default)
+  return ['-p', '--dangerously-skip-permissions'];
+}
+
+function binaryFor(agent, settings) {
+  if (agent === 'codex') return settings['llm.bin.codex'] || 'codex';
+  if (agent === 'gemini') return settings['llm.bin.gemini'] || 'gemini';
+  return settings['llm.bin.claude'] || 'claude';
+}
+
+/**
+ * Start an agent run. Returns the new run id immediately. The child process
+ * runs in the background and updates the DB row when it exits.
+ *
+ * Args:
+ *   db          — better-sqlite3 instance
+ *   dataDir     — base data directory (logs go to dataDir/agent_logs/)
+ *   settings    — getAppSettings(db) result; used for `llm.bin.*` overrides
+ *   task        — { id, title, details, due_at }
+ *   project     — { id, name, path, rules, default_agent }
+ *   agent       — 'claude_code' | 'codex' | 'gemini'  (overrides project.default_agent)
+ *   gitBashPath — optional CLAUDE_CODE_GIT_BASH_PATH override
+ *   timeoutMs   — kill the child after this many ms (default 30 min)
+ */
+export function startAgentRun(db, { dataDir, settings, task, project, agent, gitBashPath, timeoutMs = 30 * 60 * 1000 }) {
+  if (!task) throw new Error('task required');
+  if (!project) throw new Error('project required');
+  const a = agent || project.default_agent || 'claude_code';
+  if (!SUPPORTED_AGENTS.has(a)) throw new Error(`unsupported agent: ${a}`);
+  if (!project.path || !isAbsolute(project.path)) {
+    throw new Error('project.path must be an absolute path');
+  }
+  if (!existsSync(project.path)) {
+    throw new Error(`project.path does not exist: ${project.path}`);
+  }
+  const logDir = ensureLogDir(dataDir);
+  const logFile = `run_${Date.now()}_${Math.random().toString(36).slice(2, 8)}.log`;
+  const logPath = join(logDir, logFile);
+  const prompt = buildPrompt({ task, project });
+
+  const runId = insertAgentRun(db, {
+    task_id: task.id,
+    project_id: project.id,
+    agent: a,
+    prompt,
+    status: 'pending',
+    log_path: logFile,
+  });
+
+  // Spawn after row exists so we always have a record even if spawn fails.
+  let child;
+  const bin = binaryFor(a, settings || {});
+  const args = buildArgs(a);
+  const env = { ...process.env };
+  if (a === 'claude_code' && (gitBashPath || settings?.['runtime.git_bash_path'])) {
+    env.CLAUDE_CODE_GIT_BASH_PATH = gitBashPath || settings['runtime.git_bash_path'];
+  }
+  const stream = createWriteStream(logPath, { flags: 'a' });
+  stream.write(`# agent: ${a}\n# bin: ${bin}\n# args: ${JSON.stringify(args)}\n# cwd: ${project.path}\n# started: ${new Date().toISOString()}\n# task: ${task.title}\n\n----- prompt -----\n${prompt}\n----- output -----\n`);
+
+  try {
+    child = spawn(bin, args, {
+      cwd: project.path,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      shell: false,
+      env,
+    });
+  } catch (e) {
+    updateAgentRun(db, runId, {
+      status: 'failed',
+      finished_at: new Date().toISOString(),
+      summary: `spawn failed: ${e.message}`,
+    });
+    stream.write(`\n----- spawn error -----\n${e.message}\n`);
+    stream.end();
+    return runId;
+  }
+
+  updateAgentRun(db, runId, { status: 'running', pid: child.pid });
+  _running.set(runId, child);
+
+  recordActivityEvent(db, {
+    kind: 'task_updated',
+    content: `[AI実装開始] ${task.title} (${a})`,
+    metadata: { agent_run_id: runId, agent: a, project: project.name },
+  });
+
+  let timer = setTimeout(() => {
+    try { child.kill('SIGKILL'); } catch {}
+  }, timeoutMs);
+
+  child.stdout.on('data', (d) => stream.write(d));
+  child.stderr.on('data', (d) => {
+    stream.write(`[stderr] `);
+    stream.write(d);
+  });
+  child.on('error', (err) => {
+    stream.write(`\n----- error -----\n${err.message}\n`);
+  });
+  child.on('close', (code) => {
+    clearTimeout(timer);
+    _running.delete(runId);
+    const finishedAt = new Date().toISOString();
+    let summary = '';
+    try {
+      const tail = readFileSync(logPath, 'utf8').slice(-2000);
+      const lines = tail.split('\n').filter(l => l.trim()).slice(-6);
+      summary = lines.join('\n').slice(-600);
+    } catch {}
+    stream.write(`\n----- finished -----\nexit: ${code}\nat: ${finishedAt}\n`);
+    stream.end();
+    updateAgentRun(db, runId, {
+      status: code === 0 ? 'done' : 'failed',
+      exit_code: code,
+      finished_at: finishedAt,
+      summary,
+    });
+    recordActivityEvent(db, {
+      kind: code === 0 ? 'task_done' : 'task_updated',
+      content: `[AI実装${code === 0 ? '完了' : '失敗'}] ${task.title}`,
+      metadata: { agent_run_id: runId, exit_code: code },
+    });
+  });
+
+  // long prompt is passed via stdin (per Windows ENAMETOOLONG handling).
+  child.stdin.end(prompt, 'utf8');
+  return runId;
+}
+
+export function cancelAgentRun(db, runId) {
+  const child = _running.get(runId);
+  if (!child) return { ok: false, error: 'not_running' };
+  try { child.kill('SIGKILL'); } catch (e) {
+    return { ok: false, error: e.message };
+  }
+  updateAgentRun(db, runId, {
+    status: 'cancelled',
+    finished_at: new Date().toISOString(),
+  });
+  return { ok: true };
+}
+
+/**
+ * Read the log file for a run. `tail` controls how many bytes from the end
+ * to return (default 64KiB).
+ */
+export function readAgentRunLog(dataDir, run, { tail = 64 * 1024 } = {}) {
+  if (!run?.log_path) return '';
+  const path = join(dataDir, 'agent_logs', run.log_path);
+  if (!existsSync(path)) return '';
+  const stat = statSync(path);
+  const len = Math.min(stat.size, Number(tail) || 64 * 1024);
+  const buf = readFileSync(path);
+  return buf.subarray(buf.length - len).toString('utf8');
+}
+
+export function isRunning(runId) {
+  return _running.has(runId);
+}

--- a/server/db.js
+++ b/server/db.js
@@ -336,6 +336,7 @@ export function openDb(dbPath) {
       share_actio   INTEGER NOT NULL DEFAULT 0,
       shared_at     TEXT,
       shared_origin TEXT,
+      project_id    INTEGER,
       created_at    TEXT NOT NULL DEFAULT (datetime('now')),
       updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
     );
@@ -343,6 +344,35 @@ export function openDb(dbPath) {
       ON tasks(status, created_at DESC);
     CREATE INDEX IF NOT EXISTS idx_tasks_due
       ON tasks(due_at);
+
+    CREATE TABLE IF NOT EXISTS agent_projects (
+      id             INTEGER PRIMARY KEY AUTOINCREMENT,
+      name           TEXT NOT NULL,
+      path           TEXT NOT NULL,
+      rules          TEXT,
+      default_agent  TEXT NOT NULL DEFAULT 'claude_code',
+      created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at     TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE TABLE IF NOT EXISTS agent_runs (
+      id             INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_id        INTEGER,
+      project_id     INTEGER,
+      agent          TEXT NOT NULL,
+      prompt         TEXT,
+      status         TEXT NOT NULL DEFAULT 'pending',
+      exit_code      INTEGER,
+      log_path       TEXT,
+      pid            INTEGER,
+      summary        TEXT,
+      started_at     TEXT NOT NULL DEFAULT (datetime('now')),
+      finished_at    TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_agent_runs_task
+      ON agent_runs(task_id, started_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_agent_runs_status
+      ON agent_runs(status);
 
     CREATE TABLE IF NOT EXISTS work_locations (
       id             INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -408,6 +438,7 @@ export function openDb(dbPath) {
     ['share_actio', 'INTEGER NOT NULL DEFAULT 0'],
     ['shared_at', 'TEXT'],
     ['shared_origin', 'TEXT'],
+    ['project_id', 'INTEGER'],
   ]) {
     if (taskCols.length > 0 && !taskCols.includes(col)) {
       db.exec(`ALTER TABLE tasks ADD COLUMN ${col} ${ddl}`);
@@ -2750,6 +2781,95 @@ export function updateImplementationNote(db, id, patch) {
 
 export function deleteImplementationNote(db, id) {
   db.prepare(`DELETE FROM implementation_notes WHERE id = ?`).run(id);
+}
+
+// ---- agent projects + runs (AI 実装委託) ----------------------------------
+
+export function listAgentProjects(db) {
+  return db.prepare(`SELECT * FROM agent_projects ORDER BY created_at ASC`).all();
+}
+
+export function getAgentProject(db, id) {
+  return db.prepare(`SELECT * FROM agent_projects WHERE id = ?`).get(id);
+}
+
+export function insertAgentProject(db, p) {
+  const info = db.prepare(`
+    INSERT INTO agent_projects (name, path, rules, default_agent)
+    VALUES (?, ?, ?, ?)
+  `).run(
+    p.name,
+    p.path,
+    p.rules ?? null,
+    p.default_agent || 'claude_code',
+  );
+  return Number(info.lastInsertRowid);
+}
+
+export function updateAgentProject(db, id, patch) {
+  const allowed = new Set(['name', 'path', 'rules', 'default_agent']);
+  const cols = [];
+  const args = [];
+  for (const [k, v] of Object.entries(patch)) {
+    if (!allowed.has(k)) continue;
+    cols.push(`${k} = ?`);
+    args.push(v);
+  }
+  if (!cols.length) return;
+  cols.push(`updated_at = datetime('now')`);
+  args.push(id);
+  db.prepare(`UPDATE agent_projects SET ${cols.join(', ')} WHERE id = ?`).run(...args);
+}
+
+export function deleteAgentProject(db, id) {
+  db.prepare(`DELETE FROM agent_projects WHERE id = ?`).run(id);
+}
+
+export function listAgentRuns(db, { taskId = null, projectId = null, limit = 100, offset = 0 } = {}) {
+  const where = [];
+  const args = [];
+  if (taskId != null) { where.push('task_id = ?'); args.push(Number(taskId)); }
+  if (projectId != null) { where.push('project_id = ?'); args.push(Number(projectId)); }
+  args.push(Number(limit) || 100, Number(offset) || 0);
+  return db.prepare(`
+    SELECT * FROM agent_runs
+    ${where.length ? 'WHERE ' + where.join(' AND ') : ''}
+    ORDER BY started_at DESC
+    LIMIT ? OFFSET ?
+  `).all(...args);
+}
+
+export function getAgentRun(db, id) {
+  return db.prepare(`SELECT * FROM agent_runs WHERE id = ?`).get(id);
+}
+
+export function insertAgentRun(db, r) {
+  const info = db.prepare(`
+    INSERT INTO agent_runs (task_id, project_id, agent, prompt, status, log_path)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run(
+    r.task_id ?? null,
+    r.project_id ?? null,
+    r.agent,
+    r.prompt ?? null,
+    r.status || 'pending',
+    r.log_path ?? null,
+  );
+  return Number(info.lastInsertRowid);
+}
+
+export function updateAgentRun(db, id, patch) {
+  const allowed = new Set(['status', 'exit_code', 'log_path', 'pid', 'summary', 'finished_at']);
+  const cols = [];
+  const args = [];
+  for (const [k, v] of Object.entries(patch)) {
+    if (!allowed.has(k)) continue;
+    cols.push(`${k} = ?`);
+    args.push(v);
+  }
+  if (!cols.length) return;
+  args.push(id);
+  db.prepare(`UPDATE agent_runs SET ${cols.join(', ')} WHERE id = ?`).run(...args);
 }
 
 // ---- work locations -------------------------------------------------------

--- a/server/db.js
+++ b/server/db.js
@@ -2991,21 +2991,30 @@ export function insertTask(db, task) {
  * app_settings as JSON `task.categories.registered`). Merged + deduped +
  * sorted ascending. Manually-registered ones can have 0 tasks attached
  * (they show up in the side menu so users can pre-create categories).
+ *
+ * 1 タスクは複数カテゴリを持てる。 `tasks.category` カラムには **カンマ区切り**
+ * で保存する (`"開発, 学習"` のように)。 ここでは split + flatten + 重複排除する。
  */
 export function listTaskCategories(db) {
-  const fromTasks = db.prepare(`
-    SELECT DISTINCT category
+  const rows = db.prepare(`
+    SELECT category
     FROM tasks
     WHERE category IS NOT NULL AND category != ''
-  `).all().map(r => r.category);
+  `).all();
+  const fromTasks = new Set();
+  for (const row of rows) {
+    for (const c of String(row.category || '').split(',')) {
+      const t = c.trim();
+      if (t) fromTasks.add(t);
+    }
+  }
   let registered = [];
   try {
     const raw = db.prepare(`SELECT value FROM app_settings WHERE key = ?`)
       .get('task.categories.registered');
     if (raw?.value) registered = JSON.parse(raw.value) || [];
   } catch {}
-  const all = new Set();
-  for (const c of fromTasks) if (c) all.add(c);
+  const all = new Set([...fromTasks]);
   for (const c of registered) if (c) all.add(c);
   return [...all].sort((a, b) => a.localeCompare(b));
 }

--- a/server/db.js
+++ b/server/db.js
@@ -336,7 +336,7 @@ export function openDb(dbPath) {
       share_actio   INTEGER NOT NULL DEFAULT 0,
       shared_at     TEXT,
       shared_origin TEXT,
-      project_id    INTEGER,
+      category      TEXT,
       created_at    TEXT NOT NULL DEFAULT (datetime('now')),
       updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
     );
@@ -360,6 +360,7 @@ export function openDb(dbPath) {
       task_id        INTEGER,
       project_id     INTEGER,
       agent          TEXT NOT NULL,
+      model          TEXT,
       prompt         TEXT,
       status         TEXT NOT NULL DEFAULT 'pending',
       exit_code      INTEGER,
@@ -438,11 +439,16 @@ export function openDb(dbPath) {
     ['share_actio', 'INTEGER NOT NULL DEFAULT 0'],
     ['shared_at', 'TEXT'],
     ['shared_origin', 'TEXT'],
-    ['project_id', 'INTEGER'],
+    ['category', 'TEXT'],
   ]) {
     if (taskCols.length > 0 && !taskCols.includes(col)) {
       db.exec(`ALTER TABLE tasks ADD COLUMN ${col} ${ddl}`);
     }
+  }
+  // agent_runs.model — add if missing on existing DBs.
+  const arCols = db.prepare(`PRAGMA table_info(agent_runs)`).all().map(c => c.name);
+  if (arCols.length > 0 && !arCols.includes('model')) {
+    db.exec(`ALTER TABLE agent_runs ADD COLUMN model TEXT`);
   }
 
   // Forward-compat: ensure newer columns exist on older word_clouds tables.
@@ -2845,12 +2851,13 @@ export function getAgentRun(db, id) {
 
 export function insertAgentRun(db, r) {
   const info = db.prepare(`
-    INSERT INTO agent_runs (task_id, project_id, agent, prompt, status, log_path)
-    VALUES (?, ?, ?, ?, ?, ?)
+    INSERT INTO agent_runs (task_id, project_id, agent, model, prompt, status, log_path)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
   `).run(
     r.task_id ?? null,
     r.project_id ?? null,
     r.agent,
+    r.model ?? null,
     r.prompt ?? null,
     r.status || 'pending',
     r.log_path ?? null,
@@ -2859,7 +2866,7 @@ export function insertAgentRun(db, r) {
 }
 
 export function updateAgentRun(db, id, patch) {
-  const allowed = new Set(['status', 'exit_code', 'log_path', 'pid', 'summary', 'finished_at']);
+  const allowed = new Set(['status', 'exit_code', 'log_path', 'pid', 'summary', 'finished_at', 'model']);
   const cols = [];
   const args = [];
   for (const [k, v] of Object.entries(patch)) {
@@ -2965,8 +2972,8 @@ export function getTask(db, id) {
 
 export function insertTask(db, task) {
   const info = db.prepare(`
-    INSERT INTO tasks (title, details, status, creator_type, due_at, share_actio)
-    VALUES (?, ?, ?, ?, ?, ?)
+    INSERT INTO tasks (title, details, status, creator_type, due_at, share_actio, category)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
   `).run(
     task.title,
     task.details ?? null,
@@ -2974,12 +2981,22 @@ export function insertTask(db, task) {
     task.creator_type === 'ai' ? 'ai' : 'human',
     task.due_at ?? null,
     task.share_actio ? 1 : 0,
+    task.category ?? null,
   );
   return Number(info.lastInsertRowid);
 }
 
+export function listTaskCategories(db) {
+  return db.prepare(`
+    SELECT DISTINCT category
+    FROM tasks
+    WHERE category IS NOT NULL AND category != ''
+    ORDER BY category ASC
+  `).all().map(r => r.category);
+}
+
 export function updateTask(db, id, patch) {
-  const allowed = new Set(['title', 'details', 'status', 'creator_type', 'due_at', 'share_actio', 'shared_at', 'shared_origin']);
+  const allowed = new Set(['title', 'details', 'status', 'creator_type', 'due_at', 'share_actio', 'shared_at', 'shared_origin', 'category']);
   const cols = [];
   const args = [];
   for (const [k, v] of Object.entries(patch)) {

--- a/server/db.js
+++ b/server/db.js
@@ -2986,13 +2986,62 @@ export function insertTask(db, task) {
   return Number(info.lastInsertRowid);
 }
 
+/**
+ * Distinct categories from tasks + manually registered ones (stored in
+ * app_settings as JSON `task.categories.registered`). Merged + deduped +
+ * sorted ascending. Manually-registered ones can have 0 tasks attached
+ * (they show up in the side menu so users can pre-create categories).
+ */
 export function listTaskCategories(db) {
-  return db.prepare(`
+  const fromTasks = db.prepare(`
     SELECT DISTINCT category
     FROM tasks
     WHERE category IS NOT NULL AND category != ''
-    ORDER BY category ASC
   `).all().map(r => r.category);
+  let registered = [];
+  try {
+    const raw = db.prepare(`SELECT value FROM app_settings WHERE key = ?`)
+      .get('task.categories.registered');
+    if (raw?.value) registered = JSON.parse(raw.value) || [];
+  } catch {}
+  const all = new Set();
+  for (const c of fromTasks) if (c) all.add(c);
+  for (const c of registered) if (c) all.add(c);
+  return [...all].sort((a, b) => a.localeCompare(b));
+}
+
+export function registerTaskCategory(db, name) {
+  const n = String(name || '').trim();
+  if (!n) return;
+  let registered = [];
+  try {
+    const raw = db.prepare(`SELECT value FROM app_settings WHERE key = ?`)
+      .get('task.categories.registered');
+    if (raw?.value) registered = JSON.parse(raw.value) || [];
+  } catch {}
+  if (!registered.includes(n)) {
+    registered.push(n);
+    db.prepare(`
+      INSERT INTO app_settings (key, value) VALUES (?, ?)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+    `).run('task.categories.registered', JSON.stringify(registered));
+  }
+}
+
+export function unregisterTaskCategory(db, name) {
+  const n = String(name || '').trim();
+  if (!n) return;
+  let registered = [];
+  try {
+    const raw = db.prepare(`SELECT value FROM app_settings WHERE key = ?`)
+      .get('task.categories.registered');
+    if (raw?.value) registered = JSON.parse(raw.value) || [];
+  } catch {}
+  const next = registered.filter(c => c !== n);
+  db.prepare(`
+    INSERT INTO app_settings (key, value) VALUES (?, ?)
+      ON CONFLICT(key) DO UPDATE SET value = excluded.value
+  `).run('task.categories.registered', JSON.stringify(next));
 }
 
 export function updateTask(db, id, patch) {

--- a/server/index.js
+++ b/server/index.js
@@ -97,7 +97,13 @@ import {
   insertExternalChatMessage, listExternalChatMessages,
   listWorkLocations, getWorkLocation, insertWorkLocation,
   updateWorkLocation, deleteWorkLocation, setWorkLocationOwner,
+  listAgentProjects, getAgentProject, insertAgentProject,
+  updateAgentProject, deleteAgentProject,
+  listAgentRuns, getAgentRun,
 } from './db.js';
+import {
+  startAgentRun, cancelAgentRun, readAgentRunLog, isRunning as isAgentRunning,
+} from './agent-dispatch.js';
 import {
   ensureUserStopwordsTable, listUserStopwords, addUserStopword, removeUserStopword,
 } from './db.js';
@@ -1933,6 +1939,113 @@ app.delete('/api/tasks/:id', (c) => {
   if (!getTask(db, id)) return c.json({ error: 'not found' }, 404);
   deleteTask(db, id);
   return c.json({ ok: true });
+});
+
+// ---- agent projects + runs (AI 実装委託) ----------------------------------
+
+app.get('/api/agent-projects', (c) => {
+  return c.json({ items: listAgentProjects(db) });
+});
+
+app.post('/api/agent-projects', async (c) => {
+  const body = await c.req.json().catch(() => ({}));
+  const name = String(body.name || '').trim();
+  const path = String(body.path || '').trim();
+  if (!name) return c.json({ error: 'name required' }, 400);
+  if (!path) return c.json({ error: 'path required' }, 400);
+  const id = insertAgentProject(db, {
+    name,
+    path,
+    rules: typeof body.rules === 'string' ? body.rules : null,
+    default_agent: ['claude_code', 'codex', 'gemini'].includes(body.default_agent) ? body.default_agent : 'claude_code',
+  });
+  return c.json({ project: getAgentProject(db, id) }, 201);
+});
+
+app.patch('/api/agent-projects/:id', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (!getAgentProject(db, id)) return c.json({ error: 'not found' }, 404);
+  const body = await c.req.json().catch(() => ({}));
+  const patch = {};
+  if (typeof body.name === 'string') patch.name = body.name.trim();
+  if (typeof body.path === 'string') patch.path = body.path.trim();
+  if (typeof body.rules === 'string' || body.rules === null) patch.rules = body.rules;
+  if (['claude_code', 'codex', 'gemini'].includes(body.default_agent)) patch.default_agent = body.default_agent;
+  updateAgentProject(db, id, patch);
+  return c.json({ project: getAgentProject(db, id) });
+});
+
+app.delete('/api/agent-projects/:id', (c) => {
+  const id = Number(c.req.param('id'));
+  if (!getAgentProject(db, id)) return c.json({ error: 'not found' }, 404);
+  deleteAgentProject(db, id);
+  return c.json({ ok: true });
+});
+
+// Spawn an agent run for a task.
+// Body: { project_id, agent? }
+app.post('/api/tasks/:id/agent-run', async (c) => {
+  const taskId = Number(c.req.param('id'));
+  const task = getTask(db, taskId);
+  if (!task) return c.json({ error: 'task not found' }, 404);
+  const body = await c.req.json().catch(() => ({}));
+  const projectId = Number(body.project_id || task.project_id);
+  if (!projectId) return c.json({ error: 'project_id required' }, 400);
+  const project = getAgentProject(db, projectId);
+  if (!project) return c.json({ error: 'project not found' }, 404);
+  const agent = body.agent || project.default_agent || 'claude_code';
+  try {
+    const settings = getAppSettings(db);
+    const runId = startAgentRun(db, {
+      dataDir: DATA_DIR,
+      settings,
+      task,
+      project,
+      agent,
+      gitBashPath: settings['runtime.git_bash_path'] || null,
+    });
+    // Persist project_id on the task so re-runs have a default.
+    if (task.project_id !== projectId) {
+      updateTask(db, taskId, { /* not allowed via patch list */ });
+      // direct write since updateTask doesn't allow project_id
+      db.prepare(`UPDATE tasks SET project_id = ?, updated_at = datetime('now') WHERE id = ?`)
+        .run(projectId, taskId);
+    }
+    return c.json({ run: getAgentRun(db, runId) }, 201);
+  } catch (e) {
+    return c.json({ error: e.message }, 400);
+  }
+});
+
+app.get('/api/agent-runs', (c) => {
+  const taskId = c.req.query('task_id') ? Number(c.req.query('task_id')) : null;
+  const projectId = c.req.query('project_id') ? Number(c.req.query('project_id')) : null;
+  const limit = Math.min(Number(c.req.query('limit') || 100), 500);
+  return c.json({ items: listAgentRuns(db, { taskId, projectId, limit }) });
+});
+
+app.get('/api/agent-runs/:id', (c) => {
+  const id = Number(c.req.param('id'));
+  const run = getAgentRun(db, id);
+  if (!run) return c.json({ error: 'not found' }, 404);
+  return c.json({ run, running: isAgentRunning(id) });
+});
+
+app.get('/api/agent-runs/:id/log', (c) => {
+  const id = Number(c.req.param('id'));
+  const run = getAgentRun(db, id);
+  if (!run) return c.json({ error: 'not found' }, 404);
+  const tail = Math.min(Number(c.req.query('tail') || 64 * 1024), 1024 * 1024);
+  const log = readAgentRunLog(DATA_DIR, run, { tail });
+  return c.json({ run, running: isAgentRunning(id), log });
+});
+
+app.post('/api/agent-runs/:id/cancel', (c) => {
+  const id = Number(c.req.param('id'));
+  const run = getAgentRun(db, id);
+  if (!run) return c.json({ error: 'not found' }, 404);
+  const r = cancelAgentRun(db, id);
+  return c.json(r);
 });
 
 // ---- work locations -------------------------------------------------------

--- a/server/index.js
+++ b/server/index.js
@@ -73,6 +73,7 @@ import {
 } from './diary.js';
 import {
   TASKS as LLM_TASKS, PROVIDERS as LLM_PROVIDERS,
+  PROVIDER_MODELS as LLM_PROVIDER_MODELS, PROVIDER_DEFAULT_MODEL as LLM_PROVIDER_DEFAULT_MODEL,
   getLlmConfig, loadLlmConfigFromSettings, settingsPatchFromConfig,
 } from './llm.js';
 import { getAppSettings, setAppSettings } from './db.js';
@@ -2332,7 +2333,10 @@ app.get('/api/llm/config', (c) => {
       label: v.label,
       kind: v.kind,
       supportsTools: v.supportsTools,
+      supportsModel: v.supportsModel,
     })),
+    provider_models: LLM_PROVIDER_MODELS,
+    provider_default_model: LLM_PROVIDER_DEFAULT_MODEL,
     runtime: {
       // Read-only — these are fixed for the process lifetime. Exposing them
       // so the AI / Settings panel can show "Memoria is running on port X

--- a/server/index.js
+++ b/server/index.js
@@ -94,7 +94,7 @@ import {
 import {
   listImplementationNotes, getImplementationNote, insertImplementationNote,
   updateImplementationNote, deleteImplementationNote,
-  listTasks, getTask, insertTask, updateTask, deleteTask,
+  listTasks, listTaskCategories, getTask, insertTask, updateTask, deleteTask,
   insertExternalChatMessage, listExternalChatMessages,
   listWorkLocations, getWorkLocation, insertWorkLocation,
   updateWorkLocation, deleteWorkLocation, setWorkLocationOwner,
@@ -1866,6 +1866,10 @@ app.get('/api/tasks', (c) => {
   return c.json({ items: listTasks(db, { status, limit, offset }) });
 });
 
+app.get('/api/tasks/categories', (c) => {
+  return c.json({ items: listTaskCategories(db) });
+});
+
 function appendTaskDiaryLog(line) {
   const date = formatLocalDate(new Date());
   const row = getDiary(db, date);
@@ -1889,6 +1893,7 @@ app.post('/api/tasks', async (c) => {
     creator_type: body.creator_type === 'ai' ? 'ai' : 'human',
     due_at: body.due_at || null,
     share_actio: !!body.share_actio,
+    category: typeof body.category === 'string' ? body.category.trim() : null,
   });
   const created = getTask(db, id);
   appendTaskDiaryLog(`タスク発行: ${created.title}${created.due_at ? ` (期日: ${created.due_at})` : ''}`);
@@ -1911,6 +1916,7 @@ app.patch('/api/tasks/:id', async (c) => {
   if (['todo', 'doing', 'done'].includes(body.status)) patch.status = body.status;
   if (body.due_at === null || typeof body.due_at === 'string') patch.due_at = body.due_at || null;
   if (typeof body.share_actio === 'boolean') patch.share_actio = body.share_actio;
+  if (typeof body.category === 'string' || body.category === null) patch.category = body.category;
   if (before.creator_type === 'ai' && Object.hasOwn(patch, 'due_at') && patch.due_at !== before.due_at) {
     patch.creator_type = 'human';
   }
@@ -1984,17 +1990,18 @@ app.delete('/api/agent-projects/:id', (c) => {
 });
 
 // Spawn an agent run for a task.
-// Body: { project_id, agent? }
+// Body: { project_id, agent?, model? }
 app.post('/api/tasks/:id/agent-run', async (c) => {
   const taskId = Number(c.req.param('id'));
   const task = getTask(db, taskId);
   if (!task) return c.json({ error: 'task not found' }, 404);
   const body = await c.req.json().catch(() => ({}));
-  const projectId = Number(body.project_id || task.project_id);
+  const projectId = Number(body.project_id);
   if (!projectId) return c.json({ error: 'project_id required' }, 400);
   const project = getAgentProject(db, projectId);
   if (!project) return c.json({ error: 'project not found' }, 404);
   const agent = body.agent || project.default_agent || 'claude_code';
+  const model = typeof body.model === 'string' ? body.model.trim() : '';
   try {
     const settings = getAppSettings(db);
     const runId = startAgentRun(db, {
@@ -2003,15 +2010,9 @@ app.post('/api/tasks/:id/agent-run', async (c) => {
       task,
       project,
       agent,
+      model: model || null,
       gitBashPath: settings['runtime.git_bash_path'] || null,
     });
-    // Persist project_id on the task so re-runs have a default.
-    if (task.project_id !== projectId) {
-      updateTask(db, taskId, { /* not allowed via patch list */ });
-      // direct write since updateTask doesn't allow project_id
-      db.prepare(`UPDATE tasks SET project_id = ?, updated_at = datetime('now') WHERE id = ?`)
-        .run(projectId, taskId);
-    }
     return c.json({ run: getAgentRun(db, runId) }, 201);
   } catch (e) {
     return c.json({ error: e.message }, 400);

--- a/server/index.js
+++ b/server/index.js
@@ -4384,6 +4384,115 @@ app.get('/api/locations', (c) => {
 });
 
 /**
+ * GPS 軌跡 + 作業場所カタログから「その日の仕事セッション」を検出する。
+ *
+ * 検出ルール:
+ *   - 各 GPS 点について最近接の work_location (lat/lng 設定済) を探し、
+ *     **10m 以内** ならその場所に居たと見なす。
+ *   - 同じ workplace 上の連続点を 1 セッションにまとめる。
+ *   - **継続 60 分以上** のセッションだけを採用 (短滞在は除外)。
+ *   - workplace 名に "自宅" を含む場合は、 セッション窓内の activity_events
+ *     (git_commit / claude_code_prompt / etc.) が 1 件以上あるときのみ
+ *     `is_working = true` とする。 ない場合は private time として除外しない
+ *     が working フラグを立てない。
+ *   - その他の場所は常に `is_working = true`。
+ */
+app.get('/api/work-sessions', (c) => {
+  const date = c.req.query('date');
+  if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return c.json({ error: 'date=YYYY-MM-DD required' }, 400);
+  }
+  const points = listGpsLocationsForDate(db, date);
+  if (!points.length) return c.json({ date, items: [] });
+
+  const places = listWorkLocations(db, { limit: 500 }).filter(w =>
+    Number.isFinite(w.latitude) && Number.isFinite(w.longitude)
+  );
+  if (!places.length) return c.json({ date, items: [] });
+
+  const placesById = new Map(places.map(p => [p.id, p]));
+
+  function distMeters(p1, p2) {
+    const R = 6_371_008;
+    const toRad = d => (d * Math.PI) / 180;
+    const f1 = toRad(p1.lat), f2 = toRad(p2.lat);
+    const df = toRad(p2.lat - p1.lat), dl = toRad(p2.lon - p1.lon);
+    const h = Math.sin(df/2) ** 2 + Math.cos(f1) * Math.cos(f2) * Math.sin(dl/2) ** 2;
+    return 2 * R * Math.asin(Math.min(1, Math.sqrt(h)));
+  }
+
+  // 10m 圏内ルール: 各点を最近接 workplace に紐付け
+  const RADIUS_M = 10;
+  const tagged = points.map(p => {
+    let bestId = null;
+    let bestDist = Infinity;
+    for (const w of places) {
+      const d = distMeters({ lat: p.lat, lon: p.lon }, { lat: w.latitude, lon: w.longitude });
+      if (d <= RADIUS_M && d < bestDist) {
+        bestId = w.id;
+        bestDist = d;
+      }
+    }
+    return { recorded_at: p.recorded_at, workplace_id: bestId };
+  });
+
+  // 連続する同 workplace の点を 1 セッションに畳む
+  const sessions = [];
+  let cur = null;
+  for (const t of tagged) {
+    if (!t.workplace_id) {
+      if (cur) { sessions.push(cur); cur = null; }
+      continue;
+    }
+    if (!cur || cur.workplace_id !== t.workplace_id) {
+      if (cur) sessions.push(cur);
+      cur = { workplace_id: t.workplace_id, started_at: t.recorded_at, ended_at: t.recorded_at, points: 1 };
+    } else {
+      cur.ended_at = t.recorded_at;
+      cur.points += 1;
+    }
+  }
+  if (cur) sessions.push(cur);
+
+  // 継続 60 分ルール + working 判定
+  const MIN_DURATION_MIN = 60;
+  const items = sessions
+    .map(s => {
+      const w = placesById.get(s.workplace_id);
+      const startMs = Date.parse(s.started_at);
+      const endMs = Date.parse(s.ended_at);
+      const durationMin = Math.max(0, Math.round((endMs - startMs) / 60000));
+      const isHome = (w?.name || '').includes('自宅') || /home/i.test(w?.name || '');
+      const out = {
+        workplace_id: s.workplace_id,
+        workplace_name: w?.name || '',
+        workplace_address: w?.address || '',
+        started_at: s.started_at,
+        ended_at: s.ended_at,
+        duration_min: durationMin,
+        points_count: s.points,
+        is_home: isHome,
+        is_working: !isHome,
+        activity_counts: {},
+      };
+      // 自宅: activity_events で working 判定
+      const acts = db.prepare(`
+        SELECT kind, COUNT(*) AS n
+        FROM activity_events
+        WHERE occurred_at >= ? AND occurred_at <= ?
+        GROUP BY kind
+      `).all(s.started_at, s.ended_at);
+      for (const a of acts) out.activity_counts[a.kind] = a.n;
+      const totalActs = acts.reduce((acc, a) => acc + a.n, 0);
+      if (isHome) out.is_working = totalActs > 0;
+      return out;
+    })
+    .filter(s => s.duration_min >= MIN_DURATION_MIN);
+
+  return c.json({ date, items });
+});
+
+/**
  * 位置情報を持っている日と件数。 UI の date picker 用。
  */
 app.get('/api/locations/days', (c) => {

--- a/server/index.js
+++ b/server/index.js
@@ -94,7 +94,8 @@ import {
 import {
   listImplementationNotes, getImplementationNote, insertImplementationNote,
   updateImplementationNote, deleteImplementationNote,
-  listTasks, listTaskCategories, getTask, insertTask, updateTask, deleteTask,
+  listTasks, listTaskCategories, registerTaskCategory, unregisterTaskCategory,
+  getTask, insertTask, updateTask, deleteTask,
   insertExternalChatMessage, listExternalChatMessages,
   listWorkLocations, getWorkLocation, insertWorkLocation,
   updateWorkLocation, deleteWorkLocation, setWorkLocationOwner,
@@ -1867,6 +1868,20 @@ app.get('/api/tasks', (c) => {
 });
 
 app.get('/api/tasks/categories', (c) => {
+  return c.json({ items: listTaskCategories(db) });
+});
+
+app.post('/api/tasks/categories', async (c) => {
+  const body = await c.req.json().catch(() => ({}));
+  const name = String(body.name || '').trim();
+  if (!name) return c.json({ error: 'name required' }, 400);
+  registerTaskCategory(db, name);
+  return c.json({ items: listTaskCategories(db) }, 201);
+});
+
+app.delete('/api/tasks/categories/:name', (c) => {
+  const name = decodeURIComponent(c.req.param('name'));
+  unregisterTaskCategory(db, name);
   return c.json({ items: listTaskCategories(db) });
 });
 

--- a/server/index.js
+++ b/server/index.js
@@ -4388,7 +4388,8 @@ app.get('/api/locations', (c) => {
  *
  * 検出ルール:
  *   - 各 GPS 点について最近接の work_location (lat/lng 設定済) を探し、
- *     **10m 以内** ならその場所に居たと見なす。
+ *     **50m 以内** ならその場所に居たと見なす (iPhone の GPS accuracy_m
+ *     は 14-47m 程度なので 10m だと取りこぼす).
  *   - 同じ workplace 上の連続点を 1 セッションにまとめる。
  *   - **継続 60 分以上** のセッションだけを採用 (短滞在は除外)。
  *   - workplace 名に "自宅" を含む場合は、 セッション窓内の activity_events
@@ -4421,8 +4422,9 @@ app.get('/api/work-sessions', (c) => {
     return 2 * R * Math.asin(Math.min(1, Math.sqrt(h)));
   }
 
-  // 10m 圏内ルール: 各点を最近接 workplace に紐付け
-  const RADIUS_M = 10;
+  // 50m 圏内ルール: 各点を最近接 workplace に紐付け
+  // (iPhone GPS の accuracy_m は 14-47m 程度 + 屋内ビルでオフセット)
+  const RADIUS_M = 50;
   const tagged = points.map(p => {
     let bestId = null;
     let bestDist = Infinity;

--- a/server/index.js
+++ b/server/index.js
@@ -4473,40 +4473,47 @@ app.get('/api/work-sessions', (c) => {
 
   // 継続 60 分ルール + working 判定
   const MIN_DURATION_MIN = 60;
-  const items = sessions
-    .map(s => {
-      const w = placesById.get(s.workplace_id);
-      const startMs = Date.parse(s.started_at);
-      const endMs = Date.parse(s.ended_at);
-      const durationMin = Math.max(0, Math.round((endMs - startMs) / 60000));
-      const isHome = (w?.name || '').includes('自宅') || /home/i.test(w?.name || '');
-      const out = {
-        workplace_id: s.workplace_id,
-        workplace_name: w?.name || '',
-        workplace_address: w?.address || '',
-        started_at: s.started_at,
-        ended_at: s.ended_at,
-        duration_min: durationMin,
-        points_count: s.points,
-        is_home: isHome,
-        is_working: !isHome,
-        activity_counts: {},
-      };
-      // 自宅: activity_events で working 判定
-      const acts = db.prepare(`
-        SELECT kind, COUNT(*) AS n
-        FROM activity_events
-        WHERE occurred_at >= ? AND occurred_at <= ?
-        GROUP BY kind
-      `).all(s.started_at, s.ended_at);
-      for (const a of acts) out.activity_counts[a.kind] = a.n;
-      const totalActs = acts.reduce((acc, a) => acc + a.n, 0);
-      if (isHome) out.is_working = totalActs > 0;
-      return out;
-    })
-    .filter(s => s.duration_min >= MIN_DURATION_MIN);
+  const allSessions = sessions.map(s => {
+    const w = placesById.get(s.workplace_id);
+    const startMs = Date.parse(s.started_at);
+    const endMs = Date.parse(s.ended_at);
+    const durationMin = Math.max(0, Math.round((endMs - startMs) / 60000));
+    const isHome = (w?.name || '').includes('自宅') || /home/i.test(w?.name || '');
+    const out = {
+      workplace_id: s.workplace_id,
+      workplace_name: w?.name || '',
+      workplace_address: w?.address || '',
+      started_at: s.started_at,
+      ended_at: s.ended_at,
+      duration_min: durationMin,
+      points_count: s.points,
+      is_home: isHome,
+      is_working: !isHome,
+      activity_counts: {},
+    };
+    // 自宅: activity_events で working 判定
+    const acts = db.prepare(`
+      SELECT kind, COUNT(*) AS n
+      FROM activity_events
+      WHERE occurred_at >= ? AND occurred_at <= ?
+      GROUP BY kind
+    `).all(s.started_at, s.ended_at);
+    for (const a of acts) out.activity_counts[a.kind] = a.n;
+    const totalActs = acts.reduce((acc, a) => acc + a.n, 0);
+    if (isHome) out.is_working = totalActs > 0;
+    return out;
+  });
 
-  return c.json({ date, items });
+  // tallies は短いセッションも含める。 items は ≥60 分のみ。
+  const tallies = { home_minutes: 0, workplace_minutes: 0, by_workplace: {} };
+  for (const s of allSessions) {
+    if (s.is_home) tallies.home_minutes += s.duration_min;
+    else tallies.workplace_minutes += s.duration_min;
+    tallies.by_workplace[s.workplace_name] = (tallies.by_workplace[s.workplace_name] || 0) + s.duration_min;
+  }
+  const items = allSessions.filter(s => s.duration_min >= MIN_DURATION_MIN);
+
+  return c.json({ date, items, tallies });
 });
 
 /**

--- a/server/index.js
+++ b/server/index.js
@@ -4256,15 +4256,15 @@ app.post('/api/locations/ingest', async (c) => {
  *   GET  /api/tracks/settings → { decimate_meters, show_polyline }
  *   PATCH /api/tracks/settings { decimate_meters?, show_polyline? }
  *
- * - decimate_meters: 0 = 全点描画 (既定). >0 で連続点を間引く.
- * - show_polyline:   false = 点マーカーのみ (既定). true で区間色分け線も描く.
+ * - decimate_meters: 0 = 全点描画 (既定 / 推奨).
+ * - show_polyline:   true = 区間色分け線も描く (既定 / 推奨).  false で点マーカーのみ.
  */
 app.get('/api/tracks/settings', (c) => {
   const s = getAppSettings(db);
   const v = Number(s['tracks.decimate_meters'] ?? '0');
   return c.json({
     decimate_meters: Number.isFinite(v) ? v : 0,
-    show_polyline: (s['tracks.show_polyline'] ?? 'false') === 'true',
+    show_polyline: (s['tracks.show_polyline'] ?? 'true') === 'true',
   });
 });
 app.patch('/api/tracks/settings', async (c) => {

--- a/server/index.js
+++ b/server/index.js
@@ -170,7 +170,9 @@ function privacySettings() {
     mcp_autostart_enabled: settingBool(s, 'features.mcp.autostart.enabled', false),
     workplace_geo_enabled: settingBool(s, 'features.workplace.geo.enabled', true),
     workplace_auto_share_enabled: settingBool(s, 'features.workplace.share.enabled', false),
-    workplace_match_radius_m: Number(s['features.workplace.match.radius_m'] ?? 150),
+    // OwnTracks の locator displacement と整合させやすい 50m を既定に。
+    // 屋内ビルや GPS が荒い環境では 100-200m に上げる。
+    workplace_match_radius_m: Number(s['features.workplace.match.radius_m'] ?? 50),
   };
 }
 
@@ -4422,9 +4424,13 @@ app.get('/api/work-sessions', (c) => {
     return 2 * R * Math.asin(Math.min(1, Math.sqrt(h)));
   }
 
-  // 50m 圏内ルール: 各点を最近接 workplace に紐付け
-  // (iPhone GPS の accuracy_m は 14-47m 程度 + 屋内ビルでオフセット)
-  const RADIUS_M = 50;
+  // 圏内ルール: 各点を最近接 workplace に紐付け。
+  // 半径は privacySettings.workplace_match_radius_m (default 50m) を共有。
+  // ・OwnTracks の locator displacement 設定 (50m / 100m など) や、
+  //   ビル内の GPS オフセット (室内では 30-100m 平気でずれる) に応じて
+  //   設定 → プライバシー → 「マッチ半径」 で調整可。
+  const settings = privacySettings();
+  const RADIUS_M = Math.max(20, Math.min(2000, Number(settings.workplace_match_radius_m) || 50));
   const tagged = points.map(p => {
     let bestId = null;
     let bestDist = Infinity;
@@ -4438,20 +4444,29 @@ app.get('/api/work-sessions', (c) => {
     return { recorded_at: p.recorded_at, workplace_id: bestId };
   });
 
-  // 連続する同 workplace の点を 1 セッションに畳む
+  // 連続する同 workplace の点を 1 セッションに畳む。
+  // **離脱判定**: GPS 点が「workplace 外 (50m+)」 または「別の workplace 圏内」に
+  // なった瞬間のタイムスタンプを `ended_at` とする。 この方が
+  // 「最終 inside 点」より正確 (GPS が sparse な場合に滞在時間が短く出る問題を緩和).
   const sessions = [];
   let cur = null;
   for (const t of tagged) {
-    if (!t.workplace_id) {
-      if (cur) { sessions.push(cur); cur = null; }
+    if (!cur) {
+      if (t.workplace_id) {
+        cur = { workplace_id: t.workplace_id, started_at: t.recorded_at, ended_at: t.recorded_at, points: 1 };
+      }
       continue;
     }
-    if (!cur || cur.workplace_id !== t.workplace_id) {
-      if (cur) sessions.push(cur);
-      cur = { workplace_id: t.workplace_id, started_at: t.recorded_at, ended_at: t.recorded_at, points: 1 };
-    } else {
+    if (t.workplace_id === cur.workplace_id) {
       cur.ended_at = t.recorded_at;
       cur.points += 1;
+    } else {
+      // 離脱: この点 (workplace 外 or 別 workplace) の時刻を離脱時刻に。
+      cur.ended_at = t.recorded_at;
+      sessions.push(cur);
+      cur = t.workplace_id
+        ? { workplace_id: t.workplace_id, started_at: t.recorded_at, ended_at: t.recorded_at, points: 1 }
+        : null;
     }
   }
   if (cur) sessions.push(cur);

--- a/server/llm.js
+++ b/server/llm.js
@@ -32,18 +32,17 @@ const TASK_DEFAULT_MODELS = {
 };
 
 export const PROVIDERS = {
+  algorithm: {
+    label: 'アルゴリズム (AI なし)',
+    kind: 'none',
+    supportsTools: false,
+    supportsModel: false,
+  },
   claude: {
     label: 'Claude CLI',
     kind: 'cli',
     defaultBin: 'claude',
     supportsTools: true,
-    supportsModel: true,
-  },
-  gemini: {
-    label: 'Gemini CLI',
-    kind: 'cli',
-    defaultBin: 'gemini',
-    supportsTools: false,
     supportsModel: true,
   },
   codex: {
@@ -54,12 +53,55 @@ export const PROVIDERS = {
     supportsModel: true,
     jsonOutput: true,
   },
+  gemini: {
+    label: 'Gemini CLI',
+    kind: 'cli',
+    defaultBin: 'gemini',
+    supportsTools: false,
+    supportsModel: true,
+  },
   openai: {
     label: 'OpenAI API',
     kind: 'api',
     supportsTools: false,
     supportsModel: true,
   },
+};
+
+// 各 provider で選べる主要モデル一覧。空文字 id = provider のデフォルトを使う。
+// 現行モデル (2026-05 時点) を網羅。新しいモデルが出たらここに追加すれば
+// UI のドロップダウンが自動で更新される。
+export const PROVIDER_MODELS = {
+  algorithm: [],
+  claude: [
+    { id: 'sonnet',                 label: 'Sonnet 4.6 (default)' },
+    { id: 'haiku',                  label: 'Haiku 4.5 (fast)' },
+    { id: 'opus',                   label: 'Opus 4.7' },
+    { id: 'claude-opus-4-7[1m]',    label: 'Opus 4.7 (1M context)' },
+    { id: 'claude-sonnet-4-6',      label: 'Sonnet 4.6 (full id)' },
+    { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5 (full id)' },
+  ],
+  codex: [
+    { id: '5.3-codex',  label: '5.3-codex (default)' },
+    { id: 'gpt-5-codex', label: 'GPT-5 Codex' },
+  ],
+  gemini: [
+    { id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash (default)' },
+    { id: 'gemini-2.5-pro',   label: 'Gemini 2.5 Pro' },
+  ],
+  openai: [
+    { id: 'gpt-4o-mini', label: 'GPT-4o mini (default)' },
+    { id: 'gpt-4o',      label: 'GPT-4o' },
+    { id: 'gpt-5-mini',  label: 'GPT-5 mini' },
+  ],
+};
+
+// 各 provider の既定モデル ID (model 未指定時に runCli で渡す値)。
+export const PROVIDER_DEFAULT_MODEL = {
+  claude: 'sonnet',
+  codex:  '5.3-codex',
+  gemini: 'gemini-2.5-flash',
+  openai: 'gpt-4o-mini',
 };
 
 let cfg = {
@@ -136,16 +178,19 @@ export async function runLlm({ task, prompt, tools, timeoutMs = 180_000 }) {
   if (provider === 'openai' && !cfg.openai_api_key) provider = 'claude';
   const p = PROVIDERS[provider];
   if (!p) throw new Error(`unknown provider: ${provider}`);
+  // 'algorithm' provider = "AI なし" 指定。タスクごとに deterministic な
+  // 代替を持たせる責務は呼び出し側にあるので、ここでは空文字を返す。
+  if (p.kind === 'none') return '';
   if (p.kind === 'api') {
     return runOpenAi({
       apiKey: cfg.openai_api_key,
-      model: taskCfg.model || cfg.openai_model || 'gpt-4o-mini',
+      model: taskCfg.model || cfg.openai_model || PROVIDER_DEFAULT_MODEL.openai,
       prompt, timeoutMs,
     });
   }
   // CLI providers
   const bin = cfg.bins[provider] || p.defaultBin;
-  const modelToUse = taskCfg.model || TASK_DEFAULT_MODELS[task] || '';
+  const modelToUse = taskCfg.model || TASK_DEFAULT_MODELS[task] || PROVIDER_DEFAULT_MODEL[provider] || '';
   const args = buildCliArgs({
     provider,
     model: modelToUse,

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -5644,6 +5644,7 @@ function formatTaskDue(dueAt) {
 
 function taskCardHtml(t) {
   const aiBadge = t.creator_type === 'ai' ? '<span class="task-origin ai">AI</span>' : '<span class="task-origin human">人間</span>';
+  const catBadge = t.category ? `<span class="task-category">${escapeHtml(t.category)}</span>` : '';
   const doneBtn = t.status === 'done'
     ? '<button class="ghost" disabled>Done</button>'
     : `<button class="ghost" data-task-done="${t.id}">Done</button>`;
@@ -5651,7 +5652,7 @@ function taskCardHtml(t) {
     <article class="task-card" data-task-open="${t.id}" data-task-drag="${t.id}" draggable="${t.status === 'done' ? 'false' : 'true'}">
       <div class="task-card-head">
         <strong>${escapeHtml(t.title)}</strong>
-        ${aiBadge}
+        ${aiBadge}${catBadge}
       </div>
       <div class="muted">期日: ${escapeHtml(formatTaskDue(t.due_at))}</div>
       <p>${escapeHtml(t.details || '')}</p>
@@ -5889,6 +5890,10 @@ function ensureAgentRunModal() {
         <option value="gemini">Gemini CLI</option>
       </select>
     </label>
+    <label class="simple-field">
+      <span>モデル</span>
+      <select id="agentRunModel"></select>
+    </label>
     <div class="simple-actions">
       <button id="agentRunStartBtn">▶ 実装を開始</button>
       <button id="agentRunCancelBtn" type="button" class="ghost">キャンセル</button>
@@ -5920,6 +5925,36 @@ function ensureAgentRunModal() {
   };
 }
 
+// agent ↔ model のマッピング (UI 側)。サーバ側の AGENT_DEFAULT_MODEL とほぼ同期。
+const AGENT_MODELS = {
+  claude_code: [
+    { id: 'sonnet', label: 'Sonnet 4.6 (default)' },
+    { id: 'haiku', label: 'Haiku 4.5 (fast)' },
+    { id: 'opus', label: 'Opus 4.7' },
+    { id: 'claude-opus-4-7[1m]', label: 'Opus 4.7 (1M)' },
+  ],
+  codex: [
+    { id: '5.3-codex', label: '5.3-codex (default)' },
+    { id: 'gpt-5-codex', label: 'GPT-5 Codex' },
+  ],
+  gemini: [
+    { id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash (default)' },
+    { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
+  ],
+};
+
+function refreshAgentModelDropdown() {
+  const agent = $('agentRunAgent')?.value || 'claude_code';
+  const models = AGENT_MODELS[agent] || [];
+  const sel = $('agentRunModel');
+  if (!sel) return;
+  const cur = sel.value;
+  sel.innerHTML = models.map(m =>
+    `<option value="${escapeHtml(m.id)}">${escapeHtml(m.label)}</option>`
+  ).join('');
+  if ([...sel.options].some(o => o.value === cur)) sel.value = cur;
+}
+
 async function openAgentRunModal(task) {
   ensureAgentRunModal();
   _agentRunCurrentTask = task;
@@ -5936,18 +5971,21 @@ async function openAgentRunModal(task) {
         `<option value="${p.id}" data-default-agent="${escapeHtml(p.default_agent)}">${escapeHtml(p.name)}</option>`
       ).join('');
       $('agentRunStartBtn').disabled = false;
-      // Pre-select task.project_id if any
-      if (task.project_id) $('agentRunProject').value = String(task.project_id);
       const selOpt = $('agentRunProject').selectedOptions[0];
       if (selOpt?.dataset.defaultAgent) $('agentRunAgent').value = selOpt.dataset.defaultAgent;
       $('agentRunProject').onchange = () => {
         const o = $('agentRunProject').selectedOptions[0];
-        if (o?.dataset.defaultAgent) $('agentRunAgent').value = o.dataset.defaultAgent;
+        if (o?.dataset.defaultAgent) {
+          $('agentRunAgent').value = o.dataset.defaultAgent;
+          refreshAgentModelDropdown();
+        }
       };
     }
   } catch (e) {
     alert(`プロジェクト取得失敗: ${e.message}`);
   }
+  refreshAgentModelDropdown();
+  $('agentRunAgent').onchange = refreshAgentModelDropdown;
   // Load run history.
   await refreshAgentRunHistory(task.id);
   $('agentRunLog').textContent = '';
@@ -5972,9 +6010,10 @@ async function refreshAgentRunHistory(taskId) {
       const at = (run.started_at || '').replace('T', ' ').slice(0, 19);
       const status = escapeHtml(run.status);
       const exit = run.exit_code != null ? ` (exit ${run.exit_code})` : '';
+      const model = run.model ? `:${escapeHtml(run.model)}` : '';
       return `<div class="simple-item" data-agent-run-open="${run.id}">
         <div class="simple-item-head">
-          <strong>#${run.id} ${escapeHtml(run.agent)}</strong>
+          <strong>#${run.id} ${escapeHtml(run.agent)}${model}</strong>
           <span class="muted">${at}</span>
         </div>
         <div class="muted">${status}${exit}</div>
@@ -6015,6 +6054,7 @@ async function startAgentRunFromModal() {
   if (!_agentRunCurrentTask) return;
   const projectId = Number($('agentRunProject')?.value || 0);
   const agent = $('agentRunAgent')?.value || 'claude_code';
+  const model = $('agentRunModel')?.value || '';
   if (!projectId) return alert('プロジェクトを選択してください');
   $('agentRunStartBtn').disabled = true;
   $('agentRunStartBtn').textContent = '起動中…';
@@ -6022,7 +6062,7 @@ async function startAgentRunFromModal() {
     const r = await api(`/api/tasks/${_agentRunCurrentTask.id}/agent-run`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ project_id: projectId, agent }),
+      body: JSON.stringify({ project_id: projectId, agent, model }),
     });
     await refreshAgentRunHistory(_agentRunCurrentTask.id);
     if (r.run?.id) refreshAgentRunLog(r.run.id);
@@ -6199,7 +6239,13 @@ function openTaskEditor(task = null) {
   $('taskEditorStatus').value = task?.status || 'todo';
   $('taskEditorDetails').value = task?.details || '';
   $('taskEditorShareActio').checked = !!task?.share_actio;
+  $('taskEditorCategory').value = task?.category || '';
   $('taskEditorTaskId').value = task?.id ? String(task.id) : '';
+  // populate category autocomplete
+  api('/api/tasks/categories').then(r => {
+    const dl = $('taskCategoryOptions');
+    if (dl) dl.innerHTML = (r.items || []).map(c => `<option value="${escapeHtml(c)}"></option>`).join('');
+  }).catch(() => {});
   showModal('taskEditorModal');
   $('taskEditorTitle').focus();
 }
@@ -6405,6 +6451,11 @@ ensureMemoriaFeatureViews = function () {
               <option value="done">DONE</option>
             </select>
           </label>
+          <label class="simple-field">
+            <span>カテゴリ</span>
+            <input id="taskEditorCategory" type="text" list="taskCategoryOptions" placeholder="例: 開発 / 雑務 / 学習" />
+            <datalist id="taskCategoryOptions"></datalist>
+          </label>
           <label class="simple-check-row">
             <input id="taskEditorShareActio" type="checkbox" />
             <span>Actio にシェアする</span>
@@ -6519,6 +6570,7 @@ addTaskFromForm = async function () {
   const title = $('taskEditorTitle')?.value.trim();
   if (!title) return;
   const editId = Number($('taskEditorTaskId')?.value || 0);
+  const category = $('taskEditorCategory')?.value.trim() || null;
   if (editId) {
     await api(`/api/tasks/${editId}`, {
       method: 'PATCH',
@@ -6529,6 +6581,7 @@ addTaskFromForm = async function () {
         due_at: $('taskEditorDue')?.value || null,
         status: $('taskEditorStatus')?.value || 'todo',
         share_actio: !!$('taskEditorShareActio')?.checked,
+        category,
       }),
     });
   } else {
@@ -6541,6 +6594,7 @@ addTaskFromForm = async function () {
         due_at: $('taskEditorDue')?.value || null,
         status: $('taskEditorStatus')?.value || 'todo',
         share_actio: !!$('taskEditorShareActio')?.checked,
+        category,
         creator_type: 'human',
       }),
     });

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -10,7 +10,7 @@ const state = {
   search: '',
   searchDebounce: null,
   sort: 'created_desc',
-  tab: 'bookmarks',
+  tab: 'database',
   queue: { items: [], history: [] },
   visits: [],
   visitsSelected: new Set(),
@@ -602,9 +602,10 @@ function jobLabel(item) {
   return kindHint + `seq #${item.seq}`;
 }
 
-// queue / domain / tracks / external は worklog の sub-tab として畳み込む。
-// switchTab に旧 key で来たら worklog + 該当 subtab に redirect する。
-const WORKLOG_REDIRECT_TABS = new Set(['queue', 'domain', 'tracks', 'external']);
+// queue / tracks / external は worklog の sub-tab として畳み込む。
+// bookmarks / dict / domain / workplace は database タブの sub-tab として畳み込む。
+const WORKLOG_REDIRECT_TABS = new Set(['queue', 'tracks', 'external']);
+const DATABASE_REDIRECT_TABS = new Set(['bookmarks', 'dict', 'domain', 'workplace']);
 
 function switchTab(tab) {
   if (WORKLOG_REDIRECT_TABS.has(tab)) {
@@ -614,30 +615,39 @@ function switchTab(tab) {
     switchWorklogSub(sub);
     return;
   }
+  if (DATABASE_REDIRECT_TABS.has(tab)) {
+    const sub = tab;
+    state.database = state.database || {};
+    state.database.sub = sub;
+    switchTab('database');
+    switchDatabaseSub(sub);
+    return;
+  }
   state.tab = tab;
   document.querySelectorAll('.tab').forEach(t => {
     t.classList.toggle('active', t.dataset.tab === tab);
   });
   const layout = document.querySelector('.layout');
   if (layout) layout.dataset.activeTab = tab;
-  $('bookmarksView').classList.toggle('hidden', tab !== 'bookmarks');
+  $('databaseView')?.classList.toggle('hidden', tab !== 'database');
   $('worklogView')?.classList.toggle('hidden', tab !== 'worklog');
   $('trendsView').classList.toggle('hidden', tab !== 'trends');
   $('recommendView').classList.toggle('hidden', tab !== 'recommend');
   $('digView').classList.toggle('hidden', tab !== 'dig');
-  $('dictView').classList.toggle('hidden', tab !== 'dict');
   $('diaryView').classList.toggle('hidden', tab !== 'diary');
   $('mealsView')?.classList.toggle('hidden', tab !== 'meals');
   $('tasksView')?.classList.toggle('hidden', tab !== 'tasks');
   $('implView')?.classList.toggle('hidden', tab !== 'impl');
-  $('workplaceView')?.classList.toggle('hidden', tab !== 'workplace');
-  if (tab === 'workplace') loadWorkLocations().catch(console.warn);
   $('multiView')?.classList.toggle('hidden', tab !== 'multi');
+  if (tab === 'database') {
+    // Re-show whichever DB sub was last picked.
+    const sub = state.database?.sub || 'bookmarks';
+    switchDatabaseSub(sub);
+  }
   if (tab === 'worklog') loadWorklog();
   if (tab === 'trends') loadTrends();
   if (tab === 'recommend') loadRecommendations();
   if (tab === 'dig') loadDigHistory();
-  if (tab === 'dict') loadDictionary();
   if (tab === 'diary') loadDiary();
   if (tab === 'meals') loadMeals();
   if (tab === 'tasks') loadTasks();
@@ -4757,7 +4767,6 @@ function ensureMemoriaFeatureViews() {
     for (const spec of [
       ['tasks', '📝 タスク'],
       ['impl', '✨ 実装自慢'],
-      ['workplace', '🗺️ 作業場所'],
     ]) {
       const b = document.createElement('button');
       b.className = 'tab';
@@ -6545,16 +6554,7 @@ function decorateTaskAndImplTabs() {
     if (!isNarrowViewport()) implTab.style.order = '-19';
     else implTab.style.order = '';
   }
-  if (workplaceTab) {
-    const label = workplaceTab.querySelector('.tab-label');
-    if (label) {
-      label.textContent = '🗺️ 作業場所';
-      label.dataset.full = '🗺️ 作業場所';
-      label.dataset.short = '🗺️ 作業場所';
-    }
-    if (!isNarrowViewport()) workplaceTab.style.order = '-18';
-    else workplaceTab.style.order = '';
-  }
+  if (workplaceTab) workplaceTab.remove(); // workplace は database のサブタブに移行
 }
 
 const baseEnsureMemoriaFeatureViews = ensureMemoriaFeatureViews;
@@ -6825,10 +6825,49 @@ const WL_SUB_VIEWS = {
   dig: 'wlDigView',
   // 旧トップタブから移植してきた sub
   queue: 'queueView',
-  domain: 'domainView',
   tracks: 'tracksView',
   external: 'externalView',
 };
+
+// データベースタブのサブビュー一覧
+const DB_SUB_VIEWS = {
+  bookmarks: 'bookmarksView',
+  dict: 'dictView',
+  domain: 'domainView',
+  workplace: 'workplaceView',
+};
+
+state.database = state.database || { sub: 'bookmarks' };
+
+function migrateDatabaseSubViews() {
+  const db = $('databaseView');
+  if (!db) return;
+  for (const id of Object.values(DB_SUB_VIEWS)) {
+    const v = $(id);
+    if (v && v.parentNode !== db) {
+      v.classList.add('hidden');
+      v.classList.add('wl-sub');
+      db.appendChild(v);
+    }
+  }
+}
+
+function switchDatabaseSub(sub) {
+  if (!DB_SUB_VIEWS[sub]) return;
+  state.database = state.database || {};
+  state.database.sub = sub;
+  document.querySelectorAll('#databaseSubtabs [data-db-sub]').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.dbSub === sub);
+  });
+  for (const [key, viewId] of Object.entries(DB_SUB_VIEWS)) {
+    const view = $(viewId);
+    if (view) view.classList.toggle('hidden', key !== sub);
+  }
+  if (sub === 'bookmarks') load();
+  if (sub === 'dict') loadDictionary();
+  if (sub === 'domain') loadDomainCatalog();
+  if (sub === 'workplace') loadWorkLocations().catch(console.warn);
+}
 
 // 日付ベースの sub かどうか (date toolbar / summary 表示の有無)
 const WL_DATE_BASED = new Set(['schedule', 'github', 'claude', 'gemini', 'codex', 'browsing', 'dig']);
@@ -6854,6 +6893,10 @@ function migrateWorklogSubViews() {
   }
 }
 migrateWorklogSubViews();
+migrateDatabaseSubViews();
+document.querySelectorAll('#databaseSubtabs [data-db-sub]').forEach(btn => {
+  btn.addEventListener('click', () => switchDatabaseSub(btn.dataset.dbSub));
+});
 
 function switchWorklogSub(sub) {
   if (!WL_SUB_VIEWS[sub]) return;

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -5654,9 +5654,17 @@ function formatTaskDue(dueAt) {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
+// 1 タスク複数カテゴリ: tasks.category は "tag1, tag2" のような文字列。
+// 空白を trim、 重複排除、 空文字を除く。
+function parseTaskCategories(s) {
+  if (!s) return [];
+  return [...new Set(String(s).split(',').map(x => x.trim()).filter(Boolean))];
+}
+
 function taskCardHtml(t) {
   const aiBadge = t.creator_type === 'ai' ? '<span class="task-origin ai">AI</span>' : '<span class="task-origin human">人間</span>';
-  const catBadge = t.category ? `<span class="task-category">${escapeHtml(t.category)}</span>` : '';
+  const cats = parseTaskCategories(t.category);
+  const catBadges = cats.map(c => `<span class="task-category">${escapeHtml(c)}</span>`).join('');
   const doneBtn = t.status === 'done'
     ? '<button class="ghost" disabled>Done</button>'
     : `<button class="ghost" data-task-done="${t.id}">Done</button>`;
@@ -5664,7 +5672,7 @@ function taskCardHtml(t) {
     <article class="task-card" data-task-open="${t.id}" data-task-drag="${t.id}" draggable="${t.status === 'done' ? 'false' : 'true'}">
       <div class="task-card-head">
         <strong>${escapeHtml(t.title)}</strong>
-        ${aiBadge}${catBadge}
+        ${aiBadge}${catBadges}
       </div>
       <div class="muted">期日: ${escapeHtml(formatTaskDue(t.due_at))}</div>
       <p>${escapeHtml(t.details || '')}</p>
@@ -6323,17 +6331,18 @@ function closeImplEditor() {
 function renderTaskCategoryMenu() {
   const list = $('tasksCategoryList');
   if (!list) return;
-  // Distinct categories from currently loaded tasks + pre-fetched _taskCategoriesCache
+  // Distinct categories from currently loaded tasks (each task may have many) + pre-fetched cache
   const fromTasks = new Set();
   for (const t of state.taskItems) {
-    if (t.category) fromTasks.add(t.category);
+    for (const c of parseTaskCategories(t.category)) fromTasks.add(c);
   }
   const merged = new Set([...(_taskCategoriesCache || []), ...fromTasks]);
   const cats = [...merged].sort((a, b) => a.localeCompare(b));
-  const counts = {};
+  const counts = { __none__: 0 };
   for (const t of state.taskItems) {
-    const k = t.category || '__none__';
-    counts[k] = (counts[k] || 0) + 1;
+    const cs = parseTaskCategories(t.category);
+    if (!cs.length) counts.__none__ += 1;
+    for (const c of cs) counts[c] = (counts[c] || 0) + 1;
   }
   const buttons = [
     `<button type="button" data-task-cat="" class="${state.taskCategoryFilter == null ? 'active' : ''}">全カテゴリ <span class="muted">${state.taskItems.length}</span></button>`,
@@ -6411,8 +6420,8 @@ function renderTaskBoard() {
   const base = state.taskCategoryFilter == null
     ? statusFiltered
     : (state.taskCategoryFilter === '__none__'
-        ? statusFiltered.filter((t) => !t.category)
-        : statusFiltered.filter((t) => t.category === state.taskCategoryFilter));
+        ? statusFiltered.filter((t) => parseTaskCategories(t.category).length === 0)
+        : statusFiltered.filter((t) => parseTaskCategories(t.category).includes(state.taskCategoryFilter)));
   const middleItems = base.filter((t) => taskDatePartition(t) === 'middle');
   const rightItems = base.filter((t) => taskDatePartition(t) === 'right');
   middle.innerHTML = middleItems.length ? middleItems.map(taskCardHtml).join('') : '<div class="queue-empty">対象タスクなし</div>';
@@ -6591,8 +6600,8 @@ ensureMemoriaFeatureViews = function () {
             </select>
           </label>
           <label class="simple-field">
-            <span>カテゴリ</span>
-            <input id="taskEditorCategory" type="text" list="taskCategoryOptions" placeholder="例: 開発 / 雑務 / 学習" />
+            <span>カテゴリ (カンマ区切りで複数指定可)</span>
+            <input id="taskEditorCategory" type="text" list="taskCategoryOptions" placeholder="例: 開発, 学習" />
             <datalist id="taskCategoryOptions"></datalist>
           </label>
           <label class="simple-check-row">

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -2681,9 +2681,9 @@ function renderDiaryDetail() {
   }
 
   // GPS から推定した「仕事中」セッションを上に表示
-  renderDiaryWorkSessions(d.date).catch(() => {});
+  renderDiaryWorkSessions(d.date).catch(e => console.error('[diary] work sessions render', e));
   // 移動 / 滞在時間サマリ
-  renderDiaryGpsSummary(d.date).catch(() => {});
+  renderDiaryGpsSummary(d.date).catch(e => console.error('[diary] gps summary render', e));
 
   // Hourly chart: live_metrics is computed fresh on every request and includes
   // page_visits as a fallback for events captured before visit_events existed,
@@ -8025,8 +8025,9 @@ async function renderDiaryGpsSummary(date) {
     ]);
     points = pr.points || [];
     sessions = sr.items || [];
-  } catch {
-    el.innerHTML = '<div class="muted" style="font-size:12px">GPS 情報の取得に失敗しました — 判断不能</div>';
+  } catch (err) {
+    console.error('[diary gps summary] fetch failed', err);
+    el.innerHTML = `<div class="muted" style="font-size:12px">GPS 情報の取得に失敗しました — 判断不能 (${escapeHtml(err.message || '')})</div>`;
     return;
   }
   if (!points.length) {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -5623,6 +5623,7 @@ renderDomainDetail = function () {
 
 state.taskMenu = 'todo';
 state.taskItems = [];
+state.taskCategoryFilter = null;
 state.taskDetail = null;
 
 function taskDatePartition(task) {
@@ -6273,6 +6274,82 @@ function closeImplEditor() {
   hideModal('implEditorModal');
 }
 
+function renderTaskCategoryMenu() {
+  const list = $('tasksCategoryList');
+  if (!list) return;
+  // Distinct categories from currently loaded tasks + pre-fetched _taskCategoriesCache
+  const fromTasks = new Set();
+  for (const t of state.taskItems) {
+    if (t.category) fromTasks.add(t.category);
+  }
+  const merged = new Set([...(_taskCategoriesCache || []), ...fromTasks]);
+  const cats = [...merged].sort((a, b) => a.localeCompare(b));
+  const counts = {};
+  for (const t of state.taskItems) {
+    const k = t.category || '__none__';
+    counts[k] = (counts[k] || 0) + 1;
+  }
+  const buttons = [
+    `<button type="button" data-task-cat="" class="${state.taskCategoryFilter == null ? 'active' : ''}">全カテゴリ <span class="muted">${state.taskItems.length}</span></button>`,
+    `<button type="button" data-task-cat="__none__" class="${state.taskCategoryFilter === '__none__' ? 'active' : ''}">未分類 <span class="muted">${counts['__none__'] || 0}</span></button>`,
+  ];
+  for (const c of cats) {
+    buttons.push(
+      `<button type="button" data-task-cat="${escapeHtml(c)}" class="${state.taskCategoryFilter === c ? 'active' : ''}" title="${escapeHtml(c)}">
+        ${escapeHtml(c)} <span class="muted">${counts[c] || 0}</span>
+        <span class="task-cat-del" data-task-cat-del="${escapeHtml(c)}" title="登録から外す">✕</span>
+      </button>`
+    );
+  }
+  list.innerHTML = buttons.join('');
+  list.querySelectorAll('[data-task-cat]').forEach(btn => {
+    btn.addEventListener('click', (ev) => {
+      if (ev.target.closest('[data-task-cat-del]')) return;
+      const v = btn.dataset.taskCat;
+      state.taskCategoryFilter = v === '' ? null : v;
+      renderTaskBoard();
+    });
+  });
+  list.querySelectorAll('[data-task-cat-del]').forEach(el => {
+    el.addEventListener('click', async (ev) => {
+      ev.stopPropagation();
+      const name = el.dataset.taskCatDel;
+      if (!confirm(`カテゴリ "${name}" を一覧から外しますか? (既存タスクの category 値は残ります)`)) return;
+      try {
+        await api(`/api/tasks/categories/${encodeURIComponent(name)}`, { method: 'DELETE' });
+        await reloadTaskCategoriesCache();
+        if (state.taskCategoryFilter === name) state.taskCategoryFilter = null;
+        renderTaskBoard();
+      } catch (e) { alert(e.message); }
+    });
+  });
+}
+
+let _taskCategoriesCache = [];
+async function reloadTaskCategoriesCache() {
+  try {
+    const r = await api('/api/tasks/categories');
+    _taskCategoriesCache = r.items || [];
+  } catch { _taskCategoriesCache = []; }
+}
+
+async function addNewTaskCategoryFromMenu() {
+  const inp = $('tasksNewCatInput');
+  const name = (inp?.value || '').trim();
+  if (!name) return;
+  try {
+    await api('/api/tasks/categories', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    });
+    inp.value = '';
+    await reloadTaskCategoriesCache();
+    state.taskCategoryFilter = name;
+    renderTaskBoard();
+  } catch (e) { alert(e.message); }
+}
+
 function renderTaskBoard() {
   const menu = $('tasksMenu');
   const middle = $('tasksDueNow');
@@ -6281,9 +6358,15 @@ function renderTaskBoard() {
   menu.querySelectorAll('[data-task-menu]').forEach((btn) => {
     btn.classList.toggle('active', btn.dataset.taskMenu === state.taskMenu);
   });
-  const base = state.taskMenu === 'done'
+  renderTaskCategoryMenu();
+  const statusFiltered = state.taskMenu === 'done'
     ? state.taskItems.filter((t) => t.status === 'done')
     : state.taskItems.filter((t) => t.status !== 'done');
+  const base = state.taskCategoryFilter == null
+    ? statusFiltered
+    : (state.taskCategoryFilter === '__none__'
+        ? statusFiltered.filter((t) => !t.category)
+        : statusFiltered.filter((t) => t.category === state.taskCategoryFilter));
   const middleItems = base.filter((t) => taskDatePartition(t) === 'middle');
   const rightItems = base.filter((t) => taskDatePartition(t) === 'right');
   middle.innerHTML = middleItems.length ? middleItems.map(taskCardHtml).join('') : '<div class="queue-empty">対象タスクなし</div>';
@@ -6411,8 +6494,18 @@ ensureMemoriaFeatureViews = function () {
         <div id="taskForm" class="simple-form hidden"></div>
         <div class="tasks-three-pane">
           <aside id="tasksMenu" class="tasks-menu">
-            <button type="button" data-task-menu="todo" class="active">TODO</button>
-            <button type="button" data-task-menu="done">完了済み</button>
+            <div class="tasks-menu-section">
+              <button type="button" data-task-menu="todo" class="active">TODO</button>
+              <button type="button" data-task-menu="done">完了済み</button>
+            </div>
+            <div class="tasks-menu-section">
+              <h4 class="tasks-menu-h">カテゴリ</h4>
+              <div id="tasksCategoryList"></div>
+              <div class="tasks-cat-add">
+                <input id="tasksNewCatInput" type="text" placeholder="新しいカテゴリ" />
+                <button type="button" id="tasksNewCatBtn">+ 追加</button>
+              </div>
+            </div>
             <div id="taskDoneDrop" class="task-done-drop" title="タスクをここにドロップで完了">
               完了
             </div>
@@ -6553,11 +6646,20 @@ ensureMemoriaFeatureViews = function () {
       renderTaskBoard();
     };
   });
+  if ($('tasksNewCatBtn')) $('tasksNewCatBtn').onclick = addNewTaskCategoryFromMenu;
+  if ($('tasksNewCatInput')) {
+    $('tasksNewCatInput').addEventListener('keydown', (ev) => {
+      if (ev.key === 'Enter') { ev.preventDefault(); addNewTaskCategoryFromMenu(); }
+    });
+  }
 };
 
 loadTasks = async function () {
   ensureMemoriaFeatureViews();
-  const r = await api('/api/tasks');
+  const [r] = await Promise.all([
+    api('/api/tasks'),
+    reloadTaskCategoriesCache(),
+  ]);
   state.taskItems = r.items || [];
   if (state.taskDetail?.id) {
     state.taskDetail = state.taskItems.find((t) => t.id === state.taskDetail.id) || null;

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -2680,6 +2680,9 @@ function renderDiaryDetail() {
     $('diaryHighlights').textContent = d.highlights || '(なし)';
   }
 
+  // GPS から推定した「仕事中」セッションを上に表示
+  renderDiaryWorkSessions(d.date).catch(() => {});
+
   // Hourly chart: live_metrics is computed fresh on every request and includes
   // page_visits as a fallback for events captured before visit_events existed,
   // so it's preferred over the snapshot stored at generation time.
@@ -7992,10 +7995,94 @@ async function renderTracksForCurrentDate() {
     // live append のキャッシュ。 表示中の日付が「今日 (local)」なら使われる。
     tracksState.todayPoints = (date === todayLocalIso()) ? pts.slice() : [];
     updateTracksStatsLine(pts);
+    renderWorkSessions(date).catch(() => {});
   } catch (e) {
     console.error('[tracks] render failed', e);
     $('tracksStats').textContent = '取得失敗';
   }
+}
+
+async function renderDiaryWorkSessions(date) {
+  const el = $('diaryWorkSessions');
+  if (!el) return;
+  let items = [];
+  try {
+    const r = await api(`/api/work-sessions?date=${encodeURIComponent(date)}`);
+    items = r.items || [];
+  } catch {
+    el.innerHTML = '<div class="muted" style="font-size:12px">作業セッションを取得できませんでした。</div>';
+    return;
+  }
+  if (!items.length) {
+    el.innerHTML = '<div class="muted" style="font-size:12px">この日は登録した作業場所での 1 時間以上の滞在が検出されませんでした。</div>';
+    return;
+  }
+  const totalWorkMin = items
+    .filter(s => s.is_working)
+    .reduce((acc, s) => acc + (s.duration_min || 0), 0);
+  const head = totalWorkMin > 0
+    ? `合計仕事中: ${(totalWorkMin / 60).toFixed(1)}h`
+    : 'GPS 上は作業場所滞在ありだが、 自宅 + 開発活動なしのため「仕事中」とは判定されず';
+  el.innerHTML = `
+    <div class="muted" style="font-size:12px;margin-bottom:6px">${head}</div>
+    <ul class="ws-list">${items.map(s => {
+      const start = (s.started_at || '').replace('T', ' ').slice(11, 16);
+      const end = (s.ended_at || '').replace('T', ' ').slice(11, 16);
+      const dur = s.duration_min >= 60 ? `${(s.duration_min / 60).toFixed(1)}h` : `${s.duration_min}分`;
+      const icon = s.is_home ? '🏠' : '🏢';
+      const statusBadge = s.is_working
+        ? '<span class="ws-badge ws-working">仕事中</span>'
+        : '<span class="ws-badge ws-idle">休息</span>';
+      const acts = s.activity_counts || {};
+      const actSummary = Object.entries(acts).map(([k, n]) => `${k}:${n}`).join(' / ');
+      const actNote = s.is_home && actSummary
+        ? `<span class="muted" style="font-size:11px"> · ${escapeHtml(actSummary)}</span>` : '';
+      return `<li class="ws-item">
+        <span class="ws-time">${start}-${end} (${dur})</span>
+        <span class="ws-place">${icon} ${escapeHtml(s.workplace_name || '?')}</span>
+        ${statusBadge}${actNote}
+      </li>`;
+    }).join('')}</ul>`;
+}
+
+async function renderWorkSessions(date) {
+  const el = $('tracksWorkSessions');
+  if (!el) return;
+  let items = [];
+  try {
+    const r = await api(`/api/work-sessions?date=${encodeURIComponent(date)}`);
+    items = r.items || [];
+  } catch (e) {
+    el.innerHTML = `<div class="muted" style="font-size:12px">作業セッション取得失敗: ${escapeHtml(e.message)}</div>`;
+    return;
+  }
+  if (!items.length) {
+    el.innerHTML = '<div class="muted" style="font-size:12px">この日は登録した作業場所での 1 時間以上の滞在が検出されませんでした。</div>';
+    return;
+  }
+  el.innerHTML = `
+    <h4 style="margin:8px 0 4px">🛠 作業セッション (${items.length} 件)</h4>
+    <ul class="ws-list">${items.map(s => {
+      const start = (s.started_at || '').replace('T', ' ').slice(11, 16);
+      const end = (s.ended_at || '').replace('T', ' ').slice(11, 16);
+      const dur = s.duration_min >= 60
+        ? `${(s.duration_min / 60).toFixed(1)}h`
+        : `${s.duration_min}分`;
+      const icon = s.is_home ? '🏠' : '🏢';
+      const statusBadge = s.is_working
+        ? '<span class="ws-badge ws-working">仕事中</span>'
+        : '<span class="ws-badge ws-idle">休息</span>';
+      const acts = s.activity_counts || {};
+      const actSummary = Object.entries(acts)
+        .map(([k, n]) => `${k}:${n}`).join(' / ');
+      const actNote = s.is_home && actSummary
+        ? `<span class="muted" style="font-size:11px"> · ${escapeHtml(actSummary)}</span>` : '';
+      return `<li class="ws-item">
+        <span class="ws-time">${start}-${end} (${dur})</span>
+        <span class="ws-place">${icon} ${escapeHtml(s.workplace_name || '?')}</span>
+        ${statusBadge}${actNote}
+      </li>`;
+    }).join('')}</ul>`;
 }
 
 function updateTracksStatsLine(pts, { live = false } = {}) {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -4939,10 +4939,16 @@ function ensureMemoriaFeatureViews() {
       <h4 style="margin-top:12px">作業場所 (GPS / Hub 共有)</h4>
       <label class="check-inline"><input id="workplaceGeoEnabled" type="checkbox" /> GPS で現在地を取得して作業場所をマッチする</label>
       <label class="check-inline"><input id="workplaceAutoShareEnabled" type="checkbox" /> 作業場所が切り替わったとき Hub に共有する (オプトイン)</label>
-      <label style="display:flex;align-items:center;gap:6px;margin-bottom:6px">マッチ半径:
+      <label style="display:flex;align-items:center;gap:6px;margin-bottom:6px">マッチ半径 (作業場所判定 / 1 日の作業セッション検出):
         <input id="workplaceMatchRadiusM" type="number" min="20" max="2000" step="10" style="width:80px" />
         m
       </label>
+      <p class="diary-settings-help" style="margin-top:6px">
+        OwnTracks の locator displacement (移動 N m ごとに送信) と GPS の精度を考慮した距離。
+        既定 50m。 OwnTracks 側を 50m に設定しているならここも 50-100m が目安。
+        屋内ビル (室内 GPS オフセット) で取りこぼす場合は 100-200m に上げてください。
+        この半径を超えた点で「離脱」と判定し、 セッションがそこで終了します。
+      </p>
       <p class="diary-settings-help" style="margin-top:6px">iOS で受け取る場合はホーム画面に追加 + 通知を許可してください。GPS 共有は Hub 接続済みのときのみ動作します。</p>`;
     footer.parentNode.insertBefore(sec, footer);
   }
@@ -5201,7 +5207,7 @@ async function loadPrivacySettings() {
   if ($('mcpAutostartEnabled')) $('mcpAutostartEnabled').checked = !!s.mcp_autostart_enabled;
   if ($('workplaceGeoEnabled')) $('workplaceGeoEnabled').checked = !!s.workplace_geo_enabled;
   if ($('workplaceAutoShareEnabled')) $('workplaceAutoShareEnabled').checked = !!s.workplace_auto_share_enabled;
-  if ($('workplaceMatchRadiusM')) $('workplaceMatchRadiusM').value = s.workplace_match_radius_m ?? 150;
+  if ($('workplaceMatchRadiusM')) $('workplaceMatchRadiusM').value = s.workplace_match_radius_m ?? 50;
   configureWorkplaceCheckin(!!s.workplace_geo_enabled);
   if (s.tasks_reminder_enabled) {
     scheduleLocalTaskReminder(s.tasks_reminder_hour ?? 6, s.tasks_reminder_minute ?? 0);

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -471,16 +471,20 @@ async function refreshQueue() {
     if (totalDepth === 0) totalDepth = snap.depth || 0;
     const badge = $('queueBadge');
     const tabCount = $('tabQueueCount');
+    const wlBadge = $('wlQueueBadge');
     if (totalDepth > 0) {
       badge.classList.remove('hidden');
-      tabCount.classList.remove('hidden');
+      tabCount?.classList.remove('hidden');
+      wlBadge?.classList.remove('hidden');
       $('queueCount').textContent = totalDepth;
-      tabCount.textContent = totalDepth;
+      if (tabCount) tabCount.textContent = totalDepth;
+      if (wlBadge) wlBadge.textContent = totalDepth;
     } else {
       badge.classList.add('hidden');
-      tabCount.classList.add('hidden');
+      tabCount?.classList.add('hidden');
+      wlBadge?.classList.add('hidden');
     }
-    if (state.tab === 'queue') renderQueue();
+    if (state.tab === 'worklog' && state.worklog?.sub === 'queue') renderQueue();
     return totalDepth;
   } catch { return 0; }
 }
@@ -598,7 +602,18 @@ function jobLabel(item) {
   return kindHint + `seq #${item.seq}`;
 }
 
+// queue / domain / tracks / external は worklog の sub-tab として畳み込む。
+// switchTab に旧 key で来たら worklog + 該当 subtab に redirect する。
+const WORKLOG_REDIRECT_TABS = new Set(['queue', 'domain', 'tracks', 'external']);
+
 function switchTab(tab) {
+  if (WORKLOG_REDIRECT_TABS.has(tab)) {
+    const sub = tab;
+    if (state.worklog) state.worklog.sub = sub;
+    switchTab('worklog');
+    switchWorklogSub(sub);
+    return;
+  }
   state.tab = tab;
   document.querySelectorAll('.tab').forEach(t => {
     t.classList.toggle('active', t.dataset.tab === tab);
@@ -606,35 +621,27 @@ function switchTab(tab) {
   const layout = document.querySelector('.layout');
   if (layout) layout.dataset.activeTab = tab;
   $('bookmarksView').classList.toggle('hidden', tab !== 'bookmarks');
-  $('queueView').classList.toggle('hidden', tab !== 'queue');
   $('worklogView')?.classList.toggle('hidden', tab !== 'worklog');
   $('trendsView').classList.toggle('hidden', tab !== 'trends');
   $('recommendView').classList.toggle('hidden', tab !== 'recommend');
   $('digView').classList.toggle('hidden', tab !== 'dig');
   $('dictView').classList.toggle('hidden', tab !== 'dict');
-  $('domainView').classList.toggle('hidden', tab !== 'domain');
   $('diaryView').classList.toggle('hidden', tab !== 'diary');
-  $('tracksView')?.classList.toggle('hidden', tab !== 'tracks');
   $('mealsView')?.classList.toggle('hidden', tab !== 'meals');
   $('tasksView')?.classList.toggle('hidden', tab !== 'tasks');
   $('implView')?.classList.toggle('hidden', tab !== 'impl');
   $('workplaceView')?.classList.toggle('hidden', tab !== 'workplace');
   if (tab === 'workplace') loadWorkLocations().catch(console.warn);
-  $('externalView')?.classList.toggle('hidden', tab !== 'external');
   $('multiView')?.classList.toggle('hidden', tab !== 'multi');
-  if (tab === 'queue') renderQueue();
   if (tab === 'worklog') loadWorklog();
   if (tab === 'trends') loadTrends();
   if (tab === 'recommend') loadRecommendations();
   if (tab === 'dig') loadDigHistory();
   if (tab === 'dict') loadDictionary();
-  if (tab === 'domain') loadDomainCatalog();
   if (tab === 'diary') loadDiary();
-  if (tab === 'tracks') loadTracks();
   if (tab === 'meals') loadMeals();
   if (tab === 'tasks') loadTasks();
   if (tab === 'impl') loadImplementationNotes();
-  if (tab === 'external') loadExternalConfig();
   if (tab === 'multi') loadMulti();
   bumpTabUsage(tab);
   closeTabMoreMenu();
@@ -4172,7 +4179,7 @@ setInterval(async () => {
   const depth = await refreshQueue();
   await refreshVisitsBadge();
   if (depth > 0 || state.bookmarks.some(b => b.status === 'pending')) load();
-  if (state.tab === 'queue') renderQueue();
+  if (state.tab === 'worklog' && state.worklog?.sub === 'queue') renderQueue();
 }, 2000);
 refreshQueue();
 refreshVisitsBadge();
@@ -4743,9 +4750,9 @@ function ensureMemoriaFeatureViews() {
   const tabs = document.querySelector('.tabs-scroll');
   if (tabs && !document.querySelector('.tab[data-tab="tasks"]')) {
     for (const spec of [
-      ['tasks', 'タスク'],
-      ['impl', '実装自慢'],
-      ['workplace', '作業場所'],
+      ['tasks', '📝 タスク'],
+      ['impl', '✨ 実装自慢'],
+      ['workplace', '🗺️ 作業場所'],
     ]) {
       const b = document.createElement('button');
       b.className = 'tab';
@@ -5224,7 +5231,7 @@ function applyFeatureVisibility(s) {
   const mealsTab = document.querySelector('.tab[data-tab="meals"]');
   if (tracksTab) tracksTab.hidden = s.tracks_visible === false;
   if (mealsTab) mealsTab.hidden = s.meals_visible === false;
-  if (state.tab === 'tracks' && s.tracks_visible === false) switchTab('bookmarks');
+  if (state.tab === 'worklog' && state.worklog?.sub === 'tracks' && s.tracks_visible === false) switchTab('bookmarks');
   if (state.tab === 'meals' && s.meals_visible === false) switchTab('bookmarks');
   reflowTabsForViewport();
 }
@@ -6512,6 +6519,7 @@ function renderTaskBoard() {
 function decorateTaskAndImplTabs() {
   const taskTab = document.querySelector('.tab[data-tab="tasks"]');
   const implTab = document.querySelector('.tab[data-tab="impl"]');
+  const workplaceTab = document.querySelector('.tab[data-tab="workplace"]');
   if (taskTab) {
     const label = taskTab.querySelector('.tab-label');
     if (label) {
@@ -6531,6 +6539,16 @@ function decorateTaskAndImplTabs() {
     }
     if (!isNarrowViewport()) implTab.style.order = '-19';
     else implTab.style.order = '';
+  }
+  if (workplaceTab) {
+    const label = workplaceTab.querySelector('.tab-label');
+    if (label) {
+      label.textContent = '🗺️ 作業場所';
+      label.dataset.full = '🗺️ 作業場所';
+      label.dataset.short = '🗺️ 作業場所';
+    }
+    if (!isNarrowViewport()) workplaceTab.style.order = '-18';
+    else workplaceTab.style.order = '';
   }
 }
 
@@ -6800,7 +6818,15 @@ const WL_SUB_VIEWS = {
   codex: 'wlCodexView',
   browsing: 'wlBrowsingView',
   dig: 'wlDigView',
+  // 旧トップタブから移植してきた sub
+  queue: 'queueView',
+  domain: 'domainView',
+  tracks: 'tracksView',
+  external: 'externalView',
 };
+
+// 日付ベースの sub かどうか (date toolbar / summary 表示の有無)
+const WL_DATE_BASED = new Set(['schedule', 'github', 'claude', 'gemini', 'codex', 'browsing', 'dig']);
 
 const WL_KIND_BY_SUB = {
   github: 'git_commit',
@@ -6808,6 +6834,21 @@ const WL_KIND_BY_SUB = {
   gemini: 'gemini_prompt',
   codex: 'codex_prompt',
 };
+
+// 起動時に top-level だった 4 view を worklogView に取り込む。
+function migrateWorklogSubViews() {
+  const wl = $('worklogView');
+  if (!wl) return;
+  for (const id of ['queueView', 'domainView', 'tracksView', 'externalView']) {
+    const v = $(id);
+    if (v && v.parentNode !== wl) {
+      v.classList.add('hidden');
+      v.classList.add('wl-sub');
+      wl.appendChild(v);
+    }
+  }
+}
+migrateWorklogSubViews();
 
 function switchWorklogSub(sub) {
   if (!WL_SUB_VIEWS[sub]) return;
@@ -6819,6 +6860,9 @@ function switchWorklogSub(sub) {
     const view = $(viewId);
     if (view) view.classList.toggle('hidden', key !== sub);
   }
+  // date-based でない sub のときは date toolbar / summary を隠す
+  const dateBar = document.querySelector('#worklogView .worklog-daynav');
+  if (dateBar) dateBar.classList.toggle('hidden', !WL_DATE_BASED.has(sub));
   loadWorklog();
 }
 
@@ -6829,6 +6873,10 @@ async function loadWorklog() {
   if (sub === 'schedule') return loadWorklogSchedule(date);
   if (sub === 'browsing') return loadWorklogBrowsing(date);
   if (sub === 'dig') return loadWorklogDig(date);
+  if (sub === 'queue') return renderQueue();
+  if (sub === 'domain') return loadDomainCatalog();
+  if (sub === 'tracks') return loadTracks();
+  if (sub === 'external') return loadExternalConfig();
   if (WL_KIND_BY_SUB[sub]) {
     await loadWorklogActivity(date, sub);
     if (sub === 'gemini') await loadGeminiWebResearchLogs(date);
@@ -7497,7 +7545,7 @@ async function loadTracks() {
     });
     document.addEventListener('visibilitychange', () => {
       // タブに戻ってきたら最新の状態に再同期 + WS 再接続
-      if (document.visibilityState === 'visible' && state.tab === 'tracks') {
+      if (document.visibilityState === 'visible' && (state.tab === 'worklog' && state.worklog?.sub === 'tracks')) {
         renderTracksForCurrentDate();
         ensureLiveSocket();
       }
@@ -7596,7 +7644,7 @@ function scheduleLiveReconnect() {
   if (document.visibilityState !== 'visible') return;
   tracksState.wsReconnectTimer = setTimeout(() => {
     tracksState.wsReconnectTimer = null;
-    if (state.tab === 'tracks') ensureLiveSocket();
+    if ((state.tab === 'worklog' && state.worklog?.sub === 'tracks')) ensureLiveSocket();
   }, 3000);
 }
 

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -8067,6 +8067,7 @@ async function renderDiaryGpsSummary(date) {
   if (!el) return;
   let points = [];
   let sessions = [];
+  let tallies = { home_minutes: 0, workplace_minutes: 0, by_workplace: {} };
   try {
     const [pr, sr] = await Promise.all([
       api(`/api/locations?date=${encodeURIComponent(date)}`),
@@ -8074,6 +8075,7 @@ async function renderDiaryGpsSummary(date) {
     ]);
     points = pr.points || [];
     sessions = sr.items || [];
+    if (sr.tallies) tallies = sr.tallies;
   } catch (err) {
     console.error('[diary gps summary] fetch failed', err);
     el.innerHTML = `<div class="muted" style="font-size:12px">GPS 情報の取得に失敗しました — 判断不能 (${escapeHtml(err.message || '')})</div>`;
@@ -8089,28 +8091,45 @@ async function renderDiaryGpsSummary(date) {
   const transitMin = (stats.transitSec || 0) / 60;
   const stillMin = (stats.stillSec || 0) / 60;
   const totalMoveMin = walkMin + transitMin;
-  // 作業場所ごとの滞在時間 (work-sessions API は ≥60 分のみ返す前提)
-  const placeTotals = new Map();
-  let totalAtWorkMin = 0;
-  for (const s of sessions) {
-    placeTotals.set(s.workplace_name || '?', (placeTotals.get(s.workplace_name || '?') || 0) + (s.duration_min || 0));
-    totalAtWorkMin += s.duration_min || 0;
-  }
-  const placesHtml = placeTotals.size
-    ? [...placeTotals.entries()]
-        .sort((a, b) => b[1] - a[1])
-        .map(([name, min]) => `<li>${escapeHtml(name)} <span class="muted">${fmtHm(min)}</span></li>`).join('')
-    : '<li class="muted">この日は登録した作業場所での 1 時間以上の滞在なし</li>';
+  const homeMin = tallies.home_minutes || 0;
+  const workMin = tallies.workplace_minutes || 0;
+  // 不明または停止: 全停止時間から自宅 + 作業場所の滞在時間を引いた残り
+  const unknownStillMin = Math.max(0, stillMin - homeMin - workMin);
+
+  // 作業場所別 (自宅以外) 内訳
+  const workPlaces = Object.entries(tallies.by_workplace || {})
+    .filter(([name]) => !(name && (name.includes('自宅') || /home/i.test(name))));
+  const workplaceDetail = workPlaces.length
+    ? workPlaces.sort((a, b) => b[1] - a[1])
+        .map(([name, min]) => `${escapeHtml(name)} ${fmtHm(min)}`).join(' / ')
+    : '';
+
+  // 移動手段の内訳
+  const moveDetail = (walkMin > 0 || transitMin > 0)
+    ? `🚶 ${fmtHm(walkMin)} / 🚃 ${fmtHm(transitMin)}`
+    : '';
+
   el.innerHTML = `
     <ul class="diary-gps-stats">
-      <li><span class="muted">🚶 徒歩</span> <strong>${fmtHm(walkMin)}</strong></li>
-      <li><span class="muted">🚃 交通機関</span> <strong>${fmtHm(transitMin)}</strong></li>
-      <li><span class="muted">⏸ 停止</span> <strong>${fmtHm(stillMin)}</strong></li>
-      <li><span class="muted">移動 合計</span> <strong>${fmtHm(totalMoveMin)}</strong></li>
-      <li><span class="muted">作業場所 滞在 合計</span> <strong>${fmtHm(totalAtWorkMin)}</strong></li>
+      <li>
+        <span class="diary-gps-label">🚆 移動手段</span>
+        <strong>${fmtHm(totalMoveMin)}</strong>
+        ${moveDetail ? `<span class="muted diary-gps-detail">${moveDetail}</span>` : ''}
+      </li>
+      <li>
+        <span class="diary-gps-label">🏠 自宅滞在</span>
+        <strong>${fmtHm(homeMin)}</strong>
+      </li>
+      <li>
+        <span class="diary-gps-label">🏢 作業場所滞在</span>
+        <strong>${fmtHm(workMin)}</strong>
+        ${workplaceDetail ? `<span class="muted diary-gps-detail">${workplaceDetail}</span>` : ''}
+      </li>
+      <li>
+        <span class="diary-gps-label">⏸ 不明または停止</span>
+        <strong>${fmtHm(unknownStillMin)}</strong>
+      </li>
     </ul>
-    <div class="muted" style="font-size:11px;margin:6px 0 4px">作業場所別:</div>
-    <ul class="diary-gps-places">${placesHtml}</ul>
   `;
 }
 
@@ -8142,6 +8161,7 @@ async function renderDiaryWorkSessions(date) {
       const end = (s.ended_at || '').replace('T', ' ').slice(11, 16);
       const dur = s.duration_min >= 60 ? `${(s.duration_min / 60).toFixed(1)}h` : `${s.duration_min}分`;
       const icon = s.is_home ? '🏠' : '🏢';
+      const placeLabel = s.is_home ? '自宅' : (s.workplace_name || '?');
       const statusBadge = s.is_working
         ? '<span class="ws-badge ws-working">仕事中</span>'
         : '<span class="ws-badge ws-idle">休息</span>';
@@ -8151,7 +8171,7 @@ async function renderDiaryWorkSessions(date) {
         ? `<span class="muted" style="font-size:11px"> · ${escapeHtml(actSummary)}</span>` : '';
       return `<li class="ws-item">
         <span class="ws-time">${start}-${end} (${dur})</span>
-        <span class="ws-place">${icon} ${escapeHtml(s.workplace_name || '?')}</span>
+        <span class="ws-place">${icon} ${escapeHtml(placeLabel)}</span>
         ${statusBadge}${actNote}
       </li>`;
     }).join('')}</ul>`;

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -4130,7 +4130,9 @@ function hideModal(panelId) {
   const taskOpen = $('taskEditorModal') ? !$('taskEditorModal').classList.contains('hidden') : false;
   const implOpen = $('implEditorModal') ? !$('implEditorModal').classList.contains('hidden') : false;
   const workOpen = $('workplaceEditorModal') ? !$('workplaceEditorModal').classList.contains('hidden') : false;
-  $('modalBackdrop').hidden = !(dictOpen || domOpen || taskOpen || implOpen || workOpen);
+  const apOpen = $('agentProjectEditor') ? !$('agentProjectEditor').classList.contains('hidden') : false;
+  const arOpen = $('agentRunModal') ? !$('agentRunModal').classList.contains('hidden') : false;
+  $('modalBackdrop').hidden = !(dictOpen || domOpen || taskOpen || implOpen || workOpen || apOpen || arOpen);
 }
 function closeAllModals() {
   state.dictDetail = null;
@@ -4141,6 +4143,8 @@ function closeAllModals() {
   hideModal('taskEditorModal');
   hideModal('implEditorModal');
   hideModal('workplaceEditorModal');
+  if ($('agentProjectEditor')) hideModal('agentProjectEditor');
+  if ($('agentRunModal')) hideModal('agentRunModal');
 }
 $('dictDetailClose')?.addEventListener('click', () => {
   state.dictDetail = null;
@@ -4630,6 +4634,7 @@ document.addEventListener('click', (ev) => {
   // タブを切り替えたら panel を上にリセット (各タブの先頭から見たい)
   if (stab === 'privacy') loadPrivacySettings().catch(console.warn);
   if (stab === 'setup') loadSetupDocs().catch(console.warn);
+  if (stab === 'agent-projects') loadAgentProjects().catch(console.warn);
   panel.scrollTop = 0;
 });
 
@@ -4840,6 +4845,7 @@ function ensureMemoriaFeatureViews() {
     for (const spec of [
       ['privacy', 'プライバシー / 表示'],
       ['setup', 'セットアップ手順'],
+      ['agent-projects', 'AI 実装プロジェクト'],
     ]) {
       const b = document.createElement('button');
       b.type = 'button';
@@ -4894,6 +4900,47 @@ function ensureMemoriaFeatureViews() {
       <h4>セットアップ手順</h4>
       <div id="setupDocsList" class="setup-docs-list"></div>
       <pre id="setupDocBody" class="setup-doc-body"></pre>`;
+    footer.parentNode.insertBefore(sec, footer);
+  }
+  if (footer && !$('agentProjectsBody')) {
+    const sec = document.createElement('section');
+    sec.id = 'agentProjectsBody';
+    sec.className = 'settings-tab-body hidden';
+    sec.dataset.stab = 'agent-projects';
+    sec.innerHTML = `
+      <h4>AI 実装プロジェクト</h4>
+      <p class="diary-settings-help">タスクに「🤖 AI実装」を依頼するときに使うプロジェクト一覧です。プロジェクトごとにルール・パス・既定エージェントを登録します。</p>
+      <div id="agentProjectsList" class="simple-list"></div>
+      <div class="simple-actions"><button id="agentProjectAddBtn" type="button">+ プロジェクト追加</button></div>
+      <section id="agentProjectEditor" class="dict-detail modal-panel hidden foundation-form">
+        <button type="button" class="modal-close" id="agentProjectEditorClose" aria-label="close">×</button>
+        <h3 id="agentProjectEditorHeading">プロジェクトを追加</h3>
+        <input type="hidden" id="agentProjectEditorId" />
+        <label class="simple-field">
+          <span>名前</span>
+          <input id="agentProjectEditorName" type="text" placeholder="例: Memoria" />
+        </label>
+        <label class="simple-field">
+          <span>パス (絶対パス)</span>
+          <input id="agentProjectEditorPath" type="text" placeholder="例: E:\\Document\\Ars\\Memoria" />
+        </label>
+        <label class="simple-field">
+          <span>既定エージェント</span>
+          <select id="agentProjectEditorAgent">
+            <option value="claude_code">Claude Code</option>
+            <option value="codex">Codex CLI</option>
+            <option value="gemini">Gemini CLI</option>
+          </select>
+        </label>
+        <label class="simple-field">
+          <span>ルール (Markdown)</span>
+          <textarea id="agentProjectEditorRules" rows="14" placeholder="技術スタック・規約・Do/Don't・完了条件 など。AI 実装時にプロンプトの先頭に貼られます。"></textarea>
+        </label>
+        <div class="simple-actions">
+          <button id="agentProjectEditorSaveBtn">保存</button>
+          <button id="agentProjectEditorCancelBtn" type="button" class="ghost">キャンセル</button>
+        </div>
+      </section>`;
     footer.parentNode.insertBefore(sec, footer);
   }
 
@@ -5587,6 +5634,7 @@ function taskCardHtml(t) {
       <p>${escapeHtml(t.details || '')}</p>
       <div class="simple-actions">
         ${doneBtn}
+        <button class="ghost" data-task-agent="${t.id}">🤖 AI実装</button>
         <button class="ghost" data-task-share="${t.id}">Actioにシェア</button>
         <button class="danger" data-task-delete="${t.id}">削除</button>
       </div>
@@ -5696,6 +5744,271 @@ function openWorkplaceEditor(w = null) {
 
 function closeWorkplaceEditor() {
   hideModal('workplaceEditorModal');
+}
+
+// ── Agent projects (AI 実装プロジェクト) ───────────────────────────────────
+
+let _agentProjectsCache = [];
+
+async function loadAgentProjects() {
+  const list = $('agentProjectsList');
+  if (!list) return;
+  try {
+    const r = await api('/api/agent-projects');
+    _agentProjectsCache = r.items || [];
+  } catch (e) {
+    list.innerHTML = `<div class="queue-empty">読み込み失敗: ${escapeHtml(e.message)}</div>`;
+    return;
+  }
+  if (!_agentProjectsCache.length) {
+    list.innerHTML = '<div class="queue-empty">プロジェクトがまだ登録されていません。「+ プロジェクト追加」から登録してください。</div>';
+  } else {
+    list.innerHTML = _agentProjectsCache.map(p => `
+      <div class="simple-item" data-id="${p.id}" data-agent-project-open="${p.id}">
+        <div class="simple-item-head">
+          <strong>${escapeHtml(p.name)}</strong>
+          <span class="muted">${escapeHtml(p.default_agent || 'claude_code')}</span>
+        </div>
+        <div class="muted" style="font-family:ui-monospace,monospace;font-size:11px">${escapeHtml(p.path)}</div>
+        <div class="simple-actions">
+          <button class="ghost" data-agent-project-edit="${p.id}">編集</button>
+          <button class="danger" data-agent-project-delete="${p.id}">削除</button>
+        </div>
+      </div>`).join('');
+  }
+  list.querySelectorAll('[data-agent-project-edit]').forEach(btn => {
+    btn.addEventListener('click', (ev) => {
+      ev.stopPropagation();
+      const p = _agentProjectsCache.find(x => x.id === Number(btn.dataset.agentProjectEdit));
+      if (p) openAgentProjectEditor(p);
+    });
+  });
+  list.querySelectorAll('[data-agent-project-delete]').forEach(btn => {
+    btn.addEventListener('click', async (ev) => {
+      ev.stopPropagation();
+      if (!confirm('このプロジェクトを削除しますか?')) return;
+      await api(`/api/agent-projects/${btn.dataset.agentProjectDelete}`, { method: 'DELETE' });
+      loadAgentProjects();
+    });
+  });
+}
+
+function openAgentProjectEditor(p = null) {
+  const isEdit = !!p;
+  if (!$('agentProjectEditor')) return;
+  $('agentProjectEditorHeading').textContent = isEdit ? 'プロジェクトを変更' : 'プロジェクトを追加';
+  $('agentProjectEditorId').value = p?.id ? String(p.id) : '';
+  $('agentProjectEditorName').value = p?.name || '';
+  $('agentProjectEditorPath').value = p?.path || '';
+  $('agentProjectEditorAgent').value = p?.default_agent || 'claude_code';
+  $('agentProjectEditorRules').value = p?.rules || '';
+  showModal('agentProjectEditor');
+  $('agentProjectEditorName').focus();
+}
+
+function closeAgentProjectEditor() { hideModal('agentProjectEditor'); }
+
+async function saveAgentProjectFromForm() {
+  const name = $('agentProjectEditorName')?.value.trim();
+  const path = $('agentProjectEditorPath')?.value.trim();
+  if (!name) return alert('名前を入力してください');
+  if (!path) return alert('パスを入力してください');
+  const editId = Number($('agentProjectEditorId')?.value || 0);
+  const payload = {
+    name, path,
+    default_agent: $('agentProjectEditorAgent')?.value || 'claude_code',
+    rules: $('agentProjectEditorRules')?.value || '',
+  };
+  try {
+    if (editId) {
+      await api(`/api/agent-projects/${editId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+    } else {
+      await api('/api/agent-projects', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+    }
+    closeAgentProjectEditor();
+    loadAgentProjects();
+  } catch (e) {
+    alert(`保存失敗: ${e.message}`);
+  }
+}
+
+// ── Agent run modal (AI 実装依頼) ──────────────────────────────────────────
+
+let _agentRunCurrentTask = null;
+let _agentRunPollTimer = null;
+
+function ensureAgentRunModal() {
+  if ($('agentRunModal')) return;
+  const modal = document.createElement('section');
+  modal.id = 'agentRunModal';
+  modal.className = 'dict-detail modal-panel hidden foundation-form';
+  modal.innerHTML = `
+    <button type="button" class="modal-close" id="agentRunClose" aria-label="close">×</button>
+    <h3 id="agentRunHeading">🤖 AI に実装を依頼</h3>
+    <div id="agentRunTaskInfo" class="muted" style="margin-bottom:8px"></div>
+    <label class="simple-field">
+      <span>プロジェクト</span>
+      <select id="agentRunProject"></select>
+    </label>
+    <label class="simple-field">
+      <span>エージェント</span>
+      <select id="agentRunAgent">
+        <option value="claude_code">Claude Code</option>
+        <option value="codex">Codex CLI</option>
+        <option value="gemini">Gemini CLI</option>
+      </select>
+    </label>
+    <div class="simple-actions">
+      <button id="agentRunStartBtn">▶ 実装を開始</button>
+      <button id="agentRunCancelBtn" type="button" class="ghost">キャンセル</button>
+    </div>
+    <h4 style="margin-top:16px">実行履歴</h4>
+    <div id="agentRunHistory" class="simple-list" style="max-height:180px;overflow-y:auto"></div>
+    <h4 style="margin-top:16px">ログ</h4>
+    <div id="agentRunLogStatus" class="muted" style="font-size:11px"></div>
+    <pre id="agentRunLog" class="setup-doc-body" style="max-height:280px;overflow:auto;font-size:11px;white-space:pre-wrap"></pre>
+    <div class="simple-actions">
+      <button id="agentRunRefreshBtn" type="button" class="ghost">ログ更新</button>
+      <button id="agentRunCancelRunBtn" type="button" class="danger" hidden>実行をキャンセル</button>
+    </div>`;
+  document.body.appendChild(modal);
+  $('agentRunClose').onclick = closeAgentRunModal;
+  $('agentRunCancelBtn').onclick = closeAgentRunModal;
+  $('agentRunStartBtn').onclick = startAgentRunFromModal;
+  $('agentRunRefreshBtn').onclick = () => {
+    const id = Number($('agentRunLog').dataset.runId || 0);
+    if (id) refreshAgentRunLog(id);
+  };
+  $('agentRunCancelRunBtn').onclick = async () => {
+    const id = Number($('agentRunLog').dataset.runId || 0);
+    if (!id) return;
+    if (!confirm('実行中のエージェントを停止しますか?')) return;
+    try { await api(`/api/agent-runs/${id}/cancel`, { method: 'POST' }); }
+    catch (e) { alert(e.message); }
+    refreshAgentRunLog(id);
+  };
+}
+
+async function openAgentRunModal(task) {
+  ensureAgentRunModal();
+  _agentRunCurrentTask = task;
+  $('agentRunTaskInfo').textContent = `タスク: ${task.title}`;
+  // load projects
+  try {
+    const r = await api('/api/agent-projects');
+    const items = r.items || [];
+    if (!items.length) {
+      $('agentRunProject').innerHTML = '<option value="">（プロジェクト未登録 — 設定→AI 実装プロジェクトから登録してください）</option>';
+      $('agentRunStartBtn').disabled = true;
+    } else {
+      $('agentRunProject').innerHTML = items.map(p =>
+        `<option value="${p.id}" data-default-agent="${escapeHtml(p.default_agent)}">${escapeHtml(p.name)}</option>`
+      ).join('');
+      $('agentRunStartBtn').disabled = false;
+      // Pre-select task.project_id if any
+      if (task.project_id) $('agentRunProject').value = String(task.project_id);
+      const selOpt = $('agentRunProject').selectedOptions[0];
+      if (selOpt?.dataset.defaultAgent) $('agentRunAgent').value = selOpt.dataset.defaultAgent;
+      $('agentRunProject').onchange = () => {
+        const o = $('agentRunProject').selectedOptions[0];
+        if (o?.dataset.defaultAgent) $('agentRunAgent').value = o.dataset.defaultAgent;
+      };
+    }
+  } catch (e) {
+    alert(`プロジェクト取得失敗: ${e.message}`);
+  }
+  // Load run history.
+  await refreshAgentRunHistory(task.id);
+  $('agentRunLog').textContent = '';
+  $('agentRunLog').dataset.runId = '';
+  $('agentRunLogStatus').textContent = '';
+  $('agentRunCancelRunBtn').hidden = true;
+  showModal('agentRunModal');
+}
+
+function closeAgentRunModal() {
+  hideModal('agentRunModal');
+  if (_agentRunPollTimer) { clearInterval(_agentRunPollTimer); _agentRunPollTimer = null; }
+}
+
+async function refreshAgentRunHistory(taskId) {
+  try {
+    const r = await api(`/api/agent-runs?task_id=${encodeURIComponent(taskId)}&limit=20`);
+    const items = r.items || [];
+    const el = $('agentRunHistory');
+    if (!items.length) { el.innerHTML = '<div class="queue-empty">履歴なし</div>'; return; }
+    el.innerHTML = items.map(run => {
+      const at = (run.started_at || '').replace('T', ' ').slice(0, 19);
+      const status = escapeHtml(run.status);
+      const exit = run.exit_code != null ? ` (exit ${run.exit_code})` : '';
+      return `<div class="simple-item" data-agent-run-open="${run.id}">
+        <div class="simple-item-head">
+          <strong>#${run.id} ${escapeHtml(run.agent)}</strong>
+          <span class="muted">${at}</span>
+        </div>
+        <div class="muted">${status}${exit}</div>
+        ${run.summary ? `<div style="font-size:11px">${escapeHtml(run.summary).slice(0, 200)}</div>` : ''}
+      </div>`;
+    }).join('');
+    el.querySelectorAll('[data-agent-run-open]').forEach(it => {
+      it.addEventListener('click', () => refreshAgentRunLog(Number(it.dataset.agentRunOpen)));
+    });
+  } catch (e) {
+    console.warn(e);
+  }
+}
+
+async function refreshAgentRunLog(runId) {
+  try {
+    const r = await api(`/api/agent-runs/${runId}/log?tail=131072`);
+    $('agentRunLog').textContent = r.log || '(ログなし)';
+    $('agentRunLog').dataset.runId = String(runId);
+    const status = r.run?.status || 'unknown';
+    const at = (r.run?.started_at || '').replace('T', ' ').slice(0, 19);
+    const exit = r.run?.exit_code != null ? ` (exit ${r.run.exit_code})` : '';
+    $('agentRunLogStatus').textContent = `#${runId} · ${status}${exit} · started ${at} · ${r.running ? '実行中' : '停止'}`;
+    $('agentRunCancelRunBtn').hidden = !r.running;
+    if (_agentRunPollTimer) { clearInterval(_agentRunPollTimer); _agentRunPollTimer = null; }
+    if (r.running) {
+      _agentRunPollTimer = setInterval(() => refreshAgentRunLog(runId), 3000);
+    }
+    // tail-like behaviour: scroll to bottom
+    const pre = $('agentRunLog');
+    pre.scrollTop = pre.scrollHeight;
+  } catch (e) {
+    $('agentRunLogStatus').textContent = `ログ取得失敗: ${e.message}`;
+  }
+}
+
+async function startAgentRunFromModal() {
+  if (!_agentRunCurrentTask) return;
+  const projectId = Number($('agentRunProject')?.value || 0);
+  const agent = $('agentRunAgent')?.value || 'claude_code';
+  if (!projectId) return alert('プロジェクトを選択してください');
+  $('agentRunStartBtn').disabled = true;
+  $('agentRunStartBtn').textContent = '起動中…';
+  try {
+    const r = await api(`/api/tasks/${_agentRunCurrentTask.id}/agent-run`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ project_id: projectId, agent }),
+    });
+    await refreshAgentRunHistory(_agentRunCurrentTask.id);
+    if (r.run?.id) refreshAgentRunLog(r.run.id);
+  } catch (e) {
+    alert(`起動失敗: ${e.message}`);
+  } finally {
+    $('agentRunStartBtn').disabled = false;
+    $('agentRunStartBtn').textContent = '▶ 実装を開始';
+  }
 }
 
 // ── GPS / Place API helpers ────────────────────────────────────────────────
@@ -5938,6 +6251,14 @@ function renderTaskBoard() {
       await loadTasks();
     });
   });
+  document.querySelectorAll('[data-task-agent]').forEach((btn) => {
+    btn.addEventListener('click', (ev) => {
+      ev.stopPropagation();
+      const id = Number(btn.dataset.taskAgent);
+      const task = state.taskItems.find((t) => t.id === id);
+      if (task) openAgentRunModal(task);
+    });
+  });
   document.querySelectorAll('[data-task-delete]').forEach((btn) => {
     btn.addEventListener('click', async (ev) => {
       ev.stopPropagation();
@@ -6141,6 +6462,10 @@ ensureMemoriaFeatureViews = function () {
   if ($('implEditorClose')) $('implEditorClose').onclick = closeImplEditor;
   if ($('implEditorCancelBtn')) $('implEditorCancelBtn').onclick = closeImplEditor;
   if ($('implEditorSaveBtn')) $('implEditorSaveBtn').onclick = addImplementationNoteFromForm;
+  if ($('agentProjectAddBtn')) $('agentProjectAddBtn').onclick = () => openAgentProjectEditor(null);
+  if ($('agentProjectEditorClose')) $('agentProjectEditorClose').onclick = closeAgentProjectEditor;
+  if ($('agentProjectEditorCancelBtn')) $('agentProjectEditorCancelBtn').onclick = closeAgentProjectEditor;
+  if ($('agentProjectEditorSaveBtn')) $('agentProjectEditorSaveBtn').onclick = saveAgentProjectFromForm;
   if ($('workplaceNewBtn')) $('workplaceNewBtn').onclick = () => openWorkplaceEditor(null);
   if ($('workplaceEditorClose')) $('workplaceEditorClose').onclick = closeWorkplaceEditor;
   if ($('workplaceEditorCancelBtn')) $('workplaceEditorCancelBtn').onclick = closeWorkplaceEditor;

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -4184,9 +4184,17 @@ async function openAiSettings() {
     const r = await api('/api/llm/config');
     const cfg = r.config;
     const tasks = r.tasks;
-    const providers = r.providers;
-    const providerModels = r.provider_models || {};
+    let providers = r.providers || [];
+    const providerModelsRaw = r.provider_models || {};
+    const providerModels = {};
+    for (const k of Object.keys(PROVIDER_MODELS_FALLBACK)) {
+      providerModels[k] = (providerModelsRaw[k] && providerModelsRaw[k].length) ? providerModelsRaw[k] : PROVIDER_MODELS_FALLBACK[k];
+    }
     const providerDefaults = r.provider_default_model || {};
+    // サーバが旧版で 'algorithm' を providers に含めない場合は前置きで補完
+    if (!providers.find(p => p.key === 'algorithm')) {
+      providers = [{ key: 'algorithm', label: 'アルゴリズム (AI なし)', kind: 'none' }, ...providers];
+    }
     // 同じ /api/llm/config をタスク AI 依頼モーダルでも引くので、共有キャッシュにも入れておく
     _providerModelsCache = providerModels;
     _providerDefaultsCache = providerDefaults;
@@ -5883,10 +5891,6 @@ function ensureAgentRunModal() {
     <h3 id="agentRunHeading">🤖 AI に実装を依頼</h3>
     <div id="agentRunTaskInfo" class="muted" style="margin-bottom:8px"></div>
     <label class="simple-field">
-      <span>プロジェクト</span>
-      <select id="agentRunProject"></select>
-    </label>
-    <label class="simple-field">
       <span>エージェント</span>
       <select id="agentRunAgent">
         <option value="claude_code">Claude Code</option>
@@ -5898,6 +5902,7 @@ function ensureAgentRunModal() {
       <span>モデル</span>
       <select id="agentRunModel"></select>
     </label>
+    <div id="agentRunProjectInfo" class="muted" style="font-size:11px;margin:-4px 0 8px"></div>
     <div class="simple-actions">
       <button id="agentRunStartBtn">▶ 実装を開始</button>
       <button id="agentRunCancelBtn" type="button" class="ghost">キャンセル</button>
@@ -5931,17 +5936,44 @@ function ensureAgentRunModal() {
 
 // 設定画面とタスク AI 依頼でモデル一覧を共有するためのキャッシュ。
 // サーバの `/api/llm/config` (server/llm.js の PROVIDER_MODELS / PROVIDER_DEFAULT_MODEL)
-// が単一の出所。
+// が単一の出所。サーバが旧バージョンで provider_models を返さない場合のフォールバックも保持。
+const PROVIDER_MODELS_FALLBACK = {
+  algorithm: [],
+  claude: [
+    { id: 'sonnet', label: 'Sonnet 4.6 (default)' },
+    { id: 'haiku',  label: 'Haiku 4.5 (fast)' },
+    { id: 'opus',   label: 'Opus 4.7' },
+    { id: 'claude-opus-4-7[1m]', label: 'Opus 4.7 (1M)' },
+  ],
+  codex: [
+    { id: '5.3-codex',   label: '5.3-codex (default)' },
+    { id: 'gpt-5-codex', label: 'GPT-5 Codex' },
+  ],
+  gemini: [
+    { id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash (default)' },
+    { id: 'gemini-2.5-pro',   label: 'Gemini 2.5 Pro' },
+  ],
+  openai: [
+    { id: 'gpt-4o-mini', label: 'GPT-4o mini (default)' },
+    { id: 'gpt-4o',      label: 'GPT-4o' },
+  ],
+};
 let _providerModelsCache = null;
 let _providerDefaultsCache = null;
 async function ensureProviderModels() {
   if (_providerModelsCache) return _providerModelsCache;
   try {
     const r = await api('/api/llm/config');
-    _providerModelsCache = r.provider_models || {};
+    const fromServer = r.provider_models || {};
+    // サーバが provider_models を返さない (旧版) 場合は fallback を使用。
+    const merged = {};
+    for (const k of Object.keys(PROVIDER_MODELS_FALLBACK)) {
+      merged[k] = (fromServer[k] && fromServer[k].length) ? fromServer[k] : PROVIDER_MODELS_FALLBACK[k];
+    }
+    _providerModelsCache = merged;
     _providerDefaultsCache = r.provider_default_model || {};
   } catch {
-    _providerModelsCache = {};
+    _providerModelsCache = { ...PROVIDER_MODELS_FALLBACK };
     _providerDefaultsCache = {};
   }
   return _providerModelsCache;
@@ -5973,34 +6005,31 @@ async function refreshAgentModelDropdown() {
   if ([...sel.options].some(o => o.value === cur)) sel.value = cur;
 }
 
+// 単一プロジェクト前提: 登録された最初のプロジェクト (created_at ASC) を自動選択。
+// 編集は設定 → AI 実装プロジェクト から。
+let _agentRunDefaultProject = null;
 async function openAgentRunModal(task) {
   ensureAgentRunModal();
   _agentRunCurrentTask = task;
   $('agentRunTaskInfo').textContent = `タスク: ${task.title}`;
-  // load projects
+  // load default project (silently)
   try {
     const r = await api('/api/agent-projects');
     const items = r.items || [];
     if (!items.length) {
-      $('agentRunProject').innerHTML = '<option value="">（プロジェクト未登録 — 設定→AI 実装プロジェクトから登録してください）</option>';
+      _agentRunDefaultProject = null;
+      $('agentRunProjectInfo').textContent = '⚠ プロジェクト未登録 — 設定 → AI 実装プロジェクトから登録してください';
       $('agentRunStartBtn').disabled = true;
     } else {
-      $('agentRunProject').innerHTML = items.map(p =>
-        `<option value="${p.id}" data-default-agent="${escapeHtml(p.default_agent)}">${escapeHtml(p.name)}</option>`
-      ).join('');
+      _agentRunDefaultProject = items[0];
+      $('agentRunProjectInfo').textContent = `実行ディレクトリ: ${_agentRunDefaultProject.name} (${_agentRunDefaultProject.path})`;
       $('agentRunStartBtn').disabled = false;
-      const selOpt = $('agentRunProject').selectedOptions[0];
-      if (selOpt?.dataset.defaultAgent) $('agentRunAgent').value = selOpt.dataset.defaultAgent;
-      $('agentRunProject').onchange = () => {
-        const o = $('agentRunProject').selectedOptions[0];
-        if (o?.dataset.defaultAgent) {
-          $('agentRunAgent').value = o.dataset.defaultAgent;
-          refreshAgentModelDropdown().catch(() => {});
-        }
-      };
+      if (_agentRunDefaultProject.default_agent) {
+        $('agentRunAgent').value = _agentRunDefaultProject.default_agent;
+      }
     }
   } catch (e) {
-    alert(`プロジェクト取得失敗: ${e.message}`);
+    $('agentRunProjectInfo').textContent = `プロジェクト取得失敗: ${e.message}`;
   }
   await refreshAgentModelDropdown();
   $('agentRunAgent').onchange = () => { refreshAgentModelDropdown().catch(() => {}); };
@@ -6070,10 +6099,10 @@ async function refreshAgentRunLog(runId) {
 
 async function startAgentRunFromModal() {
   if (!_agentRunCurrentTask) return;
-  const projectId = Number($('agentRunProject')?.value || 0);
+  const projectId = Number(_agentRunDefaultProject?.id || 0);
   const agent = $('agentRunAgent')?.value || 'claude_code';
   const model = $('agentRunModel')?.value || '';
-  if (!projectId) return alert('プロジェクトを選択してください');
+  if (!projectId) return alert('プロジェクトが未登録です。設定 → AI 実装プロジェクトから登録してください');
   $('agentRunStartBtn').disabled = true;
   $('agentRunStartBtn').textContent = '起動中…';
   try {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -2682,6 +2682,8 @@ function renderDiaryDetail() {
 
   // GPS から推定した「仕事中」セッションを上に表示
   renderDiaryWorkSessions(d.date).catch(() => {});
+  // 移動 / 滞在時間サマリ
+  renderDiaryGpsSummary(d.date).catch(() => {});
 
   // Hourly chart: live_metrics is computed fresh on every request and includes
   // page_visits as a fallback for events captured before visit_events existed,
@@ -8000,6 +8002,66 @@ async function renderTracksForCurrentDate() {
     console.error('[tracks] render failed', e);
     $('tracksStats').textContent = '取得失敗';
   }
+}
+
+function fmtHm(totalMin) {
+  if (!Number.isFinite(totalMin) || totalMin <= 0) return '0分';
+  const h = Math.floor(totalMin / 60);
+  const m = Math.round(totalMin - h * 60);
+  if (h === 0) return `${m}分`;
+  if (m === 0) return `${h}h`;
+  return `${h}h ${m}m`;
+}
+
+async function renderDiaryGpsSummary(date) {
+  const el = $('diaryGpsSummary');
+  if (!el) return;
+  let points = [];
+  let sessions = [];
+  try {
+    const [pr, sr] = await Promise.all([
+      api(`/api/locations?date=${encodeURIComponent(date)}`),
+      api(`/api/work-sessions?date=${encodeURIComponent(date)}`),
+    ]);
+    points = pr.points || [];
+    sessions = sr.items || [];
+  } catch {
+    el.innerHTML = '<div class="muted" style="font-size:12px">GPS 情報の取得に失敗しました — 判断不能</div>';
+    return;
+  }
+  if (!points.length) {
+    el.innerHTML = '<div class="muted" style="font-size:12px">この日は GPS の記録がありません — 移動・滞在時間は判断不能</div>';
+    return;
+  }
+  // 区分別時間 (walk / transit / still)
+  const stats = classifyAll(points);
+  const walkMin = (stats.walkSec || 0) / 60;
+  const transitMin = (stats.transitSec || 0) / 60;
+  const stillMin = (stats.stillSec || 0) / 60;
+  const totalMoveMin = walkMin + transitMin;
+  // 作業場所ごとの滞在時間 (work-sessions API は ≥60 分のみ返す前提)
+  const placeTotals = new Map();
+  let totalAtWorkMin = 0;
+  for (const s of sessions) {
+    placeTotals.set(s.workplace_name || '?', (placeTotals.get(s.workplace_name || '?') || 0) + (s.duration_min || 0));
+    totalAtWorkMin += s.duration_min || 0;
+  }
+  const placesHtml = placeTotals.size
+    ? [...placeTotals.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .map(([name, min]) => `<li>${escapeHtml(name)} <span class="muted">${fmtHm(min)}</span></li>`).join('')
+    : '<li class="muted">この日は登録した作業場所での 1 時間以上の滞在なし</li>';
+  el.innerHTML = `
+    <ul class="diary-gps-stats">
+      <li><span class="muted">🚶 徒歩</span> <strong>${fmtHm(walkMin)}</strong></li>
+      <li><span class="muted">🚃 交通機関</span> <strong>${fmtHm(transitMin)}</strong></li>
+      <li><span class="muted">⏸ 停止</span> <strong>${fmtHm(stillMin)}</strong></li>
+      <li><span class="muted">移動 合計</span> <strong>${fmtHm(totalMoveMin)}</strong></li>
+      <li><span class="muted">作業場所 滞在 合計</span> <strong>${fmtHm(totalAtWorkMin)}</strong></li>
+    </ul>
+    <div class="muted" style="font-size:11px;margin:6px 0 4px">作業場所別:</div>
+    <ul class="diary-gps-places">${placesHtml}</ul>
+  `;
 }
 
 async function renderDiaryWorkSessions(date) {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -4187,6 +4187,9 @@ async function openAiSettings() {
     const providers = r.providers;
     const providerModels = r.provider_models || {};
     const providerDefaults = r.provider_default_model || {};
+    // 同じ /api/llm/config をタスク AI 依頼モーダルでも引くので、共有キャッシュにも入れておく
+    _providerModelsCache = providerModels;
+    _providerDefaultsCache = providerDefaults;
     const optionsHtml = providers.map(p => `<option value="${p.key}">${escapeHtml(p.label)}</option>`).join('');
     function modelOptionsFor(provider, current) {
       const list = providerModels[provider] || [];
@@ -5926,29 +5929,43 @@ function ensureAgentRunModal() {
   };
 }
 
-// agent ↔ model のマッピング (UI 側)。サーバ側の AGENT_DEFAULT_MODEL とほぼ同期。
-const AGENT_MODELS = {
-  claude_code: [
-    { id: 'sonnet', label: 'Sonnet 4.6 (default)' },
-    { id: 'haiku', label: 'Haiku 4.5 (fast)' },
-    { id: 'opus', label: 'Opus 4.7' },
-    { id: 'claude-opus-4-7[1m]', label: 'Opus 4.7 (1M)' },
-  ],
-  codex: [
-    { id: '5.3-codex', label: '5.3-codex (default)' },
-    { id: 'gpt-5-codex', label: 'GPT-5 Codex' },
-  ],
-  gemini: [
-    { id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash (default)' },
-    { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
-  ],
+// 設定画面とタスク AI 依頼でモデル一覧を共有するためのキャッシュ。
+// サーバの `/api/llm/config` (server/llm.js の PROVIDER_MODELS / PROVIDER_DEFAULT_MODEL)
+// が単一の出所。
+let _providerModelsCache = null;
+let _providerDefaultsCache = null;
+async function ensureProviderModels() {
+  if (_providerModelsCache) return _providerModelsCache;
+  try {
+    const r = await api('/api/llm/config');
+    _providerModelsCache = r.provider_models || {};
+    _providerDefaultsCache = r.provider_default_model || {};
+  } catch {
+    _providerModelsCache = {};
+    _providerDefaultsCache = {};
+  }
+  return _providerModelsCache;
+}
+function invalidateProviderModelsCache() {
+  _providerModelsCache = null;
+  _providerDefaultsCache = null;
+}
+
+// 実装エージェント名 → llm provider key のマッピング。
+// 設定画面と AI 依頼モーダルで同じモデルリストを引けるようにする。
+const AGENT_TO_PROVIDER = {
+  claude_code: 'claude',
+  codex:       'codex',
+  gemini:      'gemini',
 };
 
-function refreshAgentModelDropdown() {
+async function refreshAgentModelDropdown() {
   const agent = $('agentRunAgent')?.value || 'claude_code';
-  const models = AGENT_MODELS[agent] || [];
   const sel = $('agentRunModel');
   if (!sel) return;
+  await ensureProviderModels();
+  const provider = AGENT_TO_PROVIDER[agent] || 'claude';
+  const models = (_providerModelsCache && _providerModelsCache[provider]) || [];
   const cur = sel.value;
   sel.innerHTML = models.map(m =>
     `<option value="${escapeHtml(m.id)}">${escapeHtml(m.label)}</option>`
@@ -5978,15 +5995,15 @@ async function openAgentRunModal(task) {
         const o = $('agentRunProject').selectedOptions[0];
         if (o?.dataset.defaultAgent) {
           $('agentRunAgent').value = o.dataset.defaultAgent;
-          refreshAgentModelDropdown();
+          refreshAgentModelDropdown().catch(() => {});
         }
       };
     }
   } catch (e) {
     alert(`プロジェクト取得失敗: ${e.message}`);
   }
-  refreshAgentModelDropdown();
-  $('agentRunAgent').onchange = refreshAgentModelDropdown;
+  await refreshAgentModelDropdown();
+  $('agentRunAgent').onchange = () => { refreshAgentModelDropdown().catch(() => {}); };
   // Load run history.
   await refreshAgentRunHistory(task.id);
   $('agentRunLog').textContent = '';

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -4185,18 +4185,40 @@ async function openAiSettings() {
     const cfg = r.config;
     const tasks = r.tasks;
     const providers = r.providers;
+    const providerModels = r.provider_models || {};
+    const providerDefaults = r.provider_default_model || {};
     const optionsHtml = providers.map(p => `<option value="${p.key}">${escapeHtml(p.label)}</option>`).join('');
+    function modelOptionsFor(provider, current) {
+      const list = providerModels[provider] || [];
+      if (!list.length) return '<option value="">(なし)</option>';
+      const opts = [
+        `<option value="">(default: ${escapeHtml(providerDefaults[provider] || '')})</option>`,
+        ...list.map(m => `<option value="${escapeHtml(m.id)}" ${m.id === current ? 'selected' : ''}>${escapeHtml(m.label)}</option>`),
+      ];
+      return opts.join('');
+    }
     $('aiTaskRows').innerHTML = tasks.map(t => `
       <div class="ai-task-row">
         <label>${escapeHtml(t)}</label>
         <select data-task="${t}" class="ai-task-provider">${optionsHtml}</select>
-        <input data-task="${t}" class="ai-task-model" type="text" placeholder="モデル名 (任意)" />
+        <select data-task="${t}" class="ai-task-model"></select>
       </div>
     `).join('');
     for (const t of tasks) {
       const tCfg = cfg.tasks?.[t] || {};
-      $('aiTaskRows').querySelector(`select[data-task="${t}"]`).value = tCfg.provider || 'claude';
-      $('aiTaskRows').querySelector(`input[data-task="${t}"]`).value = tCfg.model || '';
+      const prov = tCfg.provider || 'claude';
+      const sel = $('aiTaskRows').querySelector(`select.ai-task-provider[data-task="${t}"]`);
+      const mSel = $('aiTaskRows').querySelector(`select.ai-task-model[data-task="${t}"]`);
+      sel.value = prov;
+      mSel.innerHTML = modelOptionsFor(prov, tCfg.model || '');
+      mSel.value = tCfg.model || '';
+      // provider 変更時に model dropdown を再構築
+      sel.addEventListener('change', () => {
+        const cur = mSel.value;
+        mSel.innerHTML = modelOptionsFor(sel.value, cur);
+        // 新しい provider に同じ model が無ければ default に
+        if (![...mSel.options].some(o => o.value === cur)) mSel.value = '';
+      });
     }
     $('aiBinClaude').value = cfg.bins?.claude || '';
     $('aiBinGemini').value = cfg.bins?.gemini || '';
@@ -4531,9 +4553,10 @@ async function saveAiSettings() {
   const tasks = {};
   document.querySelectorAll('.ai-task-row').forEach(row => {
     const sel = row.querySelector('.ai-task-provider');
-    const inp = row.querySelector('.ai-task-model');
+    const mSel = row.querySelector('.ai-task-model');
     const t = sel.dataset.task;
-    tasks[t] = { provider: sel.value, model: inp.value.trim() };
+    const modelVal = mSel.tagName === 'SELECT' ? mSel.value : (mSel.value || '').trim();
+    tasks[t] = { provider: sel.value, model: modelVal };
   });
   const body = {
     tasks,

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -8002,19 +8002,23 @@ function updateTracksStatsLine(pts, { live = false } = {}) {
   const el = $('tracksStats');
   if (!el) return;
   if (!pts.length) { el.textContent = '点なし'; return; }
-  const w = tracksState.walkingStats || { walkMeters: 0, walkSec: 0, transitMeters: 0, transitSec: 0 };
+  const w = tracksState.walkingStats || { walkMeters: 0, walkSec: 0, transitMeters: 0, transitSec: 0, walkCapped: false };
   const walkKm = w.walkMeters / 1000;
   const walkMin = w.walkSec / 60;
   const transitKm = (w.transitMeters || 0) / 1000;
   const liveTag = live ? ' (live)' : '';
+  const cappedTag = w.walkCapped ? ' (20km上限)' : '';
   // 運動 = 徒歩のみ. 交通機関 (>5 km/h) は移動量として別立てで表示するが運動換算しない.
   el.textContent =
-    `${pts.length} 点 · 🚶 徒歩 ${walkKm.toFixed(2)} km / ${walkMin.toFixed(0)} 分 (運動) · 🚃 交通機関 ${transitKm.toFixed(2)} km${liveTag}`;
+    `${pts.length} 点 · 🚶 徒歩 ${walkKm.toFixed(2)} km${cappedTag} / ${walkMin.toFixed(0)} 分 (運動) · 🚃 交通機関 ${transitKm.toFixed(2)} km${liveTag}`;
 }
 
 // 徒歩判定 — 連続 2 点の速度が 1〜5 km/h なら walk と分類.
 const WALK_MIN_KMH = 1.0;
 const WALK_MAX_KMH = 5.0;
+// 1 日の徒歩(運動)累計上限. これ以上は GPS ジッタ / 誤検知の可能性が高いので
+// 累計を打ち切る (距離は cap、 区分は walk のまま色付けは維持).
+const WALK_DAILY_CAP_M = 20_000;
 
 /**
  * 連続点を tracksState.decimateMeters (default 2m) で間引く.
@@ -8063,12 +8067,25 @@ function classifyAll(points) {
   let walkMeters = 0, walkSec = 0;
   let transitMeters = 0, transitSec = 0;
   let stillMeters = 0, stillSec = 0;
+  let walkCapped = false;
   for (let i = 1; i < points.length; i++) {
     const seg = classifySegment(points[i-1], points[i]);
     cats[i] = seg.category;
     if (seg.category === 'walk') {
-      walkMeters += seg.meters;
-      walkSec += seg.dt;
+      // 1 日 20 km を超えた walk 区間は運動換算しない (transit に振り替え).
+      if (walkMeters + seg.meters > WALK_DAILY_CAP_M) {
+        const remain = Math.max(0, WALK_DAILY_CAP_M - walkMeters);
+        walkMeters += remain;
+        walkSec += seg.dt * (seg.meters > 0 ? remain / seg.meters : 0);
+        const overMeters = seg.meters - remain;
+        const overSec = seg.dt - seg.dt * (seg.meters > 0 ? remain / seg.meters : 0);
+        transitMeters += overMeters;
+        transitSec += overSec;
+        walkCapped = true;
+      } else {
+        walkMeters += seg.meters;
+        walkSec += seg.dt;
+      }
     } else if (seg.category === 'fast') {
       // 5 km/h 超 = 交通機関想定. 軌跡には出すが運動換算しない.
       transitMeters += seg.meters;
@@ -8078,7 +8095,7 @@ function classifyAll(points) {
       stillSec += seg.dt;
     }
   }
-  return { cats, walkMeters, walkSec, transitMeters, transitSec, stillMeters, stillSec };
+  return { cats, walkMeters, walkSec, transitMeters, transitSec, stillMeters, stillSec, walkCapped };
 }
 
 const CAT_COLORS = {
@@ -8109,7 +8126,7 @@ function drawTracks(points) {
   tracksState.lastDrawnKeptCount = points.length;
 
   // 徒歩判定 → 各点を色分けで打つ
-  const { cats, walkMeters, walkSec, transitMeters, transitSec, stillMeters, stillSec } = classifyAll(points);
+  const { cats, walkMeters, walkSec, transitMeters, transitSec, stillMeters, stillSec, walkCapped } = classifyAll(points);
 
   // 区間ごとに polyline を 1 本ずつ描画 (cats[i] = points[i-1] → points[i] の category).
   // 既定では「点のみ表示」 (tracksState.showPolyline=false) で線を描かない.
@@ -8163,6 +8180,7 @@ function drawTracks(points) {
   }
 
   // 始点 / 終点に大きい marker
+  const path = points.map(p => ({ lat: p.lat, lng: p.lon }));
   const start = path[0];
   const end = path[path.length - 1];
   tracksState.dotMarkers.push(new google.maps.Marker({
@@ -8185,7 +8203,7 @@ function drawTracks(points) {
   }
 
   // 区分別 stats を保持. 表示は renderTracksForCurrentDate / handleLivePoint が更新.
-  tracksState.walkingStats = { walkMeters, walkSec, transitMeters, transitSec, stillMeters, stillSec };
+  tracksState.walkingStats = { walkMeters, walkSec, transitMeters, transitSec, stillMeters, stillSec, walkCapped };
 
   if (path.length >= 2) {
     const b = new google.maps.LatLngBounds();

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -1193,6 +1193,6 @@ bogus-priv</code></pre>
       <button id="aiSettingsSave">保存</button>
     </div>
   </div>
-  <script src="app.js?v=20260507a"></script>
+  <script src="app.js?v=20260507b"></script>
 </body>
 </html>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -340,6 +340,8 @@
               <button id="diaryGenerate" class="ghost">再生成</button>
               <button id="diaryDelete" class="danger">削除</button>
             </div>
+            <h4>仕事中タイムライン (GPS + 行動ログ)</h4>
+            <div id="diaryWorkSessions" class="diary-summary"></div>
             <h4>作業内容 (Sonnet)</h4>
             <div id="diaryWork" class="diary-summary"></div>
             <h4>ハイライト (Opus 1M)</h4>
@@ -535,6 +537,7 @@
           Google Maps API key 未設定。 設定 → AI / 連携 で <code>maps_api_key</code>
           を入れるか、 環境変数 <code>GOOGLE_MAPS_API_KEY</code> を設定してください。
         </div>
+        <div id="tracksWorkSessions" class="tracks-work-sessions"></div>
         <div id="tracksMap" class="tracks-map"></div>
         <div class="tracks-recent">
           <div class="tracks-recent-head">

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -75,8 +75,8 @@
     <section class="content">
       <nav class="tabs">
         <div class="tabs-scroll">
-          <button class="tab active" data-tab="bookmarks">
-            <span class="tab-label" data-full="📚 ブックマーク" data-short="📚 ブクマ">📚 ブックマーク</span>
+          <button class="tab active" data-tab="database">
+            <span class="tab-label" data-full="🗄 データベース" data-short="🗄 DB">🗄 データベース</span>
           </button>
           <button class="tab" data-tab="worklog">
             <span class="tab-label" data-full="📝 作業ログ" data-short="📝 ログ">📝 作業ログ</span>
@@ -91,9 +91,6 @@
           </button>
           <button class="tab" data-tab="dig">
             <span class="tab-label" data-full="🔎 ディグる" data-short="🔎 ディグ">🔎 ディグる</span>
-          </button>
-          <button class="tab" data-tab="dict">
-            <span class="tab-label" data-full="📖 辞書" data-short="📖 辞書">📖 辞書</span>
           </button>
           <button class="tab" data-tab="diary">
             <span class="tab-label" data-full="📅 日記" data-short="📅 日記">📅 日記</span>
@@ -414,6 +411,15 @@
         <div id="queueHistory" class="queue-history-list"></div>
       </div>
 
+      <div id="databaseView" class="hidden">
+        <nav class="worklog-subtabs" id="databaseSubtabs">
+          <button class="wl-subtab active" data-db-sub="bookmarks">📚 ブックマーク</button>
+          <button class="wl-subtab" data-db-sub="dict">📖 辞書</button>
+          <button class="wl-subtab" data-db-sub="domain">🏷 ドメイン</button>
+          <button class="wl-subtab" data-db-sub="workplace">🗺️ 作業場所</button>
+        </nav>
+      </div>
+
       <div id="worklogView" class="hidden">
         <div class="worklog-daynav">
           <button id="wlPrevDay" class="ghost" title="前日">◀</button>
@@ -433,7 +439,6 @@
           <button class="wl-subtab" data-sub="browsing">🌐 ブラウジング</button>
           <button class="wl-subtab" data-sub="dig">🔎 ディグ</button>
           <button class="wl-subtab" data-sub="queue">⚙ キュー <span id="wlQueueBadge" class="tab-count hidden">0</span></button>
-          <button class="wl-subtab" data-sub="domain">🏷 ドメイン</button>
           <button class="wl-subtab" data-sub="tracks">🗺 軌跡</button>
           <button class="wl-subtab" data-sub="external">🔌 外部</button>
         </nav>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -1193,6 +1193,6 @@ bogus-priv</code></pre>
       <button id="aiSettingsSave">保存</button>
     </div>
   </div>
-  <script src="app.js?v=20260507b"></script>
+  <script src="app.js?v=20260507c"></script>
 </body>
 </html>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -78,12 +78,9 @@
           <button class="tab active" data-tab="bookmarks">
             <span class="tab-label" data-full="📚 ブックマーク" data-short="📚 ブクマ">📚 ブックマーク</span>
           </button>
-          <button class="tab" data-tab="queue">
-            <span class="tab-label" data-full="⚙ 作業キュー" data-short="⚙ キュー">⚙ 作業キュー</span>
-            <span id="tabQueueCount" class="tab-count hidden">0</span>
-          </button>
           <button class="tab" data-tab="worklog">
             <span class="tab-label" data-full="📝 作業ログ" data-short="📝 ログ">📝 作業ログ</span>
+            <span id="tabQueueCount" class="tab-count hidden">0</span>
           </button>
           <button class="tab" data-tab="trends">
             <span class="tab-label" data-full="📊 傾向" data-short="📊 傾向">📊 傾向</span>
@@ -98,20 +95,11 @@
           <button class="tab" data-tab="dict">
             <span class="tab-label" data-full="📖 辞書" data-short="📖 辞書">📖 辞書</span>
           </button>
-          <button class="tab" data-tab="domain">
-            <span class="tab-label" data-full="🏷 ドメイン" data-short="🏷 ドメ">🏷 ドメイン</span>
-          </button>
           <button class="tab" data-tab="diary">
             <span class="tab-label" data-full="📅 日記" data-short="📅 日記">📅 日記</span>
           </button>
-          <button class="tab" data-tab="tracks">
-            <span class="tab-label" data-full="🗺 軌跡" data-short="🗺 軌跡">🗺 軌跡</span>
-          </button>
           <button class="tab" data-tab="meals">
             <span class="tab-label" data-full="🍽 食事" data-short="🍽 食事">🍽 食事</span>
-          </button>
-          <button class="tab" data-tab="external">
-            <span class="tab-label" data-full="🔌 外部情報設定" data-short="🔌 設定">🔌 外部情報設定</span>
           </button>
           <!-- マルチビューはトップバーのマルチスイッチからのみアクセス。
                機能タブからは外す (PC/スマホ共通)。 -->
@@ -440,6 +428,10 @@
           <button class="wl-subtab" data-sub="codex">📜 Codex</button>
           <button class="wl-subtab" data-sub="browsing">🌐 ブラウジング</button>
           <button class="wl-subtab" data-sub="dig">🔎 ディグ</button>
+          <button class="wl-subtab" data-sub="queue">⚙ キュー <span id="wlQueueBadge" class="tab-count hidden">0</span></button>
+          <button class="wl-subtab" data-sub="domain">🏷 ドメイン</button>
+          <button class="wl-subtab" data-sub="tracks">🗺 軌跡</button>
+          <button class="wl-subtab" data-sub="external">🔌 外部</button>
         </nav>
 
         <section id="wlScheduleView" class="wl-sub">

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -1188,6 +1188,6 @@ bogus-priv</code></pre>
       <button id="aiSettingsSave">保存</button>
     </div>
   </div>
-  <script src="app.js?v=20260503c"></script>
+  <script src="app.js?v=20260507a"></script>
 </body>
 </html>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -1193,6 +1193,6 @@ bogus-priv</code></pre>
       <button id="aiSettingsSave">保存</button>
     </div>
   </div>
-  <script src="app.js?v=20260507c"></script>
+  <script src="app.js?v=20260507d"></script>
 </body>
 </html>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -368,6 +368,8 @@
             <div id="diaryMeals" class="diary-meals"></div>
             <h4>⚖️ カロリーバランス (適正 vs 摂取 vs 消費)</h4>
             <div id="diaryCaloricBalance" class="diary-caloric-balance"></div>
+            <h4>📍 移動・滞在時間 (GPS)</h4>
+            <div id="diaryGpsSummary" class="diary-gps-summary"></div>
             <h4>GitHub commits (リポ別件数)</h4>
             <ul id="diaryGithub" class="diary-github"></ul>
             <h4>🛠 開発活動 (git commit + Claude Code 指示)</h4>

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -3915,6 +3915,10 @@ dialog.meal-modal[open] {
   max-width: 960px;
   margin: 0 auto;
 }
+/* タスクは 3 ペイン + カテゴリリストが入るので PC では少し広げる */
+@media (min-width: 1100px) {
+  #tasksView .simple-panel { max-width: 1200px; }
+}
 .simple-panel h2 {
   margin: 0 0 12px;
   font-size: 20px;
@@ -4027,7 +4031,7 @@ dialog.meal-modal[open] {
 }
 .tasks-three-pane {
   display: grid;
-  grid-template-columns: 20% 40% 40%;
+  grid-template-columns: minmax(220px, 22%) 1fr 1fr;
   gap: 12px;
   align-items: start;
   margin-bottom: 12px;

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -5046,36 +5046,27 @@ dialog.loc-edit-modal[open] {
 .ws-badge.ws-working { color: #065f46; background: #d1fae5; border-color: #10b981; }
 .ws-badge.ws-idle { color: #6b7280; background: #f3f4f6; border-color: #9ca3af; }
 
-/* 日記の 移動・滞在サマリ */
+/* 日記の 移動・滞在サマリ — 4 行で表示 */
 .diary-gps-summary { padding: 4px 0; }
 .diary-gps-stats {
   list-style: none;
   padding: 0;
   margin: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px 16px;
+  display: grid;
+  gap: 4px;
   font-size: 13px;
 }
 .diary-gps-stats li {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-.diary-gps-places {
-  list-style: none;
-  padding: 0;
-  margin: 0;
   display: grid;
-  gap: 2px;
-  font-size: 12px;
+  grid-template-columns: minmax(140px, auto) 80px 1fr;
+  align-items: center;
+  gap: 12px;
+  padding: 4px 0;
+  border-bottom: 1px dashed var(--border);
 }
-.diary-gps-places li {
-  display: flex;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 2px 0;
-}
+.diary-gps-stats li:last-child { border-bottom: none; }
+.diary-gps-label { color: var(--muted); }
+.diary-gps-detail { font-size: 11px; }
 
 .wl-summary-row {
   font-size: 13px;

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -3912,12 +3912,8 @@ dialog.meal-modal[open] {
 /* Simple feature panes injected by app.js for tasks / implementation notes. */
 .simple-panel {
   padding: 16px;
-  max-width: 960px;
+  max-width: 1280px;
   margin: 0 auto;
-}
-/* タスクは 3 ペイン + カテゴリリストが入るので PC では少し広げる */
-@media (min-width: 1100px) {
-  #tasksView .simple-panel { max-width: 1200px; }
 }
 .simple-panel h2 {
   margin: 0 0 12px;

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -5046,6 +5046,37 @@ dialog.loc-edit-modal[open] {
 .ws-badge.ws-working { color: #065f46; background: #d1fae5; border-color: #10b981; }
 .ws-badge.ws-idle { color: #6b7280; background: #f3f4f6; border-color: #9ca3af; }
 
+/* 日記の 移動・滞在サマリ */
+.diary-gps-summary { padding: 4px 0; }
+.diary-gps-stats {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  font-size: 13px;
+}
+.diary-gps-stats li {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.diary-gps-places {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 2px;
+  font-size: 12px;
+}
+.diary-gps-places li {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 2px 0;
+}
+
 .wl-summary-row {
   font-size: 13px;
   color: var(--muted);

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -5018,6 +5018,34 @@ dialog.loc-edit-modal[open] {
 .wl-sub { padding: 12px; }
 .wl-sub.hidden { display: none; }
 
+/* tracks 用: 仕事セッション一覧 */
+.tracks-work-sessions { margin: 8px 0 12px; padding: 0 4px; }
+.tracks-work-sessions h4 { margin: 0 0 6px; font-size: 13px; }
+.ws-list { list-style: none; padding: 0; margin: 0; display: grid; gap: 4px; }
+.ws-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 12px;
+}
+.ws-time { font-family: ui-monospace, monospace; color: var(--muted); white-space: nowrap; }
+.ws-place { font-weight: 600; }
+.ws-badge {
+  display: inline-flex;
+  align-items: center;
+  height: 18px;
+  padding: 0 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  border: 1px solid;
+}
+.ws-badge.ws-working { color: #065f46; background: #d1fae5; border-color: #10b981; }
+.ws-badge.ws-idle { color: #6b7280; background: #f3f4f6; border-color: #9ca3af; }
+
 .wl-summary-row {
   font-size: 13px;
   color: var(--muted);

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -4057,6 +4057,56 @@ dialog.meal-modal[open] {
   color: var(--text);
   background: #fff;
 }
+.tasks-menu-section {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 14px;
+}
+.tasks-menu-h {
+  margin: 0 0 4px;
+  font-size: 11px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+#tasksCategoryList {
+  display: grid;
+  gap: 4px;
+}
+#tasksCategoryList button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 12px;
+  padding: 6px 10px;
+  position: relative;
+}
+#tasksCategoryList .task-cat-del {
+  display: none;
+  margin-left: 8px;
+  cursor: pointer;
+  color: var(--muted);
+  padding: 0 4px;
+}
+#tasksCategoryList button:hover .task-cat-del { display: inline; }
+#tasksCategoryList .task-cat-del:hover { color: #c00; }
+.tasks-cat-add {
+  display: flex;
+  gap: 4px;
+  margin-top: 4px;
+}
+.tasks-cat-add input {
+  flex: 1;
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 12px;
+}
+.tasks-cat-add button {
+  padding: 4px 10px;
+  font-size: 12px;
+  white-space: nowrap;
+}
 .task-done-drop {
   display: none;
   margin-top: 4px;

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -4127,6 +4127,18 @@ dialog.meal-modal[open] {
   color: #1f56c0;
   background: #eaf1ff;
 }
+.task-category {
+  display: inline-flex;
+  align-items: center;
+  height: 20px;
+  padding: 0 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  border: 1px solid #6b7080;
+  color: #4a4f5e;
+  background: #f3f4f8;
+  margin-left: 4px;
+}
 .task-detail-panel {
   border: 1px solid var(--border);
   border-radius: 8px;

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -4974,9 +4974,12 @@ dialog.loc-edit-modal[open] {
 
 .worklog-subtabs {
   display: flex;
+  flex-wrap: nowrap;
   gap: 4px;
   padding: 8px 12px 0 12px;
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scroll-snap-type: x proximity;
   border-bottom: 1px solid var(--border);
   scrollbar-width: thin;
 }
@@ -4990,6 +4993,18 @@ dialog.loc-edit-modal[open] {
   color: var(--muted);
   cursor: pointer;
   white-space: nowrap;
+  flex: 0 0 auto;
+  scroll-snap-align: start;
+}
+@media (max-width: 760px) {
+  .worklog-subtabs {
+    padding: 6px 8px 0 8px;
+    gap: 2px;
+  }
+  .wl-subtab {
+    padding: 6px 10px;
+    font-size: 12px;
+  }
 }
 .wl-subtab:hover { color: var(--text); background: var(--card); }
 .wl-subtab.active {


### PR DESCRIPTION
## 概要
Memoria のタスクを Claude Code / Codex CLI / Gemini CLI に渡してワンショット実装してもらう機構を追加。実行ログは保存され、UI からタイル表示で追跡できる。

## 機能
- 設定タブ「AI 実装プロジェクト」: プロジェクト (名前/パス/既定エージェント/Markdown ルール) を CRUD
- タスクカードに「🤖 AI実装」ボタン → モーダルでプロジェクト・エージェント選択 → 実行
- バックグラウンドで CLI 起動、stdout/stderr をログファイル (`<DATA>/agent_logs/run_*.log`) にストリーム保存
- 実行履歴 + ライブログ tail (3秒ポーリング)、キャンセルボタン
- `recordActivityEvent` で `task_updated/task_done` を記録 → 日記の「開発活動」に出る

## DB
| テーブル | 役割 |
|---|---|
| `agent_projects` | プロジェクト (name, path, rules, default_agent) |
| `agent_runs` | 実行ログ (task_id, project_id, agent, prompt, status, exit_code, log_path, summary) |
| `tasks.project_id` | デフォルトプロジェクト紐付け (ALTER で追加) |

## API
- `GET/POST/PATCH/DELETE /api/agent-projects`
- `POST /api/tasks/:id/agent-run`
- `GET /api/agent-runs?task_id=`
- `GET /api/agent-runs/:id` (running フラグ含む)
- `GET /api/agent-runs/:id/log?tail=N`
- `POST /api/agent-runs/:id/cancel`

## CLI 起動
- Claude Code: `claude -p --dangerously-skip-permissions` + stdin
- Codex: `codex exec --json --color never --ask-for-approval never --sandbox workspace-write -`
- Gemini: `gemini -p` + stdin
- `cwd = project.path`、Windows なら `CLAUDE_CODE_GIT_BASH_PATH` 自動付与

## 動作確認
- `node --check` 通過
- 起動失敗時は `agent_runs.status = 'failed'` + エラーメッセージ
- タイムアウト 30分 (デフォルト)、超過したら SIGKILL

🤖 Generated with [Claude Code](https://claude.com/claude-code)