### PR TITLE
docs(spec): add per-feature spec with sharing/privacy notes

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -9,7 +9,8 @@
 ```
 spec/
 ├── db/         ← SQLite テーブル定義 (列・index・制約)
-└── api/        ← HTTP API 契約 (request / response)
+├── api/        ← HTTP API 契約 (request / response)
+└── feature/    ← 機能仕様 (シェア可能性 + プライバシー注記付き)
 ```
 
 ## ルール

--- a/spec/feature/README.md
+++ b/spec/feature/README.md
@@ -1,0 +1,54 @@
+# `spec/feature/` — 機能仕様 (シェア可能性 + プライバシー注記付き)
+
+このフォルダは Memoria の **機能単位** のドキュメント。 1 機能 1 ファイルで「何のための機能か / どこから入るか / どのテーブル / どの API / Hub にシェアできるか / 個人データはどこに溜まるか」 を簡潔にまとめる。
+
+`spec/db/` (テーブル) と `spec/api/` (HTTP) を **横串で読み解くインデックス**として機能する。
+
+## 共有レベル
+- ✓ **Hub-shareable** — `/api/multi/share` 経由で Hub に共有可能 (明示的シェア操作のみ、 read-public + write-relay-only via Imperativus)
+- 🏠 **local-only** — Hub 共有経路なし。 ローカル個人 DB 限定
+- 📊 **derived-only** — 派生統計値のみ (raw データは出ない)
+
+## 機能一覧
+
+| 機能名 | ファイル | 共有レベル | 備考 |
+|---|---|---|---|
+| Web ブックマーク | [bookmark.md](bookmark.md) | ✓ | url + title + summary + memo + categories のみ。 HTML スナップショットは出ない |
+| 調査セッション (Dig) | [dig.md](dig.md) | ✓ | query + Phase 2 result のみ。 raw SERP / preview は出ない |
+| 個人辞書 | [dictionary.md](dictionary.md) | ✓ | term + definition + notes。 出典 (dictionary_links) は出ない。 受信側は `term (@owner)` で namespace 化 |
+| ワードクラウド | [wordcloud.md](wordcloud.md) | 🏠 | 元 bookmark / dig のシェア経由で各自再生成 |
+| 日次自動日記 | [diary.md](diary.md) | 🏠 | 個人情報密度最高。 シェア経路なし |
+| 週次レポート | [weekly.md](weekly.md) | 🏠 | 日記と同じ理由 |
+| ドメイン辞書 | [domain-catalog.md](domain-catalog.md) | 🏠 | ブラウジング履歴の蒸留 |
+| タスク管理 | [task.md](task.md) | ✓ | Hub ではなく **Actio** に共有 (`/api/tasks/:id/share/actio`) |
+| エージェント実行 | [agent.md](agent.md) | 🏠 | 絶対パス + プロンプト + コードログを含む |
+| 作業場所 + presence | [workplace.md](workplace.md) | ✓ | カタログ (lat/lng + 名前 + tags) と presence (enter/leave) の 2 系統 |
+| 実装自慢ノート | [implementation-notes.md](implementation-notes.md) | ✓ | `shareable=1` フラグ必須の二段階フロー |
+| 食事写真 + 栄養推定 | [meal.md](meal.md) | 🏠 | 健康情報の機微度を考慮した意図的 local-only |
+| GPS 軌跡 | [gps.md](gps.md) | 🏠 | Tailscale 経由が推奨。 workplace presence は別系統で出る |
+| ブラウジング履歴 | [visit.md](visit.md) | 🏠 | bookmark に昇格させて初めてシェア可能 |
+| PWA Web Push | [push-notification.md](push-notification.md) | 🏠 | 端末固有の機微鍵を含む |
+| Memoria Hub プレゼンス | [multi-hub.md](multi-hub.md) | ✓ | この機能自体が Hub 連携の入口 |
+| Legatus → Memoria GPS 転送 | [legatus-subscriber.md](legatus-subscriber.md) | 🏠 | loopback / tailnet 内で完結 |
+| 外部 chat 取り込み | [external-chat.md](external-chat.md) | 🏠 | チャネル名 / 個人発言を含む |
+| MCP server autostart | [mcp-server.md](mcp-server.md) | 🏠 | Claude Desktop / Code 連携 (ローカル stdio) |
+| サーバ稼働 / heartbeat | [uptime.md](uptime.md) | 🏠 | PC 起動時間ログ |
+| LLM プロバイダ設定 | [llm-config.md](llm-config.md) | 🏠 | OpenAI API key 等を含む |
+| プライバシー設定 | [privacy-settings.md](privacy-settings.md) | 🏠 | feature flag 集中管理 |
+| ストップワード | [stopwords.md](stopwords.md) | 🏠 | wordcloud 除外語 |
+
+## 凡例 (項目)
+各 feature ファイルは以下のセクションを順序固定で持つ:
+
+1. **概要** — 機能を 1-2 文で
+2. **ユースケース** — どんな場面で使うか
+3. **画面 / 入口** — UI 上どこから入るか
+4. **データ** — 主要 SQLite テーブル + 物理ファイル
+5. **API** — 関連 endpoint
+6. **シェア可能か** — Hub-shareable / local-only / derived-only + 共有フィールドの具体
+7. **プライバシー観点** — 個人データ / LLM 送信範囲 / 削除時の挙動
+
+## 参考
+- 個人データ保管禁止ルール (LUDIARS 全体): 個人データは Cernere が単一ソース。 Memoria は **個人ローカルツール** として例外的に大量保持するが、 Hub に出すのは明示的 share 操作分のみ
+- Memoria online (Hub) は **read-public + write-relay-only** (PR #17、 Imperativus 経由)
+- センシティブ情報 (GPS / 長期 WS / MQTT) は Tailscale 経由が推奨

--- a/spec/feature/agent.md
+++ b/spec/feature/agent.md
@@ -1,0 +1,33 @@
+# agent — Claude / Gemini / Codex エージェント実行
+
+## 概要
+タスクから AI コーディングエージェント (Claude Code / Codex / Gemini CLI) を spawn し、 stdout / stderr をストリーム保存しながら実装させる。 cwd と rules は `agent_projects` で管理。
+
+## ユースケース
+- タスクをそのまま AI に委託 (「このタスク実装してリポに push して」)
+- リポジトリごとにルール (`AGENTS.md` 相当の rules フィールド) を切り替え
+- 走行ログを後から検証 / cancel
+- task_id 紐付けと project_id 紐付けの両方で走らせ履歴を残す
+
+## 画面 / 入口
+- `🗄 データベース` タブ → タスク詳細 → `AI 委託` ボタン
+- `agent-projects` 一覧画面でプロジェクト追加 (パス + 名前 + rules + default_agent)
+
+## データ
+- [agent_projects](../db/agent.md) — name / path (絶対パス) / rules (Markdown) / default_agent
+- [agent_runs](../db/agent.md) — task_id / project_id / agent / model / prompt / status (pending/running/done/failed/cancelled) / pid / log_path / summary
+- ログ本体: `<DATA>/agent_logs/<file>` に stdout/stderr を tee
+
+## API
+- [agent.md](../api/agent.md) — `/api/agent-projects*` (CRUD) / `/api/agent-runs*` (一覧 / 詳細 / log / cancel) / `/api/tasks/:id/agent-run` (起動)
+
+## シェア可能か
+**local-only**
+
+エージェント実行ログは個人 dev 環境の絶対パス + プロンプト + コード変更内容を含むためシェア不可。
+
+## プライバシー観点
+- **個人データを保持するテーブル**: `agent_projects` (リポ絶対パス)、 `agent_runs` (プロンプト全体 + summary、 stdout に source code も含まれる)。 `<DATA>/agent_logs/` は機微度高め。
+- **LLM プロバイダに送る情報**: ユーザのタスク title + details + agent_projects.rules + 環境情報 (cwd) を、 spawn された CLI (claude / codex / gemini) が **ユーザの API key** で送る。 Memoria サーバ自身が直接 API を叩くわけではなく、 ローカル CLI が転送する形。 Windows では `runtime.git_bash_path` 経由で起動 (memory `feedback_claude_cli_windows_bash.md`)。
+- **共有時に外部に出ない情報**: 全部 (シェア対象外)。
+- **削除時の挙動**: `DELETE /api/agent-projects/:id` で project 行のみ削除。 関連 `agent_runs` は **残置** (project_id が orphan)。 走行ログファイル (`<DATA>/agent_logs/`) も自動削除しない (手動 cleanup)。

--- a/spec/feature/bookmark.md
+++ b/spec/feature/bookmark.md
@@ -1,0 +1,55 @@
+# bookmark — Web ブックマーク
+
+## 概要
+URL + ローカル HTML スナップショット + AI 要約をセットで保存するブックマーク機能。 Chrome 拡張からの POST、 SPA からの URL 貼り付け、 PWA Web Share Target、 Hub からのダウンロードが入口。
+
+## ユースケース
+- 後で読み直したいページを HTML 込みで保存し、 元サイトが消えても残す
+- AI 要約 + メモ + カテゴリで「あとで検索できる個人アーカイブ」 を作る
+- アクセス回数 / 最終アクセスを基にした重要度ランキング (`accessed_desc` ソート、 おすすめタブの recommendation)
+- Hub にシェアして他人 (LUDIARS Memoria 利用者) にも見せる
+
+## 画面 / 入口
+- `🗄 データベース` タブ → サブビュー `ブックマーク` (デフォルトビュー)
+- `+ 追加` ボタン (`/api/bookmarks/from-url`)
+- Chrome 拡張 (`extension/`) → `POST /api/bookmark` (HTML 込み)
+- PWA Web Share Target → `GET /share?url=…` (`misc.ts` の `extractShareUrl`)
+- Hub からのダウンロード: マルチビュー → 検索 → ダウンロード (`/api/multi/download` kind=bookmark)
+
+## データ
+- [bookmarks](../db/bookmark.md) — 主テーブル (URL / title / html_path / summary / status / owner_user_id …)
+- [bookmark_categories](../db/bookmark.md) — many-to-many カテゴリ (CASCADE)
+- [accesses](../db/bookmark.md) — アクセス履歴 1 件 1 行 (CASCADE)
+- HTML 本文は **DB ではなく** `<DATA>/html/<file>.html` に格納 (DB には `html_path` のみ)
+- ワードクラウド: [word_clouds](../db/wordcloud.md) (origin=bookmark / origin_bookmark_id, CASCADE)
+
+## API
+- [bookmark.md](../api/bookmark.md) — `/api/bookmark` (拡張投稿) / `/api/bookmarks*` (CRUD + ページング + html / wordcloud / accesses) / `/api/bookmarks/from-url`
+- 関連: [misc.md](../api/misc.md) `/api/export` `/api/import` (HTML 込み JSON dump)
+- 関連: [multi.md](../api/multi.md) `/api/multi/share` (kind=bookmark) / `/api/multi/download`
+
+## シェア可能か
+**Hub-shareable** (明示的シェア操作のみ)
+
+シェアされるフィールド:
+
+| field | 内容 |
+|---|---|
+| `url` | 元 URL |
+| `title` | ページタイトル |
+| `summary` | AI 要約 (Claude) |
+| `memo` | ユーザメモ |
+| `categories[]` | カテゴリ名 |
+
+シェア**されない**フィールド:
+- `html_path` (HTML スナップショット本体)。 Hub 側にシェアされるのはあくまで URL + 要約 + メモであり、 オリジナル HTML はローカルに留まる。 ダウンロード側は受信時にあらためて URL を fetch (`fetchPageHtml`)。
+- `accesses` (アクセス履歴)、 `access_count`, `last_accessed_at`
+- ローカル独自の `id`, `status`, `error`
+
+経路: **write-relay-only via Imperativus** (memory `feedback_memoria_online_flow.md`)。 `POST /api/multi/share` → ローカル DB の `shared_at` / `shared_origin` に印付け → Hub の `/api/shared/bookmarks` に POST (Cernere JWT 必須)。 直接書込みエンドポイントは PR #17 で削除済。
+
+## プライバシー観点
+- **個人データを保持するテーブル**: `bookmarks` (URL は閲覧履歴に等しい)、 `accesses` (いつ何を読み返したか)、 HTML スナップショットファイル (本文の完全コピー)。
+- **LLM プロバイダに送る情報**: 要約タスク (`summarize`) で **HTML 本文のテキスト化結果**を Claude / OpenAI / Gemini / Codex (ユーザが LLM 設定で選択) に送る。 ローカル CLI 経由 (`claude` / `gemini` / `codex` バイナリ) のため、 ユーザ自身の API key スコープでだけ送信される。 ワードクラウド (`/api/bookmarks/:id/wordcloud`) も同じく本文を送る。
+- **共有時に外部に出ない情報**: HTML スナップショット、 アクセス履歴、 ユーザメモのうち shareable 操作で除外したもの。
+- **削除時の挙動**: `DELETE /api/bookmarks/:id` で `bookmarks` 行と CASCADE で `bookmark_categories` / `accesses` / `word_clouds` (origin_bookmark_id) を削除し、 ファイルシステム上の HTML も `unlinkSync`。 Hub にシェア済の場合は **Hub 側は残る** (現状自動 retraction なし)。

--- a/spec/feature/diary.md
+++ b/spec/feature/diary.md
@@ -1,0 +1,35 @@
+# diary — 日次自動日記
+
+## 概要
+1 日 1 行の自動生成日記。 ブラウジング / dig / GitHub commit / activity_events / GPS / 食事を集約し、 Sonnet が「作業内容」、 Opus 1M が「全体サマリ」 + 「ハイライト」 を生成。 ユーザの `notes` 欄は手動で追記可能。
+
+## ユースケース
+- 「昨日何やったっけ」 を 30 秒で振り返る
+- ハイライト + GitHub commit でいつ何を書いたか辿る
+- タスクの開始 / 完了が自動で `notes` に追記される (`appendTaskDiaryLog`)
+- 任意の追加指示 (`improve`) を 1 度だけ流して再生成
+
+## 画面 / 入口
+- `📅 日記` タブ → 月別カレンダー → 日付クリックで詳細
+- 詳細パネル: live_metrics / summary / work_content / highlights / notes / `生成` ボタン
+- ページング: `/api/diary/:date/bookmarks` `/api/diary/:date/digs` (1 日のブクマ / dig が多いと WebView がフリーズするため分離)
+
+## データ
+- [diary_entries](../db/diary.md) — date (PK) / summary / work_content / highlights / notes / metrics_json / github_commits_json / work_minutes / status
+- [diary_settings](../db/diary.md) — GitHub PAT / user / repos の key/value (`app_settings` ではなく専用テーブル)
+- 集計参照: [activity_events](../db/activity.md), [page_visits / visit_events](../db/visit.md), [bookmarks / accesses](../db/bookmark.md), [dig_sessions](../db/dig.md), [meals](../db/meal.md), [gps_locations](../db/gps.md)
+- サイドカー: 太い `metrics_json` / `github_commits_json` は `<DATA>/diary/<date>.json` に切り出し (`migrateDiariesToSidecar`)
+
+## API
+- [diary.md](../api/diary.md) — `/api/diary*` (月一覧 / 詳細 / 生成キュー / 編集 / 削除) / `/api/diary/settings` / `/api/diary/test-github` / `/api/diary/:date/bookmarks` / `/api/diary/:date/digs`
+
+## シェア可能か
+**local-only**
+
+日記そのものは Hub にシェアできない (`/api/multi/share` 対象外)。 個人の生活ログ全集約のため、 共有路を意図的に持たせていない。
+
+## プライバシー観点
+- **個人データを保持するテーブル**: `diary_entries` (個人情報密度が最高クラス: その日の作業内容 + ハイライト + 自由記述メモ)、 `diary_settings` (GitHub PAT を含む)。 サイドカー JSON も同等。
+- **LLM プロバイダに送る情報**: `diary_work` (Sonnet) には当日の URL タイムライン + 作業時間概算、 `diary_highlights` (Opus 1M) と `diary_weekly` (Opus 1M) には日記サマリ + dig + bookmark + commit + 食事 + GPS 集計を含む。 ユーザの GitHub PAT は LLM には送らず、 サーバから GitHub API 直叩きで commit を取得した結果のみ送る。
+- **共有時に外部に出ない情報**: 日記全体 (シェア対象外)。
+- **削除時の挙動**: `DELETE /api/diary/:date` で行を削除。 元データ (bookmarks / activity_events / etc.) は削除しないので、 再生成すれば近い内容が戻る (notes は失われる)。 `diary_settings.github_token` は API patch で空文字を送ることで消える。

--- a/spec/feature/dictionary.md
+++ b/spec/feature/dictionary.md
@@ -1,0 +1,47 @@
+# dictionary — 個人辞書
+
+## 概要
+ユーザが集めた用語 + 定義 + 出典 (bookmark / dig / wordcloud) を紐付ける個人辞書。 ワードクラウドや dig 結果から「この単語をマイ辞書に登録」 で生やせる。
+
+## ユースケース
+- 専門用語に出会ったら定義 + ソース URL をワンクリックで蓄積
+- ブクマ / dig / wordcloud のどれから来たかを `dictionary_links` で追跡
+- Hub 経由で他人と用語集を共有 (受信側は `term (@owner)` で名前空間分離)
+
+## 画面 / 入口
+- `🗄 データベース` タブ → サブビュー `辞書`
+- ワードクラウド画面の「用語に登録」 ボタン (`/api/dictionary/upsert-from-source`)
+- dig セッション詳細 / bookmark 詳細からの追加
+
+## データ
+- [dictionary_entries](../db/dictionary.md) — term (UNIQUE) / definition / notes / owner_user_id / shared_at
+- [dictionary_links](../db/dictionary.md) — entry_id × (cloud / dig / bookmark) × source_id の many-to-many
+
+## API
+- [dict.md](../api/dict.md) — `/api/dictionary*` (CRUD + 検索) / `/api/dictionary/:id/links` (出典操作) / `/api/dictionary/upsert-from-source`
+- 関連: [multi.md](../api/multi.md) `/api/multi/share` (kind=dict) / `/api/multi/download`
+
+## シェア可能か
+**Hub-shareable** (明示的シェア操作のみ)
+
+シェアされるフィールド:
+
+| field | 内容 |
+|---|---|
+| `term` | 用語 |
+| `definition` | 定義 |
+| `notes` | 補足 |
+
+シェアされない:
+- `dictionary_links` (出典)。 出典 URL 自体は bookmark / dig をシェアしないと相手から見えない
+- ローカルの owner_user_id 等のメタ
+
+ダウンロード時の挙動: 受信側ではユニーク衝突を避けるため `term` を `term (@owner_user_name)` に namespace 化して保存。
+
+経路: **write-relay-only via Imperativus**。 `POST /api/multi/share` (kind=dict) → `markDictionaryShared` → Hub `/api/shared/dictionary`。
+
+## プライバシー観点
+- **個人データを保持するテーブル**: `dictionary_entries` / `dictionary_links` (どの語に興味を持ったかの履歴)。 単独だと識別力低いが、 dictionary_links で bookmark / dig との結びつきが見えるとプロファイルになる。
+- **LLM プロバイダに送る情報**: 辞書機能自体は LLM 呼び出しを行わない。 用語抽出は wordcloud (cloud_extract) 経由なのでそちら参照。
+- **共有時に外部に出ない情報**: 出典紐付け (bookmark / dig / cloud の id)、 owner_user_id などのローカルメタ。
+- **削除時の挙動**: `DELETE /api/dictionary/:id` で `dictionary_entries` 行 + CASCADE で `dictionary_links` を削除。 Hub にシェア済の場合は Hub 側に残る。

--- a/spec/feature/dig.md
+++ b/spec/feature/dig.md
@@ -1,0 +1,48 @@
+# dig — 調査セッション (deep research)
+
+## 概要
+ユーザクエリを起点に検索エンジン → AI 要約 → ソース付きレポートを生成する deep research 機能。 Phase 0 (raw SERP) → Phase 1 (preview) → Phase 2 (deep) の 3 段で完成形に向かう。
+
+## ユースケース
+- 「○○について最新動向まとめて」 とぶっこむと、 検索 → サイト読込 → 要約 → ソース URL リスト付きレポートが返る
+- セッション結果の URL を一括ブクマ化 (`/api/dig/:id/save`)
+- セッション間でテーマを共有してリストアップ (`?theme=...`)
+- セッション結果から辞書エントリ追加 / ワードクラウド生成
+
+## 画面 / 入口
+- `🔎 ディグる` タブ → クエリ欄 + 検索エンジン選択 + テーマ
+- セッション一覧 → 各セッション詳細
+- 関連: ブクマ詳細から「このページから dig」 / 日記から「この日の dig」
+
+## データ
+- [dig_sessions](../db/dig.md) — query / status / result_json (Phase 2) / preview_json (Phase 1) / raw_results_json (Phase 0) / theme / owner / shared
+- [recommendation_dismissals](../db/dig.md) — おすすめタブで dismissed した URL
+- 派生: [word_clouds](../db/wordcloud.md) (origin=dig)、 [dictionary_links](../db/dictionary.md) (source_kind='dig')
+
+## API
+- [dig.md](../api/dig.md) — `/api/dig` (POST queue / GET 一覧) / `/api/dig/:id` / `/api/dig/:id/save` (URL 一括ブクマ化) / `/api/dig/themes` / `/api/dig/engines`
+- 関連: [multi.md](../api/multi.md) `/api/multi/share` (kind=dig) / `/api/multi/download`
+
+## シェア可能か
+**Hub-shareable** (明示的シェア操作のみ)
+
+シェアされるフィールド:
+
+| field | 内容 |
+|---|---|
+| `query` | ユーザクエリ |
+| `status` | `done` / `error` 等 |
+| `result` (JSON) | Phase 2 の要約 + sources[] (url, title, snippet, topics) |
+
+シェアされない:
+- `raw_results_json` (raw SERP)、 `preview_json` (中間)
+- `owner_user_id` 自身
+- セッション派生のローカル ワードクラウド / 辞書リンク
+
+経路: **write-relay-only via Imperativus**。 `POST /api/multi/share` (kind=dig) → `markDigShared` → Hub `/api/shared/digs`。
+
+## プライバシー観点
+- **個人データを保持するテーブル**: `dig_sessions` (クエリ自体がリサーチ意図を直接示す)。
+- **LLM プロバイダに送る情報**: クエリ + 検索エンジン (DuckDuckGo / Bing / Yahoo / etc.) からの SERP + 各 URL の本文を、 タスク `dig` / `dig_preview` (Claude / Gemini / Codex / OpenAI のいずれか) に送る。 全文ではなく snippet + 上位ソースに限定するが、 クエリ自体は完全な形で LLM に渡る。
+- **共有時に外部に出ない情報**: raw SERP、 preview、 dismiss した URL リスト、 派生ワードクラウド。
+- **削除時の挙動**: `DELETE /api/dig/:id` で行を削除。 派生 `word_clouds.origin_dig_id` / `dictionary_links` (source_kind='dig') は **orphan として残る** (UI 側で「セッション削除済」 として handle)。 Hub シェア済は残置。

--- a/spec/feature/domain-catalog.md
+++ b/spec/feature/domain-catalog.md
@@ -1,0 +1,33 @@
+# domain-catalog — ドメイン辞書
+
+## 概要
+訪問したドメイン (host) ごとに「これは何のサイトか / 何ができるか」 を AI で自動分類 + ユーザ編集可能なカタログ。 ブラウジング履歴の lazy enqueue + バッチ recatalog で網羅する。
+
+## ユースケース
+- visits タブで「このドメインは何だっけ」 を一目で確認
+- `domain_private` フラグ付きドメインを日記処理から除外 (e.g. プライベート webmail)
+- 訪問回数集計 + サイト種別分類で傾向タブのデータソース
+
+## 画面 / 入口
+- `🗄 データベース` タブ → サブビュー `ドメイン`
+- 各ドメイン詳細 → AI 再分類 (`/api/domains/:domain/regenerate`)
+- 一括投入 `/api/domains/recatalog-all` (force=true で既存も再分類)
+- 訪問時に lazy enqueue: `recordAccess` / `upsertVisit` から `maybeQueueDomain`
+
+## データ
+- [domain_catalog](../db/page.md) — domain (PK) / title / site_name / description / can_do / kind / notes / user_edited / domain_private / status
+- 関連: [page_visits / visit_events](../db/visit.md) (集計の入力)
+
+## API
+- [domain.md](../api/domain.md) — `/api/domains*` (CRUD + 検索) / `/api/domains/from-url` / `/api/domains/:domain/regenerate` / `/api/domains/recatalog-all`
+
+## シェア可能か
+**local-only**
+
+ドメインカタログ自体は Hub シェアできない。 公開 SaaS 一覧などと違って、 ユーザのブラウジング履歴に紐付くのでローカル限定。
+
+## プライバシー観点
+- **個人データを保持するテーブル**: `domain_catalog` (どのサイトに行ったかのリスト = 本質的にブラウジング履歴の蒸留)、 ユーザ編集 notes / user_edited フラグ。
+- **LLM プロバイダに送る情報**: タスク `domain_classify` (Sonnet default) に **ドメイン名 + 取得したトップページの og: / meta** を送る。 ページ本文全体ではなく要約用ヘッダとトップ HTML 一部。
+- **共有時に外部に出ない情報**: 全部 (シェア対象外)。
+- **削除時の挙動**: `DELETE /api/domains/:domain` で 1 行削除。 lazy enqueue で再訪問時に再生成される (skip 対象 domain は `shouldSkipDomain` でガード = localhost / 127.0.0.1 等)。

--- a/spec/feature/external-chat.md
+++ b/spec/feature/external-chat.md
@@ -1,0 +1,30 @@
+# external-chat — chitchat 外部 chat 取り込み
+
+## 概要
+外部チャット (Discord / Slack / Gemini Web Research / 手動コピペ等) からの抜粋メッセージをログ。 source / conversation_id / role / content / metadata で 1 メッセージ 1 行。 主用途は Gemini Web Research の結果を作業ログに残すこと。
+
+## ユースケース
+- Gemini Web Research (LLM の検索) の結果を作業ログタブに残す (UI: `wlGeminiWebList`)
+- 手動コピペで外部 chat の重要発言を記録
+- 同じ `conversation_id` でスレッド束ね
+
+## 画面 / 入口
+- `📝 ログ` (worklog) タブ → Gemini Web Research セクション
+- `POST /api/external-chat/messages` で他ツールから投稿 (Memoria CLI / hook 等)
+
+## データ
+- [external_chat_messages](../db/chat.md) — source / conversation_id / role / content / metadata_json / received_at
+
+## API
+- [task.md](../api/task.md) (同じ router 内) — `POST /api/external-chat/messages` / `GET /api/external-chat/messages` (source / limit / offset で絞り込み)
+
+## シェア可能か
+**local-only**
+
+外部 chat 抜粋は Hub にシェアできない。 機微チャネル名や個人発言が含まれる前提のためローカル限定。
+
+## プライバシー観点
+- **個人データを保持するテーブル**: `external_chat_messages` (会話本文。 metadata_json にチャネル名 / URL / 相手の表示名等が入る)。
+- **LLM プロバイダに送る情報**: 機能自体は LLM 非依存。 ただし日記生成 / dig / wordcloud の prompt にこれらメッセージが含まれる経路は **無い** (現状 diary aggregator は external_chat を集計対象にしていない)。
+- **共有時に外部に出ない情報**: 全部。
+- **削除時の挙動**: 削除 API 無し (現状)。 SQL 直接削除のみ。 Gemini Web Research 投稿は `/api/activity/event` (kind=gemini_prompt) も同時に書く運用なので、 そちら側の row も別途処理必要。

--- a/spec/feature/gps.md
+++ b/spec/feature/gps.md
@@ -1,0 +1,40 @@
+# gps — 位置情報ログ
+
+## 概要
+OwnTracks (HTTP / MQTT) または Legatus (WS subscriber) 経由で受け取る GPS 1 点 = 1 行のログ。 停止区間は始点 + 終点 2 行に圧縮 (samples_count で代表数)。 Tracks タブで地図描画 + decimate / polyline 描画設定。
+
+## ユースケース
+- 「軌跡」 タブで日別の移動を地図描画
+- 傾向タブの「歩いた距離 / 歩いた時間」 (`trendsGpsWalking`) のソース
+- 食事 (`resolveMealLocation`) と作業場所 (`/api/work-sessions`) の場所推定入力
+- 場所名解決 (Place API) → `place_name` / `place_address` キャッシュ
+
+## 画面 / 入口
+- `📝 ログ` タブ → サブビュー `軌跡` (`tracks`) — `tracks_visible` フラグ ON のとき表示
+- ingest key 管理 (Basic auth password 用): 軌跡タブから生成
+- WebSocket `/ws/locations` で realtime 描画
+
+## データ
+- [gps_locations](../db/gps.md) — recorded_at / lat / lon / accuracy_m / altitude_m / velocity_kmh / course_deg / battery_pct / conn / raw_json / samples_count / place_name / place_address / place_source
+- 設定: `app_settings.tracks.decimate_meters` / `tracks.show_polyline` / `locations.ingest_key` / `features.tracks.enabled` / `features.tracks.visible`
+
+## API
+- [multi.md](../api/multi.md) `/api/locations*` 系統:
+  - `POST /api/locations/ingest` (1 点投入、 OwnTracks HTTP / 手動)
+  - `POST /api/legatus/location-summary` (Legatus 5 分集計、 loopback)
+  - `GET /api/locations` `/api/locations/recent` `/api/locations/latest` `/api/locations/days`
+  - `DELETE /api/locations?older_than=…` (retention)
+  - `POST /api/locations/resolve-all` `/api/locations/compress`
+- 設定: `/api/tracks/settings` / `/api/locations/settings*` (ingest key)
+- WebSocket: `/ws/locations` (`broadcastLocation`)
+
+## シェア可能か
+**local-only**
+
+GPS 軌跡そのものは Hub にシェアできない。 memory `feedback_sensitive_data_via_tailscale.md` のとおり、 GPS は **Tailscale 経由で閉じる** のが推奨経路。 workplace presence (場所名 + 座標スナップショット) は別系統で Hub に行くが、 軌跡そのものは流れない。
+
+## プライバシー観点
+- **個人データを保持するテーブル**: `gps_locations` (生活軌跡の連続記録。 個人情報密度最高クラス)。 `raw_json` には OwnTracks の元 payload (TID, BSSID 等) も含まれる。
+- **LLM プロバイダに送る情報**: GPS 機能自体は LLM 非依存。 ただし日記生成 (`diary_work` / `diary_highlights`) の prompt に **当日の歩行距離 / 移動時間 / 主要滞在地** が集計値として含まれるため間接的に流れる。 食事の場所推定は LLM ではなく `resolveMealLocation` の DB クエリ。 Place API (Nominatim default) には lat/lng が **third-party HTTPS** で出る (settings で内製 API に置換可能)。
+- **共有時に外部に出ない情報**: 軌跡そのもの (lat/lon, 速度, accuracy 等)、 device_id, raw_json。
+- **削除時の挙動**: `DELETE /api/locations?older_than=…` で古い行を一括削除 (retention)。 ingest key 認証必須。 圧縮 (`/api/locations/compress`) は中間点を間引いて始点 + 終点の 2 行に集約 (samples_count を更新)。 関連 work_locations / meals は影響なし (lat/lng 経由ではなくスナップショット保持のため)。

--- a/spec/feature/implementation-notes.md
+++ b/spec/feature/implementation-notes.md
@@ -1,0 +1,46 @@
+# implementation-notes — 実装自慢ノート
+
+## 概要
+「これ実装したぞ」 系のドヤノートを product / title / good_points / bad_points + attachment (URL / image / video / code) で蓄積。 shareable フラグ ON のものだけ Hub に共有可能。
+
+## ユースケース
+- 自分のプロダクトの面白い実装をライブラリ化前にメモ
+- スクリーンショット + GitHub URL + good/bad で技術ブログ素材
+- Hub にシェアしてエンジニア仲間に技術自慢
+
+## 画面 / 入口
+- `🗄 データベース` タブ → サブビュー `実装自慢`
+- 編集モーダル: paste / drop で attachment_type を自動分類 (画像→`screenshot`, github URL→`github` 等)
+
+## データ
+- [implementation_notes](../db/impl.md) — product / title / good_points / bad_points / attachment_type / attachment_value / shareable / shared_at
+
+## API
+- [impl.md](../api/impl.md) — `/api/implementation-notes*` (CRUD) / `/api/implementation-notes/:id/share` (ローカル shareable 印付け)
+- 関連: [multi.md](../api/multi.md) `/api/multi/share` (kind=implementation_note)
+
+## シェア可能か
+**Hub-shareable** (`shareable=1` 必須)
+
+シェア時は `note.shareable = 1` でないと 409 を返す (二段階フロー)。
+
+シェアされるフィールド:
+
+| field | 内容 |
+|---|---|
+| `product` | プロダクト名 |
+| `title` | ドヤポイント |
+| `good_points` | 良かった点 |
+| `bad_points` | しんどかった点 |
+| `attachment_type` | screenshot / github / article / video / code / other |
+| `attachment_value` | URL / data:URL / コード片等 |
+
+注意: `attachment_value` に `data:URL` (画像 base64) を入れると、 そのまま Hub に上がる。 機微画像を含めないかは投稿前にユーザ責任。
+
+経路: **write-relay-only via Imperativus**。 `POST /api/multi/share` (kind=implementation_note) → Hub `/api/shared/implementation-notes`。
+
+## プライバシー観点
+- **個人データを保持するテーブル**: `implementation_notes` (product 名から所属組織が判明する場合あり)、 `attachment_value` に embedded された画像 / コード片 / GitHub URL は内部リポを示す可能性。
+- **LLM プロバイダに送る情報**: 機能自体は LLM 呼び出しなし。 LLM に流れるのは ユーザが diary 生成時等の prompt に impl note を含めた間接的経路のみ。
+- **共有時に外部に出ない情報**: `shareable=0` のノート全体、 `shared_at` 印付け前のもの。
+- **削除時の挙動**: `DELETE /api/implementation-notes/:id` で行削除。 attachment が data:URL の場合は DB 行と一緒に消えるが、 Hub にシェア済なら Hub 側に残る。

--- a/spec/feature/legatus-subscriber.md
+++ b/spec/feature/legatus-subscriber.md
@@ -1,0 +1,31 @@
+# legatus-subscriber — Legatus 経由の OwnTracks → Memoria 転送
+
+## 概要
+同じ PC (loopback 17320) で動く Legatus が OwnTracks → MQTT 経由で受け取った GPS イベントを `/ws` で broadcast する。 Memoria はそれを WebSocket で subscribe して `gps_locations` に即時 insert + Tracks UI へリアルタイム描画。
+
+## ユースケース
+- iPhone OwnTracks → MQTT → Legatus → Memoria の細かい軌跡を遅延ゼロで描画
+- 直接 HTTP ingest (`/api/locations/ingest`) と並行運用 (どっちも同じ DB に入る)
+- Legatus 側 summary (5 分集計の `/api/legatus/location-summary`) は別経路 (start/end 2 点のみ)
+
+## 画面 / 入口
+- ユーザ操作なし (起動時に自動 connect)。 `MEMORIA_LEGATUS_WS_URL` 環境変数で接続先変更可
+- `📝 ログ` → `軌跡` で結果を視認
+
+## データ
+- [gps_locations](../db/gps.md) — `raw_json` に `{via: 'legatus-ws', topic_user, device}` を埋め込んで識別
+
+## API
+- 受信側: `ws://127.0.0.1:17320/ws` (Legatus が listen) を Memoria が subscribe
+- 出力: 内部的に `insertGpsLocation` 呼び出し → `broadcastLocation` で Memoria の `/ws/locations` に転送 → Tracks UI に realtime 描画
+
+## シェア可能か
+**local-only**
+
+転送機能自体には共有経路なし。 GPS データ ([gps.md](gps.md)) と同じく Hub には流さない。
+
+## プライバシー観点
+- **個人データを保持するテーブル**: GPS データを `gps_locations` に書くため [gps.md](gps.md) と同等の機微度。
+- **LLM プロバイダに送る情報**: 直接送信しない。
+- **共有時に外部に出ない情報**: Legatus との接続自体が **loopback / tailnet 内** で完結する想定 (memory `feedback_sensitive_data_via_tailscale.md`)。 Cloudflare Tunnel は UDP 通さないので OwnTracks に不向き (`feedback_cloudflare_tunnel_udp.md`)。
+- **削除時の挙動**: subscriber 自身は state を持たない。 切断時は exponential backoff で再接続 (1s → 30s 上限)。 GPS 行の retention は [gps.md](gps.md) 側の `DELETE /api/locations`。

--- a/spec/feature/llm-config.md
+++ b/spec/feature/llm-config.md
@@ -1,0 +1,33 @@
+# llm-config — LLM プロバイダ設定
+
+## 概要
+タスクごと (要約 / dig / wordcloud / 日記 / 食事 vision 等 12 タスク) に **どの LLM プロバイダ** (Claude CLI / Codex CLI / Gemini CLI / OpenAI API / アルゴリズム) を使うか、 どの **モデル** を使うかを設定する。 OpenAI のみ API key を Memoria サーバに保持、 残り 3 種は CLI バイナリをユーザの API key スコープで呼ぶ。
+
+## ユースケース
+- 「日記ハイライトは Opus 4.7 (1M)、 ブクマ要約は Sonnet」 のようなタスク別ルーティング
+- ローカル CLI バイナリ (`claude` / `gemini` / `codex`) のパスを overide
+- diary global memo (毎回の日記生成 prompt 末尾に貼られる立ち位置メモ)
+- ユーザプロファイル (年齢 / 性別 / 体重 / 身長 / 活動量) を栄養計算に使う
+
+## 画面 / 入口
+- 設定 → `AI / LLM` タブ — 12 タスク × プロバイダ / モデル選択 + diary memo + user profile
+- 公開 endpoint で 12 タスク + 5 プロバイダ + モデル一覧を返す
+
+## データ
+- 設定: `app_settings.llm.*` (プロバイダ / モデル / バイナリパス / API key)
+- 関連: `app_settings.diary.global_memo` / `user.age` / `user.sex` / `user.weight_kg` / `user.height_cm` / `user.activity_level`
+- runtime: `runtime.git_bash_path` (Windows + claude CLI 用、 memory `feedback_claude_cli_windows_bash.md`)
+
+## API
+- [config.md](../api/config.md) — `GET /api/llm/config` (タスク + プロバイダ + モデル + 現状) / `PATCH /api/llm/config` (設定更新、 API key は `'***'` で来たら無視)
+
+## シェア可能か
+**local-only**
+
+API key と CLI binary path はマシン固有の機微情報。 シェア対象外。
+
+## プライバシー観点
+- **個人データを保持するテーブル**: `app_settings.llm.openai.api_key` (OpenAI API key、 `getLlmConfig` から **取り出すときだけ** plain で返り、 API レスポンス時に `'***'` でマスクされる)、 `user.*` のプロファイル (健康情報)、 `diary.global_memo` (個人指示メモ)。
+- **LLM プロバイダに送る情報**: 設定値そのものは LLM に送らない。 設定によって決まる **下流タスク** (要約 / wordcloud / dig / 日記 / 食事 vision) で各プロバイダにデータが流れる。 各 feature 個別の「LLM プロバイダに送る情報」 を参照。
+- **共有時に外部に出ない情報**: 全部 (シェア対象外)。
+- **削除時の挙動**: PATCH で空文字を送ると key/value が空になる。 OpenAI API key を空にすると、 そのプロバイダに割り当てたタスクは失敗する。

--- a/spec/feature/mcp-server.md
+++ b/spec/feature/mcp-server.md
@@ -1,0 +1,33 @@
+# mcp-server — MCP server autostart
+
+## 概要
+Memoria 同梱の MCP server (`mcp-server/index.js`) を Memoria 子プロセスとして spawn。 Claude Desktop / Claude Code から `add_task` `list_tasks` `search_bookmarks` `list_diary_entries` 等の Memoria API を叩けるようにする。
+
+## ユースケース
+- Claude Desktop の会話中に「これブクマしといて」 → 直接 Memoria に登録
+- Claude Code セッションで「今日の日記取ってきて」 → MCP 経由
+- autostart ON で Memoria 起動と一緒に MCP server が立つ
+
+## 画面 / 入口
+- 設定 → `プライバシー` → `MCP autostart` チェック (`mcp_autostart_enabled`)
+- ON / OFF を変更すると `onMcpAutostartChange` 経由で `McpServerControl.sync` が走り、 子プロセスを start / stop
+
+## データ
+- 設定値のみ: `app_settings.features.mcp.autostart.enabled`
+- 子プロセスは state を DB に持たない (PID は `McpServerControl` 内でのみ保持)
+- セットアップガイド: `/api/setup-docs/mcp` で Markdown を返す (Claude Desktop / Code config 例)
+
+## API
+- [config.md](../api/config.md) — `/api/privacy/settings` PATCH `mcp_autostart_enabled` / `/api/setup-docs/mcp`
+- 子プロセスへの env: `MEMORIA_URL=http://127.0.0.1:<port>` を渡す
+
+## シェア可能か
+**local-only**
+
+MCP は完全にローカル機能 (Memoria サーバ + Claude クライアント間の stdio)。 Hub 連携対象外。
+
+## プライバシー観点
+- **個人データを保持するテーブル**: なし (起動状態フラグのみ)。 ただし MCP tools 経由で Claude が **Memoria の全 API を叩ける** ため、 結果として個人 DB の中身が Claude に流れる。
+- **LLM プロバイダに送る情報**: ユーザの Claude Desktop / Code セッションが必要に応じて Memoria の API を呼んだ結果 (ブクマ / タスク / 日記抜粋等) を Anthropic API に送る。 これはユーザの **Claude 側 API key スコープ**。 Memoria サーバ自身は Anthropic と直接通信しない。
+- **共有時に外部に出ない情報**: 全部 (シェア機能なし)。
+- **削除時の挙動**: autostart を OFF にすると `SIGTERM` で子プロセスを kill。 Claude Desktop / Code 側の MCP server 設定はユーザ手動で削除。

--- a/spec/feature/meal.md
+++ b/spec/feature/meal.md
@@ -1,0 +1,35 @@
+# meal — 食事写真 + EXIF + 栄養推定
+
+## 概要
+食事写真を multipart で投稿 → EXIF (撮影時刻 / GPS) 抽出 → Vision LLM で内容説明 + カロリー / 栄養素推定。 写真なし「手動入力」 経路もあり。 おかわり等の追加分は `additions_json` に追記。
+
+## ユースケース
+- 食ったものを撮って放り込むだけで栄養記録
+- LLM の説明 / カロリーを手動補正 (`user_corrected_*`)
+- ユーザプロファイル (年齢 / 性別 / 体重 / 身長 / 活動量) から適正カロリー計算
+- 後から「あれ食べた」 を追加 (`/api/meals/:id/additions`)
+
+## 画面 / 入口
+- `🍽 食事` タブ (top-level) → カメラ / ファイル選択 → POST
+- 「写真なし手動」 経路: `POST /api/meals/manual`
+- 詳細: 補正フィールド + 追加 / 編集 / 再分析 (`/api/meals/:id/reanalyze`)
+
+## データ
+- [meals](../db/meal.md) — photo_path / eaten_at / eaten_at_source (manual/exif/gps/inference) / lat/lon / location_label / location_source / description / calories / items_json / nutrients_json / ai_status / user_note / user_corrected_* / additions_json
+- 写真本体: `<DATA>/meals/<id>-<8hex>.<ext>` (DB は `photo_path` のみ)
+- 場所推定の入力: `gps_locations` (撮影時刻に最も近い GPS 点を `resolveMealLocation`)
+
+## API
+- [meal.md](../api/meal.md) — `/api/meals` (multipart 投稿) / `/api/meals/manual` (JSON 投稿) / `/api/meals*` (一覧 / 詳細 / 写真 / 補正 / 削除 / 再分析) / `/api/meals/:id/additions*`
+- 全 endpoint は `features.meals.enabled` / `features.meals.visible` フラグで gate
+
+## シェア可能か
+**local-only**
+
+食事は Hub にシェアできない (`/api/multi/share` 対象外)。 健康情報の機微度を考慮した意図的設計。
+
+## プライバシー観点
+- **個人データを保持するテーブル**: `meals` (食事内容、 撮影位置 lat/lon、 栄養補正データ。 健康・行動情報の機微度高)、 写真ファイル本体 (EXIF 込み)、 `user.age` / `user.sex` / `user.weight_kg` / `user.height_cm` (`app_settings`)。
+- **LLM プロバイダに送る情報**: タスク `meal_vision` (Sonnet default) で **写真 image data + EXIF メタ** を Claude / OpenAI / Gemini に送り内容説明 + カロリー推定。 タスク `meal_calorie` で食品名 (description) のみ送って手動補正のカロリー推定。 ユーザの API key スコープ。 LLM 出力の妥当性は人間が確認する前提。
+- **共有時に外部に出ない情報**: 全部 (シェア対象外)。
+- **削除時の挙動**: `DELETE /api/meals/:id` で DB 行削除 + 写真ファイル `unlinkSync`。 Vision queue に積まれた job は `ai_status=cancelled` 相当のスキップ (実装上は対象 row が消えればワーカ側でスルー)。

--- a/spec/feature/multi-hub.md
+++ b/spec/feature/multi-hub.md
@@ -1,0 +1,43 @@
+# multi-hub — Memoria Hub プレゼンス (他人との共有)
+
+## 概要
+複数の Memoria Hub (公開 / 限定の OAuth 付きサーバ) に同時接続し、 ブクマ / dig / 辞書 / 実装自慢 / workplace を共有 / ダウンロードする多サーバ管理レイヤ。 個人ローカルの Memoria が **read-public + write-relay-only** の意味で Hub と関わる。
+
+## ユースケース
+- 複数 Hub (社内 + 公開 + 個人運営) に同時所属し、 シェア先を選んで POST
+- 他人がシェアしたブクマ / dig をローカルに取り込み (HTML は受信時に再 fetch)
+- Cernere SSO (OAuth → JWT) でログイン
+
+## 画面 / 入口
+- トップバー右上「マルチ」 スイッチ → マルチビュー (機能タブには出さない)
+- 設定 → `データ / Hub` タブ: 接続先一覧 / 追加 / 削除 / 有効化 / 切断
+
+## データ
+- 接続情報は専用テーブルではなく `app_settings` の JSON:
+  - `multi_servers` — 登録済 Hub 配列 `[{label, url, jwt, userId, userName, role, connectedAt}]`
+  - `multi_active_urls` — 現在 active な URL 配列 (subset)
+  - レガシーキー (`multi_url` 等) は初回読み込みで migrate
+- 共有印付けは各テーブルの `shared_at` / `shared_origin` / `owner_user_id` 列
+
+## API
+- [multi.md](../api/multi.md) — `/api/multi/status` `/api/multi/servers*` `/api/multi/active` `/api/multi/connect` `/api/multi/finish` `/api/multi/disconnect` `/api/multi/proxy/*` `/api/multi/share` `/api/multi/download`
+
+## シェア可能か
+**Hub-shareable** (この機能自体が Hub 連携の入口)
+
+`/api/multi/share` の対応 kind:
+- `bookmark` ([bookmark.md](bookmark.md))
+- `dig` ([dig.md](dig.md))
+- `dict` ([dictionary.md](dictionary.md))
+- `implementation_note` ([implementation-notes.md](implementation-notes.md))
+- `work_location` ([workplace.md](workplace.md))
+
+その他: workplace presence (場所スナップショット) は `shareWorkplacePresence` 経由で別 endpoint。
+
+経路: **read-public + write-relay-only via Imperativus** (memory `feedback_memoria_online_flow.md`)。 直接書込みエンドポイントは PR #17 で削除済。 proxy passthrough も POST は `/api/shared/moderation/*` のみ許可 (それ以外は 403)。
+
+## プライバシー観点
+- **個人データを保持するテーブル**: `app_settings.multi_servers` (Cernere JWT、 user 情報を保持)。 各シェア対象テーブルの `shared_at` / `shared_origin` / `owner_user_id` 列で「これは誰のもので、 いつどこにシェアした」 を追跡。
+- **LLM プロバイダに送る情報**: multi 自体は LLM 非依存。 シェア対象データ (bookmark summary 等) はシェア前の生成段階で LLM を経由しているが、 multi 経路は HTTP 転送のみ。
+- **共有時に外部に出ない情報**: 各 feature 個別に規定 (HTML スナップショット / アクセス履歴 / dig raw_results / GPS 軌跡 / 食事 / 日記)。 JWT は **絶対に** Hub 間で共有されない。
+- **削除時の挙動**: `POST /api/multi/disconnect` でローカル JWT クリア (Hub 側のセッションは残るので Hub 側 logout は別途必要)。 `DELETE /api/multi/servers` で server 行を抹消。 すでにシェア済データは Hub に残置 (削除する場合は Hub 側の moderation API)。

--- a/spec/feature/privacy-settings.md
+++ b/spec/feature/privacy-settings.md
@@ -1,0 +1,48 @@
+# privacy-settings — プライバシー設定
+
+## 概要
+各機能の ON/OFF / 表示 / シェア許可を集中管理。 `app_settings` の `features.*` キーを `privacySettings()` で正規化して返す。 PATCH で変更すると、 一部 (MCP autostart) は即時反映される。
+
+## ユースケース
+- 軌跡 (GPS) / 食事 / Actio タスク共有 / Nuntius リマインダー / MCP autostart / workplace 自動共有 を個別 ON/OFF
+- `*_visible` 系で「データは溜めるが UI には見せない」 二段階制御 (例: tracks は記録だけ続けて表示は OFF)
+- workplace 半径 (`workplace_match_radius_m`) や reminder 時刻 (`tasks_reminder_hour/minute`) も同経路で設定
+
+## 画面 / 入口
+- 設定 → `プライバシー / 表示` タブ
+
+## 設定キー (一覧)
+
+| body field | settings key | 効果 |
+|---|---|---|
+| `tracks_enabled` | `features.tracks.enabled` | GPS ingestion 全停止 |
+| `tracks_visible` | `features.tracks.visible` | UI 上の軌跡タブ非表示 |
+| `meals_enabled` | `features.meals.enabled` | 食事の記録 / 編集禁止 |
+| `meals_visible` | `features.meals.visible` | 食事タブ + 一覧空応答 |
+| `tasks_actio_share_enabled` | `features.tasks.actio_share.enabled` | Actio share 経路有効化 |
+| `tasks_reminder_enabled` | `features.tasks.reminder.enabled` | 朝のタスク reminder push |
+| `tasks_reminder_nuntius_enabled` | `features.tasks.reminder.nuntius_enabled` | Nuntius 経由 reminder |
+| `mcp_autostart_enabled` | `features.mcp.autostart.enabled` | MCP server autostart (即時反映) |
+| `workplace_geo_enabled` | `features.workplace.geo.enabled` | GPS チェックイン許可 |
+| `workplace_auto_share_enabled` | `features.workplace.share.enabled` | enter/leave の Hub 自動配信 |
+| `actio_share_url` | `actio.share_url` | Actio タスク share endpoint |
+| `tasks_reminder_hour` / `minute` | `features.tasks.reminder.hour` / `minute` | reminder 時刻 |
+| `workplace_match_radius_m` | `features.workplace.match.radius_m` | チェックイン半径 (20-2000m) |
+| `tasks_reminder_nuntius_url` | `features.tasks.reminder.nuntius_url` | Nuntius プロキシ URL |
+
+## データ
+- [app_settings](../db/settings.md) — 上記キーをすべて格納
+
+## API
+- [config.md](../api/config.md) — `GET /api/privacy/settings` / `PATCH /api/privacy/settings`
+
+## シェア可能か
+**local-only**
+
+設定値そのものは外に出さない (個人ポリシーの宣言なので)。
+
+## プライバシー観点
+- **個人データを保持するテーブル**: `app_settings` の各 feature flag。 機微度は中。 `actio.share_url` / `tasks_reminder_nuntius_url` は外部 endpoint URL (組織内 IP / hostname を含む可能性あり)。
+- **LLM プロバイダに送る情報**: なし。 ただしフラグの組み合わせで下流の LLM 呼び出し有無が変わる (`meals_enabled=false` で vision 呼び出しが止まる等)。
+- **共有時に外部に出ない情報**: 全部。
+- **削除時の挙動**: PATCH で空文字 / false を送るとそれぞれ無効化。 `mcp_autostart_enabled` を OFF にすると `onMcpAutostartChange` 経由で MCP 子プロセスが SIGTERM される。

--- a/spec/feature/push-notification.md
+++ b/spec/feature/push-notification.md
@@ -1,0 +1,31 @@
+# push-notification — PWA Web Push
+
+## 概要
+Memoria 内蔵の Web Push 配信 (web-push lib + VAPID 鍵)。 端末ごとの subscription を `push_subscriptions` で持ち、 タスクリマインダー / バッチ通知 / テスト送信を行う。 Actio と違って Nuntius プロキシは経由せず直接配信 (memory `feedback_pwa_webpush_pattern.md`)。
+
+## ユースケース
+- 朝 6:00 に未完了タスクをまとめて通知 (`tasks_reminder_*` 設定 + scheduler)
+- 日記 / Dig / ブクマ要約完了の即時 / batch 通知 (memory `feedback_memoria_push_triggers.md`)
+- iOS PWA は homescreen 追加が必須
+
+## 画面 / 入口
+- 設定 → `通知` タブ: VAPID 公開鍵 / subscribe ボタン / 端末一覧 / テスト送信
+- リマインダー時刻 / Nuntius 連携設定もここ
+
+## データ
+- [push_subscriptions](../db/push.md) — endpoint (UNIQUE) / p256dh / auth / label / user_agent / revoked_at
+- VAPID 鍵: `<DATA>/vapid.json` (DB 外、 初回起動で自動生成)
+
+## API
+- [push.md](../api/push.md) — `/api/push/vapid-public-key` / `/api/push/subscribe` / `/api/push/subscriptions` / `DELETE /api/push/subscriptions/:id` / `/api/push/test`
+
+## シェア可能か
+**local-only**
+
+push subscription は端末固有の機微鍵 (p256dh / auth) を含むためシェア対象外。
+
+## プライバシー観点
+- **個人データを保持するテーブル**: `push_subscriptions` (subscription endpoint URL = ブラウザベンダの push service への ID、 端末識別性が高い)、 `vapid.json` (秘密鍵)。
+- **LLM プロバイダに送る情報**: push 機能自体は LLM 非依存。 通知本文 (タイトル / body) は事前生成済の文字列を `webpush.sendNotification` で送るだけ。
+- **共有時に外部に出ない情報**: 全部 (シェア対象外)。
+- **削除時の挙動**: `DELETE /api/push/subscriptions/:id` で行を**ハード削除**。 web-push 失敗時 (4xx) は `revoked_at` を立てて soft revoke する経路もある (`server/push.ts`)。 VAPID 鍵 (`vapid.json`) は手動削除 (削除すると全 subscription が再 subscribe 必要)。

--- a/spec/feature/stopwords.md
+++ b/spec/feature/stopwords.md
@@ -1,0 +1,31 @@
+# stopwords — wordcloud 除外語
+
+## 概要
+ワードクラウド / 傾向タブの集計から除外したい単語のユーザ定義リスト。 lowercased で `user_stopwords` に保存。
+
+## ユースケース
+- ワードクラウドに毎回出てくる固有名詞 (自分の社名 / プロジェクト名等) を抑制
+- 傾向タブの上位語表示でノイズを消す
+- 1 度追加すれば全 wordcloud / trends で再生成時に効く
+
+## 画面 / 入口
+- ワードクラウド画面の語ノード右クリック / 設定パネル → `+` で追加
+- 設定タブの `ストップワード` 一覧で削除
+
+## データ
+- [user_stopwords](../db/stopwords.md) — word (PK, lowercased) / added_at
+- 注意: ドメインカタログ自動分類 (`classifyDomain`) のキーワード抽出には適用されない (汎用ストップワードと別運用)
+
+## API
+- [dict.md](../api/dict.md) — `GET /api/stopwords` / `POST /api/stopwords` `{ word }` / `DELETE /api/stopwords/:word`
+
+## シェア可能か
+**local-only**
+
+ストップワード = 個人の関心 / 文脈を表すノイズリスト。 シェア対象外。
+
+## プライバシー観点
+- **個人データを保持するテーブル**: `user_stopwords` (除外したい語、 関心の裏返し)。 機微度は低め。
+- **LLM プロバイダに送る情報**: 直接送らない。 wordcloud 生成時に prompt に「除外せよ」 指示として渡る場合がある (実装は wordcloud.ts 側、 算出後フィルタ + LLM 指示の両方を併用)。
+- **共有時に外部に出ない情報**: 全部。
+- **削除時の挙動**: `DELETE /api/stopwords/:word` で行を抹消。 既存 wordcloud は再生成しないと再フィルタされない。

--- a/spec/feature/task.md
+++ b/spec/feature/task.md
@@ -1,0 +1,50 @@
+# task — タスク管理
+
+## 概要
+TODO + カテゴリ + AI 委託 (agent_runs リンク) を持つタスク管理。 完了 / 更新時は自動で日記の `notes` に時刻付きで記録され、 `activity_events` にも入る。 任意で Actio に共有可能。
+
+## ユースケース
+- 個人的な TODO 管理 (`todo` / `doing` / `done`)
+- AI に「このタスク実装して」 と委託する起点 (`/api/tasks/:id/agent-run`)
+- カテゴリで開発 / 学習 / 雑務などを分けて表示
+- 期日付きタスク → 朝 6:00 にリマインダー push (`tasks_reminder_*` 設定)
+- Actio (LUDIARS のスケジューラ) に共有 (`/api/tasks/:id/share/actio`)
+
+## 画面 / 入口
+- `🗄 データベース` タブ → サブビュー `タスク`
+- 詳細モーダルから「AI に委託」 → agent project + agent + model 選択 → `agent_runs` を生成
+
+## データ
+- [tasks](../db/task.md) — title / details / status / creator_type (human/ai) / due_at / share_actio / category (カンマ区切り)
+- カテゴリプリセット: `app_settings.task.categories.registered` (JSON 配列、 0 件カテゴリも保持)
+- 連動: [agent_runs](../db/agent.md) (task_id 経由)、 [activity_events](../db/activity.md) (kind=task_created/task_done/task_updated)、 [diary_entries.notes](../db/diary.md) に時刻付き行追記
+
+## API
+- [task.md](../api/task.md) — `/api/tasks*` (CRUD) / `/api/tasks/categories*` / `/api/tasks/:id/agent-run` (AI 起動) / `/api/tasks/:id/share/actio`
+
+## シェア可能か
+**Hub-shareable** (Actio 経由のみ)
+
+シェア先は **Memoria Hub ではなく Actio** (LUDIARS スケジューラ)。 `actio.share_url` 設定 + `tasks_actio_share_enabled` フラグ ON のときのみ機能。
+
+シェアされるフィールド (Actio に POST):
+
+| field | 内容 |
+|---|---|
+| `source` | `'memoria'` |
+| `external_id` | `memoria-task-{id}` |
+| `title` | タスク名 |
+| `details` | 詳細メモ |
+| `status` | todo/doing/done |
+| `due_at` | 期日 |
+
+シェアされない:
+- `category`, `creator_type`, `agent_runs` 紐付け、 `activity_events`
+
+経路: `POST /api/tasks/:id/share/actio` → サーバから Actio の share_url に直 POST (Memoria Hub 経由ではない)。
+
+## プライバシー観点
+- **個人データを保持するテーブル**: `tasks` (個人 TODO)、 `activity_events` (task_* kind の行)。 詳細メモが個人情報になりうる。
+- **LLM プロバイダに送る情報**: タスク機能自体は LLM を呼ばない。 `agent-run` で `agent_dispatch` 経由 (claude / codex / gemini CLI を spawn) でプロンプト + project rules を送るのは別機能 ([agent.md](agent.md))。
+- **共有時に外部に出ない情報**: カテゴリ、 AI 委託履歴 (agent_runs)、 activity_events、 日記の追記行。
+- **削除時の挙動**: `DELETE /api/tasks/:id` で `tasks` 行を削除。 関連 `activity_events` (task_* kind) と `agent_runs` (task_id) は **削除しない** (履歴として残す設計)。 Actio 側にシェア済の場合は Actio に残置。

--- a/spec/feature/uptime.md
+++ b/spec/feature/uptime.md
@@ -1,0 +1,32 @@
+# uptime — サーバ稼働 / heartbeat 監視
+
+## 概要
+Memoria サーバ自身の起動 / 停止 / ダウンタイム / 再起動を `server_events` に記録。 1 秒間隔で `<DATA>/heartbeat.json` に mtime を書き、 次回起動時にギャップを検出して downtime / restart として遡及記録する。
+
+## ユースケース
+- 日記の作業時間推定でサーバダウンタイム区間を識別 (データ欠落かどうかを区別)
+- SPA で「最後にサーバが生きてた時刻」 をバッジ表示 (`/api/uptime`)
+- ダウンタイム > 5 分 = `downtime`、 ≤ 5 分 = `restart` として種別分け
+
+## 画面 / 入口
+- 設定 → `稼働状況` セクション (`/api/uptime` + `/api/events`)
+- `/api/uptime` で heartbeat + downtime_threshold を返す
+
+## データ
+- [server_events](../db/activity.md) — type (start/stop/downtime/restart) / occurred_at / ended_at / duration_ms / details_json
+- ファイル: `<DATA>/heartbeat.json` (1 秒間隔で更新)
+
+## API
+- [misc.md](../api/misc.md) `/api/uptime` / `/api/events` (server_events 一覧)
+- [visit.md](../api/visit.md) `/api/worklog/server-events` (日付指定で 1 日分)
+
+## シェア可能か
+**local-only**
+
+サーバ稼働ログは個人 PC の動作状況なのでシェア対象外。
+
+## プライバシー観点
+- **個人データを保持するテーブル**: `server_events` (PC 起動 / 停止時刻)。 直接的個人情報ではないが、 生活パターン推定の材料になる。
+- **LLM プロバイダに送る情報**: 直接送らない。 日記生成の prompt に「ダウンタイム区間あり」 という事実が間接的に入る可能性 (work_minutes 推定の文脈で)。
+- **共有時に外部に出ない情報**: 全部。
+- **削除時の挙動**: 削除 API 無し。 retention は手動 SQL。 `heartbeat.json` を削除すると次回起動時にギャップ検出が `priorHeartbeat = null` となり、 downtime 行は作られない。

--- a/spec/feature/visit.md
+++ b/spec/feature/visit.md
@@ -1,0 +1,36 @@
+# visit — ブラウジング履歴 + recommendation
+
+## 概要
+Chrome 拡張 (`POST /api/access`) や Legatus DNS / SNI tap (`POST /api/visits/external`) からブラウジング履歴を吸い上げ、 URL ごとの集計 (`page_visits`) + 個別イベント (`visit_events`) に分離。 未保存 URL からブクマ候補 / おすすめ生成。
+
+## ユースケース
+- Chrome 拡張入れたら自動でアクセス履歴が貯まる → 後で重要なものをブクマ化
+- 「今日見た中で保存してないやつ」 (`/api/visits/unsaved`) を逐次確認 → bulk save
+- おすすめタブで再訪 / 他人ブクマ等のレコメンド (`/api/recommendations`)
+- DNS / SNI tap (Legatus) でブラウザ拡張なしのデバイス (iPhone 等) もカバー
+
+## 画面 / 入口
+- `🗄 データベース` タブ → `ブクマ未保存`
+- `✨ おすすめ` タブ → `/api/recommendations`
+- 傾向タブ → `/api/trends/visit-domains` 等
+- 作業ログタブ (`📝 ログ`) → `/api/worklog/browsing`
+
+## データ
+- [page_visits](../db/visit.md) — URL (PK) / first_seen_at / last_seen_at / visit_count
+- [visit_events](../db/visit.md) — URL / domain / visited_at / device_label / device_os / source (browser/dns/sni)
+- 関連: [page_metadata](../db/page.md) (lazy fetch)、 [domain_catalog](../db/page.md)、 [recommendation_dismissals](../db/dig.md)
+
+## API
+- [visit.md](../api/visit.md) — `/api/access` (拡張ping) / `/api/visits/unsaved` `/api/visits/suggested` `/api/visits/unsaved/count` / `/api/visits/bookmark` (bulk save) / `/api/visits/external` (DNS/SNI) / `/api/visits/external/stats`
+- 関連: [misc.md](../api/misc.md) `/api/recommendations*` / `/api/trends/*`、 `/api/extension/status`
+
+## シェア可能か
+**local-only**
+
+ブラウジング履歴は丸ごとローカル限定。 個別 URL を bookmark に昇格させてはじめてシェア可能になる。
+
+## プライバシー観点
+- **個人データを保持するテーブル**: `page_visits` / `visit_events` (個人情報密度最高クラスのブラウジング履歴)。 `device_label` (Tailscale ホスト名) と `device_os` も付く。
+- **LLM プロバイダに送る情報**: visit 自体は LLM 非依存。 ただし `page_metadata` の summary 生成 (タスク `page_summary`、 Sonnet default) で **訪問 URL の HTML 本文** が LLM に流れるケースがある。 日記生成にも当日 URL タイムラインが prompt に入る。
+- **共有時に外部に出ない情報**: 全部。 visit_events.source (DNS/SNI) も外には出ない。
+- **削除時の挙動**: `DELETE /api/visits` (urls[] 指定) で `page_visits` 行のみ削除 (`visit_events` の per-event 行は残る)。 `recommendation_dismissals` は手動 clear (`DELETE /api/recommendations/dismissals`)。 retention は手動 (古い `visit_events` の自動 GC は無し)。

--- a/spec/feature/weekly.md
+++ b/spec/feature/weekly.md
@@ -1,0 +1,31 @@
+# weekly — 週次レポート
+
+## 概要
+週単位 (日曜 23:05 cron) で 7 日分の日記をまとめて Opus 1M に渡し、 サマリ + GitHub commit 集計を生成する。 月ベースで `週 N` をラベル付け。
+
+## ユースケース
+- 1 週間の振り返り / 月次 KPI の素材
+- 「先週のハイライトを LinkedIn 投稿用に」 みたいな引用元
+- 月の中の `week_in_month` で N 週目を示せる
+
+## 画面 / 入口
+- `📅 日記` タブ → 月の上部 / 下部に週次レポート行
+- 手動再生成 `POST /api/weekly/:weekStart/generate`
+
+## データ
+- [weekly_reports](../db/diary.md) — week_start (PK) / week_end / month / week_in_month / summary / github_summary_json / status
+- 集計参照: [diary_entries](../db/diary.md) / [activity_events](../db/activity.md) / [bookmarks](../db/bookmark.md)
+
+## API
+- [diary.md](../api/diary.md) — `/api/weekly` (月一覧) / `/api/weekly/:weekStart` / `/api/weekly/:weekStart/generate` / `DELETE /api/weekly/:weekStart`
+
+## シェア可能か
+**local-only**
+
+週次レポートを Hub にシェアする経路は無い。 日記と同じ理由で意図的に local-only。
+
+## プライバシー観点
+- **個人データを保持するテーブル**: `weekly_reports` (1 週間の生活ログ高度集約)。
+- **LLM プロバイダに送る情報**: タスク `diary_weekly` (Opus 1M default) に 7 日分の日記 summary / work_content / highlights + GitHub commit 集計を渡す。 これは日記生成時の prompt より大きい個人情報量。
+- **共有時に外部に出ない情報**: 週次レポート全体。
+- **削除時の挙動**: `DELETE /api/weekly/:weekStart` で行を削除。 GitHub PAT は `diary_settings` 側にあるためここでは触らない。

--- a/spec/feature/wordcloud.md
+++ b/spec/feature/wordcloud.md
@@ -1,0 +1,34 @@
+# wordcloud — ワードクラウド (キーワード抽出 + グラフ)
+
+## 概要
+Bookmark / Dig / 単一ブクマ本文 / 複数 cloud の merge から、 LLM でキーワード ○ 抽象用語 / □ 具体名詞を抽出してクラウドを作る。 子クラウドにドリルダウンできるツリー構造を持つ (`parent_cloud_id`)。
+
+## ユースケース
+- カテゴリ別ブクマ群 / 1 件のブクマ / dig セッションの **要点語** を一覧
+- 「この語をさらに掘る」 で派生 cloud を生成しドリルダウン
+- 複数 cloud をマージして共通項を炙り出す (`/api/wordcloud/merge`)
+- 抽出語を辞書に登録 (`/api/dictionary/upsert-from-source` source_kind='cloud')
+
+## 画面 / 入口
+- ブクマ一覧 → カテゴリ単位 wordcloud ボタン
+- ブクマ詳細 → 「このページの wordcloud」 (`/api/bookmarks/:id/wordcloud`)
+- dig セッション詳細 → 「sources からクラウド」
+- ワードクラウド一覧 → グラフ表示 (`/api/wordcloud/:id/graph`)
+
+## データ
+- [word_clouds](../db/wordcloud.md) — origin (bookmark / bookmarks / dig / merged) / parent_cloud_id / parent_word / result_json / origin_bookmark_id (CASCADE) / origin_dig_id
+
+## API
+- [dict.md](../api/dict.md) — `/api/wordcloud*`、 `/api/wordcloud/:id/graph` (BFS で半径 1-3)、 `/api/wordcloud/:id/siblings`、 `/api/wordcloud/merge`、 `/api/wordcloud/validate-word`
+- ストップワード: `/api/stopwords*`
+
+## シェア可能か
+**local-only**
+
+ワードクラウドそのものを Hub にシェアする経路は無い (`/api/multi/share` の kind 列挙に無し)。 派生ソースの bookmark / dig をシェアすれば、 Hub のダウンロード側で各自再生成する形。
+
+## プライバシー観点
+- **個人データを保持するテーブル**: `word_clouds.result_json` には抽出語と元 sources の URL / title / snippet が含まれる (related_pages 経由で表示)。 origin が bookmark の場合は **対象ブクマの本文要約 + URL** が間接的に紐付く。
+- **LLM プロバイダに送る情報**: タスク `cloud_extract` でブクマ群の `[Doc N] title / URL / categories / summary` (各 800 字) を、 単一ブクマでは本文テキスト 12,000 字を Claude / Gemini / Codex / OpenAI に送る。 dig 由来は overview + sources の URL/title/snippet。 `cloud_validate` (`/api/wordcloud/validate-word`) は語 + コンテキストを送る。 すべてユーザの API key スコープ。
+- **共有時に外部に出ない情報**: クラウド全部 (シェア対象外)。
+- **削除時の挙動**: 元の bookmark を削除すると CASCADE で `origin_bookmark_id` 経由のクラウドも消える。 dig セッション削除時は origin_dig_id が orphan 化 (UI ハンドル)。 ストップワード除外は再生成しないと反映されない。

--- a/spec/feature/workplace.md
+++ b/spec/feature/workplace.md
@@ -1,0 +1,58 @@
+# workplace — 作業場所 + presence
+
+## 概要
+GPS 座標付きの「作業場所」 (自宅 / コワーキング / カフェ等) をカタログ化し、 GPS チェックインで自動 enter/leave 検出。 オプションで Hub に presence (どこに居るか) をブロードキャスト。
+
+## ユースケース
+- 「今日の作業セッション」 を場所別 / 時間別に集計 (`/api/work-sessions`)
+- 自宅 = activity_events が無いと non-working 扱い (プライベート時間検出)
+- workplace を Hub にシェア (店名 / 住所 / WiFi / 電源タグ等のレビュー的用途)
+- presence 共有 → 「今 LUDIARS 仲間が WeWork に居る」 を可視化
+
+## 画面 / 入口
+- `🗄 データベース` タブ → サブビュー `作業場所` (DATABASE_REDIRECT_TABS に含まれる)
+- 詳細モーダル: name / address / lat,lng / tags / shareable
+- Place API で逆ジオコード (`/api/work-locations/resolve-place` → Nominatim default)
+- チェックイン: `POST /api/work-locations/checkin` (lat/lng → 半径内最近接 → enter/leave)
+
+## データ
+- [work_locations](../db/workplace.md) — name / address / latitude / longitude / description / url / tags / shareable / shared_at / owner_user_id
+- 集計入力: [gps_locations](../db/gps.md), [activity_events](../db/activity.md)
+- 状態: `app_settings.workplace.current.id` / `workplace.current.at` (現在チェックイン中の workplace)
+
+## API
+- [workplace.md](../api/workplace.md) — `/api/work-locations*` (CRUD) / `/api/work-locations/resolve-place` / `/api/work-locations/checkin` / `/api/work-sessions` (1 日のセッション検出)
+- 関連: [multi.md](../api/multi.md) `/api/multi/share` (kind=work_location)、 Hub への presence は `shareWorkplacePresence` 経由 (multi-client.js)
+
+## シェア可能か
+**Hub-shareable** (workplace カタログ自体 + presence の 2 系統)
+
+### workplace カタログのシェア (明示操作)
+シェアされるフィールド:
+
+| field | 内容 |
+|---|---|
+| `name` | 場所名 |
+| `address` | 住所 |
+| `latitude` / `longitude` | GPS 座標 |
+| `description` | 説明 |
+| `url` | 公式サイト |
+| `tags` | カンマ区切りタグ |
+
+### presence のシェア (チェックイン自動)
+`workplace_auto_share_enabled = true` のとき、 enter/leave 時に Hub `/api/shared/workplace-presence` に自動 POST:
+
+| field | 内容 |
+|---|---|
+| `workplace_name` | 場所名 |
+| `address` | 住所 |
+| `latitude` / `longitude` | 座標 |
+| `kind` | `enter` / `leave` |
+
+経路: いずれも **write-relay-only via Imperativus** (Cernere JWT 必須)。 GPS 軌跡そのものは流れず、 場所名 + 座標のスナップショットだけ。
+
+## プライバシー観点
+- **個人データを保持するテーブル**: `work_locations` (生活拠点が直接わかる、 自宅含む)、 `app_settings.workplace.current.*` (現在地)。
+- **LLM プロバイダに送る情報**: workplace 機能自体は LLM 非依存。 Place API (Nominatim default) には lat/lng が **third-party HTTPS** で出る点に注意 (`places.api.url` で内製 API に切り替え可能)。
+- **共有時に外部に出ない情報**: `shareable=0` の workplace は Hub に出ない。 自宅判定の名前 (`自宅` 含む) のローカル判定ロジック、 滞在時間の分単位集計、 GPS 軌跡そのもの (gps.md 参照)。
+- **削除時の挙動**: `DELETE /api/work-locations/:id` で行削除。 GPS 軌跡 / activity_events は影響なし (場所名 lookup ができなくなるだけ)。 Hub にシェア済の場合は残置。


### PR DESCRIPTION
## Summary
`spec/feature/` を新設し、 Memoria の 23 機能をそれぞれ 1 ファイルで文書化。

## 各ファイルの構成 (順序固定)
1. 概要
2. ユースケース
3. 画面 / 入口
4. データ (主要 SQLite テーブル + 物理ファイル)
5. API (関連 endpoint)
6. シェア可能か (Hub-shareable / local-only / derived-only)
7. プライバシー観点 (個人データ / LLM 送信範囲 / 削除時の CASCADE)

## 共有レベル一覧
- ✓ **Hub-shareable**: `bookmark / dig / dictionary / task (Actio) / workplace / implementation-notes / multi-hub`
- 🏠 **local-only**: `diary / weekly / meal / gps / agent / visit / wordcloud / domain-catalog / push / legatus / external-chat / mcp / uptime / llm-config / privacy-settings / stopwords`

shareable な機能には共有フィールドの具体 + 共有経路 (write-relay-only via Imperativus, PR #17) を明示。

## Test plan
- [x] 25 ファイル新規 (README + 23 feature + spec/README.md 更新)
- [x] 各機能の裏取り: `server/routes/`, `spec/db/`, `spec/api/`, memory
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)