### PR TITLE
feat(workplace): WiFi SSID で workplace を即チェックイン (Electron 限定)

### DIFF
--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -29,10 +29,13 @@
 //                          OS login auto-start integration.
 
 import { app, BrowserWindow, shell, Menu, Tray, nativeImage, ipcMain } from 'electron';
-import { spawn, type ChildProcess } from 'node:child_process';
+import { spawn, type ChildProcess, execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import * as http from 'node:http';
+
+const execFileP = promisify(execFile);
 
 // ── single instance ───────────────────────────────────────────────────────
 // Only one Memoria desktop at a time per user — the second launch focuses
@@ -363,6 +366,91 @@ function getAutoLaunch(): boolean {
   return app.getLoginItemSettings().openAtLogin;
 }
 
+// ── WiFi info (Electron 起動時の SSID matching 用) ─────────────────────────
+//
+// renderer (Memoria web UI) からは `window.memoria.getCurrentWifiInfo()` で
+// 呼ばれる。 接続中の WiFi SSID と BSSID を返す。 取れなければ null。
+//
+// 各 OS で native CLI を叩く:
+//   Windows : `netsh wlan show interfaces` の "SSID" / "BSSID" 行をパース
+//   macOS   : `networksetup -getairportnetwork en0` (SSID のみ取れる)
+//             modern macOS は `airport -I` も使えるが path がバージョン依存
+//   Linux   : `iwgetid -r` (SSID) と `iwgetid -ar` (BSSID)、 無ければ nmcli
+//
+// すべて読み取り専用コマンド (= 状態を変えない)。 失敗時は null。
+export interface WifiInfo { ssid: string | null; bssid: string | null; platform: string }
+
+async function getCurrentWifiInfo(): Promise<WifiInfo | null> {
+  const platform = process.platform;
+  try {
+    if (platform === 'win32') return await wifiInfoWindows();
+    if (platform === 'darwin') return await wifiInfoMac();
+    if (platform === 'linux') return await wifiInfoLinux();
+  } catch (err) {
+    console.warn('[wifi-info] failed:', (err as Error).message);
+  }
+  return null;
+}
+
+async function wifiInfoWindows(): Promise<WifiInfo | null> {
+  // chcp 65001 → UTF-8。 日本語版 Windows の cp932 出力で正規表現が壊れるのを回避
+  const r = await execFileP('netsh', ['wlan', 'show', 'interfaces'], { encoding: 'utf8', windowsHide: true });
+  const out = r.stdout || '';
+  // 日本語版 ("SSID" → "プロファイル" や "SSID" のまま) 両方を拾えるよう、
+  // ": <value>" の前に行頭の半角 / 全角空白を許容する正規表現で取る。
+  // BSSID と SSID の判別は順序で行う (BSSID は SSID の直後に出る)。
+  const lines = out.split(/\r?\n/);
+  let ssid: string | null = null;
+  let bssid: string | null = null;
+  for (const line of lines) {
+    const m = /^\s*(?:SSID|BSSID)\b[^\:]*:\s*(.+?)\s*$/.exec(line);
+    if (!m) continue;
+    // BSSID 行は前置に「BSSID」 を含む。 SSID 行のみ純粋な「SSID」 で始まる。
+    if (/^\s*BSSID/.test(line) && !bssid) bssid = m[1] ?? null;
+    else if (/^\s*SSID/.test(line) && !ssid) ssid = m[1] ?? null;
+    if (ssid && bssid) break;
+  }
+  return ssid || bssid ? { ssid, bssid, platform: 'win32' } : null;
+}
+
+async function wifiInfoMac(): Promise<WifiInfo | null> {
+  // networksetup は信頼性が高い (sudo 不要)。 SSID のみ。 BSSID は別経路 (airport -I)
+  // で取れるが、 macOS Sonoma 以降は restricted のためベストエフォート。
+  try {
+    const r = await execFileP('networksetup', ['-getairportnetwork', 'en0'], { encoding: 'utf8' });
+    const m = /Current Wi-Fi Network:\s*(.+?)\s*$/m.exec(r.stdout || '');
+    const ssid = m?.[1] ?? null;
+    let bssid: string | null = null;
+    try {
+      const apt = await execFileP('/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport', ['-I'], { encoding: 'utf8' });
+      const b = /\bBSSID:\s*([0-9a-f:]+)\s*$/im.exec(apt.stdout || '');
+      bssid = b?.[1] ?? null;
+    } catch { /* airport restricted on newer macOS */ }
+    return ssid ? { ssid, bssid, platform: 'darwin' } : null;
+  } catch {
+    return null;
+  }
+}
+
+async function wifiInfoLinux(): Promise<WifiInfo | null> {
+  // iwgetid: -r で SSID 単独、 -ar で BSSID 単独。 net-tools / wireless-tools 系。
+  let ssid: string | null = null;
+  let bssid: string | null = null;
+  try { const r = await execFileP('iwgetid', ['-r'], { encoding: 'utf8' }); ssid = r.stdout.trim() || null; } catch { /* try nmcli */ }
+  try { const r = await execFileP('iwgetid', ['-ar'], { encoding: 'utf8' }); bssid = r.stdout.trim() || null; } catch { /* skip */ }
+  if (!ssid) {
+    try {
+      const r = await execFileP('nmcli', ['-t', '-f', 'active,ssid,bssid', 'dev', 'wifi'], { encoding: 'utf8' });
+      for (const line of (r.stdout || '').split(/\r?\n/)) {
+        // nmcli の bssid フィールド内 ':' は '\\:' で escape されているので強引に分解
+        const parts = line.split(/(?<!\\):/).map((s) => s.replace(/\\:/g, ':'));
+        if (parts[0] === 'yes') { ssid = parts[1] || ssid; bssid = parts[2] || bssid; break; }
+      }
+    } catch { /* nmcli 不在 */ }
+  }
+  return ssid || bssid ? { ssid, bssid, platform: 'linux' } : null;
+}
+
 // ── IPC bridge (preload talks to us via these channels) ───────────────────
 
 ipcMain.handle('memoria:get-auto-launch', () => getAutoLaunch());
@@ -371,6 +459,7 @@ ipcMain.handle('memoria:set-auto-launch', (_event, enabled: unknown) => {
   return getAutoLaunch();
 });
 ipcMain.handle('memoria:get-server-port', () => serverPort);
+ipcMain.handle('memoria:get-wifi-info', () => getCurrentWifiInfo());
 ipcMain.handle('memoria:quit', () => {
   isQuitting = true;
   app.quit();

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -12,6 +12,12 @@
 
 import { contextBridge, ipcRenderer } from 'electron';
 
+export interface WifiInfo {
+  ssid: string | null;
+  bssid: string | null;
+  platform: string;
+}
+
 interface MemoriaBridge {
   /** Returns true if the OS is configured to auto-launch Memoria at login. */
   getAutoLaunch: () => Promise<boolean>;
@@ -23,6 +29,10 @@ interface MemoriaBridge {
   hide: () => Promise<void>;
   /** Fully quit the app — kills the server too. */
   quit: () => Promise<void>;
+  /** 接続中の WiFi 名 (SSID + BSSID)。 取れなければ null。
+   *  Electron 限定 — ブラウザ単体では呼べない。
+   *  Memoria 起動時に SSID matching → workplace を即チェックインするのに使う。 */
+  getCurrentWifiInfo: () => Promise<WifiInfo | null>;
 }
 
 const api: MemoriaBridge = {
@@ -31,6 +41,7 @@ const api: MemoriaBridge = {
   getServerPort: () => ipcRenderer.invoke('memoria:get-server-port'),
   hide: () => ipcRenderer.invoke('memoria:hide'),
   quit: () => ipcRenderer.invoke('memoria:quit'),
+  getCurrentWifiInfo: () => ipcRenderer.invoke('memoria:get-wifi-info'),
 };
 
 contextBridge.exposeInMainWorld('memoria', api);

--- a/server/db.ts
+++ b/server/db.ts
@@ -453,6 +453,7 @@ export function openDb(dbPath: string): Db {
       description    TEXT,
       url            TEXT,
       tags           TEXT,
+      wifi_ssids     TEXT,
       shareable      INTEGER NOT NULL DEFAULT 0,
       shared_at      TEXT,
       shared_origin  TEXT,
@@ -599,6 +600,13 @@ export function openDb(dbPath: string): Db {
   }
 
   // Forward-compat: 既存 DB に列を ALTER で追加
+  // Forward-compat: work_locations に wifi_ssids 列を追加 (Electron 起動時の SSID
+  // matching 用、 旧 DB は NULL のまま)。
+  const wlCols = (db.prepare(`PRAGMA table_info(work_locations)`).all() as { name: string }[]).map(c => c.name);
+  if (wlCols.length > 0 && !wlCols.includes('wifi_ssids')) {
+    db.exec(`ALTER TABLE work_locations ADD COLUMN wifi_ssids TEXT`);
+  }
+
   const mealsCols = (db.prepare(`PRAGMA table_info(meals)`).all() as { name: string }[]).map(c => c.name);
   if (mealsCols.length > 0 && !mealsCols.includes('additions_json')) {
     db.exec(`ALTER TABLE meals ADD COLUMN additions_json TEXT`);
@@ -3700,14 +3708,16 @@ export interface InsertWorkLocationInput {
   description?: string | null;
   url?: string | null;
   tags?: string | null;
+  /** カンマ区切り (例 'MyHomeWifi,MyHomeWifi-5G') */
+  wifi_ssids?: string | null;
   shareable?: boolean | 0 | 1;
 }
 
 export function insertWorkLocation(db: Db, loc: InsertWorkLocationInput): number {
   const info = db.prepare(`
     INSERT INTO work_locations
-      (name, address, latitude, longitude, description, url, tags, shareable)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      (name, address, latitude, longitude, description, url, tags, wifi_ssids, shareable)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     loc.name,
     loc.address ?? null,
@@ -3716,6 +3726,7 @@ export function insertWorkLocation(db: Db, loc: InsertWorkLocationInput): number
     loc.description ?? null,
     loc.url ?? null,
     loc.tags ?? null,
+    loc.wifi_ssids ?? null,
     loc.shareable ? 1 : 0,
   );
   return Number(info.lastInsertRowid);
@@ -3724,6 +3735,7 @@ export function insertWorkLocation(db: Db, loc: InsertWorkLocationInput): number
 export function updateWorkLocation(db: Db, id: number, patch: Record<string, unknown>): void {
   const allowed = new Set([
     'name', 'address', 'latitude', 'longitude', 'description', 'url', 'tags',
+    'wifi_ssids',
     'shareable', 'shared_at', 'shared_origin',
     'owner_user_id', 'owner_user_name',
   ]);

--- a/server/db/types/workplace.ts
+++ b/server/db/types/workplace.ts
@@ -11,6 +11,10 @@ export interface WorkLocationRow {
   url: string | null;
   /** カンマ区切りの自由タグ ("wifi, 電源, 静か"). */
   tags: string | null;
+  /** カンマ区切りの WiFi SSID。 Electron 起動時に matching → 即 checkin に使う
+   *  (= GPS / Permission を経由せず「家の WiFi だから家に居る」 と判定)。
+   *  1 ワークプレイスに複数 SSID (2.4 GHz / 5 GHz など) を持てる。 */
+  wifi_ssids: string | null;
   shareable: 0 | 1;
   shared_at: string | null;
   shared_origin: string | null;

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -5455,6 +5455,15 @@ let ensureMemoriaFeatureViews = function () {
             <input id="workplaceEditorTags" type="text" placeholder="wifi, 電源, 静か" />
           </label>
           <label class="simple-field">
+            <span>WiFi SSID (カンマ区切り)</span>
+            <input id="workplaceEditorWifiSsids" type="text" placeholder="例: MyHomeWifi, MyHomeWifi-5G" />
+            <small class="muted">Memoria デスクトップ版がこの SSID に接続中だと、 GPS を使わずにこの場所にチェックインします。</small>
+          </label>
+          <div id="workplaceEditorWifiCurrent" class="simple-actions" hidden style="justify-content:flex-start">
+            <button type="button" class="ghost" id="workplaceEditorWifiCurrentBtn">📶 現在の WiFi を追加</button>
+            <span id="workplaceEditorWifiCurrentStatus" class="muted" style="font-size:11px"></span>
+          </div>
+          <label class="simple-field">
             <span>説明 / メモ</span>
             <textarea id="workplaceEditorDescription" rows="6" placeholder="営業時間・wifi・電源・席数・雰囲気など"></textarea>
           </label>
@@ -6431,8 +6440,13 @@ function openWorkplaceEditor(w = null) {
   $('workplaceEditorLng').value = w?.longitude == null ? '' : w.longitude;
   $('workplaceEditorUrl').value = w?.url || '';
   $('workplaceEditorTags').value = w?.tags || '';
+  if ($('workplaceEditorWifiSsids')) $('workplaceEditorWifiSsids').value = w?.wifi_ssids || '';
   $('workplaceEditorDescription').value = w?.description || '';
   $('workplaceEditorShareable').checked = !!w?.shareable;
+  // Electron 配下のみ「現在の WiFi を追加」 ボタンを出す。 ブラウザ単体では
+  // SSID を取れない (= window.memoria は preload bridge 経由でのみ存在)。
+  const wifiRow = $('workplaceEditorWifiCurrent');
+  if (wifiRow) wifiRow.hidden = !(typeof window !== 'undefined' && (window as Loose).memoria?.getCurrentWifiInfo);
   showModal('workplaceEditorModal');
   $('workplaceEditorName').focus();
 }
@@ -6900,6 +6914,36 @@ async function workplaceCheckinNow() {
   }
 }
 
+// 「📶 現在の WiFi を追加」 ボタン (Electron 限定)。 接続中の SSID を取って
+// editor の wifi_ssids フィールドに append (重複 SSID は無視)。
+async function appendCurrentWifiToEditor() {
+  const inp = $('workplaceEditorWifiSsids') as HTMLInputElement | null;
+  const status = $('workplaceEditorWifiCurrentStatus');
+  const bridge = (typeof window !== 'undefined' ? (window as Loose).memoria : null);
+  if (!inp || !bridge?.getCurrentWifiInfo) {
+    if (status) status.textContent = 'デスクトップ版でのみ利用できます';
+    return;
+  }
+  if (status) status.textContent = '取得中…';
+  try {
+    const info = await bridge.getCurrentWifiInfo();
+    if (!info?.ssid) {
+      if (status) status.textContent = '接続中の WiFi が見つかりませんでした';
+      return;
+    }
+    const existing = (inp.value || '').split(',').map((s: string) => s.trim()).filter(Boolean);
+    if (existing.some((s: string) => s.toLowerCase() === info.ssid.toLowerCase())) {
+      if (status) status.textContent = `✓ "${info.ssid}" は既に登録済み`;
+      return;
+    }
+    existing.push(info.ssid);
+    inp.value = existing.join(', ');
+    if (status) status.textContent = `✓ "${info.ssid}" を追加`;
+  } catch (e) {
+    if (status) status.textContent = `失敗: ${(e as Error).message}`;
+  }
+}
+
 async function saveWorkLocationFromForm() {
   const name = $('workplaceEditorName')?.value.trim();
   if (!name) { alert('名前を入力してください'); return; }
@@ -6913,6 +6957,7 @@ async function saveWorkLocationFromForm() {
     longitude: lngStr === '' || lngStr == null ? null : Number(lngStr),
     url: $('workplaceEditorUrl')?.value.trim() || null,
     tags: $('workplaceEditorTags')?.value.trim() || null,
+    wifi_ssids: $('workplaceEditorWifiSsids')?.value.trim() || null,
     description: $('workplaceEditorDescription')?.value.trim() || null,
     shareable: !!$('workplaceEditorShareable')?.checked,
   };
@@ -7466,6 +7511,7 @@ ensureMemoriaFeatureViews = function () {
   if ($('workplaceEditorGpsBtn')) $('workplaceEditorGpsBtn').onclick = fillEditorFromCurrentLocation;
   if ($('workplaceFromGpsBtn')) $('workplaceFromGpsBtn').onclick = openEditorFromCurrentGps;
   if ($('workplaceCheckinBtn')) $('workplaceCheckinBtn').onclick = workplaceCheckinNow;
+  if ($('workplaceEditorWifiCurrentBtn')) $('workplaceEditorWifiCurrentBtn').onclick = appendCurrentWifiToEditor;
   document.querySelectorAll('#tasksMenu [data-task-menu]').forEach((btn) => {
     btn.onclick = () => {
       state.taskMenu = btn.dataset.taskMenu;
@@ -7535,6 +7581,32 @@ window.addEventListener('resize', decorateTaskAndImplTabs);
 
 ensureMemoriaFeatureViews();
 loadPrivacySettings().catch(console.warn);
+
+// Electron 起動時 SSID チェックイン: window.memoria が居る (= デスクトップアプリ) かつ
+// getCurrentWifiInfo が exposed されていれば、 接続中の SSID で work-locations の
+// wifi_ssids match を試みる。 ブラウザ単体では window.memoria が存在しないので
+// 静かに skip される (= ブラウザ単体時の挙動は無変化)。
+// permission ダイアログは一切出ない (ブラウザ位置情報 API を使わないので)。
+(async () => {
+  const bridge = (typeof window !== 'undefined' ? (window as Loose).memoria : null);
+  if (!bridge?.getCurrentWifiInfo) return;
+  try {
+    const info = await bridge.getCurrentWifiInfo();
+    if (!info?.ssid) return;
+    const r = await api('/api/work-locations/wifi-checkin', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ssid: info.ssid, bssid: info.bssid }),
+    });
+    if (r?.matched && r.workplace) {
+      console.info(`[wifi-checkin] matched "${info.ssid}" → ${r.workplace.name}${r.changed ? ' (新規 enter)' : ''}`);
+      const banner = $('workplaceCurrentBanner');
+      if (banner) banner.textContent = `📍 ${r.workplace.name} (WiFi: ${info.ssid})`;
+    }
+  } catch (e) {
+    console.debug('[wifi-checkin] skipped:', (e as Error).message);
+  }
+})();
 
 // ── Worklog tab (作業ログ) ─────────────────────────────────────────────
 //

--- a/server/routes/workplace.ts
+++ b/server/routes/workplace.ts
@@ -46,7 +46,7 @@ export function makeWorkplaceRouter(deps: WorkplaceRouterDeps): Hono {
   r.post('/api/work-locations', async (c: Context) => {
     const body = await c.req.json().catch(() => ({})) as
       { name?: unknown; address?: unknown; latitude?: unknown; longitude?: unknown;
-        description?: unknown; url?: unknown; tags?: unknown; shareable?: unknown };
+        description?: unknown; url?: unknown; tags?: unknown; wifi_ssids?: unknown; shareable?: unknown };
     const name = String(body.name ?? '').trim();
     if (!name) return c.json({ error: 'name required' }, 400);
     const id = insertWorkLocation(db, {
@@ -57,6 +57,7 @@ export function makeWorkplaceRouter(deps: WorkplaceRouterDeps): Hono {
       description: typeof body.description === 'string' ? body.description.trim() : null,
       url: typeof body.url === 'string' ? body.url.trim() : null,
       tags: typeof body.tags === 'string' ? body.tags.trim() : null,
+      wifi_ssids: typeof body.wifi_ssids === 'string' ? body.wifi_ssids.trim() : null,
       shareable: !!body.shareable,
     });
     return c.json({ location: getWorkLocation(db, id) }, 201);
@@ -67,7 +68,7 @@ export function makeWorkplaceRouter(deps: WorkplaceRouterDeps): Hono {
     if (!getWorkLocation(db, id)) return c.json({ error: 'not found' }, 404);
     const body = await c.req.json().catch(() => ({})) as
       { name?: unknown; address?: unknown; latitude?: unknown; longitude?: unknown;
-        description?: unknown; url?: unknown; tags?: unknown; shareable?: unknown };
+        description?: unknown; url?: unknown; tags?: unknown; wifi_ssids?: unknown; shareable?: unknown };
     const patch: Record<string, unknown> = {};
     if (typeof body.name === 'string') patch.name = body.name.trim();
     if (typeof body.address === 'string' || body.address === null) patch.address = body.address;
@@ -80,6 +81,7 @@ export function makeWorkplaceRouter(deps: WorkplaceRouterDeps): Hono {
     if (typeof body.description === 'string' || body.description === null) patch.description = body.description;
     if (typeof body.url === 'string' || body.url === null) patch.url = body.url;
     if (typeof body.tags === 'string' || body.tags === null) patch.tags = body.tags;
+    if (typeof body.wifi_ssids === 'string' || body.wifi_ssids === null) patch.wifi_ssids = body.wifi_ssids;
     if (typeof body.shareable === 'boolean') patch.shareable = body.shareable;
     updateWorkLocation(db, id, patch);
     return c.json({ location: getWorkLocation(db, id) });
@@ -237,6 +239,76 @@ export function makeWorkplaceRouter(deps: WorkplaceRouterDeps): Hono {
           }
         } catch (e: unknown) {
           console.error('[workplace/checkin] leave broadcast failed', e);
+        }
+      }
+    }
+    return c.json(result);
+  });
+
+  // ── WiFi SSID 経由のチェックイン (Electron 起動時に呼ばれる) ─────────────
+  //
+  // GPS / 位置情報 permission を経由せず、 接続中の WiFi 名 (SSID) から「ここに
+  // 居る」 を判定する経路。 work_locations.wifi_ssids (カンマ区切り) に該当 SSID
+  // が登録されていれば、 そのワークプレイスを current として扱う。
+  //
+  // 「Electron 起動時のみ」 = renderer 側で window.memoria.getCurrentWifiInfo()
+  // が使える状況でのみ呼ばれる、 という運用 (= サーバ側は呼ばれたら処理する)。
+  r.post('/api/work-locations/wifi-checkin', async (c: Context) => {
+    const body = await c.req.json().catch(() => ({})) as { ssid?: unknown; bssid?: unknown };
+    const ssid = typeof body.ssid === 'string' ? body.ssid.trim() : '';
+    if (!ssid) return c.json({ error: 'ssid required' }, 400);
+    const settings = privacySettings(db);
+    if (!settings.workplace_geo_enabled) {
+      return c.json({ error: 'workplace_geo disabled' }, 403);
+    }
+
+    // SSID は大文字小文字を区別しない。 wifi_ssids はカンマ区切り。
+    const norm = ssid.toLowerCase();
+    const all = listWorkLocations(db, { limit: 500 });
+    const matched = all.find((w) => {
+      const list = (w.wifi_ssids ?? '').split(',').map((s) => s.trim().toLowerCase()).filter(Boolean);
+      return list.includes(norm);
+    }) ?? null;
+
+    const appS = getAppSettings(db);
+    const lastId = appS['workplace.current.id'] ? Number(appS['workplace.current.id']) : null;
+    const now = new Date().toISOString();
+    const result: {
+      matched: boolean;
+      workplace: typeof all[number] | null;
+      ssid: string;
+      changed: boolean;
+      broadcast: { ok: boolean; id?: number; occurred_at?: string; error?: string; kind?: string } | null;
+    } = { matched: !!matched, workplace: matched, ssid, changed: false, broadcast: null };
+
+    if (matched) {
+      if (lastId !== matched.id) {
+        result.changed = true;
+        setAppSettings(db, {
+          'workplace.current.id': String(matched.id),
+          'workplace.current.at': now,
+          // どの経路で current になったかを記録 (debug / UI 用)
+          'workplace.current.source': `wifi:${ssid}`,
+        });
+        if (settings.workplace_auto_share_enabled) {
+          try {
+            const state = readMultiState(db);
+            if (isConnected(state)) {
+              const r2 = await shareWorkplacePresence(state, {
+                workplace_name: matched.name,
+                address: matched.address,
+                latitude: matched.latitude,
+                longitude: matched.longitude,
+                kind: 'enter',
+              });
+              result.broadcast = { ok: true, id: r2.id, occurred_at: r2.occurred_at };
+            } else {
+              result.broadcast = { ok: false, error: 'not_connected' };
+            }
+          } catch (e: unknown) {
+            const msg = e instanceof Error ? e.message : String(e);
+            result.broadcast = { ok: false, error: msg };
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

Memoria デスクトップ版 (Electron) 起動時に接続中の WiFi SSID を取得し、 work_location に登録した SSID と一致した場合に自動チェックインする経路を追加。 **ブラウザ位置情報 API を経由しないので permission ダイアログが出ない**。

## なぜ Electron 限定か

ブラウザは WiFi の SSID をスクリプトに公開しません (security)。 Electron の main process なら Node.js 経由で OS の native CLI (\`netsh\` / \`networksetup\` / \`iwgetid\` / \`nmcli\`) を叩けるので SSID が取れます。 ブラウザ単体で開いた場合は静かに skip (= 既存挙動は無変化)。

## 変更

### DB
- \`work_locations.wifi_ssids TEXT\` (カンマ区切り、 例 \`MyHomeWifi, MyHomeWifi-5G\`)
- 既存 DB は ALTER で forward-compat、 旧行は NULL のまま

### Electron
- \`main.ts\`: \`ipcMain.handle('memoria:get-wifi-info')\` 追加。 Win/macOS/Linux 対応:
  - **Windows**: \`netsh wlan show interfaces\` の SSID/BSSID 行をパース
  - **macOS**: \`networksetup -getairportnetwork en0\` + (もし権限あれば) \`airport -I\` で BSSID
  - **Linux**: \`iwgetid -r\` / \`iwgetid -ar\` → fallback \`nmcli -t -f active,ssid,bssid dev wifi\`
- \`preload.ts\`: \`window.memoria.getCurrentWifiInfo()\` を expose

### Server
- \`POST /api/work-locations/wifi-checkin\` — ssid を受けて work_locations.wifi_ssids と case-insensitive match → 通常 checkin と同じく \`workplace.current.id\` を更新 + (有効なら) Hub にプレゼンスを broadcast
- POST/PATCH \`/api/work-locations\`: \`wifi_ssids\` フィールドを受付
- 既存の lat/lng-based \`/checkin\` はそのまま動く

### Frontend
- 作業場所編集モーダルに「WiFi SSID (カンマ区切り)」 入力 + 「📶 現在の WiFi を追加」 ボタン (Electron 限定で表示)
- 起動時 (= app.ts の init) に Electron なら \`getCurrentWifiInfo()\` → \`wifi-checkin\` を 1 回叩く。 マッチしたら banner に \`📍 (場所名) (WiFi: SSID)\` を表示

## Test plan

- [ ] デスクトップ版 (\`npm run dev\` from desktop/) で起動 → SSID が取れて banner に表示される
- [ ] 設定 → 作業場所 → 既存の場所を編集 → 「📶 現在の WiFi を追加」 ボタン → SSID 欄に追加される
- [ ] そのまま保存 → ブラウザリロード → 自動で banner が出る
- [ ] ブラウザ単体 (Chrome 等で http://localhost:5180) で開く → 静かに skip (permission ダイアログ出ない)
- [ ] 別 SSID に切り替え → 別 workplace にマッチすれば banner 変わる、 マッチなしなら無反応

🤖 Generated with [Claude Code](https://claude.com/claude-code)