### PR TITLE
fix(electron): Memoria server を tsx 経由で正しく spawn する

### DIFF
--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -172,6 +172,17 @@ function spawnServer(port: number): ChildProcess | null {
     return null;
   }
 
+  // Memoria server は TypeScript (`index.ts`)。 dev / 同梱 (npm install --omit=dev
+  // で tsx が入っている) どちらも `tsx` CLI 経由で起動する。 旧コードは `index.js`
+  // を指定していたが、 server 側に compile step が無いので spawn が即終了して
+  // いた (= 結果、 別途 `npm start` で立てた standalone server に Electron が
+  // フォールバック接続するという紛らわしい状態になっていた)。
+  const tsxCli = path.join(serverDir, 'node_modules', 'tsx', 'dist', 'cli.mjs');
+  if (!fs.existsSync(tsxCli)) {
+    console.error(`[memoria-desktop] tsx CLI not found at ${tsxCli}. Run \`npm install\` in ${serverDir}.`);
+    return null;
+  }
+
   const env: NodeJS.ProcessEnv = { ...process.env, MEMORIA_PORT: String(port) };
   if (runAsNode) env.ELECTRON_RUN_AS_NODE = '1';
   if (process.platform === 'win32' && !env.CLAUDE_CODE_GIT_BASH_PATH) {
@@ -182,20 +193,29 @@ function spawnServer(port: number): ChildProcess | null {
     }
   }
 
-  const child = spawn(nodeBin, ['index.js'], {
+  // tsx CLI に server/index.ts を渡す。 `--env-file-if-exists` は `npm start` と
+  // 同じ二段読み (server/.env と repo-root/.env)。
+  const args = [
+    tsxCli,
+    '--env-file-if-exists=.env',
+    '--env-file-if-exists=../.env',
+    'index.ts',
+  ];
+
+  const child = spawn(nodeBin, args, {
     cwd: serverDir,
     env,
     stdio: ['ignore', 'inherit', 'inherit'],
     detached: false,
   });
   child.on('error', (e: Error) => {
-    console.error(`[memoria-desktop] failed to spawn server (${nodeBin} index.js in ${serverDir}):`, e.message);
+    console.error(`[memoria-desktop] failed to spawn server (${nodeBin} ${tsxCli} index.ts in ${serverDir}):`, e.message);
   });
   child.on('exit', (code, signal) => {
     console.log(`[memoria-desktop] server exited (code=${code}, signal=${signal ?? ''})`);
     serverChild = null;
   });
-  console.log(`[memoria-desktop] spawned ${nodeBin} (pid ${child.pid}) in ${serverDir} (port ${port}, runAsNode=${runAsNode})`);
+  console.log(`[memoria-desktop] spawned ${nodeBin} ${tsxCli} index.ts (pid ${child.pid}) in ${serverDir} (port ${port}, runAsNode=${runAsNode})`);
   return child;
 }
 
@@ -495,9 +515,14 @@ app.on('second-instance', () => {
 
 void app.whenReady().then(async () => {
   serverPort = Number(process.env.MEMORIA_PORT) || 5180;
-  serverChild = spawnServer(serverPort);
-  // Even if spawn returned null (e.g. user runs server externally) we still
-  // poll readiness — the URL might already be responding.
+  // 既に外で server が立っている場合 (= dev で `npm start` を別途走らせている等)
+  // は spawn を skip。 そうでなければ Electron が backend を自分で立てる。
+  const externalAlive = await waitForServerReady(serverPort, 500);
+  if (externalAlive) {
+    console.log(`[memoria-desktop] external server detected on :${serverPort} — skipping spawn (Electron will share the existing server)`);
+  } else {
+    serverChild = spawnServer(serverPort);
+  }
   const ready = await waitForServerReady(serverPort, 25_000);
   if (!ready) {
     console.warn(`[memoria-desktop] server on :${serverPort} did not become ready in time — opening the window anyway; the WebView will retry`);
@@ -530,7 +555,11 @@ app.on('before-quit', () => {
 // no other windows open.
 app.on('activate', async () => {
   if (BrowserWindow.getAllWindows().length === 0) {
-    if (!serverChild) serverChild = spawnServer(serverPort);
+    if (!serverChild) {
+      // 同じガード — 外で生きている server があれば spawn しない
+      const alive = await waitForServerReady(serverPort, 500);
+      if (!alive) serverChild = spawnServer(serverPort);
+    }
     await waitForServerReady(serverPort, 25_000);
     createWindow(serverPort);
   }


### PR DESCRIPTION
## 問題

Electron で Memoria を起動した状態を確認したところ、 backend (Memoria server) が **Electron の子プロセスではなく** standalone (npm start 別経路) に立っていた:

\`\`\`
Electron 起動  ─┐
                │ spawnServer() で `node index.js` を起動 (旧コード)
                ▼
              即終了 (index.js は存在しない、 server は TS)
              ↓ waitForServerReady でフォールバック
              [外部の npm start で立っていた server (port 5180) に接続]
\`\`\`

つまり 「Electron 起動 = backend + frontend を Electron が自動で建てる」 という前提が壊れていた。

## 修正

\`spawnServer\` を \`node_modules/tsx/dist/cli.mjs index.ts\` 経由で起動する形に変更。 \`npm start\` (= \`tsx index.ts\`) と同じ起動パスを再現。

- \`--env-file-if-exists=.env --env-file-if-exists=../.env\` を渡して同じ二段 .env 読み
- \`tsx CLI not found\` 時は明示的にエラー (= 旧 silent fail 防止)
- \`whenReady\` / \`activate\` で spawn 前に 500ms readiness probe を走らせ、 外部 server が live なら spawn を skip (= dev で \`npm start\` 別途運用にも対応)

## 動作

| 状況 | 結果 |
|---|---|
| 普通の Electron 起動 (server 未起動) | Electron が自分の子プロセスとして tsx + server を spawn ✓ |
| dev で \`npm start\` 別走りで先に server を立てている | Electron は spawn せず既存に接続 (= 二重 spawn 回避) |
| production (electron-builder で同梱) | resources/server/node_modules に tsx が入る (server の \`dependencies\` なので \`npm install --omit=dev\` でも残る) → 同じコードパスで動く |

## Test plan

- [ ] \`cd desktop && npm run dev\` → Electron 起動 → 子プロセスとして server が立つ
- [ ] \`ps\` / \`Get-Process\` で node プロセスの parent が Electron main process である
- [ ] \`taskkill\` で Electron を落とす → server も死ぬ (= 連動)
- [ ] dev で \`server/ && npm start\` を別途立てた状態で Electron 起動 → spawn skip ログが出て既存 server に接続
- [ ] production build (\`npm run build:win\`) でも同じ挙動

🤖 Generated with [Claude Code](https://claude.com/claude-code)