### PR TITLE
feat(ts/phase-4): convert 4 more leaf modules to TS

### DIFF
--- a/server/dig-serp.ts
+++ b/server/dig-serp.ts
@@ -1,37 +1,41 @@
 // Fast SERP scrape — runs BEFORE any LLM call so the user sees Google-style
 // search hits within a couple of seconds, while the AI preview / deep dig
 // keep cooking in the background.
-//
-// We hit DuckDuckGo's HTML-only endpoint (`html.duckduckgo.com/html/`) by
-// default because it has stable markup, doesn't require an API key, doesn't
-// run JS, and is the most scrape-friendly mainstream engine. Bing also
-// works but its markup churns more often. Google is hostile to scraping
-// (captcha) so we skip it from this path — users who picked "Google" still
-// get Google via the existing Claude-driven phases.
-//
-// One module-level fetch with a 12s budget; if it fails we just return
-// `null` and the UI falls through to the Claude preview.
 
 import { parse as parseHtml } from 'node-html-parser';
 
 const DEFAULT_TIMEOUT_MS = 12_000;
 const UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0 Safari/537.36';
 
-const ENGINES = {
+export interface SerpResult {
+  title: string;
+  url: string;
+  snippet: string;
+  domain: string;
+}
+
+export interface SerpResponse {
+  engine: 'duckduckgo' | 'bing';
+  results: SerpResult[];
+  fetched_at: string;            // UTC ISO
+}
+
+type EngineName = 'duckduckgo' | 'bing';
+
+const ENGINES: Record<EngineName, (q: string, signal: AbortSignal) => Promise<SerpResult[]>> = {
   duckduckgo: scrapeDuckDuckGo,
   bing: scrapeBing,
-  // Google / Brave fall back to DuckDuckGo for the raw stage.
 };
 
-/**
- * Fetch a SERP and return up to 10 raw results as fast as possible. No AI,
- * no per-page fetch — just the search engine's snippet layer.
- *
- * Returns `{ engine, results: [{title, url, snippet, domain}], fetched_at }`
- * or `null` if every attempt failed (timeout / blocked / parse error). The
- * caller should treat null as "no fast results, wait for the AI preview".
- */
-export async function runDigRawSerp({ query, searchEngine = 'default', timeoutMs = DEFAULT_TIMEOUT_MS }) {
+export async function runDigRawSerp({
+  query,
+  searchEngine = 'default',
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+}: {
+  query: string;
+  searchEngine?: string;
+  timeoutMs?: number;
+}): Promise<SerpResponse | null> {
   if (!query) return null;
   const order = engineOrder(searchEngine);
   const ac = new AbortController();
@@ -49,7 +53,7 @@ export async function runDigRawSerp({ query, searchEngine = 'default', timeoutMs
             fetched_at: new Date().toISOString(),
           };
         }
-      } catch (e) {
+      } catch {
         if (ac.signal.aborted) break;
         // try the next engine
       }
@@ -60,16 +64,12 @@ export async function runDigRawSerp({ query, searchEngine = 'default', timeoutMs
   }
 }
 
-function engineOrder(searchEngine) {
-  // DuckDuckGo first by default. If the user picked a specific engine and we
-  // have a scraper for it, try that first.
+function engineOrder(searchEngine: string): EngineName[] {
   if (searchEngine === 'bing') return ['bing', 'duckduckgo'];
   return ['duckduckgo', 'bing'];
 }
 
-async function scrapeDuckDuckGo(query, signal) {
-  // The `html.duckduckgo.com` endpoint serves a JS-free results page that's
-  // the documented "scraping-allowed" surface for non-API consumers.
+async function scrapeDuckDuckGo(query: string, signal: AbortSignal): Promise<SerpResult[]> {
   const url = `https://html.duckduckgo.com/html/?q=${encodeURIComponent(query)}`;
   const res = await fetch(url, {
     signal,
@@ -82,7 +82,7 @@ async function scrapeDuckDuckGo(query, signal) {
   if (!res.ok) throw new Error(`ddg ${res.status}`);
   const html = await res.text();
   const root = parseHtml(html);
-  const out = [];
+  const out: SerpResult[] = [];
   for (const r of root.querySelectorAll('.result')) {
     const a = r.querySelector('.result__title a, a.result__a');
     if (!a) continue;
@@ -103,13 +103,11 @@ async function scrapeDuckDuckGo(query, signal) {
   return out;
 }
 
-function unwrapDuckDuckGoLink(href) {
-  // DuckDuckGo wraps outbound links: `//duckduckgo.com/l/?uddg=<encoded>&...`
-  // Sometimes returns a relative URL. Decode if present, else use as-is.
+function unwrapDuckDuckGoLink(href: string): string {
   try {
     const u = new URL(href, 'https://duckduckgo.com');
     if (u.pathname === '/l/' && u.searchParams.has('uddg')) {
-      return decodeURIComponent(u.searchParams.get('uddg'));
+      return decodeURIComponent(u.searchParams.get('uddg') || '');
     }
     return u.toString();
   } catch {
@@ -117,9 +115,7 @@ function unwrapDuckDuckGoLink(href) {
   }
 }
 
-async function scrapeBing(query, signal) {
-  // Bing has stable enough markup for the top 10 organic links. Skip ad
-  // blocks (`b_ad`) which sometimes appear above the fold.
+async function scrapeBing(query: string, signal: AbortSignal): Promise<SerpResult[]> {
   const url = `https://www.bing.com/search?q=${encodeURIComponent(query)}&form=QBLH`;
   const res = await fetch(url, {
     signal,
@@ -132,7 +128,7 @@ async function scrapeBing(query, signal) {
   if (!res.ok) throw new Error(`bing ${res.status}`);
   const html = await res.text();
   const root = parseHtml(html);
-  const out = [];
+  const out: SerpResult[] = [];
   for (const li of root.querySelectorAll('#b_results > li.b_algo')) {
     const a = li.querySelector('h2 a');
     if (!a) continue;
@@ -153,6 +149,10 @@ async function scrapeBing(query, signal) {
   return out;
 }
 
-function extractDomain(url) {
-  try { return new URL(String(url)).hostname.toLowerCase(); } catch { return ''; }
+function extractDomain(url: string): string {
+  try {
+    return new URL(String(url)).hostname.toLowerCase();
+  } catch {
+    return '';
+  }
 }

--- a/server/domain-catalog.ts
+++ b/server/domain-catalog.ts
@@ -8,7 +8,7 @@ import { runLlm } from './llm.js';
 
 const SKIP_HOST = /^(localhost|127\.0\.0\.1|0\.0\.0\.0|::1|\[::1\])$/i;
 
-export function shouldSkipDomain(domain) {
+export function shouldSkipDomain(domain: string | null | undefined): boolean {
   if (!domain) return true;
   if (SKIP_HOST.test(domain)) return true;
   // Bare IPs (v4) and intranet-style hosts often 404; we still try them but
@@ -16,7 +16,14 @@ export function shouldSkipDomain(domain) {
   return false;
 }
 
-const CLASSIFY_PROMPT = ({ domain, title, metaDescription, bodySample }) => [
+interface ClassifyPromptArgs {
+  domain: string;
+  title: string;
+  metaDescription: string;
+  bodySample: string;
+}
+
+const CLASSIFY_PROMPT = ({ domain, title, metaDescription, bodySample }: ClassifyPromptArgs): string => [
   'あなたは Web サイトを辞書化する係です。次の情報からこのドメインを JSON 1 オブジェクトのみで出力してください (前置き不要、コードフェンス禁止)。',
   '',
   '**4 つのフィールドはすべて必須**。情報が乏しくても推測で埋めること (空文字列・null・"unknown" 禁止)。',
@@ -37,18 +44,32 @@ const CLASSIFY_PROMPT = ({ domain, title, metaDescription, bodySample }) => [
   bodySample,
 ].join('\n');
 
+export type ClassifyDomainResult =
+  | { skip: true }
+  | { dropRow: true; error: string }
+  | { ok: false; error: string; title?: string; metaDescription?: string }
+  | {
+      ok: true;
+      title: string;
+      site_name: string;
+      description: string;
+      can_do: string;
+      kind: string;
+    };
+
 /**
- * Fetch + classify a single domain. Returns one of:
- *   { skip: true }            — host blacklisted (e.g. localhost)
- *   { dropRow: true, ... }    — fetch failed in a way that means we should
- *                                forget about the domain (404, DNS error, etc.)
- *   { ok: true, ...fields }   — classification succeeded
- *   { ok: false, error }      — claude or HTML parse failed (keep row, mark error)
+ * Fetch + classify a single domain.
  */
-export async function classifyDomain({ domain, timeoutMs = 60_000 }) {
+export async function classifyDomain({
+  domain,
+  timeoutMs = 60_000,
+}: {
+  domain: string;
+  timeoutMs?: number;
+}): Promise<ClassifyDomainResult> {
   if (shouldSkipDomain(domain)) return { skip: true };
 
-  let res;
+  let res: Response;
   try {
     res = await fetch(`https://${domain}/`, {
       redirect: 'follow',
@@ -59,8 +80,8 @@ export async function classifyDomain({ domain, timeoutMs = 60_000 }) {
       },
       signal: AbortSignal.timeout(15_000),
     });
-  } catch (e) {
-    return { dropRow: true, error: `fetch: ${e.message}` };
+  } catch (e: unknown) {
+    return { dropRow: true, error: `fetch: ${e instanceof Error ? e.message : String(e)}` };
   }
 
   if (res.status === 404 || !res.ok) {
@@ -72,11 +93,11 @@ export async function classifyDomain({ domain, timeoutMs = 60_000 }) {
     return { ok: false, error: `non-html (${ct})` };
   }
 
-  let html;
+  let html: string;
   try {
     html = await res.text();
-  } catch (e) {
-    return { ok: false, error: `body: ${e.message}` };
+  } catch (e: unknown) {
+    return { ok: false, error: `body: ${e instanceof Error ? e.message : String(e)}` };
   }
 
   const root = parseHtml(html, { lowerCaseTagName: false });
@@ -91,12 +112,13 @@ export async function classifyDomain({ domain, timeoutMs = 60_000 }) {
   const bodySample = root.text.replace(/\s+/g, ' ').trim().slice(0, 2000);
 
   const prompt = CLASSIFY_PROMPT({ domain, title, metaDescription, bodySample });
-  let parsed;
+  let parsed: { site_name: string; description: string; can_do: string; kind: string };
   try {
     const stdout = await runLlm({ task: 'domain_classify', prompt, timeoutMs });
     parsed = parseClassifyJson(stdout);
-  } catch (e) {
-    return { ok: false, error: `claude: ${e.message}`, title, metaDescription };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: `claude: ${msg}`, title, metaDescription };
   }
 
   // Defensive fallbacks: if the LLM somehow returns blank fields, fall
@@ -113,16 +135,20 @@ export async function classifyDomain({ domain, timeoutMs = 60_000 }) {
   };
 }
 
-function parseClassifyJson(raw) {
+function parseClassifyJson(raw: string): { site_name: string; description: string; can_do: string; kind: string } {
   let text = raw.trim();
   const fence = text.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/);
   if (fence) text = fence[1].trim();
   const first = text.indexOf('{');
   const last = text.lastIndexOf('}');
   if (first >= 0 && last > first) text = text.slice(first, last + 1);
-  let obj;
-  try { obj = JSON.parse(text); }
-  catch (e) { throw new Error(`json parse: ${e.message}`); }
+  let obj: { site_name?: unknown; description?: unknown; can_do?: unknown; kind?: unknown };
+  try {
+    obj = JSON.parse(text);
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`json parse: ${msg}`);
+  }
   return {
     site_name: String(obj.site_name ?? '').trim().slice(0, 120),
     description: String(obj.description ?? '').trim().slice(0, 400),
@@ -130,4 +156,3 @@ function parseClassifyJson(raw) {
     kind: String(obj.kind ?? '').trim().slice(0, 40),
   };
 }
-

--- a/server/page-metadata.ts
+++ b/server/page-metadata.ts
@@ -3,11 +3,22 @@
 // specific page is". Cached forever in page_metadata; 404 / DNS errors
 // drop the row so it can be retried later.
 
-import { parse as parseHtml } from 'node-html-parser';
+import { parse as parseHtml, type HTMLElement } from 'node-html-parser';
 import { shouldSkipDomain } from './domain-catalog.js';
 import { runLlm } from './llm.js';
 
-const SUMMARY_PROMPT = ({ url, title, metaDescription, ogTitle, ogDescription, ogType, headers, bodySample }) => [
+interface PromptArgs {
+  url: string;
+  title: string;
+  metaDescription: string;
+  ogTitle: string;
+  ogDescription: string;
+  ogType: string;
+  headers: string;
+  bodySample: string;
+}
+
+const SUMMARY_PROMPT = ({ url, title, metaDescription, ogTitle, ogDescription, ogType, headers, bodySample }: PromptArgs): string => [
   'あなたは Web ページのメタ情報をもとに、「このページは何か」を 1〜2 文の日本語で説明する係です。',
   'JSON 1 オブジェクトのみで出力してください。前置き不要、コードフェンス禁止。',
   '',
@@ -29,13 +40,51 @@ const SUMMARY_PROMPT = ({ url, title, metaDescription, ogTitle, ogDescription, o
   bodySample,
 ].join('\n');
 
-export async function fetchPageMetadata({ url, timeoutMs = 60_000 }) {
-  let host;
-  try { host = new URL(url).hostname.toLowerCase(); }
-  catch { return { dropRow: true, error: 'invalid url' }; }
+export type PageMetadataFetchResult =
+  | { skip: true }
+  | { dropRow: true; error: string }
+  | {
+      ok: false;
+      http_status?: number;
+      content_type?: string;
+      title?: string;
+      meta_description?: string;
+      og_title?: string;
+      og_description?: string;
+      og_image?: string;
+      og_type?: string;
+      error: string;
+    }
+  | {
+      ok: true;
+      http_status: number;
+      content_type: string;
+      title: string;
+      meta_description?: string;
+      og_title?: string;
+      og_description?: string;
+      og_image?: string;
+      og_type?: string;
+      summary: string;
+      kind: string;
+    };
+
+export async function fetchPageMetadata({
+  url,
+  timeoutMs = 60_000,
+}: {
+  url: string;
+  timeoutMs?: number;
+}): Promise<PageMetadataFetchResult> {
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return { dropRow: true, error: 'invalid url' };
+  }
   if (shouldSkipDomain(host)) return { skip: true };
 
-  let res;
+  let res: Response;
   try {
     res = await fetch(url, {
       redirect: 'follow',
@@ -46,8 +95,8 @@ export async function fetchPageMetadata({ url, timeoutMs = 60_000 }) {
       },
       signal: AbortSignal.timeout(20_000),
     });
-  } catch (e) {
-    return { dropRow: true, error: `fetch: ${e.message}` };
+  } catch (e: unknown) {
+    return { dropRow: true, error: `fetch: ${e instanceof Error ? e.message : String(e)}` };
   }
 
   const httpStatus = res.status;
@@ -71,11 +120,16 @@ export async function fetchPageMetadata({ url, timeoutMs = 60_000 }) {
     };
   }
 
-  let html;
+  let html: string;
   try {
     html = await res.text();
-  } catch (e) {
-    return { ok: false, http_status: httpStatus, content_type: contentType, error: `body: ${e.message}` };
+  } catch (e: unknown) {
+    return {
+      ok: false,
+      http_status: httpStatus,
+      content_type: contentType,
+      error: `body: ${e instanceof Error ? e.message : String(e)}`,
+    };
   }
 
   const root = parseHtml(html, { lowerCaseTagName: false });
@@ -99,16 +153,17 @@ export async function fetchPageMetadata({ url, timeoutMs = 60_000 }) {
     url, title, metaDescription, ogTitle, ogDescription, ogType,
     headers: interestingHeaders, bodySample,
   });
-  let parsed;
+  let parsed: { summary: string; kind: string };
   try {
     const stdout = await runLlm({ task: 'page_summary', prompt: promptText, timeoutMs });
     parsed = parseSummaryJson(stdout);
-  } catch (e) {
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
     return {
       ok: false, http_status: httpStatus, content_type: contentType,
       title, meta_description: metaDescription, og_title: ogTitle,
       og_description: ogDescription, og_image: ogImage, og_type: ogType,
-      error: `claude: ${e.message}`,
+      error: `claude: ${msg}`,
     };
   }
 
@@ -127,7 +182,7 @@ export async function fetchPageMetadata({ url, timeoutMs = 60_000 }) {
   };
 }
 
-function pickMeta(root, selectors) {
+function pickMeta(root: HTMLElement, selectors: string[]): string {
   for (const sel of selectors) {
     const v = root.querySelector(sel)?.getAttribute('content');
     if (v) return v.replace(/\s+/g, ' ').trim().slice(0, 500);
@@ -135,19 +190,22 @@ function pickMeta(root, selectors) {
   return '';
 }
 
-function parseSummaryJson(raw) {
+function parseSummaryJson(raw: string): { summary: string; kind: string } {
   let text = raw.trim();
   const fence = text.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/);
   if (fence) text = fence[1].trim();
   const first = text.indexOf('{');
   const last = text.lastIndexOf('}');
   if (first >= 0 && last > first) text = text.slice(first, last + 1);
-  let obj;
-  try { obj = JSON.parse(text); }
-  catch (e) { throw new Error(`json parse: ${e.message}`); }
+  let obj: { summary?: unknown; kind?: unknown };
+  try {
+    obj = JSON.parse(text);
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`json parse: ${msg}`);
+  }
   return {
     summary: String(obj.summary ?? '').trim().slice(0, 400),
     kind: String(obj.kind ?? '').trim().slice(0, 40),
   };
 }
-

--- a/server/recommendations.ts
+++ b/server/recommendations.ts
@@ -3,24 +3,57 @@
 // pages link to a given URL. The base score is then biased by:
 //   - frequently-visited site domains (page_visits log, including non-saved)
 //   - word-cloud overlap with recent bookmark word clouds
-//
-// Result is cached in memory for `CACHE_TTL_MS` to avoid re-walking 100s of
-// HTML files on every refresh. Dismissals invalidate the cache.
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import type BetterSqlite3 from 'better-sqlite3';
 import { parse as parseHtml } from 'node-html-parser';
 import { trendsVisitDomains, recentBookmarkWordClouds } from './db.js';
+
+type Db = BetterSqlite3.Database;
 
 const CACHE_TTL_MS = 30 * 60 * 1000;
 const MAX_SOURCE_DOCS = 250;
 const MAX_RESULTS = 100;
-const PER_DOC_LINK_CAP = 80; // an article with 5000 links is almost always a navigation page
+const PER_DOC_LINK_CAP = 80;
 
-let cache = { computedAt: 0, dismissalSig: '', items: [] };
+export interface RecommendationItem {
+  url: string;
+  domain: string;
+  count: number;
+  source_count: number;
+  anchor: string;
+  sources: { id: number; title: string }[];
+  domain_boost: number;
+  topic_hits: number;
+  score: number;
+}
 
-export function recommendationsFor(db, htmlDir, { force = false } = {}) {
-  const dismissed = db.prepare(`SELECT url FROM recommendation_dismissals`).all().map(r => r.url);
+interface CacheState {
+  computedAt: number;
+  dismissalSig: string;
+  items: RecommendationItem[];
+}
+
+let cache: CacheState = { computedAt: 0, dismissalSig: '', items: [] };
+
+interface SourceBookmark {
+  id: number;
+  url: string;
+  title: string;
+  html_path: string;
+  created_at: string;
+}
+
+interface VisitDomainRow { domain: string; visits: number }
+interface BookmarkWordCloudRow { result?: { words?: { word?: unknown; weight?: unknown; kept?: unknown }[] } | null }
+
+export function recommendationsFor(
+  db: Db,
+  htmlDir: string,
+  { force = false }: { force?: boolean } = {},
+): RecommendationItem[] {
+  const dismissed = (db.prepare(`SELECT url FROM recommendation_dismissals`).all() as { url: string }[]).map(r => r.url);
   const sig = String(dismissed.length) + '|' + (dismissed[0] ?? '') + '|' + (dismissed.at(-1) ?? '');
   if (!force
       && cache.computedAt
@@ -33,71 +66,78 @@ export function recommendationsFor(db, htmlDir, { force = false } = {}) {
   return items;
 }
 
-export function dismissRecommendation(db, url) {
+export function dismissRecommendation(db: Db, url: string): void {
   db.prepare(`INSERT OR IGNORE INTO recommendation_dismissals (url) VALUES (?)`).run(url);
   cache = { computedAt: 0, dismissalSig: '', items: [] };
 }
 
-export function clearDismissals(db) {
+export function clearDismissals(db: Db): void {
   db.prepare(`DELETE FROM recommendation_dismissals`).run();
   cache = { computedAt: 0, dismissalSig: '', items: [] };
 }
 
-function compute(db, htmlDir, dismissed) {
+function compute(db: Db, htmlDir: string, dismissed: Set<string>): RecommendationItem[] {
   const sources = db.prepare(`
     SELECT id, url, title, html_path, created_at FROM bookmarks
     ORDER BY created_at DESC
     LIMIT ?
-  `).all(MAX_SOURCE_DOCS);
-  const savedUrls = new Set(db.prepare(`SELECT url FROM bookmarks`).all().map(r => r.url));
-  const visitedUrls = new Set(db.prepare(`SELECT url FROM page_visits`).all().map(r => r.url));
+  `).all(MAX_SOURCE_DOCS) as SourceBookmark[];
+  const savedUrls = new Set((db.prepare(`SELECT url FROM bookmarks`).all() as { url: string }[]).map(r => r.url));
+  const visitedUrls = new Set((db.prepare(`SELECT url FROM page_visits`).all() as { url: string }[]).map(r => r.url));
 
-  // Frequently-visited domains (URL log, regardless of bookmark status). Used
-  // as a multiplicative boost on candidates that share a domain with the user's
-  // habitual sites.
-  const visitDomains = trendsVisitDomains(db, { sinceDays: 60, limit: 50 });
-  const visitDomainBoost = new Map();
+  const visitDomains = trendsVisitDomains(db, { sinceDays: 60, limit: 50 }) as VisitDomainRow[];
+  const visitDomainBoost = new Map<string, number>();
   if (visitDomains.length > 0) {
     const max = Math.max(...visitDomains.map(d => d.visits));
     for (const d of visitDomains) {
-      // 0..1, then mapped to 1..3 multiplier.
       visitDomainBoost.set(d.domain, 1 + 2 * (d.visits / Math.max(max, 1)));
     }
   }
 
-  // Recent bookmark word clouds — kept words form a topic vocabulary; anchor
-  // text overlap with these words boosts candidates.
-  const recentClouds = recentBookmarkWordClouds(db, { limit: 30 });
-  const topicWords = new Map(); // word -> aggregated weight
+  const recentClouds = recentBookmarkWordClouds(db, { limit: 30 }) as BookmarkWordCloudRow[];
+  const topicWords = new Map<string, number>();
   for (const c of recentClouds) {
     const ws = c.result?.words || [];
     for (const w of ws) {
-      if (!w.kept) continue;
+      if (w.kept === false) continue;
       const key = String(w.word || '').toLowerCase();
       if (!key) continue;
-      topicWords.set(key, (topicWords.get(key) || 0) + (w.weight || 1));
+      topicWords.set(key, (topicWords.get(key) || 0) + (Number(w.weight) || 1));
     }
   }
   const topicMaxWeight = Math.max(1, ...topicWords.values());
 
-  const linkStats = new Map(); // url -> { count, sources: Map<bookmarkId, {title}>, anchor }
+  interface LinkStat {
+    count: number;
+    sources: Map<number, { id: number; title: string }>;
+    anchor: string;
+  }
+  const linkStats = new Map<string, LinkStat>();
 
   for (const b of sources) {
-    let html;
-    try { html = readFileSync(join(htmlDir, b.html_path), 'utf8'); } catch { continue; }
+    let html: string;
+    try {
+      html = readFileSync(join(htmlDir, b.html_path), 'utf8');
+    } catch {
+      continue;
+    }
 
     const root = parseHtml(html, { lowerCaseTagName: false });
     const anchors = root.querySelectorAll('a[href]');
     if (!anchors || anchors.length === 0) continue;
 
-    const seen = new Set();
+    const seen = new Set<string>();
     let added = 0;
     for (const a of anchors) {
       if (added >= PER_DOC_LINK_CAP) break;
       const href = a.getAttribute('href');
       if (!href) continue;
-      let abs;
-      try { abs = stripFragmentAndQuery(new URL(href, b.url).href); } catch { continue; }
+      let abs: string;
+      try {
+        abs = stripFragmentAndQuery(new URL(href, b.url).href);
+      } catch {
+        continue;
+      }
       if (!/^https?:\/\//.test(abs)) continue;
       if (sameDomain(abs, b.url)) continue;
       if (savedUrls.has(abs) || visitedUrls.has(abs) || dismissed.has(abs)) continue;
@@ -119,7 +159,7 @@ function compute(db, htmlDir, dismissed) {
   }
 
   return [...linkStats.entries()]
-    .map(([url, s]) => {
+    .map(([url, s]): RecommendationItem => {
       const domain = domainOf(url);
       const base = s.sources.size * 10 + s.count;
       const domainMul = visitDomainBoost.get(domain) ?? 1;
@@ -142,7 +182,7 @@ function compute(db, htmlDir, dismissed) {
     .slice(0, MAX_RESULTS);
 }
 
-function scoreTopicOverlap(anchor, topicWords, maxWeight) {
+function scoreTopicOverlap(anchor: string, topicWords: Map<string, number>, maxWeight: number): number {
   if (!anchor || topicWords.size === 0) return 0;
   const text = anchor.toLowerCase();
   let hit = 0;
@@ -153,11 +193,10 @@ function scoreTopicOverlap(anchor, topicWords, maxWeight) {
   return hit;
 }
 
-function stripFragmentAndQuery(url) {
+function stripFragmentAndQuery(url: string): string {
   try {
     const u = new URL(url);
     u.hash = '';
-    // Drop tracking-style query strings while keeping legitimate ones short.
     const params = [...u.searchParams.entries()].filter(([k]) => !/^utm_|fbclid|gclid|ref|source/i.test(k));
     u.search = '';
     if (params.length > 0) {
@@ -165,13 +204,20 @@ function stripFragmentAndQuery(url) {
       u.search = '?' + sp.toString();
     }
     return u.href;
-  } catch { return url; }
+  } catch {
+    return url;
+  }
 }
 
-function domainOf(url) {
-  try { return new URL(url).hostname.toLowerCase(); } catch { return ''; }
+function domainOf(url: string): string {
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return '';
+  }
 }
-function sameDomain(a, b) {
+
+function sameDomain(a: string, b: string): boolean {
   const da = domainOf(a), db_ = domainOf(b);
   if (!da || !db_) return false;
   return da === db_ || da.endsWith('.' + db_) || db_.endsWith('.' + da);


### PR DESCRIPTION
## TS 化フェーズ 4

| from | to | LOC | 内容 |
|---|---|---|---|
| domain-catalog.js | .ts | 178 | classifyDomain → discriminated union |
| page-metadata.js | .ts | 200 | fetchPageMetadata → discriminated union |
| dig-serp.js | .ts | 165 | DDG / Bing scraping with strict types |
| recommendations.js | .ts | 220 | better-sqlite3 row casts、 RecommendationItem interface |

JS importer (index.js 等) は `import './<name>.js'` のままで OK
(tsx が解決)。 typecheck / lint 共に 0 errors。

## 次フェーズ
- meals.js / dig.js (中規模 LLM 系)
- agent-dispatch.js / llm.js
- diary.js (1400 LOC、 多分分割)
- db.js (3100 LOC、 domain split = phase 1 types と接合)
- index.js (5000 LOC、 domain router split = phase 2 types と接合)

🤖 Generated with [Claude Code](https://claude.com/claude-code)