### PR TITLE
fix: parse SQLite datetime('now') as UTC so +9h actually applies

### DIFF
--- a/server/public/app.js
+++ b/server/public/app.js
@@ -8189,31 +8189,49 @@ async function renderTracksForCurrentDate() {
   }
 }
 
-// ISO 文字列 (UTC または +09:00) を JST (= ブラウザのローカル) で HH:MM 形式に整形
+// SQLite の `datetime('now')` は "YYYY-MM-DD HH:MM:SS" (TZ なし、 内部は UTC) を返すが、
+// `new Date()` はこれをローカル時刻として解釈してしまう。 Memoria は UTC で
+// 統一して保管しているので、 TZ サフィックスがなければ UTC とみなして parse する。
+function parseUtcIso(iso) {
+  if (iso == null) return null;
+  let s = String(iso).trim();
+  if (!s) return null;
+  // 末尾に TZ 指定がない場合は UTC として扱う
+  const hasTz = /(Z|[+-]\d{2}:?\d{2})$/.test(s);
+  if (!hasTz) {
+    s = s.replace(' ', 'T');
+    // 秒・ミリ秒の有無に関わらず Z を付ければ UTC parse される
+    s = s + 'Z';
+  } else if (s.includes(' ') && !s.includes('T')) {
+    // "YYYY-MM-DD HH:MM:SSZ" のような hybrid も一応サポート
+    s = s.replace(' ', 'T');
+  }
+  const d = new Date(s);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+// HH:MM (local — = JST for JST users)
 function fmtLocalHm(iso) {
-  if (!iso) return '';
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) return '';
+  const d = parseUtcIso(iso);
+  if (!d) return '';
   return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
 }
 
 // HH:MM:SS (local)
 function fmtLocalHms(iso) {
-  if (!iso) return '';
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) return '';
+  const d = parseUtcIso(iso);
+  if (!d) return '';
   return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}`;
 }
 
 // YYYY-MM-DD HH:MM:SS (local)
 function fmtLocalDateTime(iso) {
-  if (!iso) return '';
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) return '';
+  const d = parseUtcIso(iso);
+  if (!d) return '';
   const y = d.getFullYear();
   const mo = String(d.getMonth() + 1).padStart(2, '0');
   const dd = String(d.getDate()).padStart(2, '0');
-  return `${y}-${mo}-${dd} ${fmtLocalHms(iso)}`;
+  return `${y}-${mo}-${dd} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}`;
 }
 
 function fmtHm(totalMin) {

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -1193,6 +1193,6 @@ bogus-priv</code></pre>
       <button id="aiSettingsSave">保存</button>
     </div>
   </div>
-  <script src="app.js?v=20260507d"></script>
+  <script src="app.js?v=20260508a"></script>
 </body>
 </html>


### PR DESCRIPTION
## 原因
PR #102 / #103 で導入した `fmtLocalHm` 系ヘルパーは `new Date(iso)` で parse していたが、 SQLite の `datetime('now')` は **タイムゾーン無し** の `YYYY-MM-DD HH:MM:SS` を返す。 JS はこれをローカル時刻として解釈するので +9h されず、 表示は元の UTC 値のまま。

## 修正
`parseUtcIso(iso)` ヘルパーを追加: TZ サフィックス (`Z` / `±HH:MM`) を持たない文字列を UTC として正規化 (space → T、 末尾に Z 付加) してから parse。 全 3 ヘルパー (`fmtLocalHm` / `fmtLocalHms` / `fmtLocalDateTime`) を経由させる。

期待動作: `2026-05-08 13:00:00` (UTC、 SQLite 出力) → JST `22:00:00` で表示。

## 影響範囲
PR #103 で置き換えた全箇所 (作業ログ各サブタブ、 イベント、 AI 実装履歴、 外部チャット、 仕事中タイムライン)。

## 確認待ち
**マージは指示が来てから** (memory feedback_no_auto_merge.md 参照)。 確認後にマージ指示をください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)