### PR TITLE
feat(activity): PC アプリ活動 + Steam プレイ統計の取り込み

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -342,6 +342,36 @@ export function openDb(dbPath: string): Db {
     CREATE INDEX IF NOT EXISTS idx_gps_locations_dedup
       ON gps_locations(user_id, device_id, recorded_at);
 
+    -- アプリ活動サンプル: 一定周期 (default 30秒) で PC の活動を記録する。
+    -- foreground row = 取得時に最前面だったプロセス (= 1 サンプル 1 件)。
+    -- 同じ sample_at に複数 process 行を入れない設計 (= 表面に出ていたものだけ
+    -- 残す。 全プロセス列挙は別運用)。 集計はカウント * sample_interval_sec で
+    -- おおよその使用時間を出す。
+    CREATE TABLE IF NOT EXISTS app_samples (
+      id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+      sampled_at          TEXT NOT NULL,
+      process_name        TEXT NOT NULL,
+      window_title        TEXT,
+      sample_interval_sec INTEGER NOT NULL DEFAULT 30
+    );
+    CREATE INDEX IF NOT EXISTS idx_app_samples_at ON app_samples(sampled_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_app_samples_proc_at ON app_samples(process_name, sampled_at);
+
+    -- Steam recently-played スナップショット。 1 時間おきに Web API で取得して
+    -- 各 game 行を 1 つ insert。 集計 (今日の Steam プレイ時間) は同じ appid の
+    -- 連続スナップショット間で playtime_forever_min の差分から出す。
+    CREATE TABLE IF NOT EXISTS steam_activity (
+      id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+      sampled_at           TEXT NOT NULL,
+      appid                INTEGER NOT NULL,
+      name                 TEXT NOT NULL,
+      playtime_2weeks_min  INTEGER,
+      playtime_forever_min INTEGER,
+      img_icon_url         TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_steam_activity_at ON steam_activity(sampled_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_steam_activity_app ON steam_activity(appid, sampled_at);
+
     CREATE TABLE IF NOT EXISTS push_subscriptions (
       id          INTEGER PRIMARY KEY AUTOINCREMENT,
       endpoint    TEXT NOT NULL UNIQUE,

--- a/server/index.ts
+++ b/server/index.ts
@@ -47,6 +47,8 @@ import { makeDiaryRouter } from './routes/diary.js';
 import { makeTaskRouter } from './routes/task.js';
 import { makeAgentRouter } from './routes/agent.js';
 import { makeWorkplaceRouter } from './routes/workplace.js';
+import { makeActivityRouter } from './routes/activity.js';
+import { configureActivitySamplers } from './lib/activity-sampler.js';
 import { makeImplRouter } from './routes/impl.js';
 import { makePushRouter } from './routes/push.js';
 import { makeNoteRouter } from './routes/note.js';
@@ -163,12 +165,14 @@ app.route('/', makeDiaryRouter({
 app.route('/', makeTaskRouter({ db }));
 app.route('/', makeAgentRouter({ db, dataDir: DATA_DIR }));
 app.route('/', makeWorkplaceRouter({ db }));
+app.route('/', makeActivityRouter({ db }));
 app.route('/', makeImplRouter({ db }));
 app.route('/', makePushRouter({ db }));
 app.route('/', makeNoteRouter({ db, htmlDir: HTML_DIR }));
 app.route('/', makeConfigRouter({
   db, port: PORT, dataDir: DATA_DIR,
   onMcpAutostartChange: (enabled) => mcp.sync(enabled),
+  onActivitySettingsChange: () => configureActivitySamplers(db),
   summaryQueue: queues.summaryQueue,
   cloudQueue: queues.cloudQueue,
   digQueue: queues.digQueue,
@@ -279,6 +283,10 @@ startSchedulers({
     };
   },
 });
+
+// ── activity samplers (PC アプリ + Steam) ─────────────────────────────────
+// feature flag が OFF なら no-op (起動時 + 設定変更時に再構成)
+configureActivitySamplers(db);
 
 // ---- in-process MQTT subscriber (任意) ----------------------------------
 //

--- a/server/lib/activity-sampler.ts
+++ b/server/lib/activity-sampler.ts
@@ -1,0 +1,117 @@
+// アプリ活動 + Steam 活動の周期サンプラ。 server 起動時に start() を呼ぶと
+// 内部 timer を立ち上げて、 一定間隔で:
+//   - 最前面アプリを 1 サンプリング (app_samples へ insert)
+//   - Steam Web API or local VDF からプレイ統計を snapshot (steam_activity へ insert)
+//
+// すべて feature flag (= privacySettings) で OFF にできる。 設定変更時は
+// configureActivitySamplers() を呼んで timer を再構成する。
+
+import type BetterSqlite3 from 'better-sqlite3';
+import { getForegroundApp } from './app-activity-sampler.js';
+import { getRecentlyPlayedGames, type SteamGameSnapshot } from './steam-client.js';
+import { getRecentlyPlayedFromVdf } from './steam-vdf.js';
+import { getAppSettings } from '../db.js';
+import { privacySettings } from './privacy.js';
+
+type Db = BetterSqlite3.Database;
+
+const DEFAULT_APP_SAMPLE_SEC = 30;
+const DEFAULT_STEAM_INTERVAL_MIN = 60;
+
+let appTimer: ReturnType<typeof setInterval> | null = null;
+let steamTimer: ReturnType<typeof setInterval> | null = null;
+
+export function configureActivitySamplers(db: Db): void {
+  // 都度 clear → 設定に応じて再 schedule
+  if (appTimer) { clearInterval(appTimer); appTimer = null; }
+  if (steamTimer) { clearInterval(steamTimer); steamTimer = null; }
+
+  const priv = privacySettings(db);
+  const settings = getAppSettings(db);
+  const appSampleSec = clamp(Number(settings['activity.app_sample_sec'] ?? DEFAULT_APP_SAMPLE_SEC), 5, 600);
+  const steamMin = clamp(Number(settings['activity.steam_interval_min'] ?? DEFAULT_STEAM_INTERVAL_MIN), 5, 24 * 60);
+
+  if (priv.activity_app_sampling_enabled) {
+    void sampleAppOnce(db, appSampleSec); // 起動直後に 1 サンプル
+    appTimer = setInterval(() => { void sampleAppOnce(db, appSampleSec); }, appSampleSec * 1000);
+    appTimer.unref?.();
+    console.log(`[activity] app sampler started — interval ${appSampleSec}s`);
+  }
+
+  if (priv.activity_steam_enabled) {
+    void sampleSteamOnce(db); // 起動直後に 1 スナップショット
+    steamTimer = setInterval(() => { void sampleSteamOnce(db); }, steamMin * 60_000);
+    steamTimer.unref?.();
+    console.log(`[activity] steam sampler started — interval ${steamMin}m`);
+  }
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  if (!Number.isFinite(n)) return lo;
+  return Math.max(lo, Math.min(hi, n));
+}
+
+export async function sampleAppOnce(db: Db, sampleIntervalSec: number): Promise<void> {
+  const fg = await getForegroundApp();
+  if (!fg) return;
+  try {
+    db.prepare(`
+      INSERT INTO app_samples (sampled_at, process_name, window_title, sample_interval_sec)
+      VALUES (datetime('now'), ?, ?, ?)
+    `).run(fg.process_name, fg.window_title, sampleIntervalSec);
+  } catch (e) {
+    console.warn('[activity] app sample insert failed:', (e as Error).message);
+  }
+}
+
+export async function sampleSteamOnce(db: Db): Promise<{ source: 'api' | 'vdf' | 'none'; count: number; error?: string }> {
+  const settings = getAppSettings(db);
+  const apiKey = (settings['steam.web_api_key'] || '').trim();
+  const steamId = (settings['steam.steam_id'] || '').trim();
+
+  let games: SteamGameSnapshot[] = [];
+  let source: 'api' | 'vdf' | 'none' = 'none';
+  let error: string | undefined;
+
+  if (apiKey && steamId) {
+    const r = await getRecentlyPlayedGames({ apiKey, steamId });
+    if (r.ok) {
+      games = r.games;
+      source = 'api';
+    } else {
+      error = r.error;
+    }
+  }
+  // API が無い / 失敗時に VDF fallback
+  if (source === 'none') {
+    const r = getRecentlyPlayedFromVdf();
+    if (r.ok) {
+      games = r.games;
+      source = 'vdf';
+      error = undefined;
+    } else if (!error) {
+      error = r.reason;
+    }
+  }
+  if (source === 'none' || games.length === 0) {
+    if (error) console.debug('[activity] steam sample skipped:', error);
+    return { source, count: 0, error };
+  }
+
+  const stmt = db.prepare(`
+    INSERT INTO steam_activity
+      (sampled_at, appid, name, playtime_2weeks_min, playtime_forever_min, img_icon_url)
+    VALUES (datetime('now'), ?, ?, ?, ?, ?)
+  `);
+  const insertMany = db.transaction((rows: SteamGameSnapshot[]) => {
+    for (const g of rows) {
+      stmt.run(g.appid, g.name, g.playtime_2weeks_min, g.playtime_forever_min, g.img_icon_url);
+    }
+  });
+  try {
+    insertMany(games);
+  } catch (e) {
+    console.warn('[activity] steam snapshot insert failed:', (e as Error).message);
+  }
+  return { source, count: games.length };
+}

--- a/server/lib/app-activity-sampler.ts
+++ b/server/lib/app-activity-sampler.ts
@@ -1,0 +1,141 @@
+// Memoria server が動いている PC の「いま最前面にあるアプリ」 を周期サンプリング
+// する。 結果は `app_samples` テーブルに 1 行ずつ insert。 集計 (= 今日 X 時間
+// Code.exe を使った 等) は別 endpoint で count * sample_interval_sec から算出。
+//
+// プライバシ:
+// - feature flag `features.activity.app_sampling.enabled` (default false) で
+//   opt-in。 OFF の間は一切起動しない
+// - 取得対象は **最前面ウィンドウの process 名 + window title のみ**。 全プロセス
+//   列挙はしない (= ノイズ + メモリ重い + ユーザの興味は前面アプリ)
+//
+// 各 OS の native CLI (すべて読み取り専用、 sudo 不要):
+//   Windows : PowerShell + Win32 API (GetForegroundWindow / GetWindowText /
+//             GetWindowThreadProcessId → process name lookup)
+//   macOS   : `osascript` (System Events → frontmost process)
+//   Linux   : `xdotool getactivewindow getwindowname` + `xdotool getwindowpid`
+
+import { execFile, spawn } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileP = promisify(execFile);
+
+export interface ForegroundApp {
+  process_name: string;
+  window_title: string | null;
+  platform: NodeJS.Platform;
+}
+
+export async function getForegroundApp(): Promise<ForegroundApp | null> {
+  const platform = process.platform;
+  try {
+    if (platform === 'win32') return await foregroundWindows();
+    if (platform === 'darwin') return await foregroundMac();
+    if (platform === 'linux') return await foregroundLinux();
+  } catch (e) {
+    // 詳細ログは debug 用に出す (= サーバ stdout は info+ のみが望ましいので silent)
+    void e;
+  }
+  return null;
+}
+
+// ── Windows ─────────────────────────────────────────────────────────────
+// PowerShell から Win32 API を呼ぶ。 Add-Type で C# inline 定義 → GetForegroundWindow
+// + GetWindowTextW + GetWindowThreadProcessId を使う。 出力は JSON で渡す。
+//
+// 別アプローチとして UI Automation (System.Windows.Forms) でも取れるが、
+// PowerShell 起動 + Add-Type のコストは ~150ms 程度なので、 30 秒に 1 回なら
+// 許容できる。
+const PS_FOREGROUND_SCRIPT = `
+$ErrorActionPreference = 'Stop'
+$sig = @'
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+public class Mem {
+  [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+  [DllImport("user32.dll")] public static extern int GetWindowTextLength(IntPtr h);
+  [DllImport("user32.dll", CharSet=CharSet.Unicode)] public static extern int GetWindowText(IntPtr h, StringBuilder s, int n);
+  [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
+}
+'@
+Add-Type -TypeDefinition $sig | Out-Null
+$h = [Mem]::GetForegroundWindow()
+if ($h -eq [IntPtr]::Zero) { Write-Output '{}'; exit }
+$len = [Mem]::GetWindowTextLength($h)
+$sb = New-Object System.Text.StringBuilder($len + 2)
+[Mem]::GetWindowText($h, $sb, $sb.Capacity) | Out-Null
+$title = $sb.ToString()
+[uint32]$pid = 0
+[Mem]::GetWindowThreadProcessId($h, [ref]$pid) | Out-Null
+$p = $null
+try { $p = Get-Process -Id $pid -ErrorAction Stop } catch { }
+$name = if ($p) { $p.ProcessName } else { 'unknown' }
+[pscustomobject]@{ process_name = $name; window_title = $title } | ConvertTo-Json -Compress
+`;
+
+async function foregroundWindows(): Promise<ForegroundApp | null> {
+  const r = await execFileP('powershell', ['-NoProfile', '-NonInteractive', '-Command', PS_FOREGROUND_SCRIPT], {
+    encoding: 'utf8',
+    windowsHide: true,
+    timeout: 10_000,
+  });
+  const out = (r.stdout || '').trim();
+  if (!out) return null;
+  try {
+    const j = JSON.parse(out) as { process_name?: string; window_title?: string };
+    if (!j.process_name) return null;
+    return {
+      process_name: j.process_name,
+      window_title: j.window_title || null,
+      platform: 'win32',
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ── macOS ──────────────────────────────────────────────────────────────
+async function foregroundMac(): Promise<ForegroundApp | null> {
+  // 最前面 process の name + その window title (= System Events の「frontmost
+  // application 」 + 最初の window の title)。 sandbox 制約 (Accessibility 許可)
+  // が無いと name は取れるが window title が空になることがある。
+  const script = `
+tell application "System Events"
+  set frontApp to first process whose frontmost is true
+  set procName to name of frontApp
+  set winTitle to ""
+  try
+    set winTitle to name of front window of frontApp
+  end try
+  return procName & "|" & winTitle
+end tell`;
+  const r = await execFileP('osascript', ['-e', script], { encoding: 'utf8', timeout: 10_000 });
+  const out = (r.stdout || '').trim();
+  if (!out) return null;
+  const [name, title = ''] = out.split('|', 2);
+  if (!name) return null;
+  return { process_name: name, window_title: title || null, platform: 'darwin' };
+}
+
+// ── Linux (X11 専用 — Wayland は xdotool が動かないので別途対応が要る) ──
+async function foregroundLinux(): Promise<ForegroundApp | null> {
+  // xdotool で前面 window の id → name → pid → process name の順で取る。
+  // Wayland 環境では失敗する。 その場合は GNOME extension などが必要だが、
+  // ここでは silent fail に留める。
+  const id = (await execFileP('xdotool', ['getactivewindow'], { encoding: 'utf8' })).stdout.trim();
+  if (!id) return null;
+  const title = (await execFileP('xdotool', ['getwindowname', id], { encoding: 'utf8' })).stdout.trim();
+  let processName = 'unknown';
+  try {
+    const pidStr = (await execFileP('xdotool', ['getwindowpid', id], { encoding: 'utf8' })).stdout.trim();
+    const pid = Number(pidStr);
+    if (Number.isFinite(pid)) {
+      const c = await execFileP('ps', ['-p', String(pid), '-o', 'comm='], { encoding: 'utf8' });
+      processName = c.stdout.trim() || processName;
+    }
+  } catch { /* leave 'unknown' */ }
+  return { process_name: processName, window_title: title || null, platform: 'linux' };
+}
+
+// silence unused suppression — spawn は将来 streaming sampler で使う可能性
+void spawn;

--- a/server/lib/privacy.ts
+++ b/server/lib/privacy.ts
@@ -32,6 +32,9 @@ export interface PrivacySettings {
   domain_catalog_auto_classify: boolean;
   meals_auto_vision: boolean;
   diary_auto_generate: boolean;
+  // PC 活動 / Steam 取り込み。 どちらも default false (= 明示 opt-in)。
+  activity_app_sampling_enabled: boolean;
+  activity_steam_enabled: boolean;
 }
 
 export type PrivacyBoolKey = keyof Pick<PrivacySettings,
@@ -44,6 +47,7 @@ export type PrivacyBoolKey = keyof Pick<PrivacySettings,
   | 'bookmarks_auto_summarize' | 'page_metadata_auto_fetch'
   | 'domain_catalog_auto_classify' | 'meals_auto_vision'
   | 'diary_auto_generate'
+  | 'activity_app_sampling_enabled' | 'activity_steam_enabled'
 >;
 
 export function settingBool(settings: Record<string, string | null>, key: string, fallback = true): boolean {
@@ -84,6 +88,9 @@ export function privacySettings(db: Db): PrivacySettings {
     domain_catalog_auto_classify: settingBool(s, 'features.domain_catalog.auto_classify', true),
     meals_auto_vision: settingBool(s, 'features.meals.auto_vision', true),
     diary_auto_generate: settingBool(s, 'features.diary.auto_generate', true),
+    // PC 活動 / Steam — default OFF。 設定 → AI / モデル の opt-out グループから ON。
+    activity_app_sampling_enabled: settingBool(s, 'features.activity.app_sampling.enabled', false),
+    activity_steam_enabled: settingBool(s, 'features.activity.steam.enabled', false),
   };
 }
 

--- a/server/lib/steam-client.ts
+++ b/server/lib/steam-client.ts
@@ -1,0 +1,78 @@
+// Steam Web API クライアント。
+//
+// 必要な credentials:
+// - Steam Web API key: https://steamcommunity.com/dev/apikey
+// - SteamID64 (= 17 桁の数値): https://steamid.io/ 等で取得
+//
+// 取得対象:
+// - GetRecentlyPlayedGames — 直近 2 週間にプレイした game の playtime (分単位)
+//   + appid + name + img_icon_url
+//
+// プライバシ:
+// - Steam Web API key はサーバ side の app_settings に保存 (= secret)
+// - feature flag `features.activity.steam.enabled` (default false) で opt-in
+// - 取得結果は steam_activity テーブルに 1 row / game の snapshot として記録
+
+export interface SteamGameSnapshot {
+  appid: number;
+  name: string;
+  playtime_2weeks_min: number | null;
+  playtime_forever_min: number | null;
+  img_icon_url: string | null;
+}
+
+export interface GetRecentlyPlayedResult {
+  ok: boolean;
+  error?: string;
+  games: SteamGameSnapshot[];
+}
+
+/**
+ * Steam Web API の `IPlayerService/GetRecentlyPlayedGames/v1` を叩く。
+ * - key / steamId が空なら ok=false で何もしない (= 設定未投入時の no-op 経路)。
+ * - HTTP / 解析エラーは ok=false で error メッセージを返す。
+ */
+export async function getRecentlyPlayedGames(
+  args: { apiKey: string; steamId: string; count?: number; timeoutMs?: number },
+): Promise<GetRecentlyPlayedResult> {
+  const apiKey = (args.apiKey || '').trim();
+  const steamId = (args.steamId || '').trim();
+  if (!apiKey || !steamId) {
+    return { ok: false, error: 'apiKey or steamId not configured', games: [] };
+  }
+  const count = Math.max(1, Math.min(100, args.count ?? 50));
+  const url = `https://api.steampowered.com/IPlayerService/GetRecentlyPlayedGames/v1/?key=${encodeURIComponent(apiKey)}&steamid=${encodeURIComponent(steamId)}&count=${count}&format=json`;
+  try {
+    const res = await fetch(url, {
+      headers: { 'Accept': 'application/json' },
+      signal: AbortSignal.timeout(args.timeoutMs ?? 10_000),
+    });
+    if (!res.ok) return { ok: false, error: `steam api ${res.status}`, games: [] };
+    const json = await res.json() as {
+      response?: {
+        total_count?: number;
+        games?: Array<{
+          appid?: number;
+          name?: string;
+          playtime_2weeks?: number;
+          playtime_forever?: number;
+          img_icon_url?: string;
+        }>;
+      };
+    };
+    const games = (json.response?.games ?? []).flatMap<SteamGameSnapshot>((g) => {
+      if (typeof g.appid !== 'number' || typeof g.name !== 'string') return [];
+      return [{
+        appid: g.appid,
+        name: g.name,
+        playtime_2weeks_min: typeof g.playtime_2weeks === 'number' ? g.playtime_2weeks : null,
+        playtime_forever_min: typeof g.playtime_forever === 'number' ? g.playtime_forever : null,
+        img_icon_url: g.img_icon_url ?? null,
+      }];
+    });
+    return { ok: true, games };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: `steam api: ${msg}`, games: [] };
+  }
+}

--- a/server/lib/steam-vdf.ts
+++ b/server/lib/steam-vdf.ts
@@ -1,0 +1,287 @@
+// Steam の VDF (Valve's KeyValue) ファイルから「最近プレイした game」 を取る。
+// Steam Web API key 無しで動かしたい場合のフォールバック経路。
+//
+// 読みに行くファイル:
+//   <steam>/userdata/<id3>/config/localconfig.vdf    — appid 別の Playtime / LastPlayed
+//   <steam>/steamapps/appmanifest_<appid>.acf        — 各 game の name
+//
+// Steam ディレクトリの推定:
+//   1. MEMORIA_STEAM_DIR 環境変数があればそれを使う
+//   2. Windows: %PROGRAMFILES(X86)%\Steam → C:\Program Files (x86)\Steam → 32 bit %PROGRAMFILES%\Steam
+//   3. macOS  : ~/Library/Application Support/Steam
+//   4. Linux  : ~/.steam/steam → ~/.local/share/Steam
+//
+// 同じ PC に複数 Steam アカウントがあれば userdata/* を全部走査して
+// playtime をマージ (= ユーザは単一視点で見たい想定)。
+
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import type { SteamGameSnapshot } from './steam-client.js';
+
+export function detectSteamDir(): string | null {
+  const env = process.env.MEMORIA_STEAM_DIR;
+  if (env && existsSync(env)) return env;
+  const candidates: string[] = [];
+  if (process.platform === 'win32') {
+    const p86 = process.env['ProgramFiles(x86)'];
+    const p64 = process.env.ProgramFiles;
+    if (p86) candidates.push(join(p86, 'Steam'));
+    if (p64) candidates.push(join(p64, 'Steam'));
+    candidates.push('C:\\Program Files (x86)\\Steam');
+  } else if (process.platform === 'darwin') {
+    candidates.push(join(homedir(), 'Library', 'Application Support', 'Steam'));
+  } else {
+    candidates.push(join(homedir(), '.steam', 'steam'));
+    candidates.push(join(homedir(), '.local', 'share', 'Steam'));
+  }
+  for (const c of candidates) {
+    if (existsSync(c)) return c;
+  }
+  return null;
+}
+
+// ── 極小 VDF パーサ ────────────────────────────────────────────────────
+//
+// Steam の VDF は JSON 風だが、 区切り記号がなく値も常に文字列。 ネストは
+// `{ ... }`、 各エントリは `"key" "value"` または `"key" { ... }`。
+// 改行 / 空白を区切り、 「//」 はラインコメント。 keyとnested object の間に
+// 改行があるパターンを許容する。
+//
+// 戻り値は再帰的に `Record<string, string | Vdf>` (Vdf = 子オブジェクト)。
+type Vdf = { [k: string]: string | Vdf };
+
+export function parseVdf(text: string): Vdf {
+  // tokenize
+  const tokens: string[] = [];
+  let i = 0;
+  while (i < text.length) {
+    const c = text[i]!;
+    if (c === '/' && text[i + 1] === '/') {
+      while (i < text.length && text[i] !== '\n') i++;
+      continue;
+    }
+    if (c === '"') {
+      // quoted string — Steam doesn't typically escape within VDF values
+      let j = i + 1;
+      let s = '';
+      while (j < text.length && text[j] !== '"') {
+        if (text[j] === '\\' && j + 1 < text.length) {
+          s += text[j + 1];
+          j += 2;
+        } else {
+          s += text[j];
+          j++;
+        }
+      }
+      tokens.push(s);
+      i = j + 1;
+      continue;
+    }
+    if (c === '{' || c === '}') {
+      tokens.push(c);
+      i++;
+      continue;
+    }
+    // whitespace / control
+    i++;
+  }
+  // parse
+  let p = 0;
+  function parseObject(): Vdf {
+    const obj: Vdf = {};
+    while (p < tokens.length) {
+      const tok = tokens[p]!;
+      if (tok === '}') { p++; return obj; }
+      // tok = key
+      const key = tok;
+      p++;
+      const next = tokens[p];
+      if (next === '{') {
+        p++;
+        obj[key] = parseObject();
+      } else if (next != null) {
+        obj[key] = next;
+        p++;
+      } else {
+        break;
+      }
+    }
+    return obj;
+  }
+  return parseObject();
+}
+
+// ── localconfig.vdf から playtime を抽出 ─────────────────────────────
+//
+// パス: <steam>/userdata/<id3>/config/localconfig.vdf
+// 構造 (要点):
+//   "UserLocalConfigStore"
+//   {
+//     "Software"
+//     {
+//       "Valve"
+//       {
+//         "Steam"
+//         {
+//           "apps"
+//           {
+//             "<appid>"
+//             {
+//               "Playtime"      "1234"     // 分
+//               "Playtime2wks"  "120"
+//               "LastPlayed"    "1715000000"  // epoch sec
+//             }
+//             ...
+//           }
+//         }
+//       }
+//     }
+//   }
+//
+// Steam バージョン / OS によって case は揺れる ("Software" vs "software"、
+// "Apps" vs "apps")。 lookup は case-insensitive にする。
+
+function ci<T extends object>(obj: T, key: string): unknown {
+  const lower = key.toLowerCase();
+  for (const k of Object.keys(obj)) {
+    if (k.toLowerCase() === lower) return (obj as Record<string, unknown>)[k];
+  }
+  return undefined;
+}
+
+function navigate(root: Vdf, path: string[]): Vdf | null {
+  let cur: unknown = root;
+  for (const p of path) {
+    if (typeof cur !== 'object' || cur === null) return null;
+    cur = ci(cur as Vdf, p);
+  }
+  return (typeof cur === 'object' && cur !== null) ? (cur as Vdf) : null;
+}
+
+interface AppPlaytimeRaw { playtime: number; playtime2wks: number; lastPlayed: number }
+
+function appsFromLocalConfig(vdf: Vdf): Map<number, AppPlaytimeRaw> {
+  const apps = navigate(vdf, ['UserLocalConfigStore', 'Software', 'Valve', 'Steam', 'apps'])
+    ?? navigate(vdf, ['UserLocalConfigStore', 'Software', 'Valve', 'Steam', 'Apps']);
+  const result = new Map<number, AppPlaytimeRaw>();
+  if (!apps) return result;
+  for (const [appidStr, node] of Object.entries(apps)) {
+    const appid = Number(appidStr);
+    if (!Number.isFinite(appid)) continue;
+    if (typeof node !== 'object' || node === null) continue;
+    const playtime = Number(ci(node, 'Playtime') ?? 0);
+    const playtime2wks = Number(ci(node, 'Playtime2wks') ?? 0);
+    const lastPlayed = Number(ci(node, 'LastPlayed') ?? 0);
+    if (!playtime && !playtime2wks && !lastPlayed) continue;
+    result.set(appid, {
+      playtime: Number.isFinite(playtime) ? playtime : 0,
+      playtime2wks: Number.isFinite(playtime2wks) ? playtime2wks : 0,
+      lastPlayed: Number.isFinite(lastPlayed) ? lastPlayed : 0,
+    });
+  }
+  return result;
+}
+
+// ── appmanifest_<appid>.acf から name を取る ───────────────────────────
+function appIdToName(steamDir: string): Map<number, string> {
+  const out = new Map<number, string>();
+  const dir = join(steamDir, 'steamapps');
+  if (!existsSync(dir)) return out;
+  for (const f of readdirSync(dir)) {
+    const m = /^appmanifest_(\d+)\.acf$/i.exec(f);
+    if (!m) continue;
+    const appid = Number(m[1]);
+    if (!Number.isFinite(appid)) continue;
+    try {
+      const text = readFileSync(join(dir, f), 'utf8');
+      const vdf = parseVdf(text);
+      const state = ci(vdf, 'AppState');
+      if (state && typeof state === 'object') {
+        const name = ci(state as Vdf, 'name');
+        if (typeof name === 'string') out.set(appid, name);
+      }
+    } catch { /* corrupt or unreadable, skip */ }
+  }
+  return out;
+}
+
+// ── 公開関数 ──────────────────────────────────────────────────────────
+//
+// 戻り値は Web API と同じ形 (SteamGameSnapshot[]) で揃えてある。
+// playtime_2weeks_min === 0 のものは UI で「最近未プレイ」 扱いなのでフィルタ
+// せずに全部返す (= 集計側で判断)。
+
+export interface VdfRecentResult {
+  ok: boolean;
+  source: 'vdf';
+  steamDir?: string;
+  reason?: string;
+  games: SteamGameSnapshot[];
+}
+
+export function getRecentlyPlayedFromVdf(): VdfRecentResult {
+  const steamDir = detectSteamDir();
+  if (!steamDir) {
+    return { ok: false, source: 'vdf', reason: 'Steam directory not found', games: [] };
+  }
+  const userdataDir = join(steamDir, 'userdata');
+  if (!existsSync(userdataDir)) {
+    return { ok: false, source: 'vdf', steamDir, reason: 'userdata directory not found', games: [] };
+  }
+  const accounts: string[] = [];
+  try {
+    for (const f of readdirSync(userdataDir)) {
+      if (/^\d+$/.test(f)) accounts.push(f);
+    }
+  } catch {
+    return { ok: false, source: 'vdf', steamDir, reason: 'cannot list userdata', games: [] };
+  }
+  if (accounts.length === 0) {
+    return { ok: false, source: 'vdf', steamDir, reason: 'no Steam accounts found', games: [] };
+  }
+
+  const nameMap = appIdToName(steamDir);
+  const merged = new Map<number, AppPlaytimeRaw>();
+  for (const acc of accounts) {
+    const cfg = join(userdataDir, acc, 'config', 'localconfig.vdf');
+    if (!existsSync(cfg)) continue;
+    try {
+      const text = readFileSync(cfg, 'utf8');
+      const vdf = parseVdf(text);
+      const apps = appsFromLocalConfig(vdf);
+      for (const [appid, raw] of apps) {
+        const prev = merged.get(appid);
+        if (!prev) {
+          merged.set(appid, { ...raw });
+        } else {
+          // 複数アカウントでマージ — 各値は max を取る (= 同一 PC 内最大の値)
+          merged.set(appid, {
+            playtime: Math.max(prev.playtime, raw.playtime),
+            playtime2wks: Math.max(prev.playtime2wks, raw.playtime2wks),
+            lastPlayed: Math.max(prev.lastPlayed, raw.lastPlayed),
+          });
+        }
+      }
+    } catch { /* corrupted vdf — skip */ }
+  }
+
+  const games: SteamGameSnapshot[] = [];
+  for (const [appid, raw] of merged) {
+    if (raw.playtime === 0 && raw.lastPlayed === 0) continue; // 未プレイ
+    games.push({
+      appid,
+      name: nameMap.get(appid) ?? `appid:${appid}`,
+      playtime_2weeks_min: raw.playtime2wks || null,
+      playtime_forever_min: raw.playtime || null,
+      img_icon_url: null,
+    });
+  }
+  // 最近プレイ順に並べる (lastPlayed が無いものは末尾)
+  games.sort((a, b) => {
+    const la = merged.get(a.appid)?.lastPlayed ?? 0;
+    const lb = merged.get(b.appid)?.lastPlayed ?? 0;
+    return lb - la;
+  });
+  return { ok: true, source: 'vdf', steamDir, games };
+}

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -650,6 +650,7 @@
           <button class="wl-subtab" data-sub="browsing">🌐 ブラウジング</button>
           <button class="wl-subtab" data-sub="dig">🔎 ディグ</button>
           <button class="wl-subtab" data-sub="tracks">🗺 軌跡</button>
+          <button class="wl-subtab" data-sub="activity">💻 アプリ</button>
         </nav>
 
         <section id="wlScheduleView" class="wl-sub">
@@ -718,6 +719,36 @@
           <div class="wl-summary-row" id="wlDigSummary"></div>
           <ul id="wlDigList" class="wl-list"></ul>
           <div id="wlDigEmpty" class="queue-empty hidden">この日のディグはありません。</div>
+        </section>
+
+        <!-- 💻 PC アプリ活動 + Steam (= activity-sampler の出力)
+             feature flag は features.activity.app_sampling.enabled / features.activity.steam.enabled。
+             OFF のときは「現在 OFF。 設定 → 🚦 AI 自動処理 で ON にできます」 案内を表示。 -->
+        <section id="wlActivityView" class="wl-sub hidden">
+          <div class="wl-activity-disabled hidden" id="wlActivityDisabled">
+            <p>💻 PC アプリ活動 / 🎮 Steam の取り込みは default OFF です。 <strong>設定 → 🚦 AI 自動処理</strong> の「💻 PC アプリ使用統計」「🎮 Steam プレイ統計」 で有効化してください。</p>
+          </div>
+          <div class="wl-activity-row">
+            <div class="wl-activity-card">
+              <header>
+                <h4>💻 PC アプリ使用時間</h4>
+                <span id="wlActivityAppsHint" class="muted"></span>
+              </header>
+              <ul id="wlActivityAppsList" class="wl-list"></ul>
+              <div id="wlActivityAppsEmpty" class="queue-empty hidden">この日のアプリサンプルはまだありません。</div>
+            </div>
+            <div class="wl-activity-card">
+              <header>
+                <h4>🎮 Steam — 最近プレイした</h4>
+                <span id="wlActivitySteamHint" class="muted"></span>
+              </header>
+              <ul id="wlActivitySteamList" class="wl-list"></ul>
+              <div id="wlActivitySteamEmpty" class="queue-empty hidden">Steam の snapshot はまだありません。 ON 後 1 時間以内 (もしくは「いますぐ取得」 ボタン) で表示されます。</div>
+              <div class="wl-activity-actions">
+                <button id="wlActivitySteamSampleNow" class="ghost" type="button">🔄 いますぐ取得</button>
+              </div>
+            </div>
+          </div>
         </section>
       </div>
 
@@ -1219,7 +1250,22 @@
           <input id="aiAutoDiaryGenerate" type="checkbox" />
           📓 毎日 0:00 の日記 / 日曜 23:00 の週報を自動生成
         </label>
+        <label class="check-inline">
+          <input id="activityAppSampling" type="checkbox" />
+          💻 PC アプリ使用統計 (= 30 秒おきに最前面のアプリ名を記録)
+        </label>
+        <label class="check-inline">
+          <input id="activitySteamEnabled" type="checkbox" />
+          🎮 Steam プレイ統計 (= 1 時間おきに最近プレイした game を取得)
+        </label>
       </div>
+
+      <h4>🎮 Steam Web API (オプション)</h4>
+      <p class="ai-settings-help">API key + SteamID を入れると <a href="https://api.steampowered.com/IPlayerService/GetRecentlyPlayedGames" target="_blank" rel="noopener">公式 GetRecentlyPlayedGames</a> で取得します。 未設定でも同じ PC に Steam が入っていればローカル VDF ファイルからフォールバックで取得 (= key 不要)。</p>
+      <label>Steam Web API Key: <input id="activitySteamApiKey" type="password" placeholder="未設定 = VDF fallback" autocomplete="off" /></label>
+      <span id="activitySteamApiKeyStatus" class="ai-keystatus"></span>
+      <label>SteamID64 (17 桁): <input id="activitySteamId" type="text" placeholder="76561198..." autocomplete="off" /></label>
+      <p class="ai-settings-help">API key: <a href="https://steamcommunity.com/dev/apikey" target="_blank" rel="noopener">steamcommunity.com/dev/apikey</a> で発行 (無料、 ドメインは <code>localhost</code> でも OK)。 SteamID64 は <a href="https://steamid.io/" target="_blank" rel="noopener">steamid.io</a> 等。 プロフィール公開設定が ON でないと空が返る。</p>
     </section>
 
     <!-- ── 🔌 連携 / API key ── -->

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -5805,6 +5805,10 @@ async function loadPrivacySettings() {
   if ($('aiAutoDomainClassify')) $('aiAutoDomainClassify').checked = s.domain_catalog_auto_classify !== false;
   if ($('aiAutoMealVision')) $('aiAutoMealVision').checked = s.meals_auto_vision !== false;
   if ($('aiAutoDiaryGenerate')) $('aiAutoDiaryGenerate').checked = s.diary_auto_generate !== false;
+  if ($('activityAppSampling')) $('activityAppSampling').checked = !!s.activity_app_sampling_enabled;
+  if ($('activitySteamEnabled')) $('activitySteamEnabled').checked = !!s.activity_steam_enabled;
+  // Steam credentials (= 別 endpoint なので非同期 load)
+  loadActivityCredentials().catch(() => { /* swallow */ });
   configureWorkplaceCheckin(!!s.workplace_geo_enabled);
   if (s.tasks_reminder_enabled) {
     scheduleLocalTaskReminder(s.tasks_reminder_hour ?? 6, s.tasks_reminder_minute ?? 0);
@@ -5839,8 +5843,12 @@ async function savePrivacySettings() {
       domain_catalog_auto_classify: !!($('aiAutoDomainClassify')?.checked),
       meals_auto_vision: !!($('aiAutoMealVision')?.checked),
       diary_auto_generate: !!($('aiAutoDiaryGenerate')?.checked),
+      activity_app_sampling_enabled: !!($('activityAppSampling')?.checked),
+      activity_steam_enabled: !!($('activitySteamEnabled')?.checked),
     }),
   });
+  // Steam credentials は別 endpoint で保存
+  await saveActivityCredentials().catch(() => { /* swallow */ });
   const s = r.settings || {};
   if (s.tasks_reminder_enabled) {
     scheduleLocalTaskReminder(s.tasks_reminder_hour ?? 6, s.tasks_reminder_minute ?? 0);
@@ -7654,6 +7662,7 @@ const WL_SUB_VIEWS = {
   browsing: 'wlBrowsingView',
   dig: 'wlDigView',
   tracks: 'tracksView',
+  activity: 'wlActivityView',
 };
 
 // データベースタブのサブビュー一覧 (旧 'external' は軌跡タブに統合)
@@ -7758,10 +7767,136 @@ async function loadWorklog() {
   if (sub === 'browsing') return loadWorklogBrowsing(date);
   if (sub === 'dig') return loadWorklogDig(date);
   if (sub === 'tracks') return loadTracks();
+  if (sub === 'activity') return loadWorklogActivityCard(date);
   if (WL_KIND_BY_SUB[sub]) {
     await loadWorklogActivity(date, sub);
     if (sub === 'gemini') await loadGeminiWebResearchLogs(date);
     return;
+  }
+}
+
+interface ActivitySettings {
+  app_sampling: boolean;
+  steam_enabled: boolean;
+  app_sample_sec: number;
+  steam_interval_min: number;
+  steam_api_key_set: boolean;
+  steam_id: string;
+}
+interface ActivityAppRow { process_name: string; total_sec: number; samples: number; last_at: string }
+interface ActivitySteamRow {
+  appid: number; name: string;
+  playtime_2weeks_min: number | null;
+  playtime_forever_min: number | null;
+  img_icon_url: string | null;
+  sampled_at: string;
+}
+
+// Activity (PC アプリ / Steam) の credentials 部分は別 endpoint で読み書きする。
+// API key を masked で扱うため、 settings PATCH ([api/privacy/settings]) には
+// 載せない (= 上書き / 露出を避ける)。
+async function loadActivityCredentials() {
+  const r = await api('/api/activity/settings') as ActivitySettings;
+  const k = $('activitySteamApiKey') as HTMLInputElement | null;
+  if (k) k.value = ''; // password なので raw 値は返さない
+  const ks = $('activitySteamApiKeyStatus');
+  if (ks) ks.textContent = r.steam_api_key_set ? '✓ API key 設定済み (再入力で上書き、 空欄保存は維持)' : '(未設定 — VDF fallback で動く)';
+  const sid = $('activitySteamId') as HTMLInputElement | null;
+  if (sid) sid.value = r.steam_id || '';
+}
+
+async function saveActivityCredentials() {
+  const k = ($('activitySteamApiKey') as HTMLInputElement | null)?.value || '';
+  const sid = ($('activitySteamId') as HTMLInputElement | null)?.value || '';
+  const body: Record<string, unknown> = {};
+  // 空欄ならスキップ (= 既存値を維持)。 ユーザが消したいときは「___」 のような
+  // 明示テキストは要らない (= 設計判断で「明示 clear」 のフローは UI に出さない)。
+  if (k.trim()) body.steam_api_key = k.trim();
+  if (sid.trim() || ($('activitySteamId') as HTMLInputElement | null)?.value === '') {
+    body.steam_id = sid.trim();
+  }
+  if (Object.keys(body).length === 0) return;
+  await api('/api/activity/settings', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+async function loadWorklogActivityCard(date: string) {
+  const disabled = $('wlActivityDisabled');
+  const appsEmpty = $('wlActivityAppsEmpty');
+  const appsHint = $('wlActivityAppsHint');
+  const appsList = $('wlActivityAppsList');
+  const steamEmpty = $('wlActivitySteamEmpty');
+  const steamHint = $('wlActivitySteamHint');
+  const steamList = $('wlActivitySteamList');
+  // settings は別 endpoint で取って enabled/disabled の案内を出す
+  let settings: ActivitySettings | null = null;
+  try { settings = await api('/api/activity/settings') as ActivitySettings; } catch { /* swallow */ }
+  if (disabled && settings) {
+    disabled.classList.toggle('hidden', settings.app_sampling || settings.steam_enabled);
+  }
+  // PC アプリ
+  if (appsList) appsList.innerHTML = '';
+  if (settings?.app_sampling) {
+    try {
+      const r = await api(`/api/activity/apps?date=${encodeURIComponent(date)}`) as { items: ActivityAppRow[] };
+      if (!r.items || r.items.length === 0) {
+        appsEmpty?.classList.remove('hidden');
+        if (appsHint) appsHint.textContent = `周期: ${settings.app_sample_sec}s`;
+      } else {
+        appsEmpty?.classList.add('hidden');
+        if (appsHint) appsHint.textContent = `周期 ${settings.app_sample_sec}s × ${r.items.reduce((a, b) => a + b.samples, 0)} サンプル`;
+        if (appsList) {
+          appsList.innerHTML = r.items.map((it) => {
+            const min = Math.round((it.total_sec || 0) / 60);
+            return `<li class="wl-list-row">
+              <span class="wl-list-title">${escapeHtml(it.process_name)}</span>
+              <span class="wl-list-meta muted">${min} 分 / ${it.samples} samples</span>
+            </li>`;
+          }).join('');
+        }
+      }
+    } catch (e) {
+      if (appsHint) appsHint.textContent = `取得失敗: ${(e as Error).message}`;
+      appsEmpty?.classList.remove('hidden');
+    }
+  } else {
+    appsEmpty?.classList.remove('hidden');
+    if (appsHint) appsHint.textContent = '(features.activity.app_sampling.enabled が OFF)';
+  }
+  // Steam
+  if (steamList) steamList.innerHTML = '';
+  if (settings?.steam_enabled) {
+    try {
+      const r = await api('/api/activity/steam/recent') as { items: ActivitySteamRow[] };
+      if (!r.items || r.items.length === 0) {
+        steamEmpty?.classList.remove('hidden');
+        const src = settings.steam_api_key_set ? 'Web API' : 'VDF (ローカル)';
+        if (steamHint) steamHint.textContent = `ソース: ${src}、 取得待ち`;
+      } else {
+        steamEmpty?.classList.add('hidden');
+        const src = settings.steam_api_key_set ? 'Web API' : 'VDF (ローカル)';
+        if (steamHint) steamHint.textContent = `ソース: ${src}`;
+        if (steamList) {
+          steamList.innerHTML = r.items.slice(0, 30).map((it) => {
+            const m2 = it.playtime_2weeks_min ? `直近 ${it.playtime_2weeks_min} 分 / ` : '';
+            const mf = it.playtime_forever_min ? `通算 ${Math.round(it.playtime_forever_min / 60)} 時間` : '';
+            return `<li class="wl-list-row">
+              <span class="wl-list-title">${escapeHtml(it.name)}</span>
+              <span class="wl-list-meta muted">${m2}${mf}</span>
+            </li>`;
+          }).join('');
+        }
+      }
+    } catch (e) {
+      if (steamHint) steamHint.textContent = `取得失敗: ${(e as Error).message}`;
+      steamEmpty?.classList.remove('hidden');
+    }
+  } else {
+    steamEmpty?.classList.remove('hidden');
+    if (steamHint) steamHint.textContent = '(features.activity.steam.enabled が OFF)';
   }
 }
 
@@ -8156,6 +8291,22 @@ $('wlDate')?.addEventListener('change', (e) => {
   }
 });
 $('wlRefresh')?.addEventListener('click', () => loadWorklog());
+$('wlActivitySteamSampleNow')?.addEventListener('click', async () => {
+  const btn = $('wlActivitySteamSampleNow') as HTMLButtonElement | null;
+  if (btn) { btn.disabled = true; btn.textContent = '取得中…'; }
+  try {
+    const r = await api('/api/activity/steam/sample-now', { method: 'POST' }) as { source: string; count: number; error?: string };
+    if (r.error) alert(`Steam 取得失敗: ${r.error}`);
+    else alert(`Steam ${r.source} から ${r.count} 件を snapshot しました`);
+    if (state.tab === 'worklog' && state.worklog?.sub === 'activity') {
+      void loadWorklogActivityCard(state.worklog.date);
+    }
+  } catch (e) {
+    alert(`Steam 取得失敗: ${(e as Error).message}`);
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = '🔄 いますぐ取得'; }
+  }
+});
 $('wlGeminiWebSaveBtn')?.addEventListener('click', () => {
   saveGeminiWebResearchLog().catch((e) => {
     console.error(e);

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -5253,6 +5253,19 @@ dialog.loc-edit-modal[open] {
   flex-direction: column;
   gap: 4px;
 }
+/* 💻 アプリ / 🎮 Steam の 2 カラム (workflow → activity tab) */
+.wl-activity-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-top: 8px; }
+.wl-activity-card { background: var(--panel, var(--card)); border: 1px solid var(--border); border-radius: 8px; padding: 10px 12px; }
+.wl-activity-card header { display: flex; align-items: baseline; gap: 8px; margin-bottom: 6px; flex-wrap: wrap; }
+.wl-activity-card header h4 { margin: 0; font-size: 13px; }
+.wl-activity-card .wl-list-row { display: flex; justify-content: space-between; gap: 8px; }
+.wl-activity-card .wl-list-title { font-weight: 600; flex: 1; min-width: 0; word-break: break-word; }
+.wl-activity-card .wl-list-meta { font-size: 11px; white-space: nowrap; }
+.wl-activity-card .wl-activity-actions { margin-top: 8px; display: flex; gap: 6px; }
+.wl-activity-disabled { background: var(--accent-bg, #fff8c5); border: 1px solid var(--border); border-radius: 6px; padding: 10px 12px; margin-bottom: 8px; font-size: 12px; }
+@media (max-width: 760px) {
+  .wl-activity-row { grid-template-columns: 1fr; }
+}
 .wl-list li {
   padding: 8px 10px;
   border-radius: 4px;

--- a/server/routes/activity.ts
+++ b/server/routes/activity.ts
@@ -1,0 +1,156 @@
+// /api/activity/* — PC アプリ使用統計 + Steam 活動。
+// Spec: spec/api/activity.md (未作成、 本 PR で feature 投入)
+
+import { Hono, type Context } from 'hono';
+import type BetterSqlite3 from 'better-sqlite3';
+import { getAppSettings, setAppSettings } from '../db.js';
+import { privacySettings } from '../lib/privacy.js';
+import {
+  sampleAppOnce, sampleSteamOnce, configureActivitySamplers,
+} from '../lib/activity-sampler.js';
+
+type Db = BetterSqlite3.Database;
+
+interface AppDayRow {
+  process_name: string;
+  total_sec: number;
+  samples: number;
+  last_at: string;
+}
+interface SteamDayRow {
+  appid: number;
+  name: string;
+  playtime_2weeks_min: number | null;
+  playtime_forever_min: number | null;
+  img_icon_url: string | null;
+  sampled_at: string;
+}
+
+export interface ActivityRouterDeps { db: Db }
+
+export function makeActivityRouter(deps: ActivityRouterDeps): Hono {
+  const { db } = deps;
+  const r = new Hono();
+
+  // ── PC アプリ使用統計 ─────────────────────────────────────────────
+  // GET /api/activity/apps?date=YYYY-MM-DD
+  //   - process_name 別の合計サンプル時間 (= samples * sample_interval_sec)
+  //   - 上位 50 件、 多い順
+  r.get('/api/activity/apps', (c: Context) => {
+    const dateRaw = c.req.query('date');
+    const date = (typeof dateRaw === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(dateRaw))
+      ? dateRaw
+      : new Date().toISOString().slice(0, 10);
+    const rows = db.prepare(`
+      SELECT process_name,
+             SUM(sample_interval_sec) AS total_sec,
+             COUNT(*)                  AS samples,
+             MAX(sampled_at)           AS last_at
+      FROM app_samples
+      WHERE date(sampled_at, 'localtime') = ?
+      GROUP BY process_name
+      ORDER BY total_sec DESC
+      LIMIT 50
+    `).all(date) as AppDayRow[];
+    return c.json({ date, items: rows });
+  });
+
+  // GET /api/activity/apps/recent?limit=50
+  //   - 直近の raw サンプル (window_title 付き)
+  r.get('/api/activity/apps/recent', (c: Context) => {
+    const limit = Math.max(1, Math.min(200, Number(c.req.query('limit') || 50)));
+    const rows = db.prepare(`
+      SELECT id, sampled_at, process_name, window_title
+      FROM app_samples
+      ORDER BY sampled_at DESC
+      LIMIT ?
+    `).all(limit);
+    return c.json({ items: rows });
+  });
+
+  // POST /api/activity/apps/sample-now — デバッグ用に手動サンプル
+  r.post('/api/activity/apps/sample-now', async (c: Context) => {
+    const settings = getAppSettings(db);
+    const sec = Math.max(5, Number(settings['activity.app_sample_sec'] ?? 30));
+    await sampleAppOnce(db, sec);
+    return c.json({ ok: true });
+  });
+
+  // ── Steam ─────────────────────────────────────────────────────────
+  // GET /api/activity/steam/recent — 直近スナップショットを appid 単位で 1 つに
+  //   uniq して返す (= 最新の playtime_2weeks_min 順)
+  r.get('/api/activity/steam/recent', (c: Context) => {
+    const rows = db.prepare(`
+      SELECT appid, name, playtime_2weeks_min, playtime_forever_min,
+             img_icon_url, sampled_at
+      FROM steam_activity
+      WHERE id IN (
+        SELECT MAX(id) FROM steam_activity GROUP BY appid
+      )
+      ORDER BY COALESCE(playtime_2weeks_min, 0) DESC, sampled_at DESC
+      LIMIT 50
+    `).all() as SteamDayRow[];
+    return c.json({ items: rows });
+  });
+
+  // POST /api/activity/steam/sample-now — 手動 snapshot 取得
+  r.post('/api/activity/steam/sample-now', async (c: Context) => {
+    const r2 = await sampleSteamOnce(db);
+    return c.json(r2);
+  });
+
+  // ── 設定 ──────────────────────────────────────────────────────────
+  // PATCH /api/activity/settings  — feature flag + 周期 + Steam credentials
+  // body: {
+  //   app_sampling?: boolean,
+  //   app_sample_sec?: number,
+  //   steam_enabled?: boolean,
+  //   steam_interval_min?: number,
+  //   steam_api_key?: string,
+  //   steam_id?: string,
+  // }
+  r.patch('/api/activity/settings', async (c: Context) => {
+    const body = await c.req.json().catch(() => ({})) as Record<string, unknown>;
+    const patch: Record<string, string> = {};
+    if (typeof body.app_sampling === 'boolean') patch['features.activity.app_sampling.enabled'] = body.app_sampling ? '1' : '0';
+    if (typeof body.steam_enabled === 'boolean') patch['features.activity.steam.enabled'] = body.steam_enabled ? '1' : '0';
+    if (typeof body.app_sample_sec === 'number' && Number.isFinite(body.app_sample_sec)) {
+      patch['activity.app_sample_sec'] = String(Math.max(5, Math.min(600, Math.floor(body.app_sample_sec))));
+    }
+    if (typeof body.steam_interval_min === 'number' && Number.isFinite(body.steam_interval_min)) {
+      patch['activity.steam_interval_min'] = String(Math.max(5, Math.min(1440, Math.floor(body.steam_interval_min))));
+    }
+    if (typeof body.steam_api_key === 'string') patch['steam.web_api_key'] = body.steam_api_key.trim();
+    if (typeof body.steam_id === 'string') patch['steam.steam_id'] = body.steam_id.trim();
+    if (Object.keys(patch).length > 0) {
+      setAppSettings(db, patch);
+      configureActivitySamplers(db);
+    }
+    // 現在の設定を返す (api_key は masked)
+    const s = getAppSettings(db);
+    const priv = privacySettings(db);
+    return c.json({
+      app_sampling: priv.activity_app_sampling_enabled,
+      steam_enabled: priv.activity_steam_enabled,
+      app_sample_sec: Number(s['activity.app_sample_sec'] ?? 30),
+      steam_interval_min: Number(s['activity.steam_interval_min'] ?? 60),
+      steam_api_key_set: !!(s['steam.web_api_key'] || '').trim(),
+      steam_id: (s['steam.steam_id'] || '').trim(),
+    });
+  });
+
+  r.get('/api/activity/settings', (c: Context) => {
+    const s = getAppSettings(db);
+    const priv = privacySettings(db);
+    return c.json({
+      app_sampling: priv.activity_app_sampling_enabled,
+      steam_enabled: priv.activity_steam_enabled,
+      app_sample_sec: Number(s['activity.app_sample_sec'] ?? 30),
+      steam_interval_min: Number(s['activity.steam_interval_min'] ?? 60),
+      steam_api_key_set: !!(s['steam.web_api_key'] || '').trim(),
+      steam_id: (s['steam.steam_id'] || '').trim(),
+    });
+  });
+
+  return r;
+}

--- a/server/routes/config.ts
+++ b/server/routes/config.ts
@@ -48,6 +48,8 @@ export interface ConfigRouterDeps {
   dataDir: string;
   /** privacy.mcp_autostart_enabled が変更されたら呼ばれる */
   onMcpAutostartChange: (enabled: boolean) => void;
+  /** activity (app sampling / steam) フラグが変更されたら sampler を再構成 */
+  onActivitySettingsChange: () => void;
   // 全 queue の snapshot を返すために必要
   summaryQueue: FifoQueue;
   cloudQueue: FifoQueue;
@@ -61,7 +63,7 @@ export interface ConfigRouterDeps {
 
 export function makeConfigRouter(deps: ConfigRouterDeps): Hono {
   const {
-    db, port, dataDir, onMcpAutostartChange,
+    db, port, dataDir, onMcpAutostartChange, onActivitySettingsChange,
     summaryQueue, cloudQueue, digQueue, diaryQueue, weeklyQueue,
     domainCatalogQueue, pageMetadataQueue, mealVisionQueue,
   } = deps;
@@ -102,6 +104,8 @@ export function makeConfigRouter(deps: ConfigRouterDeps): Hono {
       ['domain_catalog_auto_classify', 'features.domain_catalog.auto_classify'],
       ['meals_auto_vision', 'features.meals.auto_vision'],
       ['diary_auto_generate', 'features.diary.auto_generate'],
+      ['activity_app_sampling_enabled', 'features.activity.app_sampling.enabled'],
+      ['activity_steam_enabled', 'features.activity.steam.enabled'],
     ] as const) {
       if (typeof body[bodyKey] === 'boolean') patch[settingKey] = body[bodyKey] ? '1' : '0';
     }
@@ -113,6 +117,12 @@ export function makeConfigRouter(deps: ConfigRouterDeps): Hono {
     if (Object.keys(patch).length) setAppSettings(db, patch);
     if (Object.prototype.hasOwnProperty.call(body, 'mcp_autostart_enabled')) {
       onMcpAutostartChange(privacySettings(db).mcp_autostart_enabled);
+    }
+    if (
+      Object.prototype.hasOwnProperty.call(body, 'activity_app_sampling_enabled')
+      || Object.prototype.hasOwnProperty.call(body, 'activity_steam_enabled')
+    ) {
+      onActivitySettingsChange();
     }
     return c.json({ settings: privacySettings(db) });
   });


### PR DESCRIPTION
## Summary

「いま何のアプリ使ってる」 + 「最近何の Steam ゲーム遊んだ」 を Memoria に取り込んで worklog タブで見られるようにする。 default OFF の明示 opt-in。

## 主な変更

### Backend (新規)
- \`server/lib/app-activity-sampler.ts\` — 最前面ウィンドウの process 名 + window title を取る (Win/macOS/Linux)
- \`server/lib/steam-client.ts\` — Steam Web API (\`IPlayerService/GetRecentlyPlayedGames\`)
- \`server/lib/steam-vdf.ts\` — local \`localconfig.vdf\` から playtime + \`appmanifest_<appid>.acf\` から name 解決 (key 不要 fallback)
- \`server/lib/activity-sampler.ts\` — 周期 timer (app 30 秒 / Steam 60 分)
- \`server/routes/activity.ts\` — \`/api/activity/{apps,apps/recent,steam/recent,apps/sample-now,steam/sample-now,settings}\`

### DB
- \`app_samples\` (sampled_at, process_name, window_title, sample_interval_sec)
- \`steam_activity\` (sampled_at, appid, name, playtime_2weeks_min, playtime_forever_min, img_icon_url)

### Privacy flags (= 設定 → AI / モデル → 🚦 AI 自動処理 に checkbox 追加)
- \`features.activity.app_sampling.enabled\` (default false)
- \`features.activity.steam.enabled\` (default false)

### Steam ソースの自動切替
1. \`steam.web_api_key\` + \`steam.steam_id\` が設定済み → Web API (フル情報、 名前 + img_icon)
2. 未設定 → ローカル VDF fallback (key 不要)
   - インストール済みゲームは name 解決
   - 過去プレイの未インストールゲームは \`appid:XXX\` 表示 (= key を入れれば全解決)

### UI
- worklog に「💻 アプリ」 サブタブ。 PC アプリ使用時間 (process_name 別合計) + Steam 最近プレイ。 OFF 時は案内表示
- 設定 → AI / モデル に「🎮 Steam Web API」 セクション (key + SteamID 入力)
- 「🔄 いますぐ取得」 ボタンで手動 Steam snapshot

## スモークテスト済み
- \`POST /api/activity/apps/sample-now\` → app_samples に 1 行 insert ✓
- \`POST /api/activity/steam/sample-now\` → VDF source で 78 game snapshot ✓
- 名前解決確認: Baba Is You / Rez Infinite / SteamVR ✓

## Test plan
- [ ] 設定 → 🚦 AI 自動処理 で「💻 PC アプリ使用統計」 ON → 30 秒待つ → worklog → 💻 アプリ サブタブで current ウィンドウが見える
- [ ] 「🎮 Steam プレイ統計」 ON → 「🔄 いますぐ取得」 → Steam recent が表示される
- [ ] Steam Web API key 入れて保存 → 次回 sample で uninstalled も name 解決
- [ ] OFF にすると次回 server 再起動 / configureActivitySamplers 経由で timer 停止

🤖 Generated with [Claude Code](https://claude.com/claude-code)