### PR TITLE
feat(ts/phase-2): API request/response types + per-domain specs

### DIFF
--- a/server/api/types/agent.ts
+++ b/server/api/types/agent.ts
@@ -1,0 +1,48 @@
+// agent API request/response types
+// Spec: spec/api/agent.md
+
+import type { AgentProjectRow, AgentRunRow, AgentKind, AgentRunStatus } from '../../db/types/agent.js';
+
+export interface AgentProjectsResponse {
+  items: AgentProjectRow[];
+}
+
+export interface AgentProjectCreateRequest {
+  name: string;
+  path: string;                  // absolute path
+  rules?: string | null;
+  default_agent?: AgentKind;
+}
+
+export interface AgentProjectUpdateRequest {
+  name?: string;
+  path?: string;
+  rules?: string | null;
+  default_agent?: AgentKind;
+}
+
+export interface AgentProjectMutationResponse {
+  project: AgentProjectRow;
+}
+
+export interface AgentRunListQuery {
+  task_id?: number;
+  project_id?: number;
+  limit?: number;                // default 100, max 500
+  status?: AgentRunStatus;
+}
+
+export interface AgentRunListResponse {
+  items: AgentRunRow[];
+}
+
+export interface AgentRunDetailResponse {
+  run: AgentRunRow;
+  running: boolean;
+}
+
+export interface AgentRunLogResponse {
+  run: AgentRunRow;
+  running: boolean;
+  log: string;
+}

--- a/server/api/types/bookmark.ts
+++ b/server/api/types/bookmark.ts
@@ -1,0 +1,55 @@
+// bookmark API request/response types
+// Spec: spec/api/bookmark.md
+
+import type { BookmarkRow, AccessRow } from '../../db/types/bookmark.js';
+
+export interface BookmarkSubmitRequest {
+  url: string;
+  title: string;
+  html: string;                  // 生 HTML 全体 (Chrome 拡張から)
+}
+
+export interface BookmarkSubmitResponse {
+  id: number;
+  duplicate?: true;
+  queued?: true;
+  queueDepth?: number;
+}
+
+export interface BookmarkFromUrlRequest {
+  url: string;
+}
+
+export interface BookmarkFromUrlResponse {
+  id?: number;
+  title?: string;
+  duplicate?: true;
+  queued?: true;
+  queueDepth?: number;
+}
+
+export interface BookmarkListQuery {
+  category?: string;
+  sort?: 'created_desc' | 'created_asc' | 'accessed_desc' | 'accessed_asc' | 'title_asc';
+  q?: string;
+  limit?: number;                 // default 50, max 200
+  offset?: number;                // default 0
+}
+
+export interface BookmarkListResponse {
+  items: BookmarkRow[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface BookmarkUpdateRequest {
+  title?: string;
+  memo?: string;
+  summary?: string;
+  categories?: string[];          // 全置換
+}
+
+export interface BookmarkAccessesResponse {
+  items: AccessRow[];
+}

--- a/server/api/types/config.ts
+++ b/server/api/types/config.ts
@@ -1,0 +1,108 @@
+// config API request/response types — privacy / llm / tracks / setup-docs
+// Spec: spec/api/config.md
+
+// ── プライバシー / 機能 ON/OFF ───────────────────────────────────────────
+export interface PrivacySettings {
+  tracks_enabled: boolean;
+  tracks_visible: boolean;
+  meals_enabled: boolean;
+  meals_visible: boolean;
+  tasks_actio_share_enabled: boolean;
+  actio_share_url: string;
+  tasks_reminder_enabled: boolean;
+  tasks_reminder_hour: number;          // 0-23
+  tasks_reminder_minute: number;        // 0-59
+  tasks_reminder_nuntius_enabled: boolean;
+  tasks_reminder_nuntius_url: string;
+  mcp_autostart_enabled: boolean;
+  workplace_geo_enabled: boolean;
+  workplace_auto_share_enabled: boolean;
+  workplace_match_radius_m: number;     // 20-2000m
+}
+
+export type PrivacySettingsPatch = Partial<PrivacySettings>;
+
+export interface PrivacySettingsResponse {
+  settings: PrivacySettings;
+}
+
+// ── LLM 設定 ─────────────────────────────────────────────────────────────
+export type LlmProviderKey = 'algorithm' | 'claude' | 'codex' | 'gemini' | 'openai';
+
+export interface LlmTaskConfig {
+  provider: LlmProviderKey;
+  model?: string;
+}
+
+export interface LlmConfigState {
+  tasks: Record<string, LlmTaskConfig>;
+  bins: { claude: string; gemini: string; codex: string };
+  openai_api_key: string;               // GET 時は '***' or '' に masked
+  openai_api_key_set?: boolean;
+  openai_model: string;
+  git_bash_path: string;
+  diary_global_memo?: string;
+  user_profile?: {
+    age: number | null;
+    sex: '' | 'male' | 'female';
+    weight_kg: number | null;
+    height_cm: number | null;
+    activity_level: 'low' | 'moderate' | 'high';
+  };
+}
+
+export interface LlmProviderInfo {
+  key: LlmProviderKey;
+  label: string;
+  kind: 'cli' | 'api' | 'none';
+  supportsTools?: boolean;
+  supportsModel?: boolean;
+}
+
+export interface LlmModelOption {
+  id: string;                           // '' = provider default
+  label: string;
+}
+
+export interface LlmConfigResponse {
+  config: LlmConfigState;
+  tasks: string[];                      // 既知の task 名
+  providers: LlmProviderInfo[];
+  provider_models: Partial<Record<LlmProviderKey, LlmModelOption[]>>;
+  provider_default_model: Partial<Record<LlmProviderKey, string>>;
+  runtime: { port: number; data_dir: string; platform: string };
+}
+
+export interface LlmConfigPatch {
+  tasks?: Record<string, Partial<LlmTaskConfig>>;
+  bins?: Partial<{ claude: string; gemini: string; codex: string }>;
+  openai_api_key?: string;
+  openai_model?: string;
+  git_bash_path?: string;
+  diary_global_memo?: string;
+  user_profile?: Partial<LlmConfigState['user_profile']>;
+}
+
+// ── tracks 描画 ─────────────────────────────────────────────────────────
+export interface TracksSettings {
+  decimate_meters: number;
+  show_polyline: boolean;
+}
+
+export type TracksSettingsPatch = Partial<TracksSettings>;
+
+// ── setup-docs ───────────────────────────────────────────────────────────
+export interface SetupDocSummary {
+  key: string;
+  title: string;
+}
+
+export interface SetupDoc {
+  key: string;
+  title: string;
+  body: string;                         // markdown
+}
+
+export interface SetupDocsListResponse {
+  docs: SetupDocSummary[];
+}

--- a/server/api/types/diary.ts
+++ b/server/api/types/diary.ts
@@ -1,0 +1,34 @@
+// diary API request/response types
+// Spec: spec/api/diary.md
+
+import type { DiaryEntryRow, WeeklyReportRow } from '../../db/types/diary.js';
+import type { DigSessionRow } from '../../db/types/dig.js';
+
+export interface DiaryMonthResponse {
+  month: string;                  // 'YYYY-MM'
+  start: string;                  // 'YYYY-MM-DD'
+  end: string;                    // 'YYYY-MM-DD'
+  days: { date: string; status: 'absent' | 'pending' | 'done' | 'error' }[];
+}
+
+export interface DiaryDetailResponse extends DiaryEntryRow {
+  /** generation 後にサーバ側で再計算した metrics (ブラウザ閲覧 + 食事 + 軌跡 + 開発活動). */
+  live_metrics?: unknown;
+  metrics?: unknown;
+}
+
+export interface DiaryNotesPatchRequest {
+  notes: string;
+}
+
+export interface DiaryImproveRequest {
+  improve: string;                // free-form 改善指示
+}
+
+export interface DiaryDigListResponse {
+  items: DigSessionRow[];
+}
+
+export interface WeeklyListResponse {
+  items: WeeklyReportRow[];
+}

--- a/server/api/types/dict.ts
+++ b/server/api/types/dict.ts
@@ -1,0 +1,42 @@
+// dict (dictionary + stopwords) API request/response types
+// Spec: spec/api/dict.md
+
+import type { DictionaryEntryRow, DictionaryLinkSourceKind } from '../../db/types/dictionary.js';
+import type { UserStopwordRow } from '../../db/types/stopwords.js';
+
+export interface DictionaryListResponse {
+  items: DictionaryEntryRow[];
+}
+
+export interface DictionaryCreateRequest {
+  term: string;
+  definition?: string | null;
+  notes?: string | null;
+}
+
+export interface DictionaryUpdateRequest {
+  term?: string;
+  definition?: string | null;
+  notes?: string | null;
+}
+
+export interface DictionaryLinkRequest {
+  source_kind: DictionaryLinkSourceKind;
+  source_id: number;
+}
+
+export interface UpsertFromSourceRequest {
+  source_kind: DictionaryLinkSourceKind;
+  source_id: number;
+  term: string;
+  definition?: string | null;
+  notes?: string | null;
+}
+
+export interface StopwordsListResponse {
+  items: UserStopwordRow[];
+}
+
+export interface StopwordCreateRequest {
+  word: string;
+}

--- a/server/api/types/dig.ts
+++ b/server/api/types/dig.ts
@@ -1,0 +1,76 @@
+// dig (deep research + wordcloud) API request/response types
+// Spec: spec/api/dig.md
+
+import type { DigSessionRow } from '../../db/types/dig.js';
+import type { WordCloudRow, WordCloudOrigin } from '../../db/types/wordcloud.js';
+
+export interface DigStartRequest {
+  query: string;
+  engine?: string;                // 'google' / 'bing' / 'duckduckgo' / 'brave' / 'default'
+  theme?: string;
+}
+
+export interface DigStartResponse {
+  id: number;
+  status: 'pending' | 'done' | 'error';
+  queueDepth: number;
+}
+
+export interface DigListResponse {
+  items: DigSessionRow[];
+}
+
+export interface BulkSaveResult {
+  url: string;
+  status: 'queued' | 'duplicate' | 'skipped' | 'error';
+  id?: number;
+  error?: string;
+}
+
+export interface DigEngineOption {
+  id: string;
+  label: string;
+}
+
+// ── wordcloud ─────────────────────────────────────────────────────────────
+export interface WordCloudGraphNode {
+  id: string;
+  label: string;
+  shape?: 'circle' | 'square';
+  weight?: number;
+}
+
+export interface WordCloudGraphEdge {
+  from: string;
+  to: string;
+  weight?: number;
+}
+
+export interface WordCloudGraph {
+  nodes: WordCloudGraphNode[];
+  edges: WordCloudGraphEdge[];
+  meta?: { origin: WordCloudOrigin };
+}
+
+export interface WordCloudCreateRequest {
+  origin: WordCloudOrigin;
+  origin_dig_id?: number;
+  origin_bookmark_ids?: number[];
+  parent_cloud_id?: number;
+  parent_word?: string;
+  label?: string;
+}
+
+export interface WordCloudListResponse {
+  items: WordCloudRow[];
+}
+
+export interface WordCloudValidateRequest {
+  word: string;
+  context?: string;
+}
+
+export interface WordCloudValidateResponse {
+  ok: boolean;
+  reason?: string;
+}

--- a/server/api/types/domain.ts
+++ b/server/api/types/domain.ts
@@ -1,0 +1,43 @@
+// domain (catalog) API request/response types
+// Spec: spec/api/domain.md
+
+import type { DomainCatalogRow } from '../../db/types/page.js';
+
+export interface DomainListResponse {
+  items: DomainCatalogRow[];
+}
+
+export interface DomainFromUrlRequest {
+  url: string;                    // フル URL or "example.com"
+}
+
+export interface DomainFromUrlResponse {
+  domain: string;
+  queued: true;
+  duplicate: boolean;
+}
+
+export interface DomainUpdateRequest {
+  title?: string | null;
+  site_name?: string | null;
+  description?: string | null;
+  can_do?: string | null;
+  kind?: string | null;
+  notes?: string | null;
+  user_edited?: boolean;
+  domain_private?: boolean;
+}
+
+export interface RecatalogAllRequest {
+  force?: boolean;
+}
+
+export interface RecatalogResult {
+  scanned_urls: number;
+  unique_domains: number;
+  queued: number;
+  skipped_existing: number;
+  skipped_host: number;
+  queue_depth: number;
+  force: boolean;
+}

--- a/server/api/types/impl.ts
+++ b/server/api/types/impl.ts
@@ -1,0 +1,37 @@
+// impl (implementation_notes) API request/response types
+// Spec: spec/api/impl.md
+
+import type { ImplementationNoteRow, ImplementationAttachmentType } from '../../db/types/impl.js';
+
+export interface ImplementationNoteListQuery {
+  limit?: number;                 // default 100, max 200
+  offset?: number;
+}
+
+export interface ImplementationNoteListResponse {
+  items: ImplementationNoteRow[];
+}
+
+export interface ImplementationNoteCreateRequest {
+  product?: string;
+  title: string;
+  good_points?: string;
+  bad_points?: string;
+  attachment_type?: ImplementationAttachmentType;
+  attachment_value?: string;
+  shareable?: boolean;
+}
+
+export interface ImplementationNoteUpdateRequest {
+  product?: string;
+  title?: string;
+  good_points?: string | null;
+  bad_points?: string | null;
+  attachment_type?: ImplementationAttachmentType;
+  attachment_value?: string | null;
+  shareable?: boolean;
+}
+
+export interface ImplementationNoteMutationResponse {
+  note: ImplementationNoteRow;
+}

--- a/server/api/types/index.ts
+++ b/server/api/types/index.ts
@@ -1,0 +1,18 @@
+// Re-export all API request/response types.
+// Spec: spec/api/<domain>.md
+
+export * from './task.js';
+export * from './agent.js';
+export * from './workplace.js';
+export * from './bookmark.js';
+export * from './domain.js';
+export * from './impl.js';
+export * from './dict.js';
+export * from './dig.js';
+export * from './meal.js';
+export * from './diary.js';
+export * from './visit.js';
+export * from './multi.js';
+export * from './push.js';
+export * from './config.js';
+export * from './misc.js';

--- a/server/api/types/meal.ts
+++ b/server/api/types/meal.ts
@@ -1,0 +1,38 @@
+// meal API request/response types
+// Spec: spec/api/meal.md
+
+import type { MealRow, MealAiStatus } from '../../db/types/meal.js';
+
+export interface MealsListQuery {
+  date?: string;                  // 'YYYY-MM-DD'
+  limit?: number;
+}
+
+export interface MealsListResponse {
+  items: MealRow[];
+}
+
+export interface MealManualCreateRequest {
+  eaten_at?: string;              // UTC ISO; default = now
+  description?: string;
+  calories?: number;
+  user_note?: string;
+}
+
+export interface MealUpdateRequest {
+  description?: string | null;
+  calories?: number | null;
+  eaten_at?: string;
+  lat?: number | null;
+  lon?: number | null;
+  location_label?: string | null;
+  user_note?: string | null;
+  user_corrected_description?: string | null;
+  user_corrected_calories?: number | null;
+  ai_status?: MealAiStatus;
+}
+
+export interface MealAdditionRequest {
+  name: string;
+  calories?: number;
+}

--- a/server/api/types/misc.ts
+++ b/server/api/types/misc.ts
@@ -1,0 +1,89 @@
+// misc (trends / recommend / events / activity / external-chat) API types
+// Spec: spec/api/misc.md
+
+import type { ServerEventRow, ActivityEventRow, ActivityKind } from '../../db/types/activity.js';
+import type { ExternalChatMessageRow } from '../../db/types/chat.js';
+
+// ── trends ───────────────────────────────────────────────────────────────
+export interface TrendCategoriesItem { category: string; count: number }
+export interface TrendDomainsItem { domain: string; hits: number }
+export interface TrendVisitDomainsItem { domain: string; visits: number }
+export interface TrendWorkHoursItem { date: string; minutes: number | null }
+export interface TrendKeywordsItem { word: string; weight: number }
+export interface TrendGpsWalkingItem {
+  date: string;
+  distance_km: number;
+  walking_minutes: number;
+  travel_minutes: number;
+}
+
+export interface TrendsListResponse<T> { items: T[] }
+export interface TrendsGithubResponse {
+  enabled: boolean;
+  items?: { date: string; commits: number; repos: { repo: string; n: number }[] }[];
+  error?: string;
+}
+
+// ── recommend ────────────────────────────────────────────────────────────
+export interface RecommendationItem {
+  url: string;
+  title: string | null;
+  reason: string;
+  score: number;
+}
+
+export interface RecommendationsResponse {
+  items: RecommendationItem[];
+}
+
+// ── events / external-chat ───────────────────────────────────────────────
+export interface EventsResponse {
+  items: ServerEventRow[];
+}
+
+export interface ExternalChatListQuery {
+  source?: string;
+  limit?: number;
+}
+
+export interface ExternalChatListResponse {
+  items: ExternalChatMessageRow[];
+}
+
+export interface ExternalChatPostRequest {
+  source: string;
+  conversation_id?: string;
+  role?: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+}
+
+// ── activity ─────────────────────────────────────────────────────────────
+export interface ActivityListQuery {
+  date?: string;
+  kind?: ActivityKind;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ActivityListResponse {
+  date?: string;
+  kind?: ActivityKind | null;
+  items: ActivityEventRow[];
+  total: number;
+  page: { limit: number; offset: number; returned: number };
+}
+
+export interface ActivityEventCreateRequest {
+  kind: ActivityKind;
+  occurred_at?: string;
+  source?: string;
+  ref_id?: string;
+  content?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ActivityEventCreateResponse {
+  id: number;
+  inserted: boolean;
+}

--- a/server/api/types/multi.ts
+++ b/server/api/types/multi.ts
@@ -1,0 +1,73 @@
+// multi (Hub 連携) API request/response types
+// Spec: spec/api/multi.md
+
+export interface MultiServer {
+  url: string;
+  label: string | null;
+  jwt: string | null;             // GET 時は masked にしない (内部閉じ)
+  userId: string | null;
+  userName: string | null;
+  role: 'user' | 'moderator' | 'admin' | null;
+  connectedAt: string | null;     // UTC ISO
+}
+
+export interface MultiStatusResponse {
+  servers: (MultiServer & { connected: boolean; active: boolean })[];
+  primary: { connected: boolean; user: { id: string; name: string; role: string } | null };
+}
+
+export interface MultiServerRegisterRequest {
+  url: string;
+  label?: string;
+}
+
+export interface MultiActiveRequest {
+  urls: string[];
+}
+
+export interface MultiConnectRequest {
+  url: string;
+}
+
+export interface MultiConnectResponse {
+  redirect_url: string;
+}
+
+export interface MultiFinishRequest {
+  url: string;
+  code: string;
+  state: string;
+}
+
+export interface MultiDisconnectRequest {
+  url?: string;
+}
+
+export type MultiShareKind =
+  | 'bookmark'
+  | 'dig'
+  | 'dict'
+  | 'implementation_note'
+  | 'work_location';
+
+export interface MultiShareRequest {
+  kind: MultiShareKind;
+  id: number;
+}
+
+export interface MultiShareResponse {
+  ok: true;
+  remote: { id: number; shared_at: string };
+}
+
+export interface MultiDownloadRequest {
+  kind: MultiShareKind;
+  remote_id: number;
+}
+
+export interface MultiDownloadResponse {
+  ok: true;
+  id: number;
+  duplicate?: true;
+  owner?: string;
+}

--- a/server/api/types/push.ts
+++ b/server/api/types/push.ts
@@ -1,0 +1,33 @@
+// push API request/response types
+// Spec: spec/api/push.md
+
+import type { PushSubscriptionRow } from '../../db/types/push.js';
+
+export interface VapidKeyResponse {
+  key: string;                    // base64url
+}
+
+export interface PushSubscribeRequest {
+  endpoint: string;
+  keys: { p256dh: string; auth: string };
+  label?: string;
+  user_agent?: string;
+}
+
+export interface PushSubscribeResponse {
+  id: number;
+  duplicate?: true;
+}
+
+export interface PushSubscriptionsListResponse {
+  items: PushSubscriptionRow[];
+}
+
+export interface PushTestRequest {
+  title?: string;
+  body?: string;
+}
+
+export interface PushTestResponse {
+  result: { sent: number; failed: number; errors: string[] };
+}

--- a/server/api/types/task.ts
+++ b/server/api/types/task.ts
@@ -1,0 +1,52 @@
+// task API request/response types
+// Spec: spec/api/task.md
+
+import type { TaskRow, TaskStatus, TaskCreatorType } from '../../db/types/task.js';
+import type { AgentRunRow, AgentKind } from '../../db/types/agent.js';
+
+export interface TaskListQuery {
+  limit?: number;       // default 100, max 200
+  offset?: number;      // default 0
+  status?: TaskStatus;
+}
+
+export interface TaskListResponse {
+  items: TaskRow[];
+}
+
+export interface TaskCreateRequest {
+  title: string;
+  details?: string;
+  status?: TaskStatus;
+  creator_type?: TaskCreatorType;
+  due_at?: string | null;
+  share_actio?: boolean;
+  category?: string | null;     // カンマ区切り
+}
+
+export interface TaskUpdateRequest {
+  title?: string;
+  details?: string;
+  status?: TaskStatus;
+  due_at?: string | null;
+  share_actio?: boolean;
+  category?: string | null;
+}
+
+export interface TaskMutationResponse {
+  task: TaskRow;
+}
+
+export interface TaskCategoriesResponse {
+  items: string[];              // 重複排除 + ASCII/JIS 順 sort
+}
+
+export interface AgentRunStartRequest {
+  project_id: number;
+  agent?: AgentKind;
+  model?: string;
+}
+
+export interface AgentRunStartResponse {
+  run: AgentRunRow;
+}

--- a/server/api/types/visit.ts
+++ b/server/api/types/visit.ts
@@ -1,0 +1,86 @@
+// visit (locations / page-metadata / visits) API request/response types
+// Spec: spec/api/visit.md
+
+import type { GpsLocationRow } from '../../db/types/gps.js';
+import type { PageVisitRow, VisitEventSource } from '../../db/types/visit.js';
+import type { PageMetadataRow } from '../../db/types/page.js';
+import type { ServerEventRow } from '../../db/types/activity.js';
+import type { ActivityEventRow, ActivityKind } from '../../db/types/activity.js';
+
+export interface LocationsResponse {
+  date?: string;
+  from?: string;
+  to?: string;
+  deviceId: string | null;
+  points: GpsLocationRow[];
+}
+
+export interface LocationsDaysResponse {
+  days: { day: string; points: number; first_at: string; last_at: string }[];
+}
+
+export interface LocationSettingsResponse {
+  has_key: boolean;
+  key_preview: string;            // "abcd…wxyz" 等の masked
+  source: 'env' | 'db' | 'none';
+}
+
+export interface VisitsResponse {
+  items: PageVisitRow[];
+}
+
+export interface VisitsBulkUrlsRequest {
+  urls: string[];
+}
+
+export interface VisitExternalIngest {
+  url: string;
+  domain?: string;
+  title?: string;
+  visited_at?: string;             // UTC ISO; default = now
+  device_label?: string;
+  device_os?: string;
+  source?: VisitEventSource;       // 'dns' / 'sni' / 'browser'
+}
+
+export type PageMetadataResponse = PageMetadataRow;
+
+export interface WorklogServerEventsResponse {
+  items: ServerEventRow[];
+}
+
+export interface WorklogActivityResponse {
+  items: ActivityEventRow[];
+  total: number;
+  page: { limit: number; offset: number; returned: number };
+  kind?: ActivityKind | null;
+}
+
+export interface WorklogBrowsingVisit {
+  url: string;
+  title: string | null;
+  domain: string | null;
+  last_seen_at: string;
+  visit_count: number;
+  is_bookmarked: boolean;
+  catalog: { status: string } | null;
+}
+
+export interface WorklogBrowsingResponse {
+  date: string;
+  visits: WorklogBrowsingVisit[];
+  revisits: PageVisitRow[];
+  stats: {
+    top_domains: { domain: string; pages: number; visits: number }[];
+  };
+  enrichedTopDomains?: { domain: string; pages: number; visits: number; catalog_status: string | null }[];
+}
+
+export interface UptimeResponse {
+  heartbeat: {
+    server_started_at: string;
+    last_heartbeat_at: string;
+    pid: number;
+  } | null;
+  downtime_threshold_ms: number;
+}

--- a/server/api/types/workplace.ts
+++ b/server/api/types/workplace.ts
@@ -1,0 +1,87 @@
+// workplace API request/response types
+// Spec: spec/api/workplace.md
+
+import type { WorkLocationRow } from '../../db/types/workplace.js';
+
+export interface WorkLocationListResponse {
+  items: WorkLocationRow[];
+}
+
+export interface WorkLocationCreateRequest {
+  name: string;
+  address?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  description?: string | null;
+  url?: string | null;
+  tags?: string | null;          // カンマ区切り
+  shareable?: boolean;
+}
+
+export interface WorkLocationUpdateRequest {
+  name?: string;
+  address?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  description?: string | null;
+  url?: string | null;
+  tags?: string | null;
+  shareable?: boolean;
+}
+
+export interface WorkLocationMutationResponse {
+  location: WorkLocationRow;
+}
+
+// Place API (Nominatim 等) からの逆ジオコーディング結果
+export interface ResolvePlaceRequest {
+  latitude: number;
+  longitude: number;
+}
+
+export interface ResolvePlaceResponse {
+  name: string;
+  address: string;
+  latitude: number;
+  longitude: number;
+  raw?: { osm_id?: number | string; type?: string; category?: string };
+}
+
+// 自動チェックイン
+export interface CheckinRequest {
+  latitude: number;
+  longitude: number;
+}
+
+export interface CheckinResponse {
+  matched: boolean;
+  workplace: WorkLocationRow | null;
+  distance_m: number | null;
+  changed: boolean;
+  /** opt-in した場合の Hub broadcast 結果。 */
+  broadcast: { ok: true; id: number; occurred_at: string } | { ok: false; error: string } | { ok: true; kind: 'leave' } | null;
+}
+
+// 1 日分の作業セッション (GPS + workplace + activity_events)
+export interface WorkSession {
+  workplace_id: number;
+  workplace_name: string;
+  workplace_address: string;
+  started_at: string;             // UTC ISO
+  ended_at: string;               // UTC ISO (= 50m+ になった瞬間 / 別 workplace に切り替わった瞬間)
+  duration_min: number;
+  points_count: number;
+  is_home: boolean;
+  is_working: boolean;
+  activity_counts: Record<string, number>;
+}
+
+export interface WorkSessionsResponse {
+  date: string;                   // 'YYYY-MM-DD'
+  items: WorkSession[];           // ≥60 分のみ
+  tallies: {
+    home_minutes: number;
+    workplace_minutes: number;
+    by_workplace: Record<string, number>;
+  };
+}

--- a/spec/api/README.md
+++ b/spec/api/README.md
@@ -1,0 +1,48 @@
+# `spec/api/` — HTTP API 契約
+
+Memoria ローカルサーバの REST API を request / response 単位で documenta する。
+`server/api/types/<domain>.ts` の TypeScript 型と一対一で対応。
+
+## 構成
+
+```
+spec/api/
+├── README.md            ← 全体方針 + endpoint 一覧
+└── <domain>.md          ← endpoint 群を domain で束ねた spec
+```
+
+## 表記
+
+- **path**: `/api/...` (Hono の同名)
+- **method**: GET / POST / PATCH / DELETE
+- **req**: request body の interface 名 (TS 型と一致)
+- **res**: success response の interface 名
+- **err**: 一般的なエラーレスポンス (`{ error: string }`)
+
+## ルール
+
+- **正本は spec**。 実装より先に spec を書く / 修正する。
+- timestamp 系は **UTC ISO の string** で送受信し、 client 側は `parseUtcIso`
+  経由でローカル変換 (PR #104 で導入済)。
+- enum (status / kind 等) は string literal union を使い、 typo を tsc で弾く。
+- **任意フィールド**は `?:`、 **null 許容**は `T | null` で明示的に区別する。
+
+## エンドポイント (domain 別)
+
+| Domain | spec | 主な endpoint |
+|---|---|---|
+| タスク | [task.md](task.md) | `/api/tasks*`, `/api/tasks/categories`, `/api/tasks/:id/agent-run` |
+| AI 委託 | [agent.md](agent.md) | `/api/agent-projects*`, `/api/agent-runs*` |
+| 作業場所 | [workplace.md](workplace.md) | `/api/work-locations*`, `/api/work-sessions`, `/api/work-locations/checkin`, `/api/work-locations/resolve-place` |
+| ブックマーク | [bookmark.md](bookmark.md) | `/api/bookmark*`, `/api/bookmarks/from-url` |
+| ドメイン辞書 | [domain.md](domain.md) | `/api/domains*`, `/api/domains/from-url` |
+| 実装自慢 | [impl.md](impl.md) | `/api/implementation-notes*` |
+| 辞書 | [dict.md](dict.md) | `/api/dictionary*`, `/api/stopwords*` |
+| Dig | [dig.md](dig.md) | `/api/dig*`, `/api/wordcloud*` |
+| 食事 | [meal.md](meal.md) | `/api/meals*` |
+| 日記 | [diary.md](diary.md) | `/api/diary*`, `/api/weekly*` |
+| GPS / アクセス | [visit.md](visit.md) | `/api/locations*`, `/api/visits*`, `/api/page-metadata*` |
+| 設定 | [config.md](config.md) | `/api/privacy/settings`, `/api/llm/config`, `/api/setup-docs*`, `/api/tracks/settings` |
+| マルチ | [multi.md](multi.md) | `/api/multi/*` |
+| Push | [push.md](push.md) | `/api/push/*` |
+| 傾向 / ログ | [misc.md](misc.md) | `/api/trends/*`, `/api/events`, `/api/uptime`, `/api/recommendations*` |

--- a/spec/api/agent.md
+++ b/spec/api/agent.md
@@ -1,0 +1,26 @@
+# agent — AI 委託 API (agent_projects + agent_runs)
+
+## agent_projects
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/agent-projects` | — | `{ items: AgentProjectRow[] }` |
+| POST | `/api/agent-projects` | `AgentProjectCreateRequest` | `{ project: AgentProjectRow }` (201) |
+| PATCH | `/api/agent-projects/:id` | `AgentProjectUpdateRequest` | `{ project: AgentProjectRow }` |
+| DELETE | `/api/agent-projects/:id` | — | `{ ok: true }` |
+
+## agent_runs
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/agent-runs` | `AgentRunListQuery` (qs) | `{ items: AgentRunRow[] }` |
+| GET | `/api/agent-runs/:id` | — | `{ run: AgentRunRow, running: boolean }` |
+| GET | `/api/agent-runs/:id/log` | `?tail=N` | `{ run, running, log: string }` |
+| POST | `/api/agent-runs/:id/cancel` | — | `{ ok: true }` |
+
+開始は `/api/tasks/:id/agent-run` (task.md 参照)。
+
+## 注意
+- `project.path` は **絶対パス**必須 (CLI の cwd になる)。
+- `model` 未指定時は `agent` のデフォルト (`claude_code → sonnet`,
+  `codex → 5.3-codex`, `gemini → gemini-2.5-flash`)。

--- a/spec/api/bookmark.md
+++ b/spec/api/bookmark.md
@@ -1,0 +1,18 @@
+# bookmark — ブックマーク API
+
+| method | path | req | res |
+|---|---|---|---|
+| POST | `/api/bookmark` | `BookmarkSubmitRequest` (Chrome 拡張など) | `{ id: number, queued?: true, queueDepth?: number, duplicate?: true }` |
+| POST | `/api/bookmarks/from-url` | `{ url: string }` | `BookmarkFromUrlResponse` |
+| GET | `/api/bookmarks` | `BookmarkListQuery` (qs) | `BookmarkListResponse` |
+| GET | `/api/bookmarks/:id` | — | `BookmarkRow` |
+| PATCH | `/api/bookmarks/:id` | `BookmarkUpdateRequest` | `BookmarkRow` |
+| DELETE | `/api/bookmarks/:id` | — | `{ ok: true }` |
+| POST | `/api/bookmarks/:id/resummarize` | — | `{ ok: true, queueDepth: number }` |
+| GET | `/api/bookmarks/:id/html` | — | `text/html` (HTML スナップショット) |
+| GET | `/api/bookmarks/:id/accesses` | — | `{ items: AccessRow[] }` |
+
+## 注意
+- `/api/bookmark` は Chrome 拡張からの POST 経路 (HTML body を含む)。
+- `/api/bookmarks/from-url` はサーバ側で fetch + 要約キューイン。 fetch 失敗時は 502。
+- `/api/bookmarks` のページング: 既定 50 件、 max 200。 `?q=` でサーバ側 LIKE 検索。

--- a/spec/api/config.md
+++ b/spec/api/config.md
@@ -1,0 +1,33 @@
+# config — 設定 API (privacy / LLM / tracks / setup-docs)
+
+## privacy
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/privacy/settings` | — | `{ settings: PrivacySettings }` |
+| PATCH | `/api/privacy/settings` | `PrivacySettingsPatch` | `{ settings: PrivacySettings }` |
+
+## LLM (`/api/llm/config`)
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/llm/config` | — | `LlmConfigResponse` |
+| PATCH | `/api/llm/config` | `LlmConfigPatch` | `LlmConfigResponse` |
+
+## tracks 描画設定
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/tracks/settings` | — | `{ decimate_meters: number, show_polyline: boolean }` |
+| PATCH | `/api/tracks/settings` | `{ decimate_meters?, show_polyline? }` | 同上 |
+
+## セットアップ手順 (read-only docs)
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/setup-docs` | — | `{ docs: SetupDocSummary[] }` |
+| GET | `/api/setup-docs/:key` | — | `SetupDoc` |
+
+## 注意
+- `PrivacySettingsPatch` は **部分 patch**。 boolean は明示で送信、 number は range clamp (workplace_match_radius_m: 20-2000m, hour: 0-23, minute: 0-59)。
+- LLM 設定の OpenAI key は GET レスポンスで `'***'` にマスク。 PATCH で `'***'` を送ると元の値を保持。

--- a/spec/api/diary.md
+++ b/spec/api/diary.md
@@ -1,0 +1,17 @@
+# diary — 日記 / 週報 API
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/diary` | `?month=YYYY-MM` | `DiaryMonthResponse` |
+| GET | `/api/diary/:date` | — | `DiaryDetailResponse` |
+| POST | `/api/diary/:date/generate` | — | `{ queued: true, status }` |
+| PATCH | `/api/diary/:date/notes` | `{ notes: string }` | `DiaryEntryRow` |
+| DELETE | `/api/diary/:date` | — | `{ ok: true }` |
+| POST | `/api/diary/:date/improve` | `{ improve: string }` | `DiaryEntryRow` |
+| GET | `/api/diary/:date/digs` | `?limit=200` | `{ items: DigSessionRow[] }` |
+| GET | `/api/weekly` | — | `{ items: WeeklyReportRow[] }` |
+| GET | `/api/weekly/:week_start` | — | `WeeklyReportRow` |
+| POST | `/api/weekly/:week_start/generate` | — | `{ queued: true }` |
+| DELETE | `/api/weekly/:week_start` | — | `{ ok: true }` |
+| GET | `/api/diary-settings` | — | `Record<string, string>` |
+| PATCH | `/api/diary-settings` | `Record<string, string>` | `Record<string, string>` |

--- a/spec/api/dict.md
+++ b/spec/api/dict.md
@@ -1,0 +1,22 @@
+# dict — 辞書 + ストップワード API
+
+## dictionary
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/dictionary` | `?q=` | `{ items: DictionaryEntryRow[] }` |
+| GET | `/api/dictionary/:id` | — | `DictionaryEntryRow` |
+| POST | `/api/dictionary` | `DictionaryCreateRequest` | `DictionaryEntryRow` |
+| PATCH | `/api/dictionary/:id` | `DictionaryUpdateRequest` | `DictionaryEntryRow` |
+| DELETE | `/api/dictionary/:id` | — | `{ ok: true }` |
+| POST | `/api/dictionary/:id/links` | `{ source_kind, source_id }` | `{ ok: true }` |
+| DELETE | `/api/dictionary/:id/links` | `{ source_kind, source_id }` | `{ ok: true }` |
+| POST | `/api/dictionary/upsert-from-source` | `UpsertFromSourceRequest` | `DictionaryEntryRow` |
+
+## stopwords
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/stopwords` | — | `{ items: UserStopwordRow[] }` |
+| POST | `/api/stopwords` | `{ word: string }` | `{ ok: true }` |
+| DELETE | `/api/stopwords/:word` | — | `{ ok: true }` |

--- a/spec/api/dig.md
+++ b/spec/api/dig.md
@@ -1,0 +1,27 @@
+# dig — Deep research + ワードクラウド API
+
+## dig
+
+| method | path | req | res |
+|---|---|---|---|
+| POST | `/api/dig` | `DigStartRequest` | `{ id, status, queueDepth }` |
+| GET | `/api/dig` | `?limit=` | `{ items: DigSessionRow[] }` |
+| GET | `/api/dig/:id` | — | `DigSessionRow` |
+| DELETE | `/api/dig/:id` | — | `{ ok: true }` |
+| POST | `/api/dig/:id/save` | `{ urls: string[] }` | `{ results: BulkSaveResult[] }` |
+| GET | `/api/dig/engines` | — | `{ items: { id, label }[] }` |
+| GET | `/api/dig/themes` | — | `{ items: string[] }` |
+
+## wordcloud
+
+| method | path | req | res |
+|---|---|---|---|
+| POST | `/api/wordcloud` | `WordCloudCreateRequest` | `{ id }` |
+| GET | `/api/wordcloud` | — | `{ items: WordCloudRow[] }` |
+| GET | `/api/wordcloud/:id` | — | `WordCloudRow & { graph?: WordCloudGraph }` |
+| GET | `/api/wordcloud/:id/graph` | — | `WordCloudGraph` |
+| GET | `/api/wordcloud/:id/siblings` | — | `{ items: WordCloudRow[] }` |
+| POST | `/api/wordcloud/merge` | `{ ids: number[] }` | `{ id }` |
+| POST | `/api/wordcloud/validate-word` | `{ word, context }` | `{ ok: boolean, reason?: string }` |
+| POST | `/api/bookmarks/:id/wordcloud` | — | `{ id }` |
+| GET | `/api/bookmarks/:id/wordcloud` | — | `WordCloudRow \| null` |

--- a/spec/api/domain.md
+++ b/spec/api/domain.md
@@ -1,0 +1,16 @@
+# domain — ドメイン辞書 API
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/domains` | `?q=&kind=` | `{ items: DomainCatalogRow[] }` |
+| POST | `/api/domains/from-url` | `{ url: string }` | `{ domain, queued: true, duplicate: boolean }` |
+| GET | `/api/domains/:domain` | — | `DomainCatalogRow` |
+| PATCH | `/api/domains/:domain` | `DomainUpdateRequest` | `DomainCatalogRow` |
+| POST | `/api/domains/:domain/regenerate` | — | `{ queued: true }` |
+| DELETE | `/api/domains/:domain` | — | `{ ok: true }` |
+| POST | `/api/domains/recatalog-all` | `{ force?: boolean }` | `RecatalogResult` |
+
+## 注意
+- `/api/domains/from-url` は URL or hostname を受け、 host を抽出して classify キュー投入。 既存行があっても再分類。
+- `regenerate` は user_edited を保護 (manual に書いたフィールドは上書きしない)。
+- `recatalog-all` の force=true は user_edited 行も再分類対象に含める。

--- a/spec/api/impl.md
+++ b/spec/api/impl.md
@@ -1,0 +1,13 @@
+# impl — 実装自慢 API
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/implementation-notes` | `?limit=100&offset=0` | `{ items: ImplementationNoteRow[] }` |
+| POST | `/api/implementation-notes` | `ImplementationNoteCreateRequest` | `{ note: ImplementationNoteRow }` |
+| PATCH | `/api/implementation-notes/:id` | `ImplementationNoteUpdateRequest` | `{ note: ImplementationNoteRow }` |
+| DELETE | `/api/implementation-notes/:id` | — | `{ ok: true }` |
+| POST | `/api/implementation-notes/:id/share` | — | `{ ok: true, note: ImplementationNoteRow }` |
+
+## 注意
+- attachment_type が `github` のときは attachment_value が github.com の URL であることを **クライアント側でバリデート** する (server もバリデート可能)。
+- attachment_type が `screenshot` のときは attachment_value に `data:image/...` が入る (画像 paste / drop)。

--- a/spec/api/meal.md
+++ b/spec/api/meal.md
@@ -1,0 +1,15 @@
+# meal — 食事 API
+
+| method | path | req | res |
+|---|---|---|---|
+| POST | `/api/meals` | `multipart/form-data` (photo + meta) | `MealRow` |
+| POST | `/api/meals/manual` | `MealManualCreateRequest` (no photo) | `MealRow` |
+| GET | `/api/meals` | `?date=YYYY-MM-DD&limit=` | `{ items: MealRow[] }` |
+| GET | `/api/meals/:id` | — | `MealRow` |
+| GET | `/api/meals/:id/photo` | — | `image/*` |
+| PATCH | `/api/meals/:id` | `MealUpdateRequest` | `MealRow` |
+| DELETE | `/api/meals/:id` | — | `{ ok: true }` |
+| POST | `/api/meals/:id/reanalyze` | — | `{ queued: true }` |
+| POST | `/api/meals/:id/additions` | `MealAdditionRequest` | `MealRow` |
+| PATCH | `/api/meals/:id/additions/:idx` | `MealAdditionRequest` | `MealRow` |
+| DELETE | `/api/meals/:id/additions/:idx` | — | `MealRow` |

--- a/spec/api/misc.md
+++ b/spec/api/misc.md
@@ -1,0 +1,38 @@
+# misc — 傾向 / イベント / おすすめ / 外部チャット / activity events
+
+## trends
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/trends/categories` | `?days=` | `{ items: { category, count }[] }` |
+| GET | `/api/trends/category-diff` | `?days=` | `{ items }` |
+| GET | `/api/trends/timeline` | `?days=` | `{ items }` |
+| GET | `/api/trends/domains` | `?days=` | `{ items: { domain, hits }[] }` |
+| GET | `/api/trends/visit-domains` | `?days=` | `{ items }` |
+| GET | `/api/trends/work-hours` | `?days=` | `{ items: { date, minutes \| null }[] }` |
+| GET | `/api/trends/keywords` | `?days=` | `{ items }` |
+| GET | `/api/trends/gps-walking` | `?days=` | `{ items: { date, distance_km, walking_minutes, travel_minutes }[] }` |
+| GET | `/api/trends/github` | `?days=` | `{ enabled: boolean, items? }` |
+
+## recommend
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/recommendations` | — | `{ items }` |
+| POST | `/api/recommendations/dismiss` | `{ url }` | `{ ok }` |
+| DELETE | `/api/recommendations/dismissals` | — | `{ removed }` |
+
+## events / external-chat
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/events` | `?limit=` | `{ items: ServerEventRow[] }` |
+| GET | `/api/external-chat` | `?source=&limit=` | `{ items: ExternalChatMessageRow[] }` |
+| POST | `/api/external-chat` | `ExternalChatPostRequest` | `{ id }` |
+
+## activity
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/activity/events` | `?date=&kind=&limit=&offset=` | `{ items, total, page }` |
+| POST | `/api/activity/event` | `ActivityEventCreateRequest` | `{ id, inserted: boolean }` |

--- a/spec/api/multi.md
+++ b/spec/api/multi.md
@@ -1,0 +1,31 @@
+# multi — Memoria Hub 連携 API
+
+ローカルから `multi/` (Hub) を proxy + 認証 + share/download するための API。
+
+## 接続管理
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/multi/status` | — | `MultiStatusResponse` |
+| POST | `/api/multi/servers` | `{ url, label? }` | `{ ok, servers }` |
+| DELETE | `/api/multi/servers` | `{ url }` | `{ ok, servers }` |
+| POST | `/api/multi/active` | `{ urls: string[] }` | `{ ok, active }` |
+| POST | `/api/multi/connect` | `{ url }` | `{ redirect_url }` |
+| POST | `/api/multi/finish` | `{ url, code, state }` | `{ ok, user }` |
+| POST | `/api/multi/disconnect` | `{ url? }` | `{ ok }` |
+
+## proxy (Hub への passthrough)
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/multi/proxy/*` | — | Hub からそのまま |
+| POST | `/api/multi/proxy/*` | (moderation のみ許可) | Hub からそのまま |
+
+## share / download
+
+| method | path | req | res |
+|---|---|---|---|
+| POST | `/api/multi/share` | `{ kind, id }` | `{ ok, remote }` |
+| POST | `/api/multi/download` | `{ kind, remote_id }` | `{ ok, id, owner? }` |
+
+`kind` は `'bookmark' \| 'dig' \| 'dict' \| 'implementation_note' \| 'work_location'`。

--- a/spec/api/push.md
+++ b/spec/api/push.md
@@ -1,0 +1,9 @@
+# push — Web Push API
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/push/vapid-public-key` | — | `{ key: string }` |
+| POST | `/api/push/subscribe` | `PushSubscribeRequest` | `{ id }` |
+| GET | `/api/push/subscriptions` | — | `{ items: PushSubscriptionRow[] }` |
+| DELETE | `/api/push/subscriptions/:id` | — | `{ ok }` |
+| POST | `/api/push/test` | `{ title?, body? }` | `{ result }` |

--- a/spec/api/task.md
+++ b/spec/api/task.md
@@ -1,0 +1,18 @@
+# task — タスク API
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/tasks` | `TaskListQuery` (query string) | `{ items: TaskRow[] }` |
+| POST | `/api/tasks` | `TaskCreateRequest` | `{ task: TaskRow }` (201) |
+| PATCH | `/api/tasks/:id` | `TaskUpdateRequest` | `{ task: TaskRow }` |
+| DELETE | `/api/tasks/:id` | — | `{ ok: true }` |
+| GET | `/api/tasks/categories` | — | `{ items: string[] }` |
+| POST | `/api/tasks/categories` | `{ name: string }` | `{ items: string[] }` (201) |
+| DELETE | `/api/tasks/categories/:name` | — | `{ items: string[] }` |
+| POST | `/api/tasks/:id/agent-run` | `AgentRunStartRequest` | `{ run: AgentRunRow }` (201) |
+| POST | `/api/tasks/:id/share/actio` | — | `{ ok: true, result, task: TaskRow }` |
+
+## 備考
+- `category` は **カンマ区切りの複数値** ("開発, 学習") として送受信。
+- `creator_type` は `'human' | 'ai'`、 デフォルト `'human'`。
+- `due_at` は UTC ISO もしくは `'YYYY-MM-DDTHH:MM'` (datetime-local)。

--- a/spec/api/visit.md
+++ b/spec/api/visit.md
@@ -1,0 +1,45 @@
+# visit — GPS / アクセス履歴 / ページメタ API
+
+## locations (GPS)
+
+| method | path | req | res |
+|---|---|---|---|
+| POST | `/api/locations/ingest` | OwnTracks JSON | `{ ok: true }` (auth: ingest_key 必須) |
+| GET | `/api/locations` | `?date=YYYY-MM-DD` or `?from=&to=&device=` | `{ date?, from?, to?, deviceId, points: GpsLocationRow[] }` |
+| GET | `/api/locations/days` | `?limit=180` | `{ days: { day, points, first_at, last_at }[] }` |
+| DELETE | `/api/locations` | `?older_than=ISO` | `{ removed: number }` |
+| GET | `/api/locations/settings` | — | `LocationSettingsResponse` |
+| POST | `/api/locations/settings/regenerate` | — | `{ key }` (1 度だけ表示) |
+| POST | `/api/locations/settings/clear` | — | `{ ok: true }` |
+| POST | `/api/locations/compress` | `{ since?, until? }` | `{ before, after, removed }` |
+| GET | `/api/locations/unresolved` | `?limit=` | `{ items: GpsLocationRow[] }` |
+| POST | `/api/locations/resolve-all` | — | `{ queued: number }` |
+
+## visits (per-event)
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/visits` | `?days=` | `{ items: PageVisit[] }` |
+| GET | `/api/visits/suggested` | `?days=30` | `{ items }` |
+| GET | `/api/visits/unsaved/count` | — | `{ count: number }` |
+| DELETE | `/api/visits` | `{ urls: string[] }` | `{ ok: true, removed }` |
+| POST | `/api/visits/save` | `{ urls: string[] }` | `{ results: BulkSaveResult[] }` |
+| POST | `/api/visits/external` | `VisitExternalIngest` | `{ ok: true }` (Legatus DNS/SNI) |
+| GET | `/api/visits/external/stats` | — | `{ ... }` |
+| POST | `/api/access` | `{ url }` | `{ ok: true }` (Chrome 拡張からの ping) |
+
+## page-metadata
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/page-metadata` | `?url=` | `PageMetadataRow` |
+| POST | `/api/page-metadata/refresh` | `{ url }` | `{ queued: true }` |
+
+## worklog 集計 (date 単位)
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/worklog/server-events` | `?date=` | `{ items: ServerEventRow[] }` |
+| GET | `/api/worklog/browsing` | `?date=` | `WorklogBrowsingResponse` |
+| GET | `/api/worklog/activity` | `?date=&kind=` | `{ items: ActivityEventRow[], total, page }` |
+| GET | `/api/uptime` | — | `{ heartbeat, downtime_threshold_ms }` |

--- a/spec/api/workplace.md
+++ b/spec/api/workplace.md
@@ -1,0 +1,24 @@
+# workplace — 作業場所 / GPS 自動チェックイン / セッション API
+
+## work_locations CRUD
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/work-locations` | `?limit=200&offset=0` | `{ items: WorkLocationRow[] }` |
+| POST | `/api/work-locations` | `WorkLocationCreateRequest` | `{ location: WorkLocationRow }` (201) |
+| PATCH | `/api/work-locations/:id` | `WorkLocationUpdateRequest` | `{ location: WorkLocationRow }` |
+| DELETE | `/api/work-locations/:id` | — | `{ ok: true }` |
+
+## GPS 自動
+
+| method | path | req | res |
+|---|---|---|---|
+| POST | `/api/work-locations/resolve-place` | `{ latitude, longitude }` | `ResolvePlaceResponse` |
+| POST | `/api/work-locations/checkin` | `{ latitude, longitude }` | `CheckinResponse` |
+| GET | `/api/work-sessions` | `?date=YYYY-MM-DD` | `WorkSessionsResponse` |
+
+## 注意
+- resolve-place は OpenStreetMap Nominatim 既定。 設定で他の Place API に切替可。
+- checkin は `workplace_match_radius_m` (privacy settings) 内の最近接 work_location とマッチ。
+- work-sessions は **GPS の連続点を 1 セッションに畳む** + 60 分以上のみ items に含める。
+  全期間集計は `tallies` フィールドで返却。


### PR DESCRIPTION
## TS 化フェーズ 2 — API contract 層

issue #31 の続き。 phase 1 の DB 行型の上に、 HTTP API contract を載せる。

## 入るもの

### spec/api/ (新規)
- README + 15 の per-domain .md
- 各 endpoint を `method | path | req | res` のテーブルで列挙
- 主要 domain: task / agent / workplace / bookmark / domain / impl / dict /
  dig / meal / diary / visit / multi / push / config / misc

### server/api/types/
- 15 の .ts ファイル + `index.ts` re-export
- request body / query / response の interface
- enum 系は string literal union で statically typed

## 検証
- `npx tsc --noEmit` → 0 errors
- `npx eslint --max-warnings 0` → 0 errors
- (途中 `interface extends` 1 件で no-empty-object-type に引っかかったので type alias に変更)

## 次フェーズ
Phase 3 以降は **`.js → .ts` 変換**:
- leaf modules から (queue / push / wordcloud / dig-serp など)
- `server/db.js` を domain 別 module に割って phase 1 の row 型と接合
- `server/index.js` の routes を domain 別 router に割って phase 2 の API 型と接合

🤖 Generated with [Claude Code](https://claude.com/claude-code)