### PR TITLE
feat(tracks): 外部情報設定タブを廃止、軌跡タブに GPS source + WiFi info を統合

### DIFF
--- a/server/public/index.html
+++ b/server/public/index.html
@@ -628,7 +628,6 @@
           <button class="wl-subtab" data-db-sub="domain">🏷 ドメイン</button>
           <button class="wl-subtab" data-db-sub="workplace">🗺️ 作業場所</button>
           <button class="wl-subtab" data-db-sub="queue">⚙ キュー <span id="dbQueueBadge" class="tab-count hidden">0</span></button>
-          <button class="wl-subtab" data-db-sub="external">🔌 外部設定</button>
         </nav>
       </div>
 
@@ -728,6 +727,7 @@
           <span id="tracksLive" class="tracks-live" title="WebSocket ライブ更新の状態">●</span>
           <span id="tracksStats" class="tracks-stats"></span>
           <span class="grow"></span>
+          <button id="tracksHowtoBtn" class="ghost" title="OwnTracks / WiFi の設定方法を見る">📖 設定方法</button>
           <button id="tracksKeyToggle" class="ghost" title="ingest key (HTTP モード用)">🔑 key</button>
         </div>
         <div id="tracksKeyPanel" class="tracks-key-panel hidden">
@@ -749,6 +749,38 @@
             HTTP ingest endpoint (<code>POST /api/locations/ingest</code>) を WAN 公開する場合に必要。 MQTT-over-WSS を使う場合は不要 (broker 側 passwd で認証)。
           </p>
         </div>
+        <!-- GPS source status (旧 🔌 外部情報設定の location セクションを移植) ─── -->
+        <div id="tracksGpsSourceCard" class="tracks-source-card">
+          <header class="tracks-source-head">
+            <span class="tracks-source-icon">📍</span>
+            <span class="tracks-source-name">位置情報 (OwnTracks GPS)</span>
+            <span class="ext-cfg-pill ext-cfg-pill-loading" id="tracksGpsPill">読み込み中…</span>
+          </header>
+          <div class="ext-cfg-status-grid">
+            <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">直近 24h</span><span id="tracksGpsCount24h" class="ext-cfg-stat-val">—</span></div>
+            <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">直近 7 日</span><span id="tracksGpsCount7d" class="ext-cfg-stat-val">—</span></div>
+            <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">デバイス</span><span id="tracksGpsDeviceCount" class="ext-cfg-stat-val">—</span></div>
+            <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">最新</span><span id="tracksGpsLatest" class="ext-cfg-stat-val">—</span></div>
+          </div>
+          <p class="ext-cfg-help" id="tracksGpsHint"></p>
+        </div>
+
+        <!-- 接続中の WiFi (Electron 限定で表示。 SSID をワークプレイスにマップするヒント付き) -->
+        <div id="tracksWifiCard" class="tracks-source-card" hidden>
+          <header class="tracks-source-head">
+            <span class="tracks-source-icon">📶</span>
+            <span class="tracks-source-name">接続中の WiFi</span>
+            <span class="ext-cfg-pill ext-cfg-pill-loading" id="tracksWifiPill">取得中…</span>
+            <button id="tracksWifiRefresh" class="ghost" type="button" title="再取得">↻</button>
+          </header>
+          <div class="tracks-wifi-grid">
+            <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">SSID</span><span id="tracksWifiSsid" class="ext-cfg-stat-val">—</span></div>
+            <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">BSSID</span><span id="tracksWifiBssid" class="ext-cfg-stat-val">—</span></div>
+            <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">対応作業場所</span><span id="tracksWifiMatch" class="ext-cfg-stat-val">—</span></div>
+          </div>
+          <p class="ext-cfg-help" id="tracksWifiHint">この SSID をワークプレイスに紐付けると、 起動するだけで自動チェックインされます。</p>
+        </div>
+
         <div id="tracksMissingKey" class="tracks-missing-key hidden">
           Google Maps API key 未設定。 設定 → AI / 連携 で <code>maps_api_key</code>
           を入れるか、 環境変数 <code>GOOGLE_MAPS_API_KEY</code> を設定してください。
@@ -823,213 +855,80 @@
         </div>
       </div>
 
-      <!-- 🔌 外部情報設定 — Legatus / OwnTracks / dnsmasq / Tailscale / iPhone のセットアップ手順 -->
-      <div id="externalView" class="hidden">
-        <div class="ext-cfg">
-          <header class="ext-cfg-head">
-            <h2>🔌 外部情報設定</h2>
-            <p class="ext-cfg-intro">
-              iPhone (Tailscale 経由) のライフログ取込み設定。 現在 2 系統対応:
-              <strong>📍 位置情報</strong> (OwnTracks GPS) と
-              <strong>🌐 DNS / SNI tap</strong> (アクセスドメイン) を別々の経路で受け、
-              Memoria に永続化します。 HTTPS 本文 / アプリ内イベントは取得しません。
-            </p>
+      <!-- 軌跡タブ用の「📖 設定方法」 モーダル — OwnTracks (内蔵 MQTT broker)
+           のセットアップ手順。 v0.2 で Memoria に MQTT broker (aedes) を内蔵
+           したため Legatus / 外部 Mosquitto は不要、 DNStap は廃止。 -->
+      <div id="tracksHowtoModal" class="modal-backdrop tutorial-overlay" hidden>
+        <div class="modal-panel tutorial-modal">
+          <header class="tutorial-head">
+            <h2>📖 OwnTracks GPS 取込みの設定</h2>
+            <button id="tracksHowtoClose" class="modal-close" title="閉じる">×</button>
           </header>
+          <main class="tutorial-body">
+            <p>Memoria は内蔵 MQTT broker (aedes、 port 1883) を持っているので、 別途 Mosquitto や Legatus を入れずに iPhone OwnTracks → Memoria 直結で GPS 軌跡を受けられます。</p>
 
-          <!-- ステータスサマリ — 各情報源の現状 -->
-          <section class="ext-cfg-status">
-            <h3>📊 各情報の取込ステータス</h3>
-            <div class="ext-cfg-sources">
-              <div class="ext-cfg-source" id="extCfgSrcLocation">
-                <header>
-                  <span class="ext-cfg-source-icon">📍</span>
-                  <span class="ext-cfg-source-name">位置情報 (OwnTracks GPS)</span>
-                  <span class="ext-cfg-pill ext-cfg-pill-loading" id="extCfgLocationPill">読み込み中…</span>
-                </header>
-                <div class="ext-cfg-status-grid">
-                  <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">直近 24h</span><span id="extCfgLocCount24h" class="ext-cfg-stat-val">—</span></div>
-                  <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">直近 7 日</span><span id="extCfgLocCount7d" class="ext-cfg-stat-val">—</span></div>
-                  <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">デバイス</span><span id="extCfgLocDeviceCount" class="ext-cfg-stat-val">—</span></div>
-                  <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">最新</span><span id="extCfgLocLatest" class="ext-cfg-stat-val">—</span></div>
-                </div>
-                <p class="ext-cfg-help" id="extCfgLocationHint"></p>
-              </div>
+            <h3>1️⃣ Memoria 側で ingest key を生成</h3>
+            <p>軌跡ページ上部の <b>🔑 key</b> ボタンを押し、 <b>「🎲 新しい key を生成」</b> → 表示された 32 桁を OwnTracks のパスワードに使います (1 度だけ表示されます)。</p>
 
-              <div class="ext-cfg-source" id="extCfgSrcDns">
-                <header>
-                  <span class="ext-cfg-source-icon">🌐</span>
-                  <span class="ext-cfg-source-name">DNS / SNI tap (Legatus dnstap)</span>
-                  <span class="ext-cfg-pill ext-cfg-pill-loading" id="extCfgDnsPill">読み込み中…</span>
-                </header>
-                <div class="ext-cfg-status-grid">
-                  <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">直近 24h</span><span id="extCfgCount24h" class="ext-cfg-stat-val">—</span></div>
-                  <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">直近 7 日</span><span id="extCfgCount7d" class="ext-cfg-stat-val">—</span></div>
-                  <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">デバイス</span><span id="extCfgDeviceCount" class="ext-cfg-stat-val">—</span></div>
-                  <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">最新</span><span id="extCfgLatest" class="ext-cfg-stat-val">—</span></div>
-                </div>
-                <p class="ext-cfg-help" id="extCfgDnsHint"></p>
-              </div>
-            </div>
-            <div id="extCfgRecent" class="ext-cfg-recent"></div>
-          </section>
-
-          <!-- ── 設定方法 (情報源別) ─────────────────────────────── -->
-          <section class="ext-cfg-howto">
-            <h3>📖 設定方法</h3>
-            <p class="ext-cfg-help">取り込みたい情報源ごとに必要なステップを実施してください。 どちらも default OFF で、 明示的に enable しないと取込まれません。</p>
-          </section>
-
-          <!-- ── A. 位置情報 (OwnTracks GPS) ─────────────────────── -->
-          <section class="ext-cfg-step ext-cfg-howto-loc">
-            <h3>📍 A. 位置情報 (OwnTracks GPS) の設定</h3>
-            <p class="ext-cfg-help">iPhone の OwnTracks アプリが Tailscale 経由で home PC 同居 Mosquitto に publish → Legatus が subscribe → Memoria の <code>gps_locations</code> に永続化。</p>
-
-            <h4>1️⃣ Memoria 側で ingest key を発行</h4>
-            <p class="ext-cfg-help">「🗺 軌跡」 タブで「ingest key を再生成」 を押す → 32 桁 hex が発行される (= Mosquitto Basic auth password として使える)。</p>
-
-            <h4>2️⃣ home PC で Mosquitto を起動 (Legatus 同居)</h4>
-            <div class="ext-cfg-env">
-              <pre><code># /etc/mosquitto/mosquitto.conf (抜粋)
-listener 1883 0.0.0.0
-allow_anonymous false
-password_file /etc/mosquitto/passwd
-# tailnet 経由のみ受ける場合 (推奨):
-# listener 1883 100.x.y.z   (home PC の Tailscale IP)</code></pre>
-              <button class="ghost" data-copy-env="mosquitto">コピー</button>
-            </div>
-            <p class="ext-cfg-help"><code>mosquitto_passwd -c /etc/mosquitto/passwd owntracks</code> で user 作成、 password に上の ingest key を入れる。</p>
-
-            <h4>3️⃣ Legatus に env vars を渡す</h4>
-            <div class="ext-cfg-env">
-              <pre><code>OWNTRACKS_ENABLED=true
-OWNTRACKS_MQTT_URL=mqtt://127.0.0.1:1883
-OWNTRACKS_MQTT_USERNAME=owntracks
-OWNTRACKS_MQTT_PASSWORD=&lt;ingest key&gt;
-OWNTRACKS_MQTT_TOPIC=owntracks/+/+
-LEGATUS_LOCATION_FLUSH_INTERVAL_MS=300000
-LEGATUS_LOCATION_MIN_DISPLACEMENT_M=100</code></pre>
-              <button class="ghost" data-copy-env="owntracks">コピー</button>
-            </div>
-
-            <h4>4️⃣ iPhone OwnTracks アプリ</h4>
-            <ul class="ext-cfg-ios-list">
-              <li>Mode = <strong>MQTT</strong></li>
-              <li>Host = home PC の Tailscale IP (例 <code>100.64.0.5</code>)</li>
-              <li>Port = <code>1883</code></li>
-              <li>User = <code>owntracks</code> / Password = ingest key</li>
-              <li>Topic format は default (<code>owntracks/&lt;user&gt;/&lt;device&gt;</code>)</li>
-              <li>「Move」 mode 推奨 (バッテリー寄りなら Significant)</li>
+            <h3>2️⃣ 接続経路を VPN で閉じる (推奨)</h3>
+            <p>MQTT broker をインターネットに直接晒すと位置情報が常時露出します。 Tailscale / WireGuard 等のオーバレイ VPN で「自端末同士」 に閉じてください。</p>
+            <ul>
+              <li>home PC と iPhone を同じ Tailscale tailnet に入れる</li>
+              <li>broker は default で <code>0.0.0.0:1883</code> に listen — tailnet IP から見えれば OK</li>
+              <li>厳格にしたい場合は <code>MEMORIA_MQTT_BROKER_HOST=&lt;tailnet IP&gt;</code> で bind を絞る</li>
             </ul>
 
-            <h4>5️⃣ オプトアウト</h4>
-            <ol class="ext-cfg-optout">
-              <li>iPhone 側 OwnTracks の publish を OFF</li>
-              <li>Legatus の <code>OWNTRACKS_ENABLED=false</code></li>
-              <li>Memoria 「🗺 軌跡」 タブで ingest key を削除 (= 受信を恒久停止)</li>
+            <h3>3️⃣ iPhone OwnTracks アプリ設定</h3>
+            <ul>
+              <li><b>Mode</b> = <code>MQTT</code></li>
+              <li><b>Host</b> = home PC の Tailscale IP (例 <code>100.64.0.5</code>)</li>
+              <li><b>Port</b> = <code>1883</code></li>
+              <li><b>WebSocket</b> = OFF</li>
+              <li><b>User</b> = <code>memoria</code> など好きな名前 (<code>MEMORIA_MQTT_USERNAME</code> 未設定なら認証スキップ)</li>
+              <li><b>Password</b> = 上で生成した ingest key</li>
+              <li><b>TopicID / Device</b> = 任意 (Memoria は <code>owntracks/+/+</code> を subscribe)</li>
+              <li><b>Reporting</b> = Move 推奨 (バッテリ寄りなら Significant)</li>
+            </ul>
+
+            <h3>4️⃣ HTTP モード (MQTT が使えない環境用)</h3>
+            <p>VPN が無い / FW が厳しい場合は HTTP モードでも受けられます。</p>
+            <ul>
+              <li><b>Mode</b> = <code>HTTP</code></li>
+              <li><b>URL</b> = <code>https://&lt;Memoria 公開ホスト&gt;/api/locations/ingest</code></li>
+              <li><b>Password</b> = 上で生成した ingest key</li>
+            </ul>
+            <p class="ext-cfg-help">HTTP モードでも ingest key (Authorization Bearer) で認証するので、 key が漏れない限り他者は POST できません。</p>
+
+            <h3>5️⃣ 接続中の WiFi で workplace を自動チェックイン (Electron 限定)</h3>
+            <p>Memoria デスクトップ版なら、 接続中の WiFi SSID から workplace を判定して自動チェックインできます (位置情報 permission を経由しない)。</p>
+            <ul>
+              <li>設定 → 作業場所 → 編集 → <b>「WiFi SSID」</b> 欄に SSID を入れる</li>
+              <li>「📶 現在の WiFi を追加」 ボタンで自動入力</li>
+              <li>その後 Memoria を起動すれば SSID 一致で自動チェックイン</li>
+            </ul>
+
+            <h3>6️⃣ オプトアウト</h3>
+            <ol>
+              <li>iPhone OwnTracks の publish を OFF</li>
+              <li>Memoria 軌跡タブ → 🔑 key → 「クリア (匿名)」 で ingest key を削除</li>
+              <li>broker 自体を止めたい場合は <code>MEMORIA_MQTT_BROKER=off</code> 環境変数</li>
             </ol>
-          </section>
 
-          <!-- ── B. DNS / SNI tap ─────────────────────────────── -->
-          <section class="ext-cfg-step ext-cfg-howto-dns">
-            <h3>🌐 B. DNS / SNI tap (Legatus dnstap) の設定</h3>
-            <p class="ext-cfg-help">home PC の dnsmasq が iPhone (Tailscale exit node) からの DNS query log を吐き、 Legatus dnstap が tail → Tailscale で device tag → Memoria に forward。</p>
-
-            <h4>1️⃣ Legatus dnstap を起動 (env vars)</h4>
-            <p class="ext-cfg-help">個人 PC で動かす Legatus に以下の環境変数を渡します。 全項目 default OFF — 明示的に enable する必要があります。</p>
-            <div class="ext-cfg-env">
-              <pre><code>LEGATUS_DNSTAP_ENABLED=true
-LEGATUS_DNSMASQ_LOG_PATH=/var/log/dnsmasq.log
-LEGATUS_DNSTAP_FLUSH_MS=30000
-LEGATUS_DNSTAP_DEDUPE_MS=5000
-LEGATUS_TAILSCALE_BIN=tailscale
-LEGATUS_TAILSCALE_REFRESH_MS=300000
-LEGATUS_DNSTAP_SKIP_DOMAINS=bank.example,hospital.test
-LEGATUS_DNSTAP_FORWARD_URL=http://localhost:5180/api/visits/external</code></pre>
-              <button class="ghost" data-copy-env="legatus">コピー</button>
-            </div>
-            <details class="ext-cfg-detail">
-              <summary>各キーの意味</summary>
-              <ul>
-                <li><code>LEGATUS_DNSTAP_ENABLED</code> — モジュール ON/OFF。 default <code>false</code></li>
-                <li><code>LEGATUS_DNSMASQ_LOG_PATH</code> — tail 対象の query log。 dnsmasq 側 <code>--log-facility</code> と一致</li>
-                <li><code>LEGATUS_DNSTAP_FLUSH_MS</code> — Memoria への flush 周期 (default 30 秒)</li>
-                <li><code>LEGATUS_DNSTAP_DEDUPE_MS</code> — A/AAAA/HTTPS RR バーストの統合窓 (default 5 秒)</li>
-                <li><code>LEGATUS_TAILSCALE_BIN</code> — <code>tailscale</code> CLI のパス</li>
-                <li><code>LEGATUS_TAILSCALE_REFRESH_MS</code> — IP→hostname map の更新間隔 (default 5 分)</li>
-                <li><code>LEGATUS_DNSTAP_SKIP_DOMAINS</code> — カンマ区切り skip 一覧 (suffix match)</li>
-                <li><code>LEGATUS_DNSTAP_FORWARD_URL</code> — この Memoria の <code>/api/visits/external</code></li>
-              </ul>
-            </details>
-
-            <h4>2️⃣ dnsmasq の設定 (<code>/etc/dnsmasq.conf</code>)</h4>
-            <div class="ext-cfg-env">
-              <pre><code>log-queries
-log-facility=/var/log/dnsmasq.log
-interface=tailscale0
-interface=lo
-bind-interfaces
-domain-needed
-bogus-priv</code></pre>
-              <button class="ghost" data-copy-env="dnsmasq">コピー</button>
-            </div>
-            <p class="ext-cfg-help"><code>tailscale0</code> インターフェイスでのみ listen、 公開しない構成。 logrotate も忘れず。</p>
-
-            <h4>3️⃣ Tailscale 設定</h4>
-            <div class="ext-cfg-grid">
-              <div>
-                <h5>home PC (Legatus 同居)</h5>
-                <ul>
-                  <li><code>tailscale up --advertise-exit-node</code></li>
-                  <li>admin console で <strong>承認</strong></li>
-                  <li>必要なら <code>--advertise-routes=192.168.x.0/24</code></li>
-                </ul>
-              </div>
-              <div>
-                <h5>Tailscale admin console</h5>
-                <ul>
-                  <li>DNS → <strong>Override local DNS</strong> ON</li>
-                  <li>Nameservers に home PC の Tailscale IP を登録</li>
-                  <li><strong>MagicDNS</strong> ON</li>
-                </ul>
-              </div>
-              <div>
-                <h5>iPhone Tailscale アプリ</h5>
-                <ul>
-                  <li><strong>Use Tailscale DNS</strong> ON</li>
-                  <li><strong>Exit Node</strong> = home PC を選択</li>
-                </ul>
-              </div>
-            </div>
-
-            <h4>4️⃣ iPhone iOS 側</h4>
-            <div class="ext-cfg-warning">
-              ⚠ 設定 → Apple ID → iCloud → <strong>Private Relay を OFF</strong> (該当 Wi-Fi のみで可)。
-              ON のままだと DNS が Apple/Cloudflare に飛んで home resolver を bypass し、 ログが空になります。
-            </div>
-            <ul class="ext-cfg-ios-list">
-              <li>Tailscale 接続を常時 ON</li>
-              <li>Wi-Fi → Configure DNS = <strong>Automatic</strong></li>
-              <li>Tailscale exit node を home PC にしている時のみ home dnsmasq 経由</li>
-            </ul>
-
-            <h4>5️⃣ オプトアウト</h4>
-            <ol class="ext-cfg-optout">
-              <li><strong>デバイス側</strong>: iPhone Tailscale を切る or exit node を外す → 即座に取込停止</li>
-              <li><strong>module 設定</strong>: <code>LEGATUS_DNSTAP_SKIP_DOMAINS</code> に銀行 / 医療 / 内部系を列挙</li>
-              <li><strong>全体停止</strong>: <code>LEGATUS_DNSTAP_ENABLED=false</code> (default 値)</li>
-            </ol>
-          </section>
-
-          <section class="ext-cfg-step">
-            <h3>📚 関連</h3>
-            <ul class="ext-cfg-links">
-              <li><a href="https://github.com/LUDIARS/Legatus" target="_blank" rel="noopener">LUDIARS/Legatus (リポジトリ)</a></li>
-              <li>Legatus PR <a href="https://github.com/LUDIARS/Legatus/pull/2" target="_blank" rel="noopener">#2 — feat(dnstap)</a></li>
-              <li>Memoria endpoint: <code>POST /api/visits/external</code></li>
-            </ul>
-          </section>
+            <p class="tutorial-help">📚 詳細: <a href="https://github.com/LUDIARS/Memoria/blob/main/docs/mqtt-vpn-setup.md" target="_blank" rel="noopener">docs/mqtt-vpn-setup.md</a></p>
+          </main>
+          <footer class="tutorial-footer">
+            <span class="tutorial-spacer"></span>
+            <button id="tracksHowtoCloseBtn" type="button">閉じる</button>
+          </footer>
         </div>
       </div>
+
+      <!-- 旧 🔌 外部情報設定 タブ (= externalView) は v0.2 で軌跡タブに統合された
+           ため削除。 GPS source status は #tracksGpsSourceCard、 設定手順は
+           #tracksHowtoModal に移動済み。 DNStap (Legatus 経由) は Legatus 非依存
+           化に伴い廃止 (server 側 /api/visits/external は当面残るが UI からは
+           参照しない)。 -->
+
 
       <!-- 単語リングメニュー — グラフ / ワードクラウドの単語クリックで開く -->
       <div id="wordRingMenu" class="word-ring hidden" role="menu" aria-label="単語アクション">

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -7646,14 +7646,13 @@ const WL_SUB_VIEWS = {
   tracks: 'tracksView',
 };
 
-// データベースタブのサブビュー一覧
+// データベースタブのサブビュー一覧 (旧 'external' は軌跡タブに統合)
 const DB_SUB_VIEWS = {
   bookmarks: 'bookmarksView',
   dict: 'dictView',
   domain: 'domainView',
   workplace: 'workplaceView',
   queue: 'queueView',
-  external: 'externalView',
 };
 
 state.database = state.database || { sub: 'bookmarks' };
@@ -7687,7 +7686,6 @@ function switchDatabaseSub(sub) {
   if (sub === 'domain') loadDomainCatalog();
   if (sub === 'workplace') loadWorkLocations().catch(console.warn);
   if (sub === 'queue') renderQueue();
-  if (sub === 'external') loadExternalConfig();
 }
 
 // 日付ベースの sub かどうか (date toolbar / summary 表示の有無)
@@ -8422,6 +8420,21 @@ async function loadTracks() {
       const v = $('tracksKeyRevealValue')?.textContent ?? '';
       if (v) navigator.clipboard?.writeText(v).catch(() => {});
     });
+    // 「📖 設定方法」 モーダル (旧 🔌 外部情報設定の手順を移植)
+    $('tracksHowtoBtn')?.addEventListener('click', () => {
+      const m = $('tracksHowtoModal');
+      if (m) m.hidden = false;
+    });
+    $('tracksHowtoClose')?.addEventListener('click', () => {
+      const m = $('tracksHowtoModal');
+      if (m) m.hidden = true;
+    });
+    $('tracksHowtoCloseBtn')?.addEventListener('click', () => {
+      const m = $('tracksHowtoModal');
+      if (m) m.hidden = true;
+    });
+    // 接続中 WiFi の再取得ボタン
+    $('tracksWifiRefresh')?.addEventListener('click', () => void loadTracksWifiInfo());
     document.addEventListener('visibilitychange', () => {
       // タブに戻ってきたら最新の状態に再同期 + WS 再接続
       if (document.visibilityState === 'visible' && (state.tab === 'worklog' && state.worklog?.sub === 'tracks')) {
@@ -8430,6 +8443,9 @@ async function loadTracks() {
       }
     });
   }
+  // GPS source status / WiFi info を毎回 (タブ切替で再表示するたび) 更新する。
+  loadTracksGpsStatus().catch(() => { /* swallow */ });
+  loadTracksWifiInfo().catch(() => { /* swallow */ });
 
   try {
     const [{ apiKey, hasKey }, { days }, ts] = await Promise.all([
@@ -9480,94 +9496,119 @@ const mealsState = {
   pollTimer: null,
 };
 
-// ── 外部情報設定 (Legatus 系統別ステータス + チュートリアル) ────────
-async function loadExternalConfig() {
+// ── 軌跡タブの GPS source status / WiFi info (旧 🔌 外部情報設定から移植) ─
+//
+// 旧 loadExternalConfig は location + DNS の 2 系統を出していたが、
+// DNS (Legatus dnstap) は Legatus 非依存化に伴い廃止。 location のみを
+// 軌跡タブの #tracksGpsSourceCard に描画する。
+
+async function loadTracksGpsStatus() {
   const $set = (id, v) => { const el = document.getElementById(id); if (el) el.textContent = v; };
   const fmtTime = (s) => s ? new Date(s.replace(' ', 'T') + (s.endsWith('Z') ? '' : 'Z')).toLocaleString() : '—';
-
   try {
     const r = await api('/api/external/stats');
-
-    // 📍 位置情報 (OwnTracks)
     const loc = r.location || {};
-    $set('extCfgLocCount24h', String(loc.count_24h ?? 0));
-    $set('extCfgLocCount7d', String(loc.count_7d ?? 0));
-    $set('extCfgLocDeviceCount', String(loc.device_count ?? 0));
-    $set('extCfgLocLatest', fmtTime(loc.latest));
-    setExtCfgPill('extCfgLocationPill', loc, {
-      activeMsg: '稼働中',
-      configuredMsg: '受信待機',
-      inactiveMsg: '未受信',
-    });
-    const locHint = document.getElementById('extCfgLocationHint');
-    if (locHint) {
-      if (loc.active) locHint.textContent = '直近 24 時間に GPS 点が届いています。';
-      else if (loc.configured) locHint.textContent = 'ingest key が設定済み。 OwnTracks 側の publish 状況を確認してください。';
-      else locHint.textContent = 'ingest key 未設定 — まず「🗺 軌跡」 タブで key を生成してください。';
-    }
-
-    // 🌐 DNS / SNI tap
-    const dns = r.dns || {};
-    $set('extCfgCount24h', String(dns.count_24h ?? 0));
-    $set('extCfgCount7d', String(dns.count_7d ?? 0));
-    $set('extCfgDeviceCount', String(dns.device_count ?? 0));
-    $set('extCfgLatest', fmtTime(dns.latest));
-    setExtCfgPill('extCfgDnsPill', dns, {
-      activeMsg: '稼働中',
-      configuredMsg: '受信待機',
-      inactiveMsg: '未受信',
-    });
-    const dnsHint = document.getElementById('extCfgDnsHint');
-    if (dnsHint) {
-      if (dns.active) dnsHint.textContent = '直近 24 時間に Legatus dnstap からドメインアクセスが届いています。';
-      else if (dns.configured) dnsHint.textContent = '直近 1 週間にデータあり、 24h 内は未到達。 Legatus / dnsmasq の稼働を確認してください。';
-      else dnsHint.textContent = 'まだデータが届いていません。 下記「📖 設定方法 B」 を実施してください。';
-    }
-
-    // 直近 20 件 (DNS のみ — domain 単位なので位置情報と混ぜない)
-    const recent = document.getElementById('extCfgRecent');
-    if (recent) {
-      const items = Array.isArray(dns.recent) ? dns.recent : [];
-      if (items.length === 0) {
-        recent.innerHTML = '<div class="hint">DNS / SNI 取り込みは未受信。 下記「設定方法 B」 を実施してください。</div>';
-      } else {
-        recent.innerHTML = `
-          <h4>🌐 DNS / SNI 直近 20 件</h4>
-          <table class="ext-cfg-recent-tbl">
-            <thead><tr><th>時刻</th><th>device</th><th>OS</th><th>source</th><th>domain</th></tr></thead>
-            <tbody>
-              ${items.map((e) => `
-                <tr>
-                  <td>${escapeHtml(fmtTime(e.visited_at))}</td>
-                  <td>${escapeHtml(e.device_label || '—')}</td>
-                  <td>${escapeHtml(e.device_os || '—')}</td>
-                  <td><span class="ext-cfg-src ext-cfg-src-${escapeHtml(e.source || 'unknown')}">${escapeHtml(e.source || '—')}</span></td>
-                  <td>${escapeHtml(e.domain || '—')}</td>
-                </tr>`).join('')}
-            </tbody>
-          </table>
-        `;
-      }
+    $set('tracksGpsCount24h', String(loc.count_24h ?? 0));
+    $set('tracksGpsCount7d', String(loc.count_7d ?? 0));
+    $set('tracksGpsDeviceCount', String(loc.device_count ?? 0));
+    $set('tracksGpsLatest', fmtTime(loc.latest));
+    setTracksGpsPill('tracksGpsPill', loc);
+    const hint = document.getElementById('tracksGpsHint');
+    if (hint) {
+      if (loc.active) hint.textContent = '直近 24 時間に GPS 点が届いています。';
+      else if (loc.configured) hint.textContent = 'ingest key が設定済み。 OwnTracks 側の publish 状況を確認してください。';
+      else hint.textContent = 'ingest key 未設定 — 上の「🔑 key」 で生成してください。 詳しい手順は「📖 設定方法」 から。';
     }
   } catch (e) {
-    const recent = document.getElementById('extCfgRecent');
-    if (recent) recent.innerHTML = `<div class="hint">取得エラー: ${escapeHtml(e.message)}</div>`;
+    const hint = document.getElementById('tracksGpsHint');
+    if (hint) hint.textContent = `取得エラー: ${e.message}`;
   }
 }
 
-function setExtCfgPill(id, src, msg) {
+function setTracksGpsPill(id, src) {
   const el = document.getElementById(id);
   if (!el) return;
   el.classList.remove('ext-cfg-pill-loading', 'ext-cfg-pill-active', 'ext-cfg-pill-configured', 'ext-cfg-pill-inactive');
   if (src.active) {
     el.classList.add('ext-cfg-pill-active');
-    el.textContent = `🟢 ${msg.activeMsg}`;
+    el.textContent = '🟢 稼働中';
   } else if (src.configured) {
     el.classList.add('ext-cfg-pill-configured');
-    el.textContent = `🟡 ${msg.configuredMsg}`;
+    el.textContent = '🟡 受信待機';
   } else {
     el.classList.add('ext-cfg-pill-inactive');
-    el.textContent = `⚪ ${msg.inactiveMsg}`;
+    el.textContent = '⚪ 未受信';
+  }
+}
+
+// ── 接続中 WiFi 情報 (Electron 限定) ─────────────────────────────────
+// window.memoria.getCurrentWifiInfo() で SSID / BSSID を取って表示。
+// さらに work_locations.wifi_ssids に登録があれば「対応作業場所」 列に出す。
+async function loadTracksWifiInfo() {
+  const card = document.getElementById('tracksWifiCard');
+  const ssidEl = document.getElementById('tracksWifiSsid');
+  const bssidEl = document.getElementById('tracksWifiBssid');
+  const matchEl = document.getElementById('tracksWifiMatch');
+  const pillEl = document.getElementById('tracksWifiPill');
+  if (!card) return;
+  const bridge = (typeof window !== 'undefined' ? (window as Loose).memoria : null);
+  if (!bridge?.getCurrentWifiInfo) {
+    // ブラウザ単体: カードごと非表示
+    card.hidden = true;
+    return;
+  }
+  card.hidden = false;
+  if (pillEl) {
+    pillEl.classList.remove('ext-cfg-pill-loading', 'ext-cfg-pill-active', 'ext-cfg-pill-configured', 'ext-cfg-pill-inactive');
+    pillEl.classList.add('ext-cfg-pill-loading');
+    pillEl.textContent = '取得中…';
+  }
+  try {
+    const info = await bridge.getCurrentWifiInfo();
+    if (!info?.ssid) {
+      if (ssidEl) ssidEl.textContent = '(未接続 / 取得失敗)';
+      if (bssidEl) bssidEl.textContent = '—';
+      if (matchEl) matchEl.textContent = '—';
+      if (pillEl) {
+        pillEl.classList.remove('ext-cfg-pill-loading');
+        pillEl.classList.add('ext-cfg-pill-inactive');
+        pillEl.textContent = '⚪ 未接続';
+      }
+      return;
+    }
+    if (ssidEl) ssidEl.textContent = info.ssid;
+    if (bssidEl) bssidEl.textContent = info.bssid || '—';
+    // work_locations.wifi_ssids との照合
+    let matchName: string | null = null;
+    try {
+      const r = await api('/api/work-locations?limit=500');
+      const all = r.items as Array<{ id: number; name: string; wifi_ssids?: string | null }>;
+      const norm = info.ssid.toLowerCase();
+      const hit = all.find((w) => {
+        const list = (w.wifi_ssids ?? '').split(',').map((s: string) => s.trim().toLowerCase()).filter(Boolean);
+        return list.includes(norm);
+      });
+      matchName = hit?.name ?? null;
+    } catch { /* swallow */ }
+    if (matchEl) matchEl.textContent = matchName ?? '(未登録 — 設定 → 作業場所 から紐付け可)';
+    if (pillEl) {
+      pillEl.classList.remove('ext-cfg-pill-loading');
+      if (matchName) {
+        pillEl.classList.add('ext-cfg-pill-active');
+        pillEl.textContent = '🟢 マッチ済';
+      } else {
+        pillEl.classList.add('ext-cfg-pill-configured');
+        pillEl.textContent = '🟡 未登録';
+      }
+    }
+  } catch (e) {
+    if (ssidEl) ssidEl.textContent = '(取得エラー)';
+    if (pillEl) {
+      pillEl.classList.remove('ext-cfg-pill-loading');
+      pillEl.classList.add('ext-cfg-pill-inactive');
+      pillEl.textContent = '⚪ 取得失敗';
+    }
+    console.debug('[tracks-wifi] failed:', (e as Error).message);
   }
 }
 

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -4874,6 +4874,33 @@ dialog.meal-modal[open] {
 .ext-cfg-pill-configured { background: #fff7d6; color: #8a6d00; border-color: #e6c97a; }
 .ext-cfg-pill-inactive { background: var(--bg-surface, #fff); color: var(--text-muted); }
 
+/* 軌跡タブの GPS source / WiFi カード (旧 🔌 外部情報設定からの移植) */
+.tracks-source-card {
+  background: var(--bg-surface, var(--panel));
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 14px;
+  margin: 8px 0;
+}
+.tracks-source-head {
+  display: flex; align-items: center; gap: 8px;
+  margin-bottom: 8px;
+  flex-wrap: wrap;
+}
+.tracks-source-icon { font-size: 18px; }
+.tracks-source-name { font-weight: 600; font-size: 13px; }
+.tracks-source-head .ext-cfg-pill { margin-left: 4px; }
+.tracks-source-head button { font-size: 11px; padding: 2px 8px; }
+.tracks-wifi-grid {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) minmax(120px, 1fr) minmax(140px, 1.4fr);
+  gap: 6px 12px;
+  font-size: 12px;
+}
+@media (max-width: 760px) {
+  .tracks-wifi-grid { grid-template-columns: 1fr 1fr; }
+}
+
 .ext-cfg-howto {
   background: var(--bg-surface, #fff);
   border: 1px solid var(--border);


### PR DESCRIPTION
> 旧 PR #133 が base 削除 (= PR #132 マージ時) で auto-closed されたため再作成。 内容は同じ + main 起点に rebase 済み。

## Summary

データベースタブの「🔌 外部設定」 サブタブを削除し、 GPS 取込ステータスと設定手順を **軌跡タブ** に集約。 同時に DNStap (Legatus dnstap) を Legatus 非依存化に伴い廃止。 軌跡タブに **接続中の WiFi 情報** カードを追加 (Electron 限定)。

## 変更点

### 削除
- データベース → 🔌 外部設定 サブタブ
- `<div id="externalView">` (約 200 行) と DNStap 設定セクション全部
- `loadExternalConfig` / `setExtCfgPill` (= 旧ロード関数)

### 追加 (軌跡タブ内)
- **`#tracksGpsSourceCard`** — GPS 取込ステータス (旧 location セクション移植)。 状態 pill + 24h/7日 件数 + デバイス数 + 最新時刻 + hint
- **`#tracksWifiCard`** — Electron 限定。 接続中の SSID/BSSID + 「対応作業場所」 (= work_locations.wifi_ssids との照合) + 「未登録なら設定 → 作業場所から紐付け可」 ヒント
- tracks bar に **「📖 設定方法」** ボタン → モーダル `#tracksHowtoModal` で OwnTracks 設定手順 (内蔵 MQTT broker 経由、 Mosquitto/Legatus 不要) を表示
- 再取得ボタン (`tracksWifiRefresh`)

### Backend
- `/api/visits/external` endpoint は当面残す (= 過去 DNStap データ保護のため)。 UI からは参照しない

## Test plan
- [ ] データベースタブの「🔌 外部設定」 が消えている
- [ ] 軌跡タブ上部に GPS source 状態カード + (Electron 限定で) WiFi カードが出る
- [ ] 「📖 設定方法」 ボタン → モーダル表示
- [ ] モーダルに OwnTracks / WiFi / オプトアウト の手順がある (DNStap は無い)
- [ ] WiFi カードの「対応作業場所」 が登録済み SSID と一致した場合に workplace 名を表示
- [ ] ブラウザ単体 (Chrome 等) で開いた場合は WiFi カードが非表示
- [ ] GPS source pill が active / configured / inactive で色変わり

🤖 Generated with [Claude Code](https://claude.com/claude-code)