### PR TITLE
fix(notes): ArrowUp/Down 移動 + メニュー位置クランプ + 色修正 + モバイル UI

### DIFF
--- a/server/public/index.html
+++ b/server/public/index.html
@@ -817,6 +817,9 @@
           <aside class="notes-comments" id="notesComments">
             <div class="muted">ノートを選択するとコメントが表示されます</div>
           </aside>
+          <!-- スマホ専用フローティングボタン: ブロックを「いま居るブロックの次」 に挿入する。
+               PC では CSS @media で非表示。 ノート未選択時も JS で hidden=true。 -->
+          <button id="notesMobileFab" class="notes-mobile-fab" type="button" hidden aria-label="ブロックを追加">＋</button>
         </div>
       </div>
 

--- a/server/public/src/notes/editor.ts
+++ b/server/public/src/notes/editor.ts
@@ -29,6 +29,8 @@ interface EditorState {
   saveTimers: Map<string, number>;
   loadingMermaid: Promise<MermaidLib> | null;
   bookmarkPickerOpen: boolean;
+  /** 最後に focus された block の uuid。 モバイル FAB の挿入位置に使う。 */
+  lastFocusedBlockUuid: string | null;
 }
 
 const state: EditorState = {
@@ -39,6 +41,7 @@ const state: EditorState = {
   saveTimers: new Map(),
   loadingMermaid: null,
   bookmarkPickerOpen: false,
+  lastFocusedBlockUuid: null,
 };
 
 const SAVE_DEBOUNCE_MS = 600;
@@ -103,11 +106,21 @@ export function initNotes(): void {
   const sidebarToggle = byId<HTMLButtonElement>('notesSidebarToggle');
   if (sidebarToggle) sidebarToggle.addEventListener('click', () => toggleNotesSidebar());
 
-  // 初期状態: mobile では drawer 閉、 PC では開。
+  // モバイル用 FAB: いま居るブロックの次にブロックを追加する挿入メニュー。
+  const mobileFab = byId<HTMLButtonElement>('notesMobileFab');
+  if (mobileFab) {
+    mobileFab.addEventListener('click', (ev) => {
+      ev.stopPropagation();   // closeOnOutside の即時クローズを回避
+      openInsertBlockMenu(mobileFab);
+    });
+  }
+
+  // 初期状態: モバイルでも note 未選択なら sidebar を開いて起動 (= ノート選択
+  // メニューから始まる)。 PC は常に開。 note を選んだ時点で closeNotesSidebarOnMobile
+  // が走って閉じる。
   const layout0 = byId<HTMLDivElement>('notesLayout');
   if (layout0) {
-    if (isMobileNotesViewport()) layout0.classList.remove('notes-sidebar-open');
-    else layout0.classList.add('notes-sidebar-open');
+    layout0.classList.add('notes-sidebar-open');
   }
   // backdrop タップ (mobile) → drawer を閉じる
   document.addEventListener('click', (e) => {
@@ -202,10 +215,21 @@ export async function openNote(uuid: string): Promise<void> {
   const note = await api.getNote(uuid);
   state.current = note;
   state.currentSet = null;
+  state.lastFocusedBlockUuid = note.blocks?.[note.blocks.length - 1]?.uuid ?? null;
   renderEditor();
   renderSidebar();
   closeNotesSidebarOnMobile();
+  updateMobileFabVisibility();
   void loadOwnCommentSet();
+}
+
+function updateMobileFabVisibility(): void {
+  const fab = byId<HTMLButtonElement>('notesMobileFab');
+  if (!fab) return;
+  // note が開かれているとき (= state.current あり) だけ表示。 PC は CSS @media で
+  // どのみち非表示になっているので、 hidden 属性での出し分けは主に「note 未選択」
+  // 用途。
+  fab.hidden = !state.current;
 }
 
 function isMobileNotesViewport(): boolean {
@@ -999,11 +1023,58 @@ function attachAutoSave(
     });
   };
   el.addEventListener('blur', flush);
+  el.addEventListener('focus', () => { state.lastFocusedBlockUuid = block.uuid; });
   el.addEventListener('input', () => {
     if (state.saveTimers.has(block.uuid)) window.clearTimeout(state.saveTimers.get(block.uuid));
     state.saveTimers.set(block.uuid, window.setTimeout(flush, SAVE_DEBOUNCE_MS));
   });
   el.addEventListener('keydown', (ev) => handleEditorKey(ev, block));
+}
+
+// ── caret 位置判定 (ArrowUp/Down で前後ブロックに移動するか決めるのに使う) ──
+//
+// contenteditable 内の Selection を見て、 caret が要素の先頭 / 末尾にあるかを返す。
+// 先頭にあって ArrowUp なら前の block に移動、 末尾にあって ArrowDown なら次に
+// 移動。 code / mermaid のような多行ブロックは「最初の行 / 最後の行」 にいる
+// ときだけ block 越え移動になる。
+function caretAtEdges(el: HTMLElement): { atStart: boolean; atEnd: boolean } {
+  const sel = window.getSelection();
+  if (!sel || sel.rangeCount === 0 || !el.contains(sel.anchorNode)) {
+    return { atStart: false, atEnd: false };
+  }
+  const range = sel.getRangeAt(0);
+  if (!range.collapsed) return { atStart: false, atEnd: false };
+  // collapsed caret の左側 / 右側に何かテキストが残っているかで判定。
+  const before = document.createRange();
+  before.selectNodeContents(el);
+  before.setEnd(range.startContainer, range.startOffset);
+  const atStart = before.toString().length === 0;
+  const after = document.createRange();
+  after.selectNodeContents(el);
+  after.setStart(range.endContainer, range.endOffset);
+  const atEnd = after.toString().length === 0;
+  return { atStart, atEnd };
+}
+
+function focusBlock(uuid: string, place: 'start' | 'end'): boolean {
+  const target = document.querySelector<HTMLElement>(`[data-block-uuid="${uuid}"] .note-block-content`);
+  if (!target) return false;
+  target.focus();
+  // caret を端に置く (Enter/Backspace の挙動と整合)
+  const range = document.createRange();
+  range.selectNodeContents(target);
+  range.collapse(place === 'start');
+  const sel = window.getSelection();
+  if (sel) { sel.removeAllRanges(); sel.addRange(range); }
+  return true;
+}
+
+function siblingBlockUuid(currentUuid: string, direction: -1 | 1): string | null {
+  const blocks = state.current?.blocks ?? [];
+  const idx = blocks.findIndex((b) => b.uuid === currentUuid);
+  if (idx < 0) return null;
+  const next = blocks[idx + direction];
+  return next?.uuid ?? null;
 }
 
 function htmlToStorageText(el: HTMLElement): string {
@@ -1037,6 +1108,22 @@ function handleEditorKey(ev: KeyboardEvent, block: NoteBlockRow): void {
     ev.preventDefault();
     openBlockMenu(block.uuid, ev.currentTarget as HTMLElement, true);
     return;
+  }
+  // ArrowUp / ArrowDown: caret が先頭 / 末尾なら前後ブロックの contenteditable に
+  // focus を移す。 中間にいるときは default 動作 (= contenteditable 内 caret 移動)。
+  // 修飾キー (Shift / Alt / Meta) が押されている場合は範囲選択 / 専用ショート
+  // カットの可能性があるので何もしない。
+  if ((ev.key === 'ArrowUp' || ev.key === 'ArrowDown') && !ev.shiftKey && !ev.altKey && !ev.metaKey && !ev.ctrlKey) {
+    const el = ev.currentTarget as HTMLElement;
+    const edges = caretAtEdges(el);
+    if (ev.key === 'ArrowUp' && edges.atStart) {
+      const prev = siblingBlockUuid(block.uuid, -1);
+      if (prev && focusBlock(prev, 'end')) { ev.preventDefault(); return; }
+    }
+    if (ev.key === 'ArrowDown' && edges.atEnd) {
+      const next = siblingBlockUuid(block.uuid, 1);
+      if (next && focusBlock(next, 'start')) { ev.preventDefault(); return; }
+    }
   }
 }
 
@@ -1091,9 +1178,7 @@ function openBlockMenu(blockUuid: string, anchor: HTMLElement, _slashMode = fals
     <button class="nbm-item nbm-danger" data-action="delete">🗑 削除</button>
   `;
   document.body.appendChild(menu);
-  const r = anchor.getBoundingClientRect();
-  menu.style.left = `${r.left}px`;
-  menu.style.top = `${r.bottom + 4}px`;
+  positionBlockMenu(menu, anchor);
   openMenu = menu;
   menu.querySelectorAll<HTMLButtonElement>('.nbm-item').forEach((btn) => {
     btn.addEventListener('click', () => {
@@ -1117,6 +1202,88 @@ function openBlockMenu(blockUuid: string, anchor: HTMLElement, _slashMode = fals
   setTimeout(() => {
     document.addEventListener('click', closeOnOutside, { once: true });
   }, 0);
+}
+
+// スマホ FAB 用「ブロック追加」 メニュー。 既存の openBlockMenu と違って
+// 「現在ブロックの種別変更」 ではなく「現在ブロックの次に新規ブロックを追加」
+// するための専用フロー。
+function openInsertBlockMenu(anchor: HTMLElement): void {
+  if (!state.current) return;
+  closeBlockMenu();
+  const blocks = state.current.blocks;
+  // 挿入位置の決定: 直前 focus → 最終ブロック → どれも無ければ undefined (=末尾)
+  const afterUuid = (state.lastFocusedBlockUuid && blocks.some((b) => b.uuid === state.lastFocusedBlockUuid))
+    ? state.lastFocusedBlockUuid
+    : blocks[blocks.length - 1]?.uuid;
+  const menu = document.createElement('div');
+  menu.className = 'note-block-menu';
+  const typeOptions = BLOCK_TYPE_OPTIONS.filter((o) => o.type !== 'floating_text');
+  menu.innerHTML = `
+    <div class="nbm-section">追加するブロック種別</div>
+    ${typeOptions.map((o) => `
+      <button class="nbm-item" data-type="${o.type}"><span class="nbm-icon">${o.icon}</span>${o.label}</button>
+    `).join('')}
+  `;
+  document.body.appendChild(menu);
+  positionBlockMenu(menu, anchor);
+  openMenu = menu;
+  menu.querySelectorAll<HTMLButtonElement>('.nbm-item').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const t = btn.dataset.type as NoteBlockType | undefined;
+      closeBlockMenu();
+      if (!t) return;
+      if (t === 'bookmark_embed' || t === 'note_link') {
+        // 既存パターン: 空 text を挿入してから picker → picker 側で change-type
+        void appendBlock('text', afterUuid).then(() => {
+          const list = state.current?.blocks ?? [];
+          const idx = afterUuid ? list.findIndex((b) => b.uuid === afterUuid) : -1;
+          const inserted = idx >= 0 ? list[idx + 1] : list[list.length - 1];
+          if (!inserted) return;
+          if (t === 'bookmark_embed') openBookmarkPickerForBlock(inserted.uuid);
+          else openNotePickerForBlock(inserted.uuid);
+        });
+        return;
+      }
+      void appendBlock(t, afterUuid);
+    });
+  });
+  setTimeout(() => {
+    document.addEventListener('click', closeOnOutside, { once: true });
+  }, 0);
+}
+
+// メニューを viewport にクランプして配置する。
+// 既定: anchor の下に出す。 下が見切れる場合は上に。 左右もはみ出さないようクランプ。
+function positionBlockMenu(menu: HTMLElement, anchor: HTMLElement): void {
+  const margin = 8;
+  // 一度フィットさせて寸法を取得 (position: fixed + 左上に仮配置)
+  menu.style.left = '0px';
+  menu.style.top = '0px';
+  menu.style.maxHeight = `${Math.max(160, window.innerHeight - 2 * margin)}px`;
+  menu.style.overflowY = 'auto';
+  const r = anchor.getBoundingClientRect();
+  const m = menu.getBoundingClientRect();
+  // 横位置: anchor 左を基準に右側にはみ出さないようクランプ
+  let left = r.left;
+  if (left + m.width > window.innerWidth - margin) left = window.innerWidth - m.width - margin;
+  if (left < margin) left = margin;
+  // 縦位置: 下に出して入るなら下、 入らなければ上に出す。 両方無理なら上端に貼り付け
+  const spaceBelow = window.innerHeight - r.bottom - margin;
+  const spaceAbove = r.top - margin;
+  let top: number;
+  if (m.height <= spaceBelow) {
+    top = r.bottom + 4;
+  } else if (m.height <= spaceAbove) {
+    top = r.top - m.height - 4;
+  } else if (spaceBelow >= spaceAbove) {
+    top = r.bottom + 4;
+    menu.style.maxHeight = `${Math.max(120, spaceBelow)}px`;
+  } else {
+    top = margin;
+    menu.style.maxHeight = `${Math.max(120, spaceAbove + r.height)}px`;
+  }
+  menu.style.left = `${left}px`;
+  menu.style.top = `${top}px`;
 }
 
 function closeOnOutside(e: MouseEvent): void {

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -5543,11 +5543,14 @@ dialog.loc-edit-modal[open] {
 .nbm-item {
   display: flex; gap: 8px; align-items: center;
   width: 100%; border: 0; background: transparent;
+  /* グローバル `button { color: #fff }` を上書き — メニュー背景が白なので
+   * そのままだと「白背景に白文字」 で読めなくなる。 */
+  color: var(--text);
   text-align: left; padding: 6px 12px; cursor: pointer;
 }
 .nbm-item:hover { background: var(--accent-bg); }
 .nbm-icon { display: inline-block; width: 24px; color: var(--muted); font-weight: 600; font-size: 12px; }
-.nbm-danger { color: #c33; }
+.nbm-danger, .nbm-danger:hover { color: #c33; }
 
 /* selection toolbar */
 .note-toolbar {
@@ -5944,13 +5947,21 @@ dialog.loc-edit-modal[open] {
   .notes-layout:not(.notes-sidebar-open) { grid-template-columns: 0 minmax(0, 1fr); }
 }
 
-/* mobile drawer */
+/* mobile drawer
+ *
+ * モバイルでは sidebar (ノート選択メニュー) を ノートウインドウ内 (= タブの
+ * 下の .notes-layout 領域内) に閉じ込めて表示する。 viewport 全体を覆う
+ * fixed overlay にはしない (タブ nav まで隠れてしまうため)。
+ * → position: absolute + parent (.notes-layout) を起点に left/top/bottom = 0。
+ */
 @media (max-width: 760px) {
-  /* 既存の `.notes-layout { grid-template-columns: 1fr }` (上の方の rule) を上書きしないが、
-     sidebar を fixed off-canvas に切替えるので grid どうこうは無視される */
-  .notes-layout { position: relative; }
+  .notes-layout {
+    position: relative;
+    overflow: hidden;   /* sidebar の transform: translateX(-100%) を内部に閉じる */
+    min-height: 60vh;   /* sidebar が absolute なので layout に高さを与える */
+  }
   .notes-sidebar {
-    position: fixed;
+    position: absolute;
     top: 0;
     left: 0;
     bottom: 0;
@@ -5962,17 +5973,17 @@ dialog.loc-edit-modal[open] {
     box-shadow: 4px 0 16px rgba(0,0,0,0.2);
     transform: translateX(-100%);
     transition: transform 0.22s ease-out;
-    z-index: 9100;
-    display: block;   /* 既定 .notes-sidebar の display を維持 */
+    z-index: 50;
+    display: block;
   }
   .notes-layout.notes-sidebar-open .notes-sidebar { transform: translateX(0); }
   .notes-layout:not(.notes-sidebar-open) .notes-sidebar { display: block; transform: translateX(-100%); }
   .notes-sidebar-backdrop {
     display: block;
-    position: fixed;
+    position: absolute;
     inset: 0;
-    background: rgba(0, 0, 0, 0.45);
-    z-index: 9099;
+    background: rgba(0, 0, 0, 0.35);
+    z-index: 49;
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.22s ease-out;
@@ -5981,6 +5992,36 @@ dialog.loc-edit-modal[open] {
     opacity: 1;
     pointer-events: auto;
   }
+}
+
+/* スマホ専用フローティング「ブロック追加」 ボタン (FAB)。
+ * 右下固定。 タップで「いま居るブロックの次」 にブロックを挿入するメニューが
+ * 開く。 PC では非表示 (= 既存の hover handle + slash menu で十分)。 */
+.notes-mobile-fab {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #fff;
+  border: 0;
+  font-size: 28px;
+  font-weight: 400;
+  line-height: 1;
+  cursor: pointer;
+  z-index: 80;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.25);
+  display: none;   /* @media で mobile のみ display: flex */
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+.notes-mobile-fab[hidden] { display: none !important; }
+.notes-mobile-fab:hover { background: var(--accent); filter: brightness(1.05); }
+@media (max-width: 760px) {
+  .notes-mobile-fab { display: flex; }
 }
 
 /* 通常ノート編集の上部ツールバー (フローティング追加など) */


### PR DESCRIPTION
## Summary

ノート編集まわりの UX 修正。

- **ArrowUp / ArrowDown でブロック間 focus 移動** — caret が contenteditable の先頭 / 末尾にあるときだけ前後ブロックへ移動。 code / mermaid のような多行ブロックは内部行間移動を優先
- **ブロック追加メニューが画面下で見切れる問題** を修正。 メニュー寸法を計測して下に収まらなければ上に出す、 左右もクランプ
- **`.nbm-item` 文字色** をグローバル `button { color: #fff }` から `var(--text)` に固定 (白背景に白文字問題)
- **モバイル sidebar をノートウインドウ内に閉じ込め** — `position: absolute` + `.notes-layout` 起点で「タブの下、 ノート画面内でスライドイン」 に
- **モバイル初期表示は sidebar を開いて起動** — note 未選択時にノート選択メニューから始まる
- **モバイル専用 FAB を右下に追加** — タップで「いま focus 中のブロックの次」 にブロックを挿入する専用メニュー。 PC は既存 UI のまま、 FAB は非表示

## Test plan

- [ ] PC: ArrowUp/Down でブロック間 focus が移動する (code/mermaid 内は内部移動を優先)
- [ ] PC: ブロック「+」 メニューを画面下で開いて、 メニューが上向きに出る
- [ ] PC: スラッシュメニューのテキストが黒で見える
- [ ] スマホ (or DevTools 760px 未満): notesView を開くと sidebar が開いた状態で起動
- [ ] スマホ: sidebar はタブ nav の下、 ノート画面領域内でスライドイン (タブまで隠さない)
- [ ] スマホ: note を選択すると sidebar が閉じる
- [ ] スマホ: 右下に FAB「＋」 が表示される
- [ ] スマホ: FAB タップ → 種別メニュー → 種別を選ぶと現在ブロックの次に挿入される
- [ ] スマホ: PC では FAB が非表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)