### PR TITLE
feat(ts/phase-5): convert llm + agent-dispatch to TS

### DIFF
--- a/server/agent-dispatch.ts
+++ b/server/agent-dispatch.ts
@@ -1,36 +1,33 @@
-// agent-dispatch.js — Memoria task → AI agent (Claude Code / Codex / Gemini) を
+// agent-dispatch.ts — Memoria task → AI agent (Claude Code / Codex / Gemini) を
 // プロジェクトディレクトリで non-interactive に走らせ、stdout/stderr を log
 // ファイルにストリーム保存しながら DB の `agent_runs` 行を更新する。
-//
-// 既存の `runLlm` (server/llm.js) は短い LLM 質問用 (タイムアウト 3 分、結果を
-// 文字列で返す) なのでこちらの長尺・1 ショット実装用とは分けて持つ。
-//
-// Usage:
-//   const runId = startAgentRun(db, { task, project, agent });
-//   // returns immediately. The child runs in the background and updates
-//   // agent_runs by id when it exits.
 
-import { spawn } from 'node:child_process';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { mkdirSync, createWriteStream, existsSync, readFileSync, statSync } from 'node:fs';
 import { join, isAbsolute } from 'node:path';
+import type BetterSqlite3 from 'better-sqlite3';
 import {
-  insertAgentRun, updateAgentRun, getAgentRun, getTask, recordActivityEvent,
+  insertAgentRun, updateAgentRun, recordActivityEvent,
 } from './db.js';
+import type { AgentKind, AgentRunRow } from './db/types/agent.js';
+import type { TaskRow } from './db/types/task.js';
+import type { AgentProjectRow } from './db/types/agent.js';
 
-const SUPPORTED_AGENTS = new Set(['claude_code', 'codex', 'gemini']);
+type Db = BetterSqlite3.Database;
 
-// Track running children by run id so cancel() can find them.
-const _running = new Map();
+const SUPPORTED_AGENTS = new Set<AgentKind>(['claude_code', 'codex', 'gemini']);
 
-function ensureLogDir(dataDir) {
+const _running = new Map<number, ChildProcessWithoutNullStreams>();
+
+function ensureLogDir(dataDir: string): string {
   const dir = join(dataDir, 'agent_logs');
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
   return dir;
 }
 
-function buildPrompt({ task, project }) {
+function buildPrompt({ task, project }: { task: TaskRow; project: AgentProjectRow }): string {
   const rules = (project.rules || '').trim();
-  const lines = [
+  const lines: string[] = [
     `あなたはこのプロジェクトのコードを 1 ショットで実装するエージェントです。`,
     `止まらず最後まで実装し、完了したらサマリを 1 行出力して終了してください。`,
     '',
@@ -59,17 +56,16 @@ function buildPrompt({ task, project }) {
   return lines.join('\n');
 }
 
-// 各エージェントのデフォルトモデル (model 未指定時に使う)
-const AGENT_DEFAULT_MODEL = {
+const AGENT_DEFAULT_MODEL: Record<AgentKind, string> = {
   claude_code: 'sonnet',
   codex:       '5.3-codex',
   gemini:      'gemini-2.5-flash',
 };
 
-function buildArgs(agent, model) {
+function buildArgs(agent: AgentKind, model: string | null | undefined): string[] {
   const m = (model && String(model).trim()) || AGENT_DEFAULT_MODEL[agent] || '';
   if (agent === 'codex') {
-    const args = [
+    const args: string[] = [
       'exec',
       '--json',
       '--color', 'never',
@@ -81,41 +77,45 @@ function buildArgs(agent, model) {
     return args;
   }
   if (agent === 'gemini') {
-    const args = [];
+    const args: string[] = [];
     if (m) args.push('-m', m);
     args.push('-p');
     return args;
   }
   // claude_code (default)
-  const args = ['-p', '--dangerously-skip-permissions'];
+  const args: string[] = ['-p', '--dangerously-skip-permissions'];
   if (m) args.push('--model', m);
   return args;
 }
 
-function binaryFor(agent, settings) {
+function binaryFor(agent: AgentKind, settings: Record<string, string | null | undefined>): string {
   if (agent === 'codex') return settings['llm.bin.codex'] || 'codex';
   if (agent === 'gemini') return settings['llm.bin.gemini'] || 'gemini';
   return settings['llm.bin.claude'] || 'claude';
 }
 
+export interface StartAgentRunArgs {
+  dataDir: string;
+  settings?: Record<string, string | null | undefined>;
+  task: TaskRow;
+  project: AgentProjectRow;
+  agent?: AgentKind;
+  model?: string | null;
+  gitBashPath?: string | null;
+  timeoutMs?: number;
+}
+
 /**
  * Start an agent run. Returns the new run id immediately. The child process
  * runs in the background and updates the DB row when it exits.
- *
- * Args:
- *   db          — better-sqlite3 instance
- *   dataDir     — base data directory (logs go to dataDir/agent_logs/)
- *   settings    — getAppSettings(db) result; used for `llm.bin.*` overrides
- *   task        — { id, title, details, due_at }
- *   project     — { id, name, path, rules, default_agent }
- *   agent       — 'claude_code' | 'codex' | 'gemini'  (overrides project.default_agent)
- *   gitBashPath — optional CLAUDE_CODE_GIT_BASH_PATH override
- *   timeoutMs   — kill the child after this many ms (default 30 min)
  */
-export function startAgentRun(db, { dataDir, settings, task, project, agent, model, gitBashPath, timeoutMs = 30 * 60 * 1000 }) {
+export function startAgentRun(
+  db: Db,
+  { dataDir, settings, task, project, agent, model, gitBashPath, timeoutMs = 30 * 60 * 1000 }: StartAgentRunArgs,
+): number {
   if (!task) throw new Error('task required');
   if (!project) throw new Error('project required');
-  const a = agent || project.default_agent || 'claude_code';
+  const a: AgentKind = (agent || project.default_agent || 'claude_code') as AgentKind;
   if (!SUPPORTED_AGENTS.has(a)) throw new Error(`unsupported agent: ${a}`);
   if (!project.path || !isAbsolute(project.path)) {
     throw new Error('project.path must be an absolute path');
@@ -140,12 +140,13 @@ export function startAgentRun(db, { dataDir, settings, task, project, agent, mod
   });
 
   // Spawn after row exists so we always have a record even if spawn fails.
-  let child;
-  const bin = binaryFor(a, settings || {});
+  let child: ChildProcessWithoutNullStreams;
+  const settingsObj = settings || {};
+  const bin = binaryFor(a, settingsObj);
   const args = buildArgs(a, effectiveModel);
-  const env = { ...process.env };
-  if (a === 'claude_code' && (gitBashPath || settings?.['runtime.git_bash_path'])) {
-    env.CLAUDE_CODE_GIT_BASH_PATH = gitBashPath || settings['runtime.git_bash_path'];
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  if (a === 'claude_code' && (gitBashPath || settingsObj['runtime.git_bash_path'])) {
+    env.CLAUDE_CODE_GIT_BASH_PATH = gitBashPath || settingsObj['runtime.git_bash_path'] || '';
   }
   const stream = createWriteStream(logPath, { flags: 'a' });
   stream.write(`# agent: ${a}\n# model: ${effectiveModel || '(default)'}\n# bin: ${bin}\n# args: ${JSON.stringify(args)}\n# cwd: ${project.path}\n# started: ${new Date().toISOString()}\n# task: ${task.title}\n\n----- prompt -----\n${prompt}\n----- output -----\n`);
@@ -157,13 +158,14 @@ export function startAgentRun(db, { dataDir, settings, task, project, agent, mod
       shell: false,
       env,
     });
-  } catch (e) {
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
     updateAgentRun(db, runId, {
       status: 'failed',
       finished_at: new Date().toISOString(),
-      summary: `spawn failed: ${e.message}`,
+      summary: `spawn failed: ${msg}`,
     });
-    stream.write(`\n----- spawn error -----\n${e.message}\n`);
+    stream.write(`\n----- spawn error -----\n${msg}\n`);
     stream.end();
     return runId;
   }
@@ -173,23 +175,26 @@ export function startAgentRun(db, { dataDir, settings, task, project, agent, mod
 
   recordActivityEvent(db, {
     kind: 'task_updated',
+    occurred_at: undefined,
+    source: undefined,
+    ref_id: undefined,
     content: `[AI実装開始] ${task.title} (${a}${effectiveModel ? `:${effectiveModel}` : ''})`,
     metadata: { agent_run_id: runId, agent: a, model: effectiveModel || null, project: project.name },
   });
 
-  let timer = setTimeout(() => {
-    try { child.kill('SIGKILL'); } catch {}
+  const timer = setTimeout(() => {
+    try { child.kill('SIGKILL'); } catch { /* ignore */ }
   }, timeoutMs);
 
-  child.stdout.on('data', (d) => stream.write(d));
-  child.stderr.on('data', (d) => {
+  child.stdout.on('data', (d: Buffer) => stream.write(d));
+  child.stderr.on('data', (d: Buffer) => {
     stream.write(`[stderr] `);
     stream.write(d);
   });
-  child.on('error', (err) => {
+  child.on('error', (err: Error) => {
     stream.write(`\n----- error -----\n${err.message}\n`);
   });
-  child.on('close', (code) => {
+  child.on('close', (code: number | null) => {
     clearTimeout(timer);
     _running.delete(runId);
     const finishedAt = new Date().toISOString();
@@ -198,7 +203,7 @@ export function startAgentRun(db, { dataDir, settings, task, project, agent, mod
       const tail = readFileSync(logPath, 'utf8').slice(-2000);
       const lines = tail.split('\n').filter(l => l.trim()).slice(-6);
       summary = lines.join('\n').slice(-600);
-    } catch {}
+    } catch { /* ignore */ }
     stream.write(`\n----- finished -----\nexit: ${code}\nat: ${finishedAt}\n`);
     stream.end();
     updateAgentRun(db, runId, {
@@ -209,21 +214,25 @@ export function startAgentRun(db, { dataDir, settings, task, project, agent, mod
     });
     recordActivityEvent(db, {
       kind: code === 0 ? 'task_done' : 'task_updated',
+      occurred_at: undefined,
+      source: undefined,
+      ref_id: undefined,
       content: `[AI実装${code === 0 ? '完了' : '失敗'}] ${task.title}`,
       metadata: { agent_run_id: runId, exit_code: code },
     });
   });
 
-  // long prompt is passed via stdin (per Windows ENAMETOOLONG handling).
   child.stdin.end(prompt, 'utf8');
   return runId;
 }
 
-export function cancelAgentRun(db, runId) {
+export function cancelAgentRun(db: Db, runId: number): { ok: true } | { ok: false; error: string } {
   const child = _running.get(runId);
   if (!child) return { ok: false, error: 'not_running' };
-  try { child.kill('SIGKILL'); } catch (e) {
-    return { ok: false, error: e.message };
+  try {
+    child.kill('SIGKILL');
+  } catch (e: unknown) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
   }
   updateAgentRun(db, runId, {
     status: 'cancelled',
@@ -236,7 +245,11 @@ export function cancelAgentRun(db, runId) {
  * Read the log file for a run. `tail` controls how many bytes from the end
  * to return (default 64KiB).
  */
-export function readAgentRunLog(dataDir, run, { tail = 64 * 1024 } = {}) {
+export function readAgentRunLog(
+  dataDir: string,
+  run: AgentRunRow | null | undefined,
+  { tail = 64 * 1024 }: { tail?: number } = {},
+): string {
   if (!run?.log_path) return '';
   const path = join(dataDir, 'agent_logs', run.log_path);
   if (!existsSync(path)) return '';
@@ -246,6 +259,6 @@ export function readAgentRunLog(dataDir, run, { tail = 64 * 1024 } = {}) {
   return buf.subarray(buf.length - len).toString('utf8');
 }
 
-export function isRunning(runId) {
+export function isRunning(runId: number): boolean {
   return _running.has(runId);
 }

--- a/server/llm.ts
+++ b/server/llm.ts
@@ -1,27 +1,23 @@
 // LLM dispatch — every place that used to call `spawn('claude', ...)` should
 // route through runLlm({ task, prompt, ... }) so the user can pick a provider
 // per task: Claude CLI, Gemini CLI, Codex CLI, or the OpenAI Chat API.
-//
-// Per-task config is loaded once at startup (and re-loaded on PATCH) from
-// app_settings. Tasks recognised at the moment:
-//   summarize, dig, dig_preview, cloud_extract, cloud_validate,
-//   domain_classify, page_summary,
-//   diary_work, diary_highlights, diary_weekly,
-//   meal_vision (画像入力あり — Claude CLI 推奨),
-//   meal_calorie (食品名テキスト → 標準カロリー推定)
 
-import { spawn } from 'node:child_process';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 
-export const TASKS = [
+export type LlmTaskName =
+  | 'summarize' | 'dig' | 'dig_preview' | 'cloud_extract' | 'cloud_validate'
+  | 'domain_classify' | 'page_summary'
+  | 'diary_work' | 'diary_highlights' | 'diary_weekly'
+  | 'meal_vision' | 'meal_calorie';
+
+export const TASKS: LlmTaskName[] = [
   'summarize', 'dig', 'dig_preview', 'cloud_extract', 'cloud_validate',
   'domain_classify', 'page_summary',
   'diary_work', 'diary_highlights', 'diary_weekly',
   'meal_vision', 'meal_calorie',
 ];
 
-// When the user hasn't explicitly chosen a model for a task, fall back to these.
-// Sonnet for cheap repeated work; Opus 1M for the integrative narratives.
-const TASK_DEFAULT_MODELS = {
+const TASK_DEFAULT_MODELS: Partial<Record<LlmTaskName, string>> = {
   domain_classify: 'sonnet',
   page_summary: 'sonnet',
   diary_work: 'sonnet',
@@ -31,47 +27,31 @@ const TASK_DEFAULT_MODELS = {
   meal_calorie: 'sonnet',
 };
 
-export const PROVIDERS = {
-  algorithm: {
-    label: 'アルゴリズム (AI なし)',
-    kind: 'none',
-    supportsTools: false,
-    supportsModel: false,
-  },
-  claude: {
-    label: 'Claude CLI',
-    kind: 'cli',
-    defaultBin: 'claude',
-    supportsTools: true,
-    supportsModel: true,
-  },
-  codex: {
-    label: 'Codex CLI',
-    kind: 'cli',
-    defaultBin: 'codex',
-    supportsTools: false,
-    supportsModel: true,
-    jsonOutput: true,
-  },
-  gemini: {
-    label: 'Gemini CLI',
-    kind: 'cli',
-    defaultBin: 'gemini',
-    supportsTools: false,
-    supportsModel: true,
-  },
-  openai: {
-    label: 'OpenAI API',
-    kind: 'api',
-    supportsTools: false,
-    supportsModel: true,
-  },
+export type LlmProviderKey = 'algorithm' | 'claude' | 'codex' | 'gemini' | 'openai';
+
+export interface LlmProviderInfo {
+  label: string;
+  kind: 'cli' | 'api' | 'none';
+  defaultBin?: string;
+  supportsTools: boolean;
+  supportsModel: boolean;
+  jsonOutput?: boolean;
+}
+
+export const PROVIDERS: Record<LlmProviderKey, LlmProviderInfo> = {
+  algorithm: { label: 'アルゴリズム (AI なし)', kind: 'none', supportsTools: false, supportsModel: false },
+  claude:    { label: 'Claude CLI', kind: 'cli', defaultBin: 'claude', supportsTools: true, supportsModel: true },
+  codex:     { label: 'Codex CLI', kind: 'cli', defaultBin: 'codex', supportsTools: false, supportsModel: true, jsonOutput: true },
+  gemini:    { label: 'Gemini CLI', kind: 'cli', defaultBin: 'gemini', supportsTools: false, supportsModel: true },
+  openai:    { label: 'OpenAI API', kind: 'api', supportsTools: false, supportsModel: true },
 };
 
-// 各 provider で選べる主要モデル一覧。空文字 id = provider のデフォルトを使う。
-// 現行モデル (2026-05 時点) を網羅。新しいモデルが出たらここに追加すれば
-// UI のドロップダウンが自動で更新される。
-export const PROVIDER_MODELS = {
+export interface LlmModelOption {
+  id: string;
+  label: string;
+}
+
+export const PROVIDER_MODELS: Record<LlmProviderKey, LlmModelOption[]> = {
   algorithm: [],
   claude: [
     { id: 'sonnet',                 label: 'Sonnet 4.6 (default)' },
@@ -96,35 +76,43 @@ export const PROVIDER_MODELS = {
   ],
 };
 
-// 各 provider の既定モデル ID (model 未指定時に runCli で渡す値)。
-export const PROVIDER_DEFAULT_MODEL = {
+export const PROVIDER_DEFAULT_MODEL: Partial<Record<LlmProviderKey, string>> = {
   claude: 'sonnet',
   codex:  '5.3-codex',
   gemini: 'gemini-2.5-flash',
   openai: 'gpt-4o-mini',
 };
 
-let cfg = {
-  tasks: Object.fromEntries(TASKS.map(t => [t, { provider: 'claude' }])),
+interface LlmTaskConfig {
+  provider: LlmProviderKey;
+  model?: string;
+}
+
+interface LlmRuntimeConfig {
+  tasks: Partial<Record<LlmTaskName, LlmTaskConfig>>;
+  bins: { claude: string; gemini: string; codex: string };
+  openai_api_key: string;
+  openai_model: string;
+  git_bash_path: string;
+}
+
+let cfg: LlmRuntimeConfig = {
+  tasks: Object.fromEntries(TASKS.map(t => [t, { provider: 'claude' as LlmProviderKey }])) as Partial<Record<LlmTaskName, LlmTaskConfig>>,
   bins: { claude: 'claude', gemini: 'gemini', codex: 'codex' },
   openai_api_key: '',
   openai_model: 'gpt-4o-mini',
-  // Windows users running the Claude CLI from a packaged Node child need
-  // CLAUDE_CODE_GIT_BASH_PATH set or the CLI dies looking for bash. The
-  // desktop app stashes its discovery here.
   git_bash_path: '',
 };
 
-export function getLlmConfig() {
+export function getLlmConfig(): LlmRuntimeConfig {
   return JSON.parse(JSON.stringify(cfg));
 }
 
-export function loadLlmConfigFromSettings(settings) {
-  // settings is the { key: value } map from app_settings.
-  const tasks = {};
+export function loadLlmConfigFromSettings(settings: Record<string, string | null | undefined>): void {
+  const tasks: Partial<Record<LlmTaskName, LlmTaskConfig>> = {};
   for (const t of TASKS) {
     tasks[t] = {
-      provider: settings[`llm.${t}.provider`] || 'claude',
+      provider: (settings[`llm.${t}.provider`] || 'claude') as LlmProviderKey,
       model: settings[`llm.${t}.model`] || '',
     };
   }
@@ -141,10 +129,16 @@ export function loadLlmConfigFromSettings(settings) {
   };
 }
 
-export function settingsPatchFromConfig(patch) {
-  // Convert a partial { tasks, bins, openai_api_key, openai_model } back into
-  // app_settings flat keys.
-  const out = {};
+export interface LlmConfigPatch {
+  tasks?: Partial<Record<LlmTaskName, Partial<LlmTaskConfig>>>;
+  bins?: Partial<{ claude: string; gemini: string; codex: string }>;
+  openai_api_key?: string;
+  openai_model?: string;
+  git_bash_path?: string;
+}
+
+export function settingsPatchFromConfig(patch: LlmConfigPatch): Record<string, string> {
+  const out: Record<string, string> = {};
   if (patch.tasks) {
     for (const [t, v] of Object.entries(patch.tasks)) {
       if (v?.provider !== undefined) out[`llm.${t}.provider`] = v.provider;
@@ -152,7 +146,9 @@ export function settingsPatchFromConfig(patch) {
     }
   }
   if (patch.bins) {
-    for (const [k, v] of Object.entries(patch.bins)) out[`llm.bin.${k}`] = v;
+    for (const [k, v] of Object.entries(patch.bins)) {
+      if (v !== undefined) out[`llm.bin.${k}`] = v;
+    }
   }
   if (patch.openai_api_key !== undefined) out['llm.openai.api_key'] = patch.openai_api_key;
   if (patch.openai_model !== undefined)   out['llm.openai.model']   = patch.openai_model;
@@ -160,36 +156,33 @@ export function settingsPatchFromConfig(patch) {
   return out;
 }
 
+export interface RunLlmArgs {
+  task: LlmTaskName;
+  prompt: string;
+  tools?: string[];
+  timeoutMs?: number;
+}
+
 /**
  * Run an LLM call for a named task. Falls back to Claude CLI if the configured
  * provider isn't usable (e.g. OpenAI selected but no API key set).
- *
- * Args:
- *   task        — one of TASKS
- *   prompt      — the full prompt text (sent over stdin for CLIs)
- *   tools       — optional array (e.g. ['WebSearch', 'WebFetch']) only honoured
- *                 by providers that support it (claude)
- *   timeoutMs
  */
-export async function runLlm({ task, prompt, tools = undefined, timeoutMs = 180_000 }) {
-  const taskCfg = cfg.tasks[task] || { provider: 'claude' };
-  let provider = taskCfg.provider || 'claude';
-  // Fallback: OpenAI without a key drops back to claude.
+export async function runLlm({ task, prompt, tools, timeoutMs = 180_000 }: RunLlmArgs): Promise<string> {
+  const taskCfg = cfg.tasks[task] || { provider: 'claude' as LlmProviderKey };
+  let provider: LlmProviderKey = taskCfg.provider || 'claude';
   if (provider === 'openai' && !cfg.openai_api_key) provider = 'claude';
   const p = PROVIDERS[provider];
   if (!p) throw new Error(`unknown provider: ${provider}`);
-  // 'algorithm' provider = "AI なし" 指定。タスクごとに deterministic な
-  // 代替を持たせる責務は呼び出し側にあるので、ここでは空文字を返す。
   if (p.kind === 'none') return '';
   if (p.kind === 'api') {
     return runOpenAi({
       apiKey: cfg.openai_api_key,
-      model: taskCfg.model || cfg.openai_model || PROVIDER_DEFAULT_MODEL.openai,
+      model: taskCfg.model || cfg.openai_model || PROVIDER_DEFAULT_MODEL.openai || 'gpt-4o-mini',
       prompt, timeoutMs,
     });
   }
   // CLI providers
-  const bin = cfg.bins[provider] || p.defaultBin;
+  const bin = (cfg.bins as Record<string, string>)[provider] || p.defaultBin || provider;
   const modelToUse = taskCfg.model || TASK_DEFAULT_MODELS[task] || PROVIDER_DEFAULT_MODEL[provider] || '';
   const args = buildCliArgs({
     provider,
@@ -198,8 +191,6 @@ export async function runLlm({ task, prompt, tools = undefined, timeoutMs = 180_
     supportsModel: p.supportsModel,
     supportsTools: p.supportsTools,
   });
-  // Pass CLAUDE_CODE_GIT_BASH_PATH to the Claude CLI on Windows. Configured
-  // via settings → runtime.git_bash_path; falls back to the parent env.
   const env = { ...process.env };
   if (provider === 'claude' && cfg.git_bash_path) {
     env.CLAUDE_CODE_GIT_BASH_PATH = cfg.git_bash_path;
@@ -207,9 +198,17 @@ export async function runLlm({ task, prompt, tools = undefined, timeoutMs = 180_
   return runCli({ bin, args, prompt, timeoutMs, env, label: provider, jsonOutput: !!p.jsonOutput });
 }
 
-function buildCliArgs({ provider, model, tools, supportsModel, supportsTools }) {
+function buildCliArgs({
+  provider, model, tools, supportsModel, supportsTools,
+}: {
+  provider: LlmProviderKey;
+  model: string;
+  tools: string[] | undefined;
+  supportsModel: boolean;
+  supportsTools: boolean;
+}): string[] {
   if (provider === 'codex') {
-    const args = [
+    const args: string[] = [
       'exec',
       '--json',
       '--color', 'never',
@@ -220,20 +219,29 @@ function buildCliArgs({ provider, model, tools, supportsModel, supportsTools }) 
     args.push('-');
     return args;
   }
-
-  const args = ['-p'];
+  const args: string[] = ['-p'];
   if (model && supportsModel) args.push('--model', model);
-  if (tools && supportsTools) args.push('--allowedTools', tools.join(','));
+  if (tools && tools.length && supportsTools) args.push('--allowedTools', tools.join(','));
   return args;
 }
 
-function runCli({ bin, args, prompt, timeoutMs, env, label, jsonOutput = false }) {
+function runCli({
+  bin, args, prompt, timeoutMs, env, label, jsonOutput = false,
+}: {
+  bin: string;
+  args: string[];
+  prompt: string;
+  timeoutMs: number;
+  env: NodeJS.ProcessEnv;
+  label: string;
+  jsonOutput?: boolean;
+}): Promise<string> {
   return new Promise((resolve, reject) => {
-    let child;
+    let child: ChildProcessWithoutNullStreams;
     try {
       child = spawn(bin, args, { stdio: ['pipe', 'pipe', 'pipe'], shell: false, env });
-    } catch (e) {
-      reject(new Error(`spawn ${bin}: ${e.message}`));
+    } catch (e: unknown) {
+      reject(new Error(`spawn ${bin}: ${e instanceof Error ? e.message : String(e)}`));
       return;
     }
     let stdout = '', stderr = '';
@@ -253,11 +261,11 @@ function runCli({ bin, args, prompt, timeoutMs, env, label, jsonOutput = false }
   });
 }
 
-function extractCodexLastMessage(raw) {
+function extractCodexLastMessage(raw: string): string {
   let lastText = '';
   const lines = raw.split(/\r?\n/).filter(l => l.trim());
   for (const line of lines) {
-    let obj;
+    let obj: unknown;
     try { obj = JSON.parse(line); } catch { continue; }
     const text = extractTextFromCodexEvent(obj);
     if (text) lastText = text;
@@ -265,16 +273,24 @@ function extractCodexLastMessage(raw) {
   return lastText || raw;
 }
 
-function extractTextFromCodexEvent(obj) {
+interface CodexEvent {
+  message?: unknown;
+  text?: unknown;
+  delta?: unknown;
+  payload?: { message?: unknown; text?: unknown; delta?: unknown } & Record<string, unknown>;
+}
+
+function extractTextFromCodexEvent(obj: unknown): string {
   if (!obj || typeof obj !== 'object') return '';
-  const candidates = [
-    obj.message,
-    obj.text,
-    obj.delta,
-    obj.payload?.message,
-    obj.payload?.text,
-    obj.payload?.delta,
-    obj.payload,
+  const o = obj as CodexEvent;
+  const candidates: unknown[] = [
+    o.message,
+    o.text,
+    o.delta,
+    o.payload?.message,
+    o.payload?.text,
+    o.payload?.delta,
+    o.payload,
   ];
   for (const candidate of candidates) {
     const text = extractContentText(candidate);
@@ -283,19 +299,33 @@ function extractTextFromCodexEvent(obj) {
   return '';
 }
 
-function extractContentText(value) {
+interface ContentLike {
+  role?: unknown;
+  content?: unknown;
+  text?: unknown;
+}
+
+function extractContentText(value: unknown): string {
   if (!value) return '';
   if (typeof value === 'string') return value;
   if (Array.isArray(value)) return value.map(extractContentText).filter(Boolean).join('\n');
   if (typeof value !== 'object') return '';
-  if (value.role && value.role !== 'assistant') return '';
-  if (typeof value.content === 'string') return value.content;
-  if (Array.isArray(value.content)) return extractContentText(value.content);
-  if (typeof value.text === 'string') return value.text;
+  const v = value as ContentLike;
+  if (v.role && v.role !== 'assistant') return '';
+  if (typeof v.content === 'string') return v.content;
+  if (Array.isArray(v.content)) return extractContentText(v.content);
+  if (typeof v.text === 'string') return v.text;
   return '';
 }
 
-async function runOpenAi({ apiKey, model, prompt, timeoutMs }) {
+async function runOpenAi({
+  apiKey, model, prompt, timeoutMs,
+}: {
+  apiKey: string;
+  model: string;
+  prompt: string;
+  timeoutMs: number;
+}): Promise<string> {
   if (!apiKey) throw new Error('OpenAI API key is not configured');
   const ac = new AbortController();
   const timer = setTimeout(() => ac.abort(), timeoutMs);
@@ -317,7 +347,7 @@ async function runOpenAi({ apiKey, model, prompt, timeoutMs }) {
       const body = (await res.text()).slice(0, 400);
       throw new Error(`OpenAI ${res.status}: ${body}`);
     }
-    const data = await res.json();
+    const data = await res.json() as { choices?: { message?: { content?: string } }[] };
     return data.choices?.[0]?.message?.content || '';
   } finally {
     clearTimeout(timer);


### PR DESCRIPTION
## TS 化フェーズ 5 — LLM コア層

llm.ts と agent-dispatch.ts を strict TS 化。 これで provider/model/agent
語彙が server 全体で一貫して typed になる。

| from | to | LOC | 内容 |
|---|---|---|---|
| llm.js | .ts | 367 | LlmTaskName / LlmProviderKey 型化、 PROVIDER_MODELS / PROVIDER_DEFAULT_MODEL を Record<> に、 codex JSON event extraction も typed |
| agent-dispatch.js | .ts | 270 | StartAgentRunArgs / cancelAgentRun / readAgentRunLog typed、 phase 1 row 型 (AgentKind / TaskRow / AgentProjectRow / AgentRunRow) を直接 import |

## 残課題
- meals.js (239 LOC) / dig.js (226 LOC) — 中規模
- diary.js (1400 LOC) — God-object 候補、 phase 6 で分割推奨
- db.js (3100 LOC) — domain split + phase 1 types 接合
- index.js (5000 LOC) — domain router split + phase 2 types 接合

🤖 Generated with [Claude Code](https://claude.com/claude-code)