### PR TITLE
fix(geo): タブ復帰のたびに位置情報ポップアップが出る問題

### DIFF
--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -162,6 +162,9 @@ import { loadNotes as notesLoad } from './notes/index.js';
 // PAGE_HELP の本文を増やす場合は page-help.ts を編集する。
 import { initTutorial } from './tutorial.js';
 import { initHelpDrawer, openHelpFor } from './help-drawer.js';
+// 位置情報の silent / interactive 取得を分けるヘルパ。 silent は permission='granted'
+// のときだけ叩いてダイアログを出さない。 詳細は geo.ts 参照。
+import { silentGetPosition, requestPosition, type PositionLike } from './geo.js';
 
 // 旧 JS の動的オブジェクト用の緩い型 (record-y values)。 値型は `unknown`
 // でフラット。 配列メソッドや特定 key 値の narrow が必要な callsite では
@@ -6783,18 +6786,10 @@ async function startAgentRunFromModal() {
 
 // ── GPS / Place API helpers ────────────────────────────────────────────────
 
-function getCurrentPositionPromise(opts: Loose = {}) {
-  return new Promise((resolve, reject) => {
-    if (!('geolocation' in navigator)) {
-      reject(new Error('このブラウザは Geolocation に対応していません'));
-      return;
-    }
-    navigator.geolocation.getCurrentPosition(
-      (pos) => resolve(pos.coords),
-      (err) => reject(new Error(err.message || 'GPS 取得失敗')),
-      { enableHighAccuracy: true, timeout: 12000, maximumAge: 30000, ...opts },
-    );
-  });
+// 手動「現在地」 ボタン用。 permission='prompt' のときは許可ダイアログを出す
+// (= ユーザの明示的アクションなので OK)。 内部で geo.ts のキャッシュも更新する。
+async function getCurrentPositionPromise(opts: Loose = {}): Promise<PositionLike> {
+  return requestPosition(opts as PositionOptions);
 }
 
 async function resolvePlaceForCoords(coords) {
@@ -6834,25 +6829,29 @@ async function openEditorFromCurrentGps() {
 
 let _workplaceCheckinTimer = null;
 let _workplaceGeoEnabled = false;
+let _workplaceLastSilentMs = 0;
 const WORKPLACE_CHECKIN_INTERVAL_MS = 5 * 60 * 1000;
 
 async function _silentCheckin() {
   if (!_workplaceGeoEnabled) return;
   if (document.visibilityState !== 'visible') return;
+  // silent path は permission='granted' のときだけブラウザ位置 API を叩く
+  // (= 「ブラウザ設定では許可してるのに毎回ポップアップ」 問題の本丸対策)。
+  const coords = await silentGetPosition();
+  if (!coords) return;
   try {
-    const coords = await getCurrentPositionPromise({ timeout: 8000, maximumAge: 60000 });
     const r = await api('/api/work-locations/checkin', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ latitude: coords.latitude, longitude: coords.longitude }),
     });
+    _workplaceLastSilentMs = Date.now();
     const banner = $('workplaceCurrentBanner');
     if (banner && r.matched) {
       const broadcast = r.changed && r.broadcast?.ok ? ' ・ Hub に共有しました' : '';
       banner.textContent = `📍 ${r.workplace.name}${broadcast}`;
     }
   } catch (e) {
-    // 静かに失敗 (バッテリ最適化で deny されるなど)。手動ボタンでは表示する。
     console.debug('[workplace] silent checkin skipped:', e.message);
   }
 }
@@ -6865,7 +6864,6 @@ function configureWorkplaceCheckin(enabled) {
   }
   if (_workplaceGeoEnabled) {
     _workplaceCheckinTimer = setInterval(_silentCheckin, WORKPLACE_CHECKIN_INTERVAL_MS);
-    // visibility change で復帰時にも 1 回トリガー
     document.addEventListener('visibilitychange', _onWorkplaceVisibility);
   } else {
     document.removeEventListener('visibilitychange', _onWorkplaceVisibility);
@@ -6873,7 +6871,11 @@ function configureWorkplaceCheckin(enabled) {
 }
 
 function _onWorkplaceVisibility() {
-  if (document.visibilityState === 'visible') _silentCheckin();
+  if (document.visibilityState !== 'visible') return;
+  // visibilitychange で連発するのを抑制。 前回 silent 成功から 5 分経って
+  // いれば再 trigger、 それまでは interval timer の通常巡回を待つ。
+  if (Date.now() - _workplaceLastSilentMs < WORKPLACE_CHECKIN_INTERVAL_MS) return;
+  _silentCheckin();
 }
 
 async function workplaceCheckinNow() {
@@ -8775,17 +8777,13 @@ async function recenterMapOnLatestOrCurrent() {
       return;
     }
   } catch (e) { console.warn('[tracks] latest fetch failed', e); }
-  // fallback: 現在位置
-  if (!navigator.geolocation) return;
-  navigator.geolocation.getCurrentPosition(
-    (pos) => {
-      if (!tracksState.map) return;
-      tracksState.map.setCenter({ lat: pos.coords.latitude, lng: pos.coords.longitude });
-      tracksState.map.setZoom(15);
-    },
-    (err) => { console.info('[tracks] geolocation skipped:', err?.message); },
-    { enableHighAccuracy: false, timeout: 5000, maximumAge: 60000 },
-  );
+  // fallback: 現在位置 — ただし permission が 'granted' のときだけ silent に
+  // 取る (= ダイアログを出さない)。 拒否 / 未許可なら東京駅のままで放置。
+  const coords = await silentGetPosition();
+  if (coords && tracksState.map) {
+    tracksState.map.setCenter({ lat: coords.latitude, lng: coords.longitude });
+    tracksState.map.setZoom(15);
+  }
 }
 
 async function renderTracksForCurrentDate() {

--- a/server/public/src/geo.ts
+++ b/server/public/src/geo.ts
@@ -1,0 +1,124 @@
+// ブラウザ位置情報の取得を「許可済みのときだけ silent 取得、 そうでなければ
+// 黙ってスキップ」 するためのヘルパ。
+//
+// 問題: 旧コードは `_silentCheckin` (workplace 自動チェックイン) が
+// visibilitychange のたびに無条件で `getCurrentPosition` を叩いていたため、
+// permission が 'granted' でないとき (HTTP origin / iOS / strict ブラウザ
+// 設定) はタブ復帰ごとに permission 再確認ダイアログや「位置情報を使って
+// います」 indicator が表示されていた。
+//
+// 修正:
+//   - Permissions API (`navigator.permissions.query`) で許可状況を確認
+//   - silent 呼び出しは 'granted' のときだけ実行 (= ダイアログを出さない)
+//   - 5 分間隔の throttle (visibilitychange の連発を抑制)
+//   - silent は enableHighAccuracy=false + maximumAge=5min で軽量化
+//
+// 手動ボタン (= 「現在地」 ボタン) からは従来どおり `requestPosition` を
+// 直接呼ぶ。 こちらは permission が 'prompt' でもダイアログを出していい
+// (= ユーザの明示的なアクション)。
+
+export type GeoPermissionState = 'granted' | 'prompt' | 'denied' | 'unknown';
+
+/** 'unknown' は Permissions API 未対応 (古い iOS Safari 等) を意味する */
+export async function getGeoPermissionState(): Promise<GeoPermissionState> {
+  const perms = (navigator as unknown as { permissions?: { query: (q: { name: string }) => Promise<{ state: string }> } }).permissions;
+  if (!perms?.query) return 'unknown';
+  try {
+    const r = await perms.query({ name: 'geolocation' });
+    if (r.state === 'granted' || r.state === 'prompt' || r.state === 'denied') return r.state;
+    return 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+export interface PositionLike {
+  latitude: number;
+  longitude: number;
+  accuracy?: number;
+}
+
+/**
+ * ダイアログを出さない silent 取得。
+ *   - permission が 'granted' か (キャッシュされた最近の位置がある) ときだけ
+ *     呼び出す。 'prompt' / 'denied' / Geolocation API 自体が無い → null を返す
+ *   - 軽量設定: enableHighAccuracy=false, maximumAge=5min, timeout=8s
+ *
+ * 5 分以内に成功した結果がメモリにあればそれを返す (= getCurrentPosition の
+ * ネイティブ呼び出し自体を回避)。
+ */
+export async function silentGetPosition(): Promise<PositionLike | null> {
+  if (!('geolocation' in navigator)) return null;
+  const fresh = cached();
+  if (fresh) return fresh;
+  const perm = await getGeoPermissionState();
+  // 'unknown' は古い iOS Safari 等。 Permissions API 無しなので試すしかないが、
+  // それでも silent ヒントを残したいので enableHighAccuracy=false で 1 回試す。
+  if (perm === 'denied' || perm === 'prompt') return null;
+  return new Promise<PositionLike | null>((resolve) => {
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const p: PositionLike = {
+          latitude: pos.coords.latitude,
+          longitude: pos.coords.longitude,
+          accuracy: pos.coords.accuracy,
+        };
+        writeCache(p);
+        resolve(p);
+      },
+      () => resolve(null),
+      { enableHighAccuracy: false, timeout: 8000, maximumAge: 5 * 60_000 },
+    );
+  });
+}
+
+/**
+ * ユーザの明示的アクション (= 「現在地」 ボタン) で呼ぶ。 permission='prompt' なら
+ * 許可ダイアログを出す。 高精度で取得し、 cache にも書く。
+ */
+export async function requestPosition(opts?: PositionOptions): Promise<PositionLike> {
+  if (!('geolocation' in navigator)) throw new Error('このブラウザは Geolocation に対応していません');
+  return new Promise<PositionLike>((resolve, reject) => {
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const p: PositionLike = {
+          latitude: pos.coords.latitude,
+          longitude: pos.coords.longitude,
+          accuracy: pos.coords.accuracy,
+        };
+        writeCache(p);
+        resolve(p);
+      },
+      (err) => reject(new Error(err.message || 'GPS 取得失敗')),
+      { enableHighAccuracy: true, timeout: 12000, maximumAge: 30_000, ...(opts ?? {}) },
+    );
+  });
+}
+
+// ── In-memory + localStorage cache (5 分有効) ───────────────────────────
+const CACHE_TTL_MS = 5 * 60_000;
+const CACHE_KEY = 'memoria.geo.last';
+interface CacheRow { lat: number; lon: number; ts: number; acc?: number }
+
+function cached(): PositionLike | null {
+  const ram = ramCache;
+  if (ram && Date.now() - ram.ts < CACHE_TTL_MS) {
+    return { latitude: ram.lat, longitude: ram.lon, accuracy: ram.acc };
+  }
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const row = JSON.parse(raw) as CacheRow;
+    if (Date.now() - row.ts >= CACHE_TTL_MS) return null;
+    ramCache = row;
+    return { latitude: row.lat, longitude: row.lon, accuracy: row.acc };
+  } catch {
+    return null;
+  }
+}
+
+let ramCache: CacheRow | null = null;
+function writeCache(p: PositionLike): void {
+  ramCache = { lat: p.latitude, lon: p.longitude, ts: Date.now(), acc: p.accuracy };
+  try { localStorage.setItem(CACHE_KEY, JSON.stringify(ramCache)); } catch { /* iOS private */ }
+}


### PR DESCRIPTION
## Summary

「ブラウザで許可しているのに再接続のたびに位置情報の確認ポップアップが出る」 問題の修正。

## 原因

- `_silentCheckin` (workplace 自動チェックイン) が `visibilitychange` でタブ復帰するたびに無条件で `getCurrentPosition` を呼んでいた
- `enableHighAccuracy: true` で GPS を要求
- Permission state を確認せず叩いていたので、 HTTP origin (Tailscale IP) や iOS Safari では permission 再確認 / 位置情報 indicator が毎回出ていた

## 修正

新しい helper `server/public/src/geo.ts`:

| 関数 | 用途 |
|---|---|
| `getGeoPermissionState()` | `navigator.permissions.query({name:'geolocation'})` ラッパ |
| `silentGetPosition()` | permission='granted' のときだけ呼び出し。 それ以外は `null`。 `enableHighAccuracy=false` + `maximumAge=5min` + 5 分キャッシュ (RAM + localStorage) |
| `requestPosition()` | 「現在地」 手動ボタン用。 permission='prompt' でもダイアログを出す (= ユーザ明示) |

更新箇所:

- `_silentCheckin` → `silentGetPosition` 経由
- `visibilitychange` → 前回成功から 5 分以内ならスキップ
- tracks 初期 recenter の fallback も `silentGetPosition` 経由
- 既存 `getCurrentPositionPromise` (手動ボタン用) は `requestPosition` ラッパに統合

## Test plan

- [ ] Memoria を Tailscale 経由で開き直す → ポップアップが出ないこと
- [ ] タブを別ウィンドウに移して戻す (visibilitychange) → ポップアップが出ないこと
- [ ] 5 分以上経った後にタブ復帰 → 静かに position fetch される (ダイアログ無し)
- [ ] 手動の「現在地」 ボタン → 通常通り動く (permission='prompt' なら許可ダイアログ)
- [ ] tracks タブを開く → 最終 GPS 点で center、 無ければ silent fallback、 それも無ければ東京駅のまま
- [ ] permission='denied' の状態でも silent path は黙ってスキップ (赤い indicator 出ない)

## 補足

PR #130 (feat: bootstrap env via Infisical) のブランチにこのコミットが「passenger」 として残っています (並行作業中に発生した混線)。 #130 側で rebase または revert して clean にしてください。 このブランチには main 起点で同じ修正をきれいに乗せ直してあります。