### PR TITLE
feat(wifi): SSID 検出を server 側に移動 (Web からも見える)

### DIFF
--- a/server/lib/wifi-info.ts
+++ b/server/lib/wifi-info.ts
@@ -1,0 +1,101 @@
+// Memoria server プロセスが動いている OS の「接続中の WiFi 名 (SSID)」 を取る。
+//
+// もともと PR #132 で Electron main process に同等のコードを置いて
+// `window.memoria.getCurrentWifiInfo()` 経由で renderer に渡していたが、
+// それだと **Electron 内蔵のレンダラからしか SSID が見えない** という制約が
+// あった。 Memoria server を Electron で起動して、 別 PC のブラウザ / スマホ
+// PWA / Chrome 拡張 から接続している場合に SSID が出せない。
+//
+// → server プロセス自体が OS native コマンドで SSID を取るようにする。 取得元は
+//   Memoria server を実行している PC (= 家の Electron 内蔵サーバ 1 台) なので
+//   どのクライアントから REST で取りに行っても同じ値が返る。
+//
+// 各 OS の native CLI (すべて読み取り専用、 sudo 不要):
+//   Windows : `netsh wlan show interfaces` の "SSID" / "BSSID" 行をパース
+//   macOS   : `networksetup -getairportnetwork en0` (SSID のみ)。 newer macOS は
+//             airport が restricted のため BSSID は best-effort
+//   Linux   : `iwgetid -r` (SSID) と `iwgetid -ar` (BSSID)、 無ければ nmcli
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileP = promisify(execFile);
+
+export interface WifiInfo {
+  ssid: string | null;
+  bssid: string | null;
+  platform: NodeJS.Platform;
+}
+
+/** 失敗時 (= 取得経路無し / 未接続 / 権限不足) は null。 */
+export async function getCurrentWifiInfo(): Promise<WifiInfo | null> {
+  const platform = process.platform;
+  try {
+    if (platform === 'win32') return await wifiInfoWindows();
+    if (platform === 'darwin') return await wifiInfoMac();
+    if (platform === 'linux') return await wifiInfoLinux();
+  } catch {
+    // server プロセスの stdout を汚さないよう silent fail。 上位で null 扱い。
+  }
+  return null;
+}
+
+async function wifiInfoWindows(): Promise<WifiInfo | null> {
+  const r = await execFileP('netsh', ['wlan', 'show', 'interfaces'], {
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+  const lines = (r.stdout || '').split(/\r?\n/);
+  let ssid: string | null = null;
+  let bssid: string | null = null;
+  for (const line of lines) {
+    const m = /^\s*(?:SSID|BSSID)\b[^\:]*:\s*(.+?)\s*$/.exec(line);
+    if (!m) continue;
+    // BSSID 行は前置に「BSSID」 を含む。 SSID 行のみ純粋な「SSID」 で始まる。
+    if (/^\s*BSSID/.test(line) && !bssid) bssid = m[1] ?? null;
+    else if (/^\s*SSID/.test(line) && !ssid) ssid = m[1] ?? null;
+    if (ssid && bssid) break;
+  }
+  return ssid || bssid ? { ssid, bssid, platform: 'win32' } : null;
+}
+
+async function wifiInfoMac(): Promise<WifiInfo | null> {
+  try {
+    const r = await execFileP('networksetup', ['-getairportnetwork', 'en0'], { encoding: 'utf8' });
+    const m = /Current Wi-Fi Network:\s*(.+?)\s*$/m.exec(r.stdout || '');
+    const ssid = m?.[1] ?? null;
+    let bssid: string | null = null;
+    try {
+      const apt = await execFileP(
+        '/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport',
+        ['-I'],
+        { encoding: 'utf8' },
+      );
+      const b = /\bBSSID:\s*([0-9a-f:]+)\s*$/im.exec(apt.stdout || '');
+      bssid = b?.[1] ?? null;
+    } catch { /* airport restricted on Sonoma+ */ }
+    return ssid ? { ssid, bssid, platform: 'darwin' } : null;
+  } catch {
+    return null;
+  }
+}
+
+async function wifiInfoLinux(): Promise<WifiInfo | null> {
+  let ssid: string | null = null;
+  let bssid: string | null = null;
+  try { const r = await execFileP('iwgetid', ['-r'], { encoding: 'utf8' }); ssid = r.stdout.trim() || null; }
+  catch { /* try nmcli */ }
+  try { const r = await execFileP('iwgetid', ['-ar'], { encoding: 'utf8' }); bssid = r.stdout.trim() || null; }
+  catch { /* skip */ }
+  if (!ssid) {
+    try {
+      const r = await execFileP('nmcli', ['-t', '-f', 'active,ssid,bssid', 'dev', 'wifi'], { encoding: 'utf8' });
+      for (const line of (r.stdout || '').split(/\r?\n/)) {
+        // nmcli の bssid フィールド内 ':' は '\\:' で escape されているので分解
+        const parts = line.split(/(?<!\\):/).map((s) => s.replace(/\\:/g, ':'));
+        if (parts[0] === 'yes') { ssid = parts[1] || ssid; bssid = parts[2] || bssid; break; }
+      }
+    } catch { /* nmcli 不在 */ }
+  }
+  return ssid || bssid ? { ssid, bssid, platform: 'linux' } : null;
+}

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -6446,10 +6446,11 @@ function openWorkplaceEditor(w = null) {
   if ($('workplaceEditorWifiSsids')) $('workplaceEditorWifiSsids').value = w?.wifi_ssids || '';
   $('workplaceEditorDescription').value = w?.description || '';
   $('workplaceEditorShareable').checked = !!w?.shareable;
-  // Electron 配下のみ「現在の WiFi を追加」 ボタンを出す。 ブラウザ単体では
-  // SSID を取れない (= window.memoria は preload bridge 経由でのみ存在)。
+  // 「現在の WiFi を追加」 ボタンは server 側 /api/wifi/current が返してくれる
+  // のでブラウザ単体でも表示してよい。 サーバ未対応時はボタン押下時に 404 で
+  // 静かに失敗する。
   const wifiRow = $('workplaceEditorWifiCurrent');
-  if (wifiRow) wifiRow.hidden = !(typeof window !== 'undefined' && (window as Loose).memoria?.getCurrentWifiInfo);
+  if (wifiRow) wifiRow.hidden = false;
   showModal('workplaceEditorModal');
   $('workplaceEditorName').focus();
 }
@@ -6916,25 +6917,27 @@ async function workplaceCheckinNow() {
   }
 }
 
-// 「📶 現在の WiFi を追加」 ボタン (Electron 限定)。 接続中の SSID を取って
-// editor の wifi_ssids フィールドに append (重複 SSID は無視)。
+// 「📶 現在の WiFi を追加」 ボタン。 Memoria server の `/api/wifi/current` から
+// 取って editor の wifi_ssids フィールドに append (重複は無視)。 server 側で
+// OS native コマンドを叩く方式なので、 ブラウザ単体接続でも動く (= Electron
+// で起動した Memoria server に別 PC のブラウザから繋ぐ運用にも対応)。
 async function appendCurrentWifiToEditor() {
   const inp = $('workplaceEditorWifiSsids') as HTMLInputElement | null;
   const status = $('workplaceEditorWifiCurrentStatus');
-  const bridge = (typeof window !== 'undefined' ? (window as Loose).memoria : null);
-  if (!inp || !bridge?.getCurrentWifiInfo) {
-    if (status) status.textContent = 'デスクトップ版でのみ利用できます';
-    return;
-  }
+  if (!inp) return;
   if (status) status.textContent = '取得中…';
   try {
-    const info = await bridge.getCurrentWifiInfo();
+    const info = await api('/api/wifi/current') as { supported?: boolean; ssid?: string | null };
+    if (info?.supported === false) {
+      if (status) status.textContent = '作業場所機能が OFF のため取得できません (設定 → 🚦)';
+      return;
+    }
     if (!info?.ssid) {
       if (status) status.textContent = '接続中の WiFi が見つかりませんでした';
       return;
     }
     const existing = (inp.value || '').split(',').map((s: string) => s.trim()).filter(Boolean);
-    if (existing.some((s: string) => s.toLowerCase() === info.ssid.toLowerCase())) {
+    if (existing.some((s: string) => s.toLowerCase() === info.ssid!.toLowerCase())) {
       if (status) status.textContent = `✓ "${info.ssid}" は既に登録済み`;
       return;
     }
@@ -6942,7 +6945,12 @@ async function appendCurrentWifiToEditor() {
     inp.value = existing.join(', ');
     if (status) status.textContent = `✓ "${info.ssid}" を追加`;
   } catch (e) {
-    if (status) status.textContent = `失敗: ${(e as Error).message}`;
+    const msg = (e as Error).message;
+    if (msg?.includes('404')) {
+      if (status) status.textContent = 'このサーバはまだ /api/wifi/current 未対応';
+    } else if (status) {
+      status.textContent = `失敗: ${msg}`;
+    }
   }
 }
 
@@ -9539,9 +9547,13 @@ function setTracksGpsPill(id, src) {
   }
 }
 
-// ── 接続中 WiFi 情報 (Electron 限定) ─────────────────────────────────
-// window.memoria.getCurrentWifiInfo() で SSID / BSSID を取って表示。
-// さらに work_locations.wifi_ssids に登録があれば「対応作業場所」 列に出す。
+// ── 接続中 WiFi 情報 (どのクライアントからも見える) ─────────────────
+// Memoria server プロセスが動く PC の WiFi 接続情報を `/api/wifi/current` から
+// 取る (= Electron で起動したサーバに別 PC のブラウザ / スマホ PWA から
+// 繋いでも同じ SSID が出る)。 対応作業場所のマッチも server 側で行う。
+//
+// サーバが `supported: false` を返した場合 (= workplace_geo OFF) や、
+// 旧サーバで endpoint が無い (404) 場合は card 自体を hidden に。
 async function loadTracksWifiInfo() {
   const card = document.getElementById('tracksWifiCard');
   const ssidEl = document.getElementById('tracksWifiSsid');
@@ -9549,23 +9561,28 @@ async function loadTracksWifiInfo() {
   const matchEl = document.getElementById('tracksWifiMatch');
   const pillEl = document.getElementById('tracksWifiPill');
   if (!card) return;
-  const bridge = (typeof window !== 'undefined' ? (window as Loose).memoria : null);
-  if (!bridge?.getCurrentWifiInfo) {
-    // ブラウザ単体: カードごと非表示
-    card.hidden = true;
-    return;
-  }
-  card.hidden = false;
   if (pillEl) {
     pillEl.classList.remove('ext-cfg-pill-loading', 'ext-cfg-pill-active', 'ext-cfg-pill-configured', 'ext-cfg-pill-inactive');
     pillEl.classList.add('ext-cfg-pill-loading');
     pillEl.textContent = '取得中…';
   }
   try {
-    const info = await bridge.getCurrentWifiInfo();
+    const info = await api('/api/wifi/current') as {
+      supported?: boolean;
+      ssid?: string | null;
+      bssid?: string | null;
+      platform?: string;
+      workplace?: { id: number; name: string } | null;
+    };
+    if (info?.supported === false) {
+      // workplace 機能が OFF — カードごと隠す
+      card.hidden = true;
+      return;
+    }
+    card.hidden = false;
     if (!info?.ssid) {
       if (ssidEl) ssidEl.textContent = '(未接続 / 取得失敗)';
-      if (bssidEl) bssidEl.textContent = '—';
+      if (bssidEl) bssidEl.textContent = info?.bssid || '—';
       if (matchEl) matchEl.textContent = '—';
       if (pillEl) {
         pillEl.classList.remove('ext-cfg-pill-loading');
@@ -9576,18 +9593,7 @@ async function loadTracksWifiInfo() {
     }
     if (ssidEl) ssidEl.textContent = info.ssid;
     if (bssidEl) bssidEl.textContent = info.bssid || '—';
-    // work_locations.wifi_ssids との照合
-    let matchName: string | null = null;
-    try {
-      const r = await api('/api/work-locations?limit=500');
-      const all = r.items as Array<{ id: number; name: string; wifi_ssids?: string | null }>;
-      const norm = info.ssid.toLowerCase();
-      const hit = all.find((w) => {
-        const list = (w.wifi_ssids ?? '').split(',').map((s: string) => s.trim().toLowerCase()).filter(Boolean);
-        return list.includes(norm);
-      });
-      matchName = hit?.name ?? null;
-    } catch { /* swallow */ }
+    const matchName = info.workplace?.name ?? null;
     if (matchEl) matchEl.textContent = matchName ?? '(未登録 — 設定 → 作業場所 から紐付け可)';
     if (pillEl) {
       pillEl.classList.remove('ext-cfg-pill-loading');
@@ -9600,6 +9606,12 @@ async function loadTracksWifiInfo() {
       }
     }
   } catch (e) {
+    // 404 / 旧サーバ → カード隠す
+    if ((e as Error).message?.includes('404')) {
+      card.hidden = true;
+      return;
+    }
+    card.hidden = false;
     if (ssidEl) ssidEl.textContent = '(取得エラー)';
     if (pillEl) {
       pillEl.classList.remove('ext-cfg-pill-loading');

--- a/server/routes/workplace.ts
+++ b/server/routes/workplace.ts
@@ -13,6 +13,7 @@ import {
   readMultiState, isConnected, shareWorkplacePresence,
 } from '../local/multi-client.js';
 import { privacySettings } from '../lib/privacy.js';
+import { getCurrentWifiInfo } from '../lib/wifi-info.js';
 
 type Db = BetterSqlite3.Database;
 
@@ -36,6 +37,37 @@ export interface WorkplaceRouterDeps {
 export function makeWorkplaceRouter(deps: WorkplaceRouterDeps): Hono {
   const { db } = deps;
   const r = new Hono();
+
+  // 接続中の WiFi 情報 (Memoria server プロセスが動いている PC で検出)。
+  // どのクライアント (Electron renderer / 別 PC のブラウザ / スマホ PWA / Chrome
+  // 拡張) から叩いても、 同じ「Memoria サーバ機の WiFi」 を返す。
+  // → Electron で起動した Memoria に Web から接続している場合も SSID が見える。
+  //
+  // 結果がカンマ区切りの登録 SSID と一致すれば対応 workplace 名も返す。
+  r.get('/api/wifi/current', async (c: Context) => {
+    const settings = privacySettings(db);
+    // workplace 機能を OFF にしているなら SSID も出さない (= 同じ flag で gate)。
+    if (!settings.workplace_geo_enabled) {
+      return c.json({ supported: false, reason: 'workplace_geo disabled' });
+    }
+    const info = await getCurrentWifiInfo();
+    if (!info?.ssid) {
+      return c.json({ supported: true, ssid: null, bssid: info?.bssid ?? null, platform: info?.platform ?? process.platform, workplace: null });
+    }
+    const norm = info.ssid.toLowerCase();
+    const all = listWorkLocations(db, { limit: 500 });
+    const hit = all.find((w) => {
+      const list = (w.wifi_ssids ?? '').split(',').map((s) => s.trim().toLowerCase()).filter(Boolean);
+      return list.includes(norm);
+    }) ?? null;
+    return c.json({
+      supported: true,
+      ssid: info.ssid,
+      bssid: info.bssid,
+      platform: info.platform,
+      workplace: hit ? { id: hit.id, name: hit.name } : null,
+    });
+  });
 
   r.get('/api/work-locations', (c: Context) => {
     const limit = Math.min(Number(c.req.query('limit') || 200), 500);


### PR DESCRIPTION
> ⚠ base = `main`。 本 PR は **PR #134** (\`feat/move-external-setup-to-tracks\`) の commit を passenger として含みます。 #134 を先に squash merge すれば、 本 PR の diff は server-side WiFi 部分だけにシュリンクします。

## Summary

PR #132 で実装した「Electron 起動時の SSID チェックイン」 は、 **Electron 内蔵のレンダラからしか** SSID が見えない構造でした。 Memoria server を Electron で起動して別 PC のブラウザ / スマホ PWA / Chrome 拡張から接続している場合、 軌跡タブの WiFi カードに何も表示されない問題があります。

→ **SSID 検出ロジックを server (Node.js) 側に持たせて REST endpoint で公開** することで、 どのクライアントから叩いても「Memoria server 機が接続中の WiFi」 が返るようになります。 1 台の Memoria を複数端末から共有する運用でも SSID が見えます。

## 変更点

### Backend (新規)
- **`server/lib/wifi-info.ts`** — Win/macOS/Linux 対応の SSID/BSSID 検出。 旧 \`desktop/src/main.ts\` の関数を server に移植 + 共通化
  - Windows: \`netsh wlan show interfaces\` の SSID/BSSID 行をパース
  - macOS: \`networksetup -getairportnetwork en0\` (BSSID は airport が許せば取得)
  - Linux: \`iwgetid\` / \`iwgetid -ar\` → fallback \`nmcli\`
- **`GET /api/wifi/current`** (\`server/routes/workplace.ts\`)
  - SSID + BSSID + platform + 対応 workplace (= wifi_ssids との照合結果) を 1 response で返す
  - \`features.workplace.geo.enabled\` で gate
  - 旧サーバ互換のため 404 / 未対応時は client が card を hidden 化

### Frontend
- \`loadTracksWifiInfo\` を \`window.memoria\` 経由から \`/api/wifi/current\` fetch に切替
- \`appendCurrentWifiToEditor\` (「📶 現在の WiFi を追加」 ボタン) も同様に server 経由に
- 編集モーダルの WiFi ボタン hide 条件を撤廃 (= ブラウザ単体でも表示)
- 旧 \`window.memoria.getCurrentWifiInfo\` IPC / bridge は残置 (renderer 側では呼ばれないので後段 PR で削除候補)

## Test plan

- [ ] Memoria server を Electron で起動
- [ ] **別 PC のブラウザ** (Chrome) で同じ Memoria サーバの軌跡タブを開く → SSID が表示される (元 #132 の構成では表示されなかった)
- [ ] **スマホ PWA** で Tailscale 経由で接続 → 同じ SSID が表示される
- [ ] WiFi カードの「対応作業場所」 がマッチした SSID は workplace 名、 未登録は「未登録 — 設定 → 作業場所 から紐付け可」
- [ ] 設定 → 作業場所 → 編集 → 「📶 現在の WiFi を追加」 ボタンがブラウザ単体でも押せて、 サーバ機の SSID が入る
- [ ] features.workplace.geo を OFF にすると WiFi カードが非表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)