### PR TITLE
feat(weekly): 週報に定量サマリ追加 + ナラティブ短縮

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -2233,13 +2233,51 @@ export function getDiary(db: Db, dateStr: string): DiaryEntryParsed | null {
   };
 }
 
-export function listDiariesInRange(db: Db, { start, end }: { start: string; end: string }): Pick<DiaryEntryRow, 'date' | 'status' | 'summary' | 'notes' | 'updated_at'>[] {
+export function listDiariesInRange(db: Db, { start, end }: { start: string; end: string }): Pick<DiaryEntryRow, 'date' | 'status' | 'summary' | 'notes' | 'work_content' | 'work_minutes' | 'updated_at'>[] {
   return db.prepare(`
-    SELECT date, status, summary, notes, updated_at
+    SELECT date, status, summary, notes, work_content, work_minutes, updated_at
     FROM diary_entries
     WHERE date >= ? AND date <= ?
     ORDER BY date ASC
-  `).all(start, end) as Pick<DiaryEntryRow, 'date' | 'status' | 'summary' | 'notes' | 'updated_at'>[];
+  `).all(start, end) as Pick<DiaryEntryRow, 'date' | 'status' | 'summary' | 'notes' | 'work_content' | 'work_minutes' | 'updated_at'>[];
+}
+
+// ── 週次レポート用 集計 helpers ─────────────────────────────────────────────
+//
+// 各テーブルの timestamp 列はすべて UTC ISO で格納されているので、
+// `date(<col>, 'localtime')` でローカル日付に丸めてから期間 (YYYY-MM-DD)
+// と突合する。 diary.date は元々ローカル日付なので変換不要。
+
+export interface DateRange { start: string; end: string }
+
+export function countBookmarksInRange(db: Db, { start, end }: DateRange): number {
+  return ((db.prepare(`
+    SELECT COUNT(*) AS c FROM bookmarks
+    WHERE date(created_at, 'localtime') BETWEEN ? AND ?
+  `).get(start, end) as { c: number } | undefined)?.c) ?? 0;
+}
+
+export function countVisitEventsInRange(db: Db, { start, end }: DateRange): number {
+  return ((db.prepare(`
+    SELECT COUNT(*) AS c FROM visit_events
+    WHERE date(visited_at, 'localtime') BETWEEN ? AND ?
+  `).get(start, end) as { c: number } | undefined)?.c) ?? 0;
+}
+
+export function countActivityEventsInRange(db: Db, kind: string, { start, end }: DateRange): number {
+  return ((db.prepare(`
+    SELECT COUNT(*) AS c FROM activity_events
+    WHERE kind = ? AND date(occurred_at, 'localtime') BETWEEN ? AND ?
+  `).get(kind, start, end) as { c: number } | undefined)?.c) ?? 0;
+}
+
+export interface WeeklyTotals {
+  work_minutes: number;
+  bookmarks: number;
+  visit_events: number;
+  github_commits: number;          // caller fills (githubByRepo.total)
+  claude_code_prompts: number;
+  git_commits_local: number;       // activity_events kind='git_commit' (= ローカル post-commit hook)
 }
 
 export interface UpsertDiaryInput {

--- a/server/diary.ts
+++ b/server/diary.ts
@@ -1630,26 +1630,32 @@ interface WeeklyPromptArgs {
   weekEnd: string;
   dailyBlock: string;
   githubBlock: string;
+  totalsBlock: string;
 }
 
-const WEEKLY_PROMPT = ({ weekStart, weekEnd, dailyBlock, githubBlock }: WeeklyPromptArgs): string => [
+const WEEKLY_PROMPT = ({ weekStart, weekEnd, dailyBlock, githubBlock, totalsBlock }: WeeklyPromptArgs): string => [
   `あなたは ${weekStart} から ${weekEnd} までの「週報」を書きます。`,
-  '7 日分の日報と GitHub コミットヒストリから、週全体での実作業を統合してください。',
+  '7 日分の日報 + GitHub commit + 定量サマリ (= 週合計の作業時間 / ブックマーク数 / 訪問数 / commit 数 / Claude Code 指示数) から週全体を統合してください。',
   '',
-  '出力フォーマット (markdown のみ。前置き不要):',
+  '出力フォーマット (markdown のみ。 前置き不要):',
   '## 今週やったこと',
-  '一段落で週全体を概観。',
+  '**2〜3 文以内**の超簡潔サマリ (詳細は書かない、 全体の流れを掴ませる程度)。',
   '## 主な成果',
-  '- 箇条書き。GitHub commit から実装した機能・修正を中心に。',
-  '- 進捗が大きかったプロジェクトを優先。',
+  '- 箇条書き。 各行は「**(N commit)** プロジェクト名: やったこと」 のように **commit 数を必ず prefix** する。',
+  '- 進捗が大きかったプロジェクトを優先 (上位 5 件まで)。',
   '## トピック別',
-  '- 学んだこと・調べたこと (作業内容ベース)',
+  '- 学んだこと・調べたこと (作業内容ベース、 1-3 行)',
   '## 来週への引き継ぎ',
-  '- 未完了に見える作業やフォローアップ',
+  '- 未完了 / フォローアップ (1-3 行)',
   '',
   '出力ルール:',
-  '- 創作禁止。日報と commit に基づくこと',
+  '- 創作禁止。 日報と commit に基づくこと',
+  '- 数字 (commit 数 / 訪問数 / etc) は提示された定量サマリと一致させる',
   '- リポジトリ名は短く (org/ は省いて末尾のみで OK)',
+  '- 全体で **300-500 字程度に収める**こと (短くまとめる)',
+  '',
+  '## 入力 0: 定量サマリ (この数値は変えない)',
+  totalsBlock,
   '',
   '## 入力 1: 日報サマリ (日付ごと)',
   dailyBlock,
@@ -1662,6 +1668,50 @@ export interface DailyDiaryEntry {
   date: string;
   summary?: string | null;
   work_content?: string | null;
+  work_minutes?: number | null;
+}
+
+export interface WeeklyMetrics {
+  /** diary_entries.work_minutes の週合計 (Sonnet 推定値の積み上げ)。 0 = 記録なし */
+  work_minutes: number;
+  /** 今週中に新規作成された bookmarks (created_at で count) */
+  bookmarks: number;
+  /** 今週中の visit_events (= 1 訪問 1 行) */
+  visit_events: number;
+  /** GitHub API から取得した commit 総数 (githubByRepo.total と一致) */
+  github_commits: number;
+  /** activity_events kind='git_commit' のローカル post-commit 件数 */
+  git_commits_local: number;
+  /** activity_events kind='claude_code_prompt' の件数 */
+  claude_code_prompts: number;
+}
+
+function formatWorkTime(minutes: number): string {
+  if (!Number.isFinite(minutes) || minutes <= 0) return '0 分 (記録なし)';
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  if (h <= 0) return `${m} 分`;
+  return m > 0 ? `${h} 時間 ${m} 分` : `${h} 時間`;
+}
+
+function formatTotalsBlock(metrics: WeeklyMetrics): string {
+  return [
+    `- ⏱ 作業時間 (Sonnet 推定の週合計): ${formatWorkTime(metrics.work_minutes)}`,
+    `- 🔖 ブックマーク新規追加: ${metrics.bookmarks} 件`,
+    `- 🌐 Web 訪問 (記録分): ${metrics.visit_events} 件`,
+    `- 🐙 GitHub commit: ${metrics.github_commits} 件 (API 取得)`,
+    `- 💻 ローカル commit (hook): ${metrics.git_commits_local} 件`,
+    `- 🤖 Claude Code 指示: ${metrics.claude_code_prompts} 件`,
+  ].join('\n');
+}
+
+function formatTotalsHeader(weekStart: string, weekEnd: string, metrics: WeeklyMetrics): string {
+  return [
+    `# 週報 ${weekStart} 〜 ${weekEnd}`,
+    '',
+    '## 今週の定量サマリ',
+    formatTotalsBlock(metrics),
+  ].join('\n');
 }
 
 export interface GenerateWeeklyArgs {
@@ -1669,28 +1719,36 @@ export interface GenerateWeeklyArgs {
   weekEnd: string;
   dailyDiaries: DailyDiaryEntry[];
   githubByRepo: GithubByRepo;
+  metrics: WeeklyMetrics;
   timeoutMs?: number;
 }
 
 /**
- * Generate a weekly narrative from 7 daily diaries + commits.
- * The caller pre-fetches both via the GitHub API (per-repo commits API).
+ * Generate a weekly narrative from 7 daily diaries + commits + 定量メトリクス。
+ * 出力には冒頭に「定量サマリ (deterministic)」 を必ず含み、 LLM はその下に
+ * 短いナラティブ (今週やったこと / 主な成果 / トピック / 引き継ぎ) を書く。
  */
 export async function generateWeekly({
-  weekStart, weekEnd, dailyDiaries, githubByRepo, timeoutMs = 360_000,
+  weekStart, weekEnd, dailyDiaries, githubByRepo, metrics, timeoutMs = 360_000,
 }: GenerateWeeklyArgs): Promise<string> {
-  const dailyBlock = dailyDiaries.map(d => {
+  const dailyBlock = dailyDiaries.map((d) => {
     const head = d.summary || d.work_content || '(日報なし)';
-    return `### ${d.date}\n${(head || '').slice(0, 1500)}`;
+    const wm = d.work_minutes != null && d.work_minutes > 0 ? ` [${formatWorkTime(d.work_minutes)}]` : '';
+    return `### ${d.date}${wm}\n${(head || '').slice(0, 1200)}`;
   }).join('\n\n');
   const githubBlock = githubByRepo.repos.length
-    ? githubByRepo.repos.map(r => {
-      const samples = (r.samples || []).map(s => `  - ${s.sha} ${s.message}`).join('\n');
+    ? githubByRepo.repos.map((r) => {
+      const samples = (r.samples || []).slice(0, 6).map((s) => `  - ${s.sha} ${s.message}`).join('\n');
       return `${r.repo}: ${r.count} commits\n${samples}`;
     }).join('\n\n')
     : '(commit なし)';
-  const prompt = WEEKLY_PROMPT({ weekStart, weekEnd, dailyBlock, githubBlock });
-  return await runLlm({ task: 'diary_weekly', prompt, timeoutMs });
+  const totalsBlock = formatTotalsBlock(metrics);
+  const prompt = WEEKLY_PROMPT({ weekStart, weekEnd, dailyBlock, githubBlock, totalsBlock });
+  const narrative = await runLlm({ task: 'diary_weekly', prompt, timeoutMs });
+  // deterministic な定量サマリ + LLM ナラティブを連結。 万一 LLM が定量見出しを
+  // 重ねて出してきた場合に備え、 narrative 側の重複は触らずそのまま残す。
+  const header = formatTotalsHeader(weekStart, weekEnd, metrics);
+  return `${header}\n\n${narrative.trim()}`;
 }
 
 export interface FetchGithubRangeArgs {

--- a/server/lib/queues.ts
+++ b/server/lib/queues.ts
@@ -24,6 +24,7 @@ import {
   digThemeContext,
   upsertWeekly, listDiariesInRange,
   getDiarySettings,
+  countBookmarksInRange, countVisitEventsInRange, countActivityEventsInRange,
 } from '../db.js';
 import { summarizeWithClaude } from '../claude.js';
 import { classifyDomain, shouldSkipDomain } from '../domain-catalog.js';
@@ -620,11 +621,25 @@ export function makeQueues(deps: QueuesDeps): QueueBundle {
       githubByRepo = summarizeGithubByRepo(fetched);
     }
 
+    // 週次定量メトリクス: ローカル DB から count + diary work_minutes 合計
+    const workMinutesTotal = dailyDiaries.reduce(
+      (acc, d) => acc + (typeof d.work_minutes === 'number' && d.work_minutes > 0 ? d.work_minutes : 0),
+      0,
+    );
+    const metrics = {
+      work_minutes: workMinutesTotal,
+      bookmarks: countBookmarksInRange(db, range),
+      visit_events: countVisitEventsInRange(db, range),
+      github_commits: githubByRepo.total,
+      git_commits_local: countActivityEventsInRange(db, 'git_commit', range),
+      claude_code_prompts: countActivityEventsInRange(db, 'claude_code_prompt', range),
+    };
+
     let summary: string;
     try {
       summary = await generateWeekly({
         weekStart: range.start, weekEnd: range.end,
-        dailyDiaries, githubByRepo,
+        dailyDiaries, githubByRepo, metrics,
       });
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);

--- a/spec/feature/weekly.md
+++ b/spec/feature/weekly.md
@@ -1,12 +1,13 @@
 # weekly — 週次レポート
 
 ## 概要
-週単位 (日曜 23:05 cron) で 7 日分の日記をまとめて Opus 1M に渡し、 サマリ + GitHub commit 集計を生成する。 月ベースで `週 N` をラベル付け。
+週単位 (日曜 23:05 cron) で 7 日分の日記をまとめて Opus 1M に渡し、 **冒頭に定量サマリ + LLM が生成する短いナラティブ**を生成する。 月ベースで `週 N` をラベル付け。
 
 ## ユースケース
 - 1 週間の振り返り / 月次 KPI の素材
 - 「先週のハイライトを LinkedIn 投稿用に」 みたいな引用元
 - 月の中の `week_in_month` で N 週目を示せる
+- 週合計の作業時間 / コミット / ブックマーク数を一目で確認
 
 ## 画面 / 入口
 - `📅 日記` タブ → 月の上部 / 下部に週次レポート行
@@ -14,7 +15,41 @@
 
 ## データ
 - [weekly_reports](../db/diary.md) — week_start (PK) / week_end / month / week_in_month / summary / github_summary_json / status
-- 集計参照: [diary_entries](../db/diary.md) / [activity_events](../db/activity.md) / [bookmarks](../db/bookmark.md)
+- 集計参照:
+  - [diary_entries](../db/diary.md) (`work_minutes` の合計を週作業時間として記載)
+  - [bookmarks](../db/bookmark.md) (`created_at` を週で count)
+  - [visit_events](../db/visit.md) (`visited_at` を週で count)
+  - [activity_events](../db/activity.md) (`kind='git_commit'` のローカル commit hook 件数 + `kind='claude_code_prompt'` の指示件数を week で count)
+  - GitHub API (per-repo commits API、 `diary_settings.github_repos` で対象を絞る)
+
+## 出力フォーマット (rev2)
+週次レポートの `summary` は以下の構造を持つ:
+
+```markdown
+# 週報 YYYY-MM-DD 〜 YYYY-MM-DD
+
+## 今週の定量サマリ
+- ⏱ 作業時間 (Sonnet 推定の週合計): X 時間 Y 分
+- 🔖 ブックマーク新規追加: N 件
+- 🌐 Web 訪問 (記録分): N 件
+- 🐙 GitHub commit: N 件 (API 取得)
+- 💻 ローカル commit (hook): N 件
+- 🤖 Claude Code 指示: N 件
+
+## 今週やったこと
+(LLM 出力、 2-3 文以内の超簡潔サマリ)
+
+## 主な成果
+- (LLM 出力、 各行は **(N commit)** prefix で commit 数を必ず含める。 上位 5 件)
+
+## トピック別
+- (LLM 出力、 1-3 行)
+
+## 来週への引き継ぎ
+- (LLM 出力、 1-3 行)
+```
+
+**冒頭の「今週の定量サマリ」 は決定論的に生成**(server/diary.ts の `formatTotalsHeader`)、 LLM が触れることはない。 LLM はそれ以下の 4 セクションを書くが、 各成果行に commit 数を埋め込ませるためプロンプトで定量サマリを文脈として渡している。 全体で 300-500 字程度に収める指示を含む。
 
 ## API
 - [diary.md](../api/diary.md) — `/api/weekly` (月一覧) / `/api/weekly/:weekStart` / `/api/weekly/:weekStart/generate` / `DELETE /api/weekly/:weekStart`
@@ -25,7 +60,7 @@
 週次レポートを Hub にシェアする経路は無い。 日記と同じ理由で意図的に local-only。
 
 ## プライバシー観点
-- **個人データを保持するテーブル**: `weekly_reports` (1 週間の生活ログ高度集約)。
-- **LLM プロバイダに送る情報**: タスク `diary_weekly` (Opus 1M default) に 7 日分の日記 summary / work_content / highlights + GitHub commit 集計を渡す。 これは日記生成時の prompt より大きい個人情報量。
+- **個人データを保持するテーブル**: `weekly_reports` (1 週間の生活ログ高度集約)。 定量サマリには 1 週間の作業時間 / アクティビティ件数が露出する。
+- **LLM プロバイダに送る情報**: タスク `diary_weekly` (Opus 1M default) に 7 日分の日記 summary / work_content + 各日の work_minutes + GitHub commit 集計 + 定量サマリを渡す。 個人情報量は日記生成時の prompt より大きい。
 - **共有時に外部に出ない情報**: 週次レポート全体。
 - **削除時の挙動**: `DELETE /api/weekly/:weekStart` で行を削除。 GitHub PAT は `diary_settings` 側にあるためここでは触らない。


### PR DESCRIPTION
## Summary
- 週報の **冒頭に週合計の定量サマリ**を deterministic に挿入: 作業時間 / ブックマーク / 訪問 / GitHub commit / ローカル commit / Claude Code 指示
- LLM ナラティブ部 (今週やったこと / 主な成果 / トピック / 引き継ぎ) を **300-500 字に短縮**、 各「主な成果」 行に **(N commit)** prefix を必須化
- 「今週やったこと」 は 2-3 文以内に制限

## 出力例 (期待される構造)

```markdown
# 週報 2026-05-04 〜 2026-05-10

## 今週の定量サマリ
- ⏱ 作業時間 (Sonnet 推定の週合計): 46 時間 35 分
- 🔖 ブックマーク新規追加: 11 件
- 🌐 Web 訪問 (記録分): 2754 件
- 🐙 GitHub commit: 142 件 (API 取得)
- 💻 ローカル commit (hook): 156 件
- 🤖 Claude Code 指示: 3096 件

## 今週やったこと
(2-3 文の超簡潔サマリ)

## 主な成果
- **(28 commit)** Memoria: ノート機能 rev1-4 + bookmark canvas + Notion 取り込み
- **(15 commit)** Synergos: …

## トピック別
- (1-3 行)

## 来週への引き継ぎ
- (1-3 行)
```

## 変更点
- `server/db.ts`: `listDiariesInRange` を work_content/work_minutes 込みに、 `countBookmarksInRange` / `countVisitEventsInRange` / `countActivityEventsInRange(kind)` を新設
- `server/diary.ts`: `WeeklyMetrics` 型、 `formatTotalsHeader` で deterministic ヘッダ生成、 `generateWeekly` を改修 (LLM 出力と連結)
- `server/lib/queues.ts`: `runWeeklyGenerationLocal` で metrics を集計して注入
- `spec/feature/weekly.md`: rev2 出力フォーマット明記

## Test plan
- [x] `npm run typecheck` グリーン
- [x] `npm run lint` グリーン (ESLint --max-warnings 0)
- [x] 集計 SQL を node で直接実行 → 過去 7 日: bookmarks 11 / visits 2754 / cc 3096 / git_commit 156 / work 2795 分
- [ ] `POST /api/weekly/:weekStart/generate` で実 LLM 経由で生成して定量サマリ + 短いナラティブが返るか
- [ ] 日記タブで rendering 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)