### PR TITLE
feat(server): env via Infisical bootstrap (scaffold, Cernere pattern)

### DIFF
--- a/server/bootstrap.ts
+++ b/server/bootstrap.ts
@@ -1,0 +1,20 @@
+/**
+ * bootstrap entry — `.env` ファイル無し運用の起動口。 LUDIARS/Cernere#79 と同パターン。
+ *
+ * Memoria server は dev 起動 `npm run dev` → `tsx watch index.ts` だが、
+ * Excubitor 経由 inject 運用へ移行する際は `tsx watch bootstrap.ts` に切り替える。
+ * REQUIRED_KEYS が空のうちは ensureEnv は即 return するので動作に影響なし。
+ */
+import { ensureEnv } from './lib/env-bootstrap.js';
+
+async function bootstrap(): Promise<void> {
+  try {
+    await ensureEnv();
+  } catch (err) {
+    console.error(`[bootstrap] ${(err as Error).message}`);
+    process.exit(1);
+  }
+  await import('./index.js');
+}
+
+void bootstrap();

--- a/server/lib/env-bootstrap.ts
+++ b/server/lib/env-bootstrap.ts
@@ -1,0 +1,64 @@
+/**
+ * env-bootstrap — `.env` ファイル無しで Memoria server を起動するための env 注入。
+ *
+ * (A) Excubitor 経由: catalog.infisical.inject=true で 親が全 secret を child env に注入。
+ * (B) 単独起動:        host shell で INFISICAL_CLIENT_ID/SECRET (+ SITE_URL/PROJECT_ID/ENVIRONMENT)
+ *
+ * Cernere/Actio/Imperativus/Nuntius と同じパターン (LUDIARS/Cernere#79)。
+ *
+ * Memoria server は ローカル個人開発前提なので REQUIRED は最小限。 LLM provider key 等
+ * (ANTHROPIC_API_KEY / OPENAI_API_KEY) が必要なら REQUIRED_KEYS に追加する。
+ */
+
+const REQUIRED_KEYS: readonly string[] = [
+  // 個人 SQLite + ローカル port、 完全に必須な env は無い。
+  // 必要に応じて 'ANTHROPIC_API_KEY' / 'OPENAI_API_KEY' / 'CERNERE_PROJECT_CLIENT_ID' 等を足す。
+];
+
+export async function ensureEnv(): Promise<void> {
+  const missing = REQUIRED_KEYS.filter((k) => !process.env[k]);
+  if (missing.length === 0) {
+    return;
+  }
+
+  const siteUrl = process.env.INFISICAL_SITE_URL?.replace(/\/$/, '');
+  const projectId = process.env.INFISICAL_PROJECT_ID;
+  const environment = process.env.INFISICAL_ENVIRONMENT ?? 'dev';
+  const clientId = process.env.INFISICAL_CLIENT_ID;
+  const clientSecret = process.env.INFISICAL_CLIENT_SECRET;
+
+  if (!siteUrl || !projectId || !clientId || !clientSecret) {
+    throw new Error(
+      `[env-bootstrap] missing env: ${missing.join(', ')}\n` +
+        `Run via Excubitor with catalog.infisical.inject=true, or provide INFISICAL_* host env.`,
+    );
+  }
+
+  const loginRes = await fetch(`${siteUrl}/api/v1/auth/universal-auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ clientId, clientSecret }),
+  });
+  if (!loginRes.ok) {
+    throw new Error(`[env-bootstrap] Infisical login failed: ${loginRes.status}`);
+  }
+  const { accessToken } = (await loginRes.json()) as { accessToken: string };
+
+  const params = new URLSearchParams({ workspaceId: projectId, environment, secretPath: '/' });
+  const secretsRes = await fetch(`${siteUrl}/api/v3/secrets/raw?${params}`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!secretsRes.ok) {
+    throw new Error(`[env-bootstrap] Infisical secrets failed: ${secretsRes.status}`);
+  }
+  const { secrets } = (await secretsRes.json()) as { secrets: Array<{ secretKey: string; secretValue: string }> };
+
+  let injected = 0;
+  for (const s of secrets) {
+    if (!process.env[s.secretKey]) {
+      process.env[s.secretKey] = s.secretValue;
+      injected++;
+    }
+  }
+  console.log(`[env-bootstrap] injected ${injected} secrets from Infisical`);
+}

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -162,6 +162,9 @@ import { loadNotes as notesLoad } from './notes/index.js';
 // PAGE_HELP の本文を増やす場合は page-help.ts を編集する。
 import { initTutorial } from './tutorial.js';
 import { initHelpDrawer, openHelpFor } from './help-drawer.js';
+// 位置情報の silent / interactive 取得を分けるヘルパ。 silent は permission='granted'
+// のときだけ叩いてダイアログを出さない。 詳細は geo.ts 参照。
+import { silentGetPosition, requestPosition, type PositionLike } from './geo.js';
 
 // 旧 JS の動的オブジェクト用の緩い型 (record-y values)。 値型は `unknown`
 // でフラット。 配列メソッドや特定 key 値の narrow が必要な callsite では
@@ -6783,18 +6786,10 @@ async function startAgentRunFromModal() {
 
 // ── GPS / Place API helpers ────────────────────────────────────────────────
 
-function getCurrentPositionPromise(opts: Loose = {}) {
-  return new Promise((resolve, reject) => {
-    if (!('geolocation' in navigator)) {
-      reject(new Error('このブラウザは Geolocation に対応していません'));
-      return;
-    }
-    navigator.geolocation.getCurrentPosition(
-      (pos) => resolve(pos.coords),
-      (err) => reject(new Error(err.message || 'GPS 取得失敗')),
-      { enableHighAccuracy: true, timeout: 12000, maximumAge: 30000, ...opts },
-    );
-  });
+// 手動「現在地」 ボタン用。 permission='prompt' のときは許可ダイアログを出す
+// (= ユーザの明示的アクションなので OK)。 内部で geo.ts のキャッシュも更新する。
+async function getCurrentPositionPromise(opts: Loose = {}): Promise<PositionLike> {
+  return requestPosition(opts as PositionOptions);
 }
 
 async function resolvePlaceForCoords(coords) {
@@ -6834,25 +6829,29 @@ async function openEditorFromCurrentGps() {
 
 let _workplaceCheckinTimer = null;
 let _workplaceGeoEnabled = false;
+let _workplaceLastSilentMs = 0;
 const WORKPLACE_CHECKIN_INTERVAL_MS = 5 * 60 * 1000;
 
 async function _silentCheckin() {
   if (!_workplaceGeoEnabled) return;
   if (document.visibilityState !== 'visible') return;
+  // silent path は permission='granted' のときだけブラウザ位置 API を叩く
+  // (= 「ブラウザ設定では許可してるのに毎回ポップアップ」 問題の本丸対策)。
+  const coords = await silentGetPosition();
+  if (!coords) return;
   try {
-    const coords = await getCurrentPositionPromise({ timeout: 8000, maximumAge: 60000 });
     const r = await api('/api/work-locations/checkin', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ latitude: coords.latitude, longitude: coords.longitude }),
     });
+    _workplaceLastSilentMs = Date.now();
     const banner = $('workplaceCurrentBanner');
     if (banner && r.matched) {
       const broadcast = r.changed && r.broadcast?.ok ? ' ・ Hub に共有しました' : '';
       banner.textContent = `📍 ${r.workplace.name}${broadcast}`;
     }
   } catch (e) {
-    // 静かに失敗 (バッテリ最適化で deny されるなど)。手動ボタンでは表示する。
     console.debug('[workplace] silent checkin skipped:', e.message);
   }
 }
@@ -6865,7 +6864,6 @@ function configureWorkplaceCheckin(enabled) {
   }
   if (_workplaceGeoEnabled) {
     _workplaceCheckinTimer = setInterval(_silentCheckin, WORKPLACE_CHECKIN_INTERVAL_MS);
-    // visibility change で復帰時にも 1 回トリガー
     document.addEventListener('visibilitychange', _onWorkplaceVisibility);
   } else {
     document.removeEventListener('visibilitychange', _onWorkplaceVisibility);
@@ -6873,7 +6871,11 @@ function configureWorkplaceCheckin(enabled) {
 }
 
 function _onWorkplaceVisibility() {
-  if (document.visibilityState === 'visible') _silentCheckin();
+  if (document.visibilityState !== 'visible') return;
+  // visibilitychange で連発するのを抑制。 前回 silent 成功から 5 分経って
+  // いれば再 trigger、 それまでは interval timer の通常巡回を待つ。
+  if (Date.now() - _workplaceLastSilentMs < WORKPLACE_CHECKIN_INTERVAL_MS) return;
+  _silentCheckin();
 }
 
 async function workplaceCheckinNow() {
@@ -8775,17 +8777,13 @@ async function recenterMapOnLatestOrCurrent() {
       return;
     }
   } catch (e) { console.warn('[tracks] latest fetch failed', e); }
-  // fallback: 現在位置
-  if (!navigator.geolocation) return;
-  navigator.geolocation.getCurrentPosition(
-    (pos) => {
-      if (!tracksState.map) return;
-      tracksState.map.setCenter({ lat: pos.coords.latitude, lng: pos.coords.longitude });
-      tracksState.map.setZoom(15);
-    },
-    (err) => { console.info('[tracks] geolocation skipped:', err?.message); },
-    { enableHighAccuracy: false, timeout: 5000, maximumAge: 60000 },
-  );
+  // fallback: 現在位置 — ただし permission が 'granted' のときだけ silent に
+  // 取る (= ダイアログを出さない)。 拒否 / 未許可なら東京駅のままで放置。
+  const coords = await silentGetPosition();
+  if (coords && tracksState.map) {
+    tracksState.map.setCenter({ lat: coords.latitude, lng: coords.longitude });
+    tracksState.map.setZoom(15);
+  }
 }
 
 async function renderTracksForCurrentDate() {

--- a/server/public/src/geo.ts
+++ b/server/public/src/geo.ts
@@ -1,0 +1,124 @@
+// ブラウザ位置情報の取得を「許可済みのときだけ silent 取得、 そうでなければ
+// 黙ってスキップ」 するためのヘルパ。
+//
+// 問題: 旧コードは `_silentCheckin` (workplace 自動チェックイン) が
+// visibilitychange のたびに無条件で `getCurrentPosition` を叩いていたため、
+// permission が 'granted' でないとき (HTTP origin / iOS / strict ブラウザ
+// 設定) はタブ復帰ごとに permission 再確認ダイアログや「位置情報を使って
+// います」 indicator が表示されていた。
+//
+// 修正:
+//   - Permissions API (`navigator.permissions.query`) で許可状況を確認
+//   - silent 呼び出しは 'granted' のときだけ実行 (= ダイアログを出さない)
+//   - 5 分間隔の throttle (visibilitychange の連発を抑制)
+//   - silent は enableHighAccuracy=false + maximumAge=5min で軽量化
+//
+// 手動ボタン (= 「現在地」 ボタン) からは従来どおり `requestPosition` を
+// 直接呼ぶ。 こちらは permission が 'prompt' でもダイアログを出していい
+// (= ユーザの明示的なアクション)。
+
+export type GeoPermissionState = 'granted' | 'prompt' | 'denied' | 'unknown';
+
+/** 'unknown' は Permissions API 未対応 (古い iOS Safari 等) を意味する */
+export async function getGeoPermissionState(): Promise<GeoPermissionState> {
+  const perms = (navigator as unknown as { permissions?: { query: (q: { name: string }) => Promise<{ state: string }> } }).permissions;
+  if (!perms?.query) return 'unknown';
+  try {
+    const r = await perms.query({ name: 'geolocation' });
+    if (r.state === 'granted' || r.state === 'prompt' || r.state === 'denied') return r.state;
+    return 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+export interface PositionLike {
+  latitude: number;
+  longitude: number;
+  accuracy?: number;
+}
+
+/**
+ * ダイアログを出さない silent 取得。
+ *   - permission が 'granted' か (キャッシュされた最近の位置がある) ときだけ
+ *     呼び出す。 'prompt' / 'denied' / Geolocation API 自体が無い → null を返す
+ *   - 軽量設定: enableHighAccuracy=false, maximumAge=5min, timeout=8s
+ *
+ * 5 分以内に成功した結果がメモリにあればそれを返す (= getCurrentPosition の
+ * ネイティブ呼び出し自体を回避)。
+ */
+export async function silentGetPosition(): Promise<PositionLike | null> {
+  if (!('geolocation' in navigator)) return null;
+  const fresh = cached();
+  if (fresh) return fresh;
+  const perm = await getGeoPermissionState();
+  // 'unknown' は古い iOS Safari 等。 Permissions API 無しなので試すしかないが、
+  // それでも silent ヒントを残したいので enableHighAccuracy=false で 1 回試す。
+  if (perm === 'denied' || perm === 'prompt') return null;
+  return new Promise<PositionLike | null>((resolve) => {
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const p: PositionLike = {
+          latitude: pos.coords.latitude,
+          longitude: pos.coords.longitude,
+          accuracy: pos.coords.accuracy,
+        };
+        writeCache(p);
+        resolve(p);
+      },
+      () => resolve(null),
+      { enableHighAccuracy: false, timeout: 8000, maximumAge: 5 * 60_000 },
+    );
+  });
+}
+
+/**
+ * ユーザの明示的アクション (= 「現在地」 ボタン) で呼ぶ。 permission='prompt' なら
+ * 許可ダイアログを出す。 高精度で取得し、 cache にも書く。
+ */
+export async function requestPosition(opts?: PositionOptions): Promise<PositionLike> {
+  if (!('geolocation' in navigator)) throw new Error('このブラウザは Geolocation に対応していません');
+  return new Promise<PositionLike>((resolve, reject) => {
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const p: PositionLike = {
+          latitude: pos.coords.latitude,
+          longitude: pos.coords.longitude,
+          accuracy: pos.coords.accuracy,
+        };
+        writeCache(p);
+        resolve(p);
+      },
+      (err) => reject(new Error(err.message || 'GPS 取得失敗')),
+      { enableHighAccuracy: true, timeout: 12000, maximumAge: 30_000, ...(opts ?? {}) },
+    );
+  });
+}
+
+// ── In-memory + localStorage cache (5 分有効) ───────────────────────────
+const CACHE_TTL_MS = 5 * 60_000;
+const CACHE_KEY = 'memoria.geo.last';
+interface CacheRow { lat: number; lon: number; ts: number; acc?: number }
+
+function cached(): PositionLike | null {
+  const ram = ramCache;
+  if (ram && Date.now() - ram.ts < CACHE_TTL_MS) {
+    return { latitude: ram.lat, longitude: ram.lon, accuracy: ram.acc };
+  }
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const row = JSON.parse(raw) as CacheRow;
+    if (Date.now() - row.ts >= CACHE_TTL_MS) return null;
+    ramCache = row;
+    return { latitude: row.lat, longitude: row.lon, accuracy: row.acc };
+  } catch {
+    return null;
+  }
+}
+
+let ramCache: CacheRow | null = null;
+function writeCache(p: PositionLike): void {
+  ramCache = { lat: p.latitude, lon: p.longitude, ts: Date.now(), acc: p.accuracy };
+  try { localStorage.setItem(CACHE_KEY, JSON.stringify(ramCache)); } catch { /* iOS private */ }
+}


### PR DESCRIPTION
Scaffold for .env-free Memoria server. Sample: LUDIARS/Cernere#79. REQUIRED_KEYS is empty until LLM provider keys move to Infisical.