### PR TITLE
feat: ログタブ整理 (作業ログ→ログ / queue・external・食事→DB / 軌跡は共通日付)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1302,6 +1302,72 @@ app.post('/api/dig/:id/save', async (c) => {
   return c.json({ results: await bulkSaveUrls(body.urls) });
 });
 
+// ---- ブックマーク: 単一 URL から fetch + 要約キュー投入 -------------------
+//
+// UI の「+ ブックマーク追加」用 endpoint。 内容取得失敗ならエラーを返す。
+app.post('/api/bookmarks/from-url', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const url = String(body?.url || '').trim();
+  if (!url || !/^https?:\/\//i.test(url)) return c.json({ error: 'url (http/https) required' }, 400);
+  const existing = findBookmarkByUrl(db, url);
+  if (existing) return c.json({ duplicate: true, id: existing.id });
+  try {
+    const fetched = await fetchPageHtml(url);
+    const title = (fetched.title || url).slice(0, 500);
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const safe = ts + '_' + Math.random().toString(36).slice(2, 8) + '.html';
+    writeFileSync(join(HTML_DIR, safe), fetched.html, 'utf8');
+    const id = insertBookmark(db, { url, title, htmlPath: safe });
+    recordAccess(db, id);
+    enqueueSummary(id);
+    return c.json({ id, title, queued: true, queueDepth: summaryQueue.depth }, 201);
+  } catch (e) {
+    return c.json({ error: `fetch / save failed: ${e.message}` }, 502);
+  }
+});
+
+// ---- ドメイン辞書: URL から domain 抽出して登録キューへ -------------------
+app.post('/api/domains/from-url', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const url = String(body?.url || '').trim();
+  if (!url) return c.json({ error: 'url required' }, 400);
+  let domain;
+  try {
+    // bare host も許容: "example.com" → URL parse で失敗 → そのまま domain 扱い
+    if (/^https?:\/\//i.test(url)) {
+      domain = new URL(url).hostname.toLowerCase();
+    } else if (/^[a-z0-9.-]+\.[a-z]{2,}/i.test(url)) {
+      domain = url.toLowerCase().split('/')[0];
+    } else {
+      return c.json({ error: 'url or hostname required' }, 400);
+    }
+  } catch (e) {
+    return c.json({ error: `invalid url: ${e.message}` }, 400);
+  }
+  if (shouldSkipDomain(domain)) return c.json({ error: 'localhost / loopback はスキップされます' }, 400);
+  const existing = getDomainCatalog(db, domain);
+  // 既存でも regenerate ルートと同じく再分類キューに積む
+  insertDomainPending(db, domain);
+  domainCatalogQueue.enqueue(async () => {
+    const result = await classifyDomain({ domain });
+    if (result.skip) { deleteDomainCatalog(db, domain); return; }
+    if (result.dropRow) {
+      setDomainCatalog(db, domain, { title: null, description: null, status: 'error', error: result.error ?? 'fetch failed' });
+      return;
+    }
+    if (!result.ok) {
+      setDomainCatalog(db, domain, { status: 'error', error: result.error });
+      return;
+    }
+    setDomainCatalog(db, domain, {
+      title: result.title, site_name: result.site_name,
+      description: result.description, can_do: result.can_do,
+      kind: result.kind, status: 'done', error: null,
+    });
+  }, { kind: 'domain', domain, title: domain });
+  return c.json({ domain, queued: true, duplicate: !!existing }, 201);
+});
+
 // ---- word clouds ---------------------------------------------------------
 
 const BOOKMARK_DOC_LIMIT = 80;

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -602,10 +602,10 @@ function jobLabel(item) {
   return kindHint + `seq #${item.seq}`;
 }
 
-// tracks のみ worklog の sub-tab。 queue / external / meals は日付情報を持たないので
-// database 配下に移動。 bookmarks / dict / domain / workplace も database に集約。
-const WORKLOG_REDIRECT_TABS = new Set(['tracks']);
-const DATABASE_REDIRECT_TABS = new Set(['bookmarks', 'dict', 'domain', 'workplace', 'queue', 'external', 'meals']);
+// 日付ベースの sub (tracks / meals) は worklog 配下。
+// 日付を持たない sub (queue / external) と物データ (bookmarks / dict / domain / workplace) は database 配下。
+const WORKLOG_REDIRECT_TABS = new Set(['tracks', 'meals']);
+const DATABASE_REDIRECT_TABS = new Set(['bookmarks', 'dict', 'domain', 'workplace', 'queue', 'external']);
 
 function switchTab(tab) {
   if (WORKLOG_REDIRECT_TABS.has(tab)) {
@@ -5245,13 +5245,13 @@ async function savePrivacySettings() {
 }
 
 function applyFeatureVisibility(s) {
-  // tracks は worklog のサブタブ、 meals は database のサブタブに移動済み。 該当ボタンを hidden に。
+  // tracks / meals とも worklog のサブタブ。
   const tracksSub = document.querySelector('#worklogSubtabs [data-sub="tracks"]');
-  const mealsSub = document.querySelector('#databaseSubtabs [data-db-sub="meals"]');
+  const mealsSub = document.querySelector('#worklogSubtabs [data-sub="meals"]');
   if (tracksSub) tracksSub.hidden = s.tracks_visible === false;
   if (mealsSub) mealsSub.hidden = s.meals_visible === false;
   if (state.tab === 'worklog' && state.worklog?.sub === 'tracks' && s.tracks_visible === false) switchTab('database');
-  if (state.tab === 'database' && state.database?.sub === 'meals' && s.meals_visible === false) switchTab('database');
+  if (state.tab === 'worklog' && state.worklog?.sub === 'meals' && s.meals_visible === false) switchTab('database');
   reflowTabsForViewport();
 }
 
@@ -6965,6 +6965,7 @@ const WL_SUB_VIEWS = {
   browsing: 'wlBrowsingView',
   dig: 'wlDigView',
   tracks: 'tracksView',
+  meals: 'mealsView',
 };
 
 // データベースタブのサブビュー一覧
@@ -6973,7 +6974,6 @@ const DB_SUB_VIEWS = {
   dict: 'dictView',
   domain: 'domainView',
   workplace: 'workplaceView',
-  meals: 'mealsView',
   queue: 'queueView',
   external: 'externalView',
 };
@@ -7008,13 +7008,12 @@ function switchDatabaseSub(sub) {
   if (sub === 'dict') loadDictionary();
   if (sub === 'domain') loadDomainCatalog();
   if (sub === 'workplace') loadWorkLocations().catch(console.warn);
-  if (sub === 'meals') loadMeals();
   if (sub === 'queue') renderQueue();
   if (sub === 'external') loadExternalConfig();
 }
 
 // 日付ベースの sub かどうか (date toolbar / summary 表示の有無)
-const WL_DATE_BASED = new Set(['schedule', 'github', 'claude', 'gemini', 'codex', 'browsing', 'dig']);
+const WL_DATE_BASED = new Set(['schedule', 'github', 'claude', 'gemini', 'codex', 'browsing', 'dig', 'tracks', 'meals']);
 
 const WL_KIND_BY_SUB = {
   github: 'git_commit',
@@ -7027,7 +7026,7 @@ const WL_KIND_BY_SUB = {
 function migrateWorklogSubViews() {
   const wl = $('worklogView');
   if (!wl) return;
-  for (const id of ['tracksView']) {
+  for (const id of ['tracksView', 'mealsView']) {
     const v = $(id);
     if (v && v.parentNode !== wl) {
       v.classList.add('hidden');
@@ -7066,6 +7065,7 @@ async function loadWorklog() {
   if (sub === 'browsing') return loadWorklogBrowsing(date);
   if (sub === 'dig') return loadWorklogDig(date);
   if (sub === 'tracks') return loadTracks();
+  if (sub === 'meals') return loadMeals();
   if (WL_KIND_BY_SUB[sub]) {
     await loadWorklogActivity(date, sub);
     if (sub === 'gemini') await loadGeminiWebResearchLogs(date);

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -602,9 +602,10 @@ function jobLabel(item) {
   return kindHint + `seq #${item.seq}`;
 }
 
-// 日付ベースの sub (tracks / meals) は worklog 配下。
+// tracks のみ worklog 配下。
 // 日付を持たない sub (queue / external) と物データ (bookmarks / dict / domain / workplace) は database 配下。
-const WORKLOG_REDIRECT_TABS = new Set(['tracks', 'meals']);
+// meals は top-level タブ。
+const WORKLOG_REDIRECT_TABS = new Set(['tracks']);
 const DATABASE_REDIRECT_TABS = new Set(['bookmarks', 'dict', 'domain', 'workplace', 'queue', 'external']);
 
 function switchTab(tab) {
@@ -635,6 +636,7 @@ function switchTab(tab) {
   $('recommendView').classList.toggle('hidden', tab !== 'recommend');
   $('digView').classList.toggle('hidden', tab !== 'dig');
   $('diaryView').classList.toggle('hidden', tab !== 'diary');
+  $('mealsView')?.classList.toggle('hidden', tab !== 'meals');
   $('tasksView')?.classList.toggle('hidden', tab !== 'tasks');
   $('implView')?.classList.toggle('hidden', tab !== 'impl');
   $('multiView')?.classList.toggle('hidden', tab !== 'multi');
@@ -648,6 +650,7 @@ function switchTab(tab) {
   if (tab === 'recommend') loadRecommendations();
   if (tab === 'dig') loadDigHistory();
   if (tab === 'diary') loadDiary();
+  if (tab === 'meals') loadMeals();
   if (tab === 'tasks') loadTasks();
   if (tab === 'impl') loadImplementationNotes();
   if (tab === 'multi') loadMulti();
@@ -4137,6 +4140,76 @@ $('domainRecatalogBtn')?.addEventListener('click', () => recatalogAllDomains({ f
 $('recatalogAllBtn')?.addEventListener('click', () => recatalogAllDomains({ force: false }));
 $('recatalogAllForceBtn')?.addEventListener('click', () => recatalogAllDomains({ force: true }));
 
+// ── ブックマーク追加 (URL → fetch + 要約キュー) ───────────────────────────
+async function addBookmarkFromUrl() {
+  const inp = $('bookmarkAddUrl');
+  const status = $('bookmarkAddStatus');
+  const btn = $('bookmarkAddBtn');
+  const url = (inp?.value || '').trim();
+  if (!url) {
+    if (status) status.textContent = 'URL を入力してください';
+    inp?.focus();
+    return;
+  }
+  if (status) status.textContent = '取得中…';
+  if (btn) btn.disabled = true;
+  try {
+    const r = await api('/api/bookmarks/from-url', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url }),
+    });
+    if (r.duplicate) {
+      if (status) status.textContent = '既に登録済み (id=' + r.id + ')';
+    } else {
+      if (status) status.textContent = `追加 → 要約キュー投入 (id=${r.id})`;
+      inp.value = '';
+    }
+    await load();
+  } catch (e) {
+    if (status) status.textContent = `失敗: ${e.message}`;
+  } finally {
+    if (btn) btn.disabled = false;
+  }
+}
+$('bookmarkAddBtn')?.addEventListener('click', addBookmarkFromUrl);
+$('bookmarkAddUrl')?.addEventListener('keydown', (ev) => {
+  if (ev.key === 'Enter') { ev.preventDefault(); addBookmarkFromUrl(); }
+});
+
+// ── ドメイン追加 (URL/host → 分類キュー) ──────────────────────────────────
+async function addDomainFromUrl() {
+  const inp = $('domainAddUrl');
+  const status = $('domainAddStatus');
+  const btn = $('domainAddBtn');
+  const url = (inp?.value || '').trim();
+  if (!url) {
+    if (status) status.textContent = 'URL or hostname を入力してください';
+    inp?.focus();
+    return;
+  }
+  if (status) status.textContent = '登録中…';
+  if (btn) btn.disabled = true;
+  try {
+    const r = await api('/api/domains/from-url', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url }),
+    });
+    if (status) status.textContent = (r.duplicate ? '既存を再分類: ' : '追加: ') + r.domain;
+    inp.value = '';
+    await loadDomainCatalog();
+  } catch (e) {
+    if (status) status.textContent = `失敗: ${e.message}`;
+  } finally {
+    if (btn) btn.disabled = false;
+  }
+}
+$('domainAddBtn')?.addEventListener('click', addDomainFromUrl);
+$('domainAddUrl')?.addEventListener('keydown', (ev) => {
+  if (ev.key === 'Enter') { ev.preventDefault(); addDomainFromUrl(); }
+});
+
 // ── modal panels (dict + domain edit) ─────────────────────────────────────
 function showModal(panelId) {
   $(panelId).classList.remove('hidden');
@@ -5245,13 +5318,13 @@ async function savePrivacySettings() {
 }
 
 function applyFeatureVisibility(s) {
-  // tracks / meals とも worklog のサブタブ。
+  // tracks は worklog のサブタブ、 meals は top-level タブ。
   const tracksSub = document.querySelector('#worklogSubtabs [data-sub="tracks"]');
-  const mealsSub = document.querySelector('#worklogSubtabs [data-sub="meals"]');
+  const mealsTab = document.querySelector('.tab[data-tab="meals"]');
   if (tracksSub) tracksSub.hidden = s.tracks_visible === false;
-  if (mealsSub) mealsSub.hidden = s.meals_visible === false;
+  if (mealsTab) mealsTab.hidden = s.meals_visible === false;
   if (state.tab === 'worklog' && state.worklog?.sub === 'tracks' && s.tracks_visible === false) switchTab('database');
-  if (state.tab === 'worklog' && state.worklog?.sub === 'meals' && s.meals_visible === false) switchTab('database');
+  if (state.tab === 'meals' && s.meals_visible === false) switchTab('database');
   reflowTabsForViewport();
 }
 
@@ -6965,7 +7038,6 @@ const WL_SUB_VIEWS = {
   browsing: 'wlBrowsingView',
   dig: 'wlDigView',
   tracks: 'tracksView',
-  meals: 'mealsView',
 };
 
 // データベースタブのサブビュー一覧
@@ -7013,7 +7085,7 @@ function switchDatabaseSub(sub) {
 }
 
 // 日付ベースの sub かどうか (date toolbar / summary 表示の有無)
-const WL_DATE_BASED = new Set(['schedule', 'github', 'claude', 'gemini', 'codex', 'browsing', 'dig', 'tracks', 'meals']);
+const WL_DATE_BASED = new Set(['schedule', 'github', 'claude', 'gemini', 'codex', 'browsing', 'dig', 'tracks']);
 
 const WL_KIND_BY_SUB = {
   github: 'git_commit',
@@ -7026,13 +7098,20 @@ const WL_KIND_BY_SUB = {
 function migrateWorklogSubViews() {
   const wl = $('worklogView');
   if (!wl) return;
-  for (const id of ['tracksView', 'mealsView']) {
+  for (const id of ['tracksView']) {
     const v = $(id);
     if (v && v.parentNode !== wl) {
       v.classList.add('hidden');
       v.classList.add('wl-sub');
       wl.appendChild(v);
     }
+  }
+  // mealsView は top-level に戻す (前 PR で worklogView 内に移していたら拾い戻す)
+  const meals = $('mealsView');
+  const content = document.querySelector('.content');
+  if (meals && content && meals.parentNode === wl) {
+    content.appendChild(meals);
+    meals.classList.remove('wl-sub');
   }
 }
 migrateWorklogSubViews();
@@ -7065,7 +7144,6 @@ async function loadWorklog() {
   if (sub === 'browsing') return loadWorklogBrowsing(date);
   if (sub === 'dig') return loadWorklogDig(date);
   if (sub === 'tracks') return loadTracks();
-  if (sub === 'meals') return loadMeals();
   if (WL_KIND_BY_SUB[sub]) {
     await loadWorklogActivity(date, sub);
     if (sub === 'gemini') await loadGeminiWebResearchLogs(date);

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -8189,31 +8189,49 @@ async function renderTracksForCurrentDate() {
   }
 }
 
-// ISO 文字列 (UTC または +09:00) を JST (= ブラウザのローカル) で HH:MM 形式に整形
+// SQLite の `datetime('now')` は "YYYY-MM-DD HH:MM:SS" (TZ なし、 内部は UTC) を返すが、
+// `new Date()` はこれをローカル時刻として解釈してしまう。 Memoria は UTC で
+// 統一して保管しているので、 TZ サフィックスがなければ UTC とみなして parse する。
+function parseUtcIso(iso) {
+  if (iso == null) return null;
+  let s = String(iso).trim();
+  if (!s) return null;
+  // 末尾に TZ 指定がない場合は UTC として扱う
+  const hasTz = /(Z|[+-]\d{2}:?\d{2})$/.test(s);
+  if (!hasTz) {
+    s = s.replace(' ', 'T');
+    // 秒・ミリ秒の有無に関わらず Z を付ければ UTC parse される
+    s = s + 'Z';
+  } else if (s.includes(' ') && !s.includes('T')) {
+    // "YYYY-MM-DD HH:MM:SSZ" のような hybrid も一応サポート
+    s = s.replace(' ', 'T');
+  }
+  const d = new Date(s);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+// HH:MM (local — = JST for JST users)
 function fmtLocalHm(iso) {
-  if (!iso) return '';
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) return '';
+  const d = parseUtcIso(iso);
+  if (!d) return '';
   return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
 }
 
 // HH:MM:SS (local)
 function fmtLocalHms(iso) {
-  if (!iso) return '';
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) return '';
+  const d = parseUtcIso(iso);
+  if (!d) return '';
   return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}`;
 }
 
 // YYYY-MM-DD HH:MM:SS (local)
 function fmtLocalDateTime(iso) {
-  if (!iso) return '';
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) return '';
+  const d = parseUtcIso(iso);
+  if (!d) return '';
   const y = d.getFullYear();
   const mo = String(d.getMonth() + 1).padStart(2, '0');
   const dd = String(d.getDate()).padStart(2, '0');
-  return `${y}-${mo}-${dd} ${fmtLocalHms(iso)}`;
+  return `${y}-${mo}-${dd} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}`;
 }
 
 function fmtHm(totalMin) {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -471,20 +471,20 @@ async function refreshQueue() {
     if (totalDepth === 0) totalDepth = snap.depth || 0;
     const badge = $('queueBadge');
     const tabCount = $('tabQueueCount');
-    const wlBadge = $('wlQueueBadge');
+    const dbBadge = $('dbQueueBadge');
     if (totalDepth > 0) {
       badge.classList.remove('hidden');
       tabCount?.classList.remove('hidden');
-      wlBadge?.classList.remove('hidden');
+      dbBadge?.classList.remove('hidden');
       $('queueCount').textContent = totalDepth;
       if (tabCount) tabCount.textContent = totalDepth;
-      if (wlBadge) wlBadge.textContent = totalDepth;
+      if (dbBadge) dbBadge.textContent = totalDepth;
     } else {
       badge.classList.add('hidden');
       tabCount?.classList.add('hidden');
-      wlBadge?.classList.add('hidden');
+      dbBadge?.classList.add('hidden');
     }
-    if (state.tab === 'worklog' && state.worklog?.sub === 'queue') renderQueue();
+    if (state.tab === 'database' && state.database?.sub === 'queue') renderQueue();
     return totalDepth;
   } catch { return 0; }
 }
@@ -602,10 +602,10 @@ function jobLabel(item) {
   return kindHint + `seq #${item.seq}`;
 }
 
-// queue / tracks / external は worklog の sub-tab として畳み込む。
-// bookmarks / dict / domain / workplace は database タブの sub-tab として畳み込む。
-const WORKLOG_REDIRECT_TABS = new Set(['queue', 'tracks', 'external']);
-const DATABASE_REDIRECT_TABS = new Set(['bookmarks', 'dict', 'domain', 'workplace']);
+// tracks のみ worklog の sub-tab。 queue / external / meals は日付情報を持たないので
+// database 配下に移動。 bookmarks / dict / domain / workplace も database に集約。
+const WORKLOG_REDIRECT_TABS = new Set(['tracks']);
+const DATABASE_REDIRECT_TABS = new Set(['bookmarks', 'dict', 'domain', 'workplace', 'queue', 'external', 'meals']);
 
 function switchTab(tab) {
   if (WORKLOG_REDIRECT_TABS.has(tab)) {
@@ -635,7 +635,6 @@ function switchTab(tab) {
   $('recommendView').classList.toggle('hidden', tab !== 'recommend');
   $('digView').classList.toggle('hidden', tab !== 'dig');
   $('diaryView').classList.toggle('hidden', tab !== 'diary');
-  $('mealsView')?.classList.toggle('hidden', tab !== 'meals');
   $('tasksView')?.classList.toggle('hidden', tab !== 'tasks');
   $('implView')?.classList.toggle('hidden', tab !== 'impl');
   $('multiView')?.classList.toggle('hidden', tab !== 'multi');
@@ -649,7 +648,6 @@ function switchTab(tab) {
   if (tab === 'recommend') loadRecommendations();
   if (tab === 'dig') loadDigHistory();
   if (tab === 'diary') loadDiary();
-  if (tab === 'meals') loadMeals();
   if (tab === 'tasks') loadTasks();
   if (tab === 'impl') loadImplementationNotes();
   if (tab === 'multi') loadMulti();
@@ -4194,7 +4192,7 @@ setInterval(async () => {
   const depth = await refreshQueue();
   await refreshVisitsBadge();
   if (depth > 0 || state.bookmarks.some(b => b.status === 'pending')) load();
-  if (state.tab === 'worklog' && state.worklog?.sub === 'queue') renderQueue();
+  if (state.tab === 'database' && state.database?.sub === 'queue') renderQueue();
 }, 2000);
 refreshQueue();
 refreshVisitsBadge();
@@ -5247,12 +5245,13 @@ async function savePrivacySettings() {
 }
 
 function applyFeatureVisibility(s) {
-  const tracksTab = document.querySelector('.tab[data-tab="tracks"]');
-  const mealsTab = document.querySelector('.tab[data-tab="meals"]');
-  if (tracksTab) tracksTab.hidden = s.tracks_visible === false;
-  if (mealsTab) mealsTab.hidden = s.meals_visible === false;
-  if (state.tab === 'worklog' && state.worklog?.sub === 'tracks' && s.tracks_visible === false) switchTab('bookmarks');
-  if (state.tab === 'meals' && s.meals_visible === false) switchTab('bookmarks');
+  // tracks は worklog のサブタブ、 meals は database のサブタブに移動済み。 該当ボタンを hidden に。
+  const tracksSub = document.querySelector('#worklogSubtabs [data-sub="tracks"]');
+  const mealsSub = document.querySelector('#databaseSubtabs [data-db-sub="meals"]');
+  if (tracksSub) tracksSub.hidden = s.tracks_visible === false;
+  if (mealsSub) mealsSub.hidden = s.meals_visible === false;
+  if (state.tab === 'worklog' && state.worklog?.sub === 'tracks' && s.tracks_visible === false) switchTab('database');
+  if (state.tab === 'database' && state.database?.sub === 'meals' && s.meals_visible === false) switchTab('database');
   reflowTabsForViewport();
 }
 
@@ -6965,10 +6964,7 @@ const WL_SUB_VIEWS = {
   codex: 'wlCodexView',
   browsing: 'wlBrowsingView',
   dig: 'wlDigView',
-  // 旧トップタブから移植してきた sub
-  queue: 'queueView',
   tracks: 'tracksView',
-  external: 'externalView',
 };
 
 // データベースタブのサブビュー一覧
@@ -6977,19 +6973,22 @@ const DB_SUB_VIEWS = {
   dict: 'dictView',
   domain: 'domainView',
   workplace: 'workplaceView',
+  meals: 'mealsView',
+  queue: 'queueView',
+  external: 'externalView',
 };
 
 state.database = state.database || { sub: 'bookmarks' };
 
 function migrateDatabaseSubViews() {
-  const db = $('databaseView');
-  if (!db) return;
+  const dbv = $('databaseView');
+  if (!dbv) return;
   for (const id of Object.values(DB_SUB_VIEWS)) {
     const v = $(id);
-    if (v && v.parentNode !== db) {
+    if (v && v.parentNode !== dbv) {
       v.classList.add('hidden');
       v.classList.add('wl-sub');
-      db.appendChild(v);
+      dbv.appendChild(v);
     }
   }
 }
@@ -7009,6 +7008,9 @@ function switchDatabaseSub(sub) {
   if (sub === 'dict') loadDictionary();
   if (sub === 'domain') loadDomainCatalog();
   if (sub === 'workplace') loadWorkLocations().catch(console.warn);
+  if (sub === 'meals') loadMeals();
+  if (sub === 'queue') renderQueue();
+  if (sub === 'external') loadExternalConfig();
 }
 
 // 日付ベースの sub かどうか (date toolbar / summary 表示の有無)
@@ -7025,7 +7027,7 @@ const WL_KIND_BY_SUB = {
 function migrateWorklogSubViews() {
   const wl = $('worklogView');
   if (!wl) return;
-  for (const id of ['queueView', 'domainView', 'tracksView', 'externalView']) {
+  for (const id of ['tracksView']) {
     const v = $(id);
     if (v && v.parentNode !== wl) {
       v.classList.add('hidden');
@@ -7063,10 +7065,7 @@ async function loadWorklog() {
   if (sub === 'schedule') return loadWorklogSchedule(date);
   if (sub === 'browsing') return loadWorklogBrowsing(date);
   if (sub === 'dig') return loadWorklogDig(date);
-  if (sub === 'queue') return renderQueue();
-  if (sub === 'domain') return loadDomainCatalog();
   if (sub === 'tracks') return loadTracks();
-  if (sub === 'external') return loadExternalConfig();
   if (WL_KIND_BY_SUB[sub]) {
     await loadWorklogActivity(date, sub);
     if (sub === 'gemini') await loadGeminiWebResearchLogs(date);
@@ -7713,15 +7712,19 @@ function todayLocalIso() {
   return `${y}-${m}-${day}`;
 }
 
-async function loadTracks() {
-  const dateInput = $('tracksDate');
-  if (dateInput && !dateInput.value) dateInput.value = todayLocalIso();
+// tracks サブタブは作業ログ共通の wlDate を参照する (自前の date input は廃止)。
+function currentTracksDate() {
+  return $('wlDate')?.value || $('tracksDate')?.value || todayLocalIso();
+}
 
+async function loadTracks() {
   // bind controls (one-time)
   if (!tracksState._bound) {
     tracksState._bound = true;
-    dateInput?.addEventListener('change', renderTracksForCurrentDate);
-    $('tracksRefresh')?.addEventListener('click', renderTracksForCurrentDate);
+    // 作業ログの日付ナビ (wlDate / wlPrev/Next/Today) が変われば軌跡も再描画
+    $('wlDate')?.addEventListener('change', () => {
+      if (state.tab === 'worklog' && state.worklog?.sub === 'tracks') renderTracksForCurrentDate();
+    });
     $('tracksRecentRefresh')?.addEventListener('click', refreshTracksRecent);
     $('tracksKeyToggle')?.addEventListener('click', () => {
       $('tracksKeyPanel').classList.toggle('hidden');
@@ -7849,7 +7852,7 @@ function handleLivePoint(point) {
   // 最新リストには 日付関係なく即時 prepend (live 通知が一番大事)
   prependTracksRecent(point);
 
-  const dateStr = $('tracksDate')?.value;
+  const dateStr = currentTracksDate();
   if (!dateStr) return;
   const localDay = isoToLocalYmd(point.recorded_at);
   if (localDay !== dateStr) {
@@ -8094,11 +8097,11 @@ function renderTracksDaysList(days) {
   ).join('');
   ul.querySelectorAll('button[data-tracks-day]').forEach(btn => {
     btn.addEventListener('click', () => {
-      const dateInput = $('tracksDate');
-      if (dateInput) {
-        dateInput.value = btn.dataset.tracksDay;
-        renderTracksForCurrentDate();
-      }
+      // 「記録のある日」リストから日付クリックで wlDate を切替 → tracks 再描画
+      const wl = $('wlDate');
+      if (wl) wl.value = btn.dataset.tracksDay;
+      if (state.worklog) state.worklog.date = btn.dataset.tracksDay;
+      renderTracksForCurrentDate();
     });
   });
 }
@@ -8173,7 +8176,7 @@ async function recenterMapOnLatestOrCurrent() {
 
 async function renderTracksForCurrentDate() {
   if (!tracksState.map) return;
-  const date = $('tracksDate')?.value;
+  const date = currentTracksDate();
   if (!date) return;
   try {
     const { points } = await api(`/api/locations?date=${encodeURIComponent(date)}`);

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -95,6 +95,9 @@
           <button class="tab" data-tab="diary">
             <span class="tab-label" data-full="📅 日記" data-short="📅 日記">📅 日記</span>
           </button>
+          <button class="tab" data-tab="meals">
+            <span class="tab-label" data-full="🍽 食事" data-short="🍽 食事">🍽 食事</span>
+          </button>
           <!-- マルチビューはトップバーのマルチスイッチからのみアクセス。
                機能タブからは外す (PC/スマホ共通)。 -->
         </div>
@@ -113,6 +116,10 @@
             <option value="title_asc">タイトル (A→Z)</option>
           </select>
           <input id="search" type="search" placeholder="検索 (タイトル・URL・要約)" />
+          <span class="grow"></span>
+          <input id="bookmarkAddUrl" type="url" placeholder="URL を貼り付けて追加…" style="min-width:240px" />
+          <button id="bookmarkAddBtn" type="button">+ 追加</button>
+          <span id="bookmarkAddStatus" class="muted" style="font-size:11px"></span>
         </div>
         <div id="bulkBar" class="bulkbar hidden">
           <span id="bulkCount">0</span> 件選択中
@@ -289,6 +296,10 @@
         <div class="dict-bar">
           <input id="domainSearch" type="search" placeholder="ドメイン・サイト名・概要で検索" />
           <button id="domainRecatalogBtn" class="ghost" title="アクセス記録に出てきた全ドメインのうち、まだ辞書に無いものを fetch + 分類キューに積む">🔄 全走査</button>
+          <span class="grow"></span>
+          <input id="domainAddUrl" type="text" placeholder="URL or hostname を入力…" style="min-width:220px" />
+          <button id="domainAddBtn" type="button">+ 追加</button>
+          <span id="domainAddStatus" class="muted" style="font-size:11px"></span>
         </div>
         <ul id="domainList" class="dict-list pin-grid"></ul>
       </div>
@@ -438,7 +449,6 @@
           <button class="wl-subtab" data-sub="browsing">🌐 ブラウジング</button>
           <button class="wl-subtab" data-sub="dig">🔎 ディグ</button>
           <button class="wl-subtab" data-sub="tracks">🗺 軌跡</button>
-          <button class="wl-subtab" data-sub="meals">🍽 食事</button>
         </nav>
 
         <section id="wlScheduleView" class="wl-sub">
@@ -1190,6 +1200,6 @@ bogus-priv</code></pre>
       <button id="aiSettingsSave">保存</button>
     </div>
   </div>
-  <script src="app.js?v=20260508c"></script>
+  <script src="app.js?v=20260508d"></script>
 </body>
 </html>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -1193,6 +1193,6 @@ bogus-priv</code></pre>
       <button id="aiSettingsSave">保存</button>
     </div>
   </div>
-  <script src="app.js?v=20260507d"></script>
+  <script src="app.js?v=20260508a"></script>
 </body>
 </html>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -79,7 +79,7 @@
             <span class="tab-label" data-full="🗄 データベース" data-short="🗄 DB">🗄 データベース</span>
           </button>
           <button class="tab" data-tab="worklog">
-            <span class="tab-label" data-full="📝 作業ログ" data-short="📝 ログ">📝 作業ログ</span>
+            <span class="tab-label" data-full="📝 ログ" data-short="📝 ログ">📝 ログ</span>
             <span id="tabQueueCount" class="tab-count hidden">0</span>
           </button>
           <button class="tab" data-tab="trends">
@@ -94,9 +94,6 @@
           </button>
           <button class="tab" data-tab="diary">
             <span class="tab-label" data-full="📅 日記" data-short="📅 日記">📅 日記</span>
-          </button>
-          <button class="tab" data-tab="meals">
-            <span class="tab-label" data-full="🍽 食事" data-short="🍽 食事">🍽 食事</span>
           </button>
           <!-- マルチビューはトップバーのマルチスイッチからのみアクセス。
                機能タブからは外す (PC/スマホ共通)。 -->
@@ -417,6 +414,9 @@
           <button class="wl-subtab" data-db-sub="dict">📖 辞書</button>
           <button class="wl-subtab" data-db-sub="domain">🏷 ドメイン</button>
           <button class="wl-subtab" data-db-sub="workplace">🗺️ 作業場所</button>
+          <button class="wl-subtab" data-db-sub="meals">🍽 食事</button>
+          <button class="wl-subtab" data-db-sub="queue">⚙ キュー <span id="dbQueueBadge" class="tab-count hidden">0</span></button>
+          <button class="wl-subtab" data-db-sub="external">🔌 外部設定</button>
         </nav>
       </div>
 
@@ -438,9 +438,7 @@
           <button class="wl-subtab" data-sub="codex">📜 Codex</button>
           <button class="wl-subtab" data-sub="browsing">🌐 ブラウジング</button>
           <button class="wl-subtab" data-sub="dig">🔎 ディグ</button>
-          <button class="wl-subtab" data-sub="queue">⚙ キュー <span id="wlQueueBadge" class="tab-count hidden">0</span></button>
           <button class="wl-subtab" data-sub="tracks">🗺 軌跡</button>
-          <button class="wl-subtab" data-sub="external">🔌 外部</button>
         </nav>
 
         <section id="wlScheduleView" class="wl-sub">
@@ -514,11 +512,10 @@
 
       <div id="tracksView" class="hidden">
         <div class="tracks-bar">
-          <input id="tracksDate" type="date" />
-          <button id="tracksRefresh" class="ghost">更新</button>
+          <!-- 日付絞り込みは作業ログ共通の wlDate を使う。 ここには live indicator + stats のみ。 -->
           <span id="tracksLive" class="tracks-live" title="WebSocket ライブ更新の状態">●</span>
-          <span class="grow"></span>
           <span id="tracksStats" class="tracks-stats"></span>
+          <span class="grow"></span>
           <button id="tracksKeyToggle" class="ghost" title="ingest key (HTTP モード用)">🔑 key</button>
         </div>
         <div id="tracksKeyPanel" class="tracks-key-panel hidden">
@@ -1193,6 +1190,6 @@ bogus-priv</code></pre>
       <button id="aiSettingsSave">保存</button>
     </div>
   </div>
-  <script src="app.js?v=20260508a"></script>
+  <script src="app.js?v=20260508b"></script>
 </body>
 </html>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -414,7 +414,6 @@
           <button class="wl-subtab" data-db-sub="dict">📖 辞書</button>
           <button class="wl-subtab" data-db-sub="domain">🏷 ドメイン</button>
           <button class="wl-subtab" data-db-sub="workplace">🗺️ 作業場所</button>
-          <button class="wl-subtab" data-db-sub="meals">🍽 食事</button>
           <button class="wl-subtab" data-db-sub="queue">⚙ キュー <span id="dbQueueBadge" class="tab-count hidden">0</span></button>
           <button class="wl-subtab" data-db-sub="external">🔌 外部設定</button>
         </nav>
@@ -439,6 +438,7 @@
           <button class="wl-subtab" data-sub="browsing">🌐 ブラウジング</button>
           <button class="wl-subtab" data-sub="dig">🔎 ディグ</button>
           <button class="wl-subtab" data-sub="tracks">🗺 軌跡</button>
+          <button class="wl-subtab" data-sub="meals">🍽 食事</button>
         </nav>
 
         <section id="wlScheduleView" class="wl-sub">
@@ -1190,6 +1190,6 @@ bogus-priv</code></pre>
       <button id="aiSettingsSave">保存</button>
     </div>
   </div>
-  <script src="app.js?v=20260508b"></script>
+  <script src="app.js?v=20260508c"></script>
 </body>
 </html>


### PR DESCRIPTION
## 変更点

### 1) 作業ログ → ログ
- タブ表記を「📝 作業ログ」→「📝 ログ」に統一 (data-full / data-short / 表示文字)

### 2) 軌跡サブタブの日付絞り込みを共通 UI に統一
- 軌跡内の `<input id="tracksDate">` と「更新」ボタンを削除
- ログタブ共通の `wlDate` (前日 / 翌日 / 今日 + date input) を参照
- `currentTracksDate()` ヘルパー追加、 `wlDate change` で軌跡再描画

### 3) ログから queue / external を database に移動
日付情報を持たないため:
- 旧 ⚙ キュー / 🔌 外部 (worklog subtab) → 削除
- 🗄 データベースのサブタブとして 「⚙ キュー」「🔌 外部設定」 追加
- キューバッジは `wlQueueBadge` → `dbQueueBadge` に移行

### 4) 食事を database 内に移動
- 旧 🍽 食事 top-level タブ → 削除
- 🗄 データベースのサブタブとして 「🍽 食事」 追加
- `applyFeatureVisibility` の hide ロジックも subtab 対応に

## マッピング更新
- `WORKLOG_REDIRECT_TABS` = `{ tracks }`
- `DATABASE_REDIRECT_TABS` = `{ bookmarks, dict, domain, workplace, queue, external, meals }`
- `WL_SUB_VIEWS` から queue / external / domain 削除 (domain は前 PR 済み)
- `DB_SUB_VIEWS` に meals / queue / external 追加

## キャッシュ
- `app.js?v=20260508b`

確認後にマージ指示ください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)