### PR TITLE
feat(workplace): 有線 = 自宅 + 位置優先度 (OwnTracks > WiFi > 有線)

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -454,6 +454,7 @@ export function openDb(dbPath: string): Db {
       url            TEXT,
       tags           TEXT,
       wifi_ssids     TEXT,
+      is_home        INTEGER NOT NULL DEFAULT 0,
       shareable      INTEGER NOT NULL DEFAULT 0,
       shared_at      TEXT,
       shared_origin  TEXT,
@@ -605,6 +606,11 @@ export function openDb(dbPath: string): Db {
   const wlCols = (db.prepare(`PRAGMA table_info(work_locations)`).all() as { name: string }[]).map(c => c.name);
   if (wlCols.length > 0 && !wlCols.includes('wifi_ssids')) {
     db.exec(`ALTER TABLE work_locations ADD COLUMN wifi_ssids TEXT`);
+  }
+  // is_home: 有線接続時のデフォルト workplace。 1 つだけ true にできる (= UI で
+  // 排他制御、 ここでは制約までは設けない)。
+  if (wlCols.length > 0 && !wlCols.includes('is_home')) {
+    db.exec(`ALTER TABLE work_locations ADD COLUMN is_home INTEGER NOT NULL DEFAULT 0`);
   }
 
   const mealsCols = (db.prepare(`PRAGMA table_info(meals)`).all() as { name: string }[]).map(c => c.name);
@@ -3710,14 +3716,20 @@ export interface InsertWorkLocationInput {
   tags?: string | null;
   /** カンマ区切り (例 'MyHomeWifi,MyHomeWifi-5G') */
   wifi_ssids?: string | null;
+  /** 有線接続時のデフォルト workplace に使う */
+  is_home?: boolean | 0 | 1;
   shareable?: boolean | 0 | 1;
 }
 
 export function insertWorkLocation(db: Db, loc: InsertWorkLocationInput): number {
+  // is_home=true なら既存の home flag を全部 clear (= 1 つだけ true 制約をソフトに維持)
+  if (loc.is_home) {
+    db.prepare(`UPDATE work_locations SET is_home = 0 WHERE is_home = 1`).run();
+  }
   const info = db.prepare(`
     INSERT INTO work_locations
-      (name, address, latitude, longitude, description, url, tags, wifi_ssids, shareable)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      (name, address, latitude, longitude, description, url, tags, wifi_ssids, is_home, shareable)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     loc.name,
     loc.address ?? null,
@@ -3727,15 +3739,20 @@ export function insertWorkLocation(db: Db, loc: InsertWorkLocationInput): number
     loc.url ?? null,
     loc.tags ?? null,
     loc.wifi_ssids ?? null,
+    loc.is_home ? 1 : 0,
     loc.shareable ? 1 : 0,
   );
   return Number(info.lastInsertRowid);
 }
 
 export function updateWorkLocation(db: Db, id: number, patch: Record<string, unknown>): void {
+  // is_home を true に変えるリクエストなら、 他の行の is_home を先に clear
+  if (patch.is_home === true || patch.is_home === 1) {
+    db.prepare(`UPDATE work_locations SET is_home = 0 WHERE is_home = 1 AND id != ?`).run(id);
+  }
   const allowed = new Set([
     'name', 'address', 'latitude', 'longitude', 'description', 'url', 'tags',
-    'wifi_ssids',
+    'wifi_ssids', 'is_home',
     'shareable', 'shared_at', 'shared_origin',
     'owner_user_id', 'owner_user_name',
   ]);
@@ -3744,7 +3761,7 @@ export function updateWorkLocation(db: Db, id: number, patch: Record<string, unk
   for (const [k, v] of Object.entries(patch)) {
     if (!allowed.has(k)) continue;
     cols.push(`${k} = ?`);
-    if (k === 'shareable') args.push(v ? 1 : 0);
+    if (k === 'shareable' || k === 'is_home') args.push(v ? 1 : 0);
     else if (k === 'latitude' || k === 'longitude') args.push(v == null ? null : Number(v));
     else args.push(v);
   }

--- a/server/db/types/workplace.ts
+++ b/server/db/types/workplace.ts
@@ -15,6 +15,9 @@ export interface WorkLocationRow {
    *  (= GPS / Permission を経由せず「家の WiFi だから家に居る」 と判定)。
    *  1 ワークプレイスに複数 SSID (2.4 GHz / 5 GHz など) を持てる。 */
   wifi_ssids: string | null;
+  /** 1 つだけ true にできる「自宅」 フラグ。 PC が有線接続のとき higher
+   *  priority な信号 (GPS / WiFi) が無ければ、 ここを current に置く。 */
+  is_home: 0 | 1;
   shareable: 0 | 1;
   shared_at: string | null;
   shared_origin: string | null;

--- a/server/lib/wifi-info.ts
+++ b/server/lib/wifi-info.ts
@@ -18,6 +18,7 @@
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { networkInterfaces } from 'node:os';
 
 const execFileP = promisify(execFile);
 
@@ -25,6 +26,58 @@ export interface WifiInfo {
   ssid: string | null;
   bssid: string | null;
   platform: NodeJS.Platform;
+}
+
+export interface NetworkInfo extends WifiInfo {
+  /** 有線 (Ethernet) アダプタが UP + IP を持っているか。 PC が物理的に
+   *  ネット設備の近く (= 自宅 / オフィス) にいる目安に使う。 */
+  wired: boolean;
+}
+
+/**
+ * 有線 (Ethernet) 接続を検出する。
+ *
+ * 厳密には「物理的にケーブルが刺さっている」 とは限らないが、 ethernet 系の
+ * インターフェース名 (eth0 / enp* / Ethernet / イーサネット) で UP かつ
+ * 非 internal な IPv4/IPv6 を持っていれば「有線で繋がっている」 とみなす。
+ *
+ * 注意:
+ * - WiFi インターフェース (wlan* / wlp* / Wi-Fi / Wireless) は除外
+ * - VPN tunnel (utun / tap / tun / vEthernet / Hyper-V) も除外
+ * - Loopback / link-local も除外
+ */
+export function hasWiredConnection(): boolean {
+  const wirelessPatterns = /^(wlan|wlp|wlx|wifi|wi[- ]?fi|wireless|airport|en[01]$)/i;
+  const tunnelPatterns = /^(utun|tap|tun|vEthernet|veth|vmnet|VirtualBox|Hyper-V|WSL|Tailscale|ZeroTier|wireguard|cloudflare)/i;
+  const ifaces = networkInterfaces();
+  for (const [name, addrs] of Object.entries(ifaces)) {
+    if (!addrs) continue;
+    if (wirelessPatterns.test(name)) continue;
+    if (tunnelPatterns.test(name)) continue;
+    // 名前が ethernet 系っぽいかチェック (= 完全に loopback/未知名は除外)
+    const looksEthernet = /(ethernet|eth\d|en(p|s)|eno|enx|イーサネット|local.*area)/i.test(name);
+    if (!looksEthernet) continue;
+    for (const a of addrs) {
+      if (a.internal) continue;
+      if (a.family !== 'IPv4' && a.family !== 'IPv6') continue;
+      // IPv6 link-local (fe80::) と IPv4 link-local (169.254.) は除外
+      if (a.family === 'IPv6' && a.address.toLowerCase().startsWith('fe80')) continue;
+      if (a.family === 'IPv4' && a.address.startsWith('169.254.')) continue;
+      return true;
+    }
+  }
+  return false;
+}
+
+/** SSID/BSSID + 有線状態を 1 つにまとめて返す。 */
+export async function getNetworkInfo(): Promise<NetworkInfo> {
+  const wifi = await getCurrentWifiInfo();
+  return {
+    ssid: wifi?.ssid ?? null,
+    bssid: wifi?.bssid ?? null,
+    platform: wifi?.platform ?? process.platform,
+    wired: hasWiredConnection(),
+  };
 }
 
 /** 失敗時 (= 取得経路無し / 未接続 / 権限不足) は null。 */

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -765,20 +765,22 @@
           <p class="ext-cfg-help" id="tracksGpsHint"></p>
         </div>
 
-        <!-- 接続中の WiFi (Electron 限定で表示。 SSID をワークプレイスにマップするヒント付き) -->
+        <!-- 接続中の WiFi / 有線 (サーバ機の接続情報を REST 経由で取得) -->
         <div id="tracksWifiCard" class="tracks-source-card" hidden>
           <header class="tracks-source-head">
-            <span class="tracks-source-icon">📶</span>
-            <span class="tracks-source-name">接続中の WiFi</span>
+            <span class="tracks-source-icon">📡</span>
+            <span class="tracks-source-name">接続情報 (サーバ機)</span>
             <span class="ext-cfg-pill ext-cfg-pill-loading" id="tracksWifiPill">取得中…</span>
             <button id="tracksWifiRefresh" class="ghost" type="button" title="再取得">↻</button>
           </header>
           <div class="tracks-wifi-grid">
             <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">SSID</span><span id="tracksWifiSsid" class="ext-cfg-stat-val">—</span></div>
             <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">BSSID</span><span id="tracksWifiBssid" class="ext-cfg-stat-val">—</span></div>
-            <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">対応作業場所</span><span id="tracksWifiMatch" class="ext-cfg-stat-val">—</span></div>
+            <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">有線</span><span id="tracksWifiWired" class="ext-cfg-stat-val">—</span></div>
+            <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">解決された作業場所</span><span id="tracksWifiMatch" class="ext-cfg-stat-val">—</span></div>
+            <div class="ext-cfg-stat"><span class="ext-cfg-stat-label">解決ソース</span><span id="tracksWifiSource" class="ext-cfg-stat-val">—</span></div>
           </div>
-          <p class="ext-cfg-help" id="tracksWifiHint">この SSID をワークプレイスに紐付けると、 起動するだけで自動チェックインされます。</p>
+          <p class="ext-cfg-help" id="tracksWifiHint">優先度: OwnTracks GPS &gt; WiFi SSID &gt; 有線 (= 自宅)。 高優先度のソースで判定できなければ次の段に fallback します。</p>
         </div>
 
         <div id="tracksMissingKey" class="tracks-missing-key hidden">

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -5471,6 +5471,11 @@ let ensureMemoriaFeatureViews = function () {
             <textarea id="workplaceEditorDescription" rows="6" placeholder="営業時間・wifi・電源・席数・雰囲気など"></textarea>
           </label>
           <label class="simple-check-row">
+            <input id="workplaceEditorIsHome" type="checkbox" />
+            <span>🏠 自宅 (有線接続時のデフォルト)</span>
+          </label>
+          <small class="muted" style="margin-top:-4px">PC が有線で繋がっていて WiFi / GPS で他の場所が判定できないとき、 ここを current にします。 1 つだけ true にできます (= 別の場所を 🏠 にすると自動的に解除)。</small>
+          <label class="simple-check-row">
             <input id="workplaceEditorShareable" type="checkbox" />
             <span>シェア可能にする</span>
           </label>
@@ -6444,6 +6449,7 @@ function openWorkplaceEditor(w = null) {
   $('workplaceEditorUrl').value = w?.url || '';
   $('workplaceEditorTags').value = w?.tags || '';
   if ($('workplaceEditorWifiSsids')) $('workplaceEditorWifiSsids').value = w?.wifi_ssids || '';
+  if ($('workplaceEditorIsHome')) $('workplaceEditorIsHome').checked = !!w?.is_home;
   $('workplaceEditorDescription').value = w?.description || '';
   $('workplaceEditorShareable').checked = !!w?.shareable;
   // 「現在の WiFi を追加」 ボタンは server 側 /api/wifi/current が返してくれる
@@ -6968,6 +6974,7 @@ async function saveWorkLocationFromForm() {
     url: $('workplaceEditorUrl')?.value.trim() || null,
     tags: $('workplaceEditorTags')?.value.trim() || null,
     wifi_ssids: $('workplaceEditorWifiSsids')?.value.trim() || null,
+    is_home: !!$('workplaceEditorIsHome')?.checked,
     description: $('workplaceEditorDescription')?.value.trim() || null,
     shareable: !!$('workplaceEditorShareable')?.checked,
   };
@@ -9558,7 +9565,9 @@ async function loadTracksWifiInfo() {
   const card = document.getElementById('tracksWifiCard');
   const ssidEl = document.getElementById('tracksWifiSsid');
   const bssidEl = document.getElementById('tracksWifiBssid');
+  const wiredEl = document.getElementById('tracksWifiWired');
   const matchEl = document.getElementById('tracksWifiMatch');
+  const sourceEl = document.getElementById('tracksWifiSource');
   const pillEl = document.getElementById('tracksWifiPill');
   if (!card) return;
   if (pillEl) {
@@ -9572,41 +9581,40 @@ async function loadTracksWifiInfo() {
       ssid?: string | null;
       bssid?: string | null;
       platform?: string;
+      wired?: boolean;
       workplace?: { id: number; name: string } | null;
+      source?: 'wifi' | 'wired' | null;
     };
     if (info?.supported === false) {
-      // workplace 機能が OFF — カードごと隠す
       card.hidden = true;
       return;
     }
     card.hidden = false;
-    if (!info?.ssid) {
-      if (ssidEl) ssidEl.textContent = '(未接続 / 取得失敗)';
-      if (bssidEl) bssidEl.textContent = info?.bssid || '—';
-      if (matchEl) matchEl.textContent = '—';
-      if (pillEl) {
-        pillEl.classList.remove('ext-cfg-pill-loading');
-        pillEl.classList.add('ext-cfg-pill-inactive');
-        pillEl.textContent = '⚪ 未接続';
-      }
-      return;
+    if (ssidEl) ssidEl.textContent = info?.ssid || '(未接続)';
+    if (bssidEl) bssidEl.textContent = info?.bssid || '—';
+    if (wiredEl) wiredEl.textContent = info?.wired ? '🟢 接続中' : '⚪ 未接続';
+    const matchName = info?.workplace?.name ?? null;
+    if (matchEl) matchEl.textContent = matchName ?? '(該当なし)';
+    if (sourceEl) {
+      const label = info?.source === 'wifi' ? '📶 WiFi SSID'
+        : info?.source === 'wired' ? '🔌 有線 (自宅)'
+        : '—';
+      sourceEl.textContent = label;
     }
-    if (ssidEl) ssidEl.textContent = info.ssid;
-    if (bssidEl) bssidEl.textContent = info.bssid || '—';
-    const matchName = info.workplace?.name ?? null;
-    if (matchEl) matchEl.textContent = matchName ?? '(未登録 — 設定 → 作業場所 から紐付け可)';
     if (pillEl) {
       pillEl.classList.remove('ext-cfg-pill-loading');
       if (matchName) {
         pillEl.classList.add('ext-cfg-pill-active');
-        pillEl.textContent = '🟢 マッチ済';
-      } else {
+        pillEl.textContent = '🟢 解決済';
+      } else if (info?.ssid || info?.wired) {
         pillEl.classList.add('ext-cfg-pill-configured');
         pillEl.textContent = '🟡 未登録';
+      } else {
+        pillEl.classList.add('ext-cfg-pill-inactive');
+        pillEl.textContent = '⚪ オフライン';
       }
     }
   } catch (e) {
-    // 404 / 旧サーバ → カード隠す
     if ((e as Error).message?.includes('404')) {
       card.hidden = true;
       return;

--- a/server/routes/workplace.ts
+++ b/server/routes/workplace.ts
@@ -13,7 +13,7 @@ import {
   readMultiState, isConnected, shareWorkplacePresence,
 } from '../local/multi-client.js';
 import { privacySettings } from '../lib/privacy.js';
-import { getCurrentWifiInfo } from '../lib/wifi-info.js';
+import { getCurrentWifiInfo, hasWiredConnection } from '../lib/wifi-info.js';
 
 type Db = BetterSqlite3.Database;
 
@@ -43,29 +43,44 @@ export function makeWorkplaceRouter(deps: WorkplaceRouterDeps): Hono {
   // 拡張) から叩いても、 同じ「Memoria サーバ機の WiFi」 を返す。
   // → Electron で起動した Memoria に Web から接続している場合も SSID が見える。
   //
-  // 結果がカンマ区切りの登録 SSID と一致すれば対応 workplace 名も返す。
+  // 結果は SSID + BSSID + 有線接続有無 + 解決済み workplace + 解決ソース。
+  // 解決優先度: GPS (= OwnTracks の最近の gps_locations) > WiFi (SSID マッチ) >
+  // 有線 (= is_home の workplace)。 endpoint 名は `/api/wifi/current` のまま
+  // 後方互換 (旧クライアントの fetch でも壊れない)、 中身は network 全般。
   r.get('/api/wifi/current', async (c: Context) => {
     const settings = privacySettings(db);
-    // workplace 機能を OFF にしているなら SSID も出さない (= 同じ flag で gate)。
     if (!settings.workplace_geo_enabled) {
       return c.json({ supported: false, reason: 'workplace_geo disabled' });
     }
     const info = await getCurrentWifiInfo();
-    if (!info?.ssid) {
-      return c.json({ supported: true, ssid: null, bssid: info?.bssid ?? null, platform: info?.platform ?? process.platform, workplace: null });
-    }
-    const norm = info.ssid.toLowerCase();
+    const wired = hasWiredConnection();
     const all = listWorkLocations(db, { limit: 500 });
-    const hit = all.find((w) => {
-      const list = (w.wifi_ssids ?? '').split(',').map((s) => s.trim().toLowerCase()).filter(Boolean);
-      return list.includes(norm);
-    }) ?? null;
+
+    // 1) WiFi SSID マッチ
+    let workplace: { id: number; name: string } | null = null;
+    let source: 'wifi' | 'wired' | null = null;
+    if (info?.ssid) {
+      const norm = info.ssid.toLowerCase();
+      const hit = all.find((w) => {
+        const list = (w.wifi_ssids ?? '').split(',').map((s) => s.trim().toLowerCase()).filter(Boolean);
+        return list.includes(norm);
+      });
+      if (hit) { workplace = { id: hit.id, name: hit.name }; source = 'wifi'; }
+    }
+    // 2) 有線 (= is_home の workplace に fallback)
+    if (!workplace && wired) {
+      const home = all.find((w) => w.is_home === 1);
+      if (home) { workplace = { id: home.id, name: home.name }; source = 'wired'; }
+    }
+
     return c.json({
       supported: true,
-      ssid: info.ssid,
-      bssid: info.bssid,
-      platform: info.platform,
-      workplace: hit ? { id: hit.id, name: hit.name } : null,
+      ssid: info?.ssid ?? null,
+      bssid: info?.bssid ?? null,
+      platform: info?.platform ?? process.platform,
+      wired,
+      workplace,
+      source,
     });
   });
 
@@ -78,7 +93,8 @@ export function makeWorkplaceRouter(deps: WorkplaceRouterDeps): Hono {
   r.post('/api/work-locations', async (c: Context) => {
     const body = await c.req.json().catch(() => ({})) as
       { name?: unknown; address?: unknown; latitude?: unknown; longitude?: unknown;
-        description?: unknown; url?: unknown; tags?: unknown; wifi_ssids?: unknown; shareable?: unknown };
+        description?: unknown; url?: unknown; tags?: unknown; wifi_ssids?: unknown;
+        is_home?: unknown; shareable?: unknown };
     const name = String(body.name ?? '').trim();
     if (!name) return c.json({ error: 'name required' }, 400);
     const id = insertWorkLocation(db, {
@@ -90,6 +106,7 @@ export function makeWorkplaceRouter(deps: WorkplaceRouterDeps): Hono {
       url: typeof body.url === 'string' ? body.url.trim() : null,
       tags: typeof body.tags === 'string' ? body.tags.trim() : null,
       wifi_ssids: typeof body.wifi_ssids === 'string' ? body.wifi_ssids.trim() : null,
+      is_home: !!body.is_home,
       shareable: !!body.shareable,
     });
     return c.json({ location: getWorkLocation(db, id) }, 201);
@@ -100,7 +117,8 @@ export function makeWorkplaceRouter(deps: WorkplaceRouterDeps): Hono {
     if (!getWorkLocation(db, id)) return c.json({ error: 'not found' }, 404);
     const body = await c.req.json().catch(() => ({})) as
       { name?: unknown; address?: unknown; latitude?: unknown; longitude?: unknown;
-        description?: unknown; url?: unknown; tags?: unknown; wifi_ssids?: unknown; shareable?: unknown };
+        description?: unknown; url?: unknown; tags?: unknown; wifi_ssids?: unknown;
+        is_home?: unknown; shareable?: unknown };
     const patch: Record<string, unknown> = {};
     if (typeof body.name === 'string') patch.name = body.name.trim();
     if (typeof body.address === 'string' || body.address === null) patch.address = body.address;
@@ -114,6 +132,7 @@ export function makeWorkplaceRouter(deps: WorkplaceRouterDeps): Hono {
     if (typeof body.url === 'string' || body.url === null) patch.url = body.url;
     if (typeof body.tags === 'string' || body.tags === null) patch.tags = body.tags;
     if (typeof body.wifi_ssids === 'string' || body.wifi_ssids === null) patch.wifi_ssids = body.wifi_ssids;
+    if (typeof body.is_home === 'boolean') patch.is_home = body.is_home;
     if (typeof body.shareable === 'boolean') patch.shareable = body.shareable;
     updateWorkLocation(db, id, patch);
     return c.json({ location: getWorkLocation(db, id) });
@@ -297,10 +316,18 @@ export function makeWorkplaceRouter(deps: WorkplaceRouterDeps): Hono {
     // SSID は大文字小文字を区別しない。 wifi_ssids はカンマ区切り。
     const norm = ssid.toLowerCase();
     const all = listWorkLocations(db, { limit: 500 });
-    const matched = all.find((w) => {
+    let matched = all.find((w) => {
       const list = (w.wifi_ssids ?? '').split(',').map((s) => s.trim().toLowerCase()).filter(Boolean);
       return list.includes(norm);
     }) ?? null;
+
+    // Fallback: SSID に対応 workplace が無くても、 PC が有線接続なら is_home を
+    // current に置く (= 「OwnTracks > WiFi > 有線」 の優先度ルール)。
+    let resolutionSource: 'wifi' | 'wired' = 'wifi';
+    if (!matched && hasWiredConnection()) {
+      const home = all.find((w) => w.is_home === 1);
+      if (home) { matched = home; resolutionSource = 'wired'; }
+    }
 
     const appS = getAppSettings(db);
     const lastId = appS['workplace.current.id'] ? Number(appS['workplace.current.id']) : null;
@@ -309,9 +336,10 @@ export function makeWorkplaceRouter(deps: WorkplaceRouterDeps): Hono {
       matched: boolean;
       workplace: typeof all[number] | null;
       ssid: string;
+      source: 'wifi' | 'wired' | null;
       changed: boolean;
       broadcast: { ok: boolean; id?: number; occurred_at?: string; error?: string; kind?: string } | null;
-    } = { matched: !!matched, workplace: matched, ssid, changed: false, broadcast: null };
+    } = { matched: !!matched, workplace: matched, ssid, source: matched ? resolutionSource : null, changed: false, broadcast: null };
 
     if (matched) {
       if (lastId !== matched.id) {
@@ -320,7 +348,7 @@ export function makeWorkplaceRouter(deps: WorkplaceRouterDeps): Hono {
           'workplace.current.id': String(matched.id),
           'workplace.current.at': now,
           // どの経路で current になったかを記録 (debug / UI 用)
-          'workplace.current.source': `wifi:${ssid}`,
+          'workplace.current.source': resolutionSource === 'wired' ? 'wired:home' : `wifi:${ssid}`,
         });
         if (settings.workplace_auto_share_enabled) {
           try {


### PR DESCRIPTION
## Summary

ユーザ要望:
1. 有線接続を考慮 — 有線で繋がっている場合は **自宅** とみなす
2. 位置情報の優先度を **OwnTracks > WiFi > 有線** とし、 高優先度かつ最新のソースを優先的に処理する

## 変更点

### DB
- \`work_locations.is_home INTEGER NOT NULL DEFAULT 0\` を追加
- insert/update で \`is_home=true\` にすると他の行を自動 clear (= 1 つだけ true)

### Backend
- \`hasWiredConnection()\` (\`server/lib/wifi-info.ts\`)
  - \`os.networkInterfaces()\` で ethernet 系 (eth*/enp*/Ethernet/イーサネット) + 非 internal IP で判定
  - WiFi / tunnel (utun/Tailscale/WSL/Hyper-V/wireguard/vEthernet/...) は除外
- \`GET /api/wifi/current\` を拡張: response に \`wired\` + 解決済 \`source\` ('wifi' | 'wired' | null) を追加
- \`POST /api/work-locations/wifi-checkin\` — SSID マッチ無し時は有線→home に fallback、 source を記録

### Frontend
- 作業場所編集モーダルに **「🏠 自宅 (有線接続時のデフォルト)」** checkbox
- 軌跡タブの WiFi カードを「**接続情報 (サーバ機)**」 に改名し、 有線状態 + 解決された workplace + 解決ソース (WiFi/有線) を表示
- ヒント文に「優先度: OwnTracks GPS > WiFi SSID > 有線」 を明示

## 動作

| 状況 | 解決 |
|---|---|
| WiFi 接続中 + SSID が workplace に登録済 | その workplace (source=wifi) |
| WiFi 接続中 + SSID 未登録 + 有線あり + is_home 設定済 | home workplace (source=wired) |
| WiFi 無し + 有線あり + is_home 設定済 | home workplace (source=wired) |
| 何も無い | source=null (current 変更なし) |

## Test plan

- [ ] 作業場所編集で「🏠 自宅」 を 1 つに ON — 別の場所を ON にすると自動で前回が解除される
- [ ] LAN ケーブル接続中の Memoria server に Web 接続 → 接続情報カードに「有線: 🟢 接続中」
- [ ] WiFi 未登録 + 有線 + home 設定 → 解決ソース「🔌 有線 (自宅)」
- [ ] WiFi 登録済み → 解決ソース「📶 WiFi SSID」 が WiFi 優先で選ばれる
- [ ] 既存の \`/api/wifi/current\` 呼び出し元 (= 軌跡タブ) で response 互換維持

## 未対応 (follow-up)

- OwnTracks 経路 (gps_locations) との優先度競合は別 PR。 「OwnTracks 最新点が 5 分以内なら WiFi/wired を override しない」 等の freshness 比較は未実装、 現状は last-write-wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)