### PR TITLE
feat(activity): applications カタログ + ゲームログ + 仕事時間集計

### DIFF
--- a/server/app-catalog.ts
+++ b/server/app-catalog.ts
@@ -1,0 +1,85 @@
+// Application catalog — process_name (= exe 名) 単位で「これは何のアプリ?」 を
+// AI に聞いて分類するパス。 domain-catalog と同じデザインで、 1 process_name
+// に 1 行、 status='pending' → 'done' (or 'error') に遷移する。
+//
+// AI 呼び出しは `runLlm({ task: 'app_classify', ... })`。 task name は llm.ts に
+// 追加。 prompt は process_name と (任意で) 既知の window_title を渡し、
+// JSON で {name, kind, description} を返してもらう。
+
+import { runLlm } from './llm.js';
+
+export type AppKindString =
+  | 'game' | 'work' | 'browser' | 'messaging' | 'media' | 'creative' | 'other';
+
+export interface AppClassifyInput {
+  processName: string;
+  /** 最近観測された window_title (= 名前推定の補助に使う、 空でも OK) */
+  recentTitles?: string[];
+  /** ユーザの OS (= ヒント; "win32"/"darwin"/"linux") */
+  platform?: string;
+  /** LLM 呼び出しタイムアウト (default 60s) */
+  timeoutMs?: number;
+}
+
+export interface AppClassifyResult {
+  name: string;
+  kind: AppKindString;
+  description: string;
+}
+
+const PROMPT = (a: AppClassifyInput): string => [
+  'あなたは PC アプリケーションを辞書化する係です。 次の情報からこの exe を 1 つの JSON オブジェクトで分類してください (前置き不要、 コードフェンス禁止)。',
+  '',
+  'スキーマ:',
+  '{',
+  '  "name": "人間に分かるアプリ名 (例: Visual Studio Code, Discord, バルダーズゲート3)。日本語名があれば優先",',
+  '  "kind": "下記 7 種類のいずれか必須: game | work | browser | messaging | media | creative | other",',
+  '  "description": "1 文 (40〜100 文字) で「このアプリで何をするか」"',
+  '}',
+  '',
+  'kind の定義 (= ユーザの 1 日の集計に使うので **厳格**に判定):',
+  '- game     : ビデオゲーム本体 (Steam ゲーム / スタンドアロン ゲーム / エミュレータ等)',
+  '- work     : IDE / ターミナル / Office / 業務ツール / DB クライアント / SSH クライアント等',
+  '- browser  : Chrome / Edge / Firefox / Brave 等のブラウザ本体',
+  '- messaging: Discord / Slack / Teams / LINE / Skype / Telegram 等',
+  '- media    : VLC / Spotify / YouTube アプリ / プレイヤー系',
+  '- creative : Photoshop / Illustrator / Blender / DAW / 動画編集 等',
+  '- other    : 上記に当てはまらない (= OS 標準 / システム / 分類困難)',
+  '',
+  '例:',
+  '- "Code.exe" → {"name":"Visual Studio Code","kind":"work","description":"プログラミング向けの軽量エディタ。"}',
+  '- "BG3.exe"  → {"name":"バルダーズゲート3","kind":"game","description":"Larian Studios のターン制 RPG。"}',
+  '- "Discord.exe" → {"name":"Discord","kind":"messaging","description":"友人とのチャット / 通話アプリ。"}',
+  '',
+  `process_name: ${a.processName}`,
+  a.platform ? `platform: ${a.platform}` : '',
+  a.recentTitles?.length ? `recent_window_titles:\n${a.recentTitles.slice(0, 3).map((t) => `  - ${t}`).join('\n')}` : '',
+  '',
+  'JSON のみを 1 行 (改行込みでも可) で返してください。',
+].filter(Boolean).join('\n');
+
+const VALID_KINDS = new Set<AppKindString>(['game', 'work', 'browser', 'messaging', 'media', 'creative', 'other']);
+
+export async function classifyApplication(input: AppClassifyInput): Promise<AppClassifyResult> {
+  const stdout = await runLlm({ task: 'app_classify', prompt: PROMPT(input), timeoutMs: input.timeoutMs ?? 60_000 });
+  const trimmed = stdout.trim();
+  // 最初の '{' 〜 最後の '}' をパース対象に
+  const a = trimmed.indexOf('{');
+  const b = trimmed.lastIndexOf('}');
+  if (a < 0 || b <= a) throw new Error(`classify response not JSON: ${trimmed.slice(0, 200)}`);
+  const raw = trimmed.slice(a, b + 1);
+  let parsed: unknown;
+  try { parsed = JSON.parse(raw); } catch (e) {
+    throw new Error(`classify response JSON parse: ${(e as Error).message} (raw: ${raw.slice(0, 200)})`);
+  }
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error('classify response not object');
+  }
+  const p = parsed as Record<string, unknown>;
+  const name = typeof p.name === 'string' ? p.name.trim() : '';
+  const kindRaw = typeof p.kind === 'string' ? p.kind.trim().toLowerCase() : '';
+  const description = typeof p.description === 'string' ? p.description.trim() : '';
+  if (!name) throw new Error('classify response missing name');
+  const kind: AppKindString = (VALID_KINDS as Set<string>).has(kindRaw) ? (kindRaw as AppKindString) : 'other';
+  return { name, kind, description };
+}

--- a/server/db.ts
+++ b/server/db.ts
@@ -16,6 +16,7 @@ import type { DictionaryEntryRow, DictionaryLinkRow } from './db/types/dictionar
 import type { WordCloudRow } from './db/types/wordcloud.js';
 import type { PageVisitRow, VisitEventRow } from './db/types/visit.js';
 import type { PageMetadataRow, DomainCatalogRow } from './db/types/page.js';
+import type { ApplicationRow } from './db/types/application.js';
 import type { ServerEventRow, ActivityEventRow, ActivityKind } from './db/types/activity.js';
 import type { PushSubscriptionRow } from './db/types/push.js';
 import type { ExternalChatMessageRow } from './db/types/chat.js';
@@ -356,6 +357,30 @@ export function openDb(dbPath: string): Db {
     );
     CREATE INDEX IF NOT EXISTS idx_app_samples_at ON app_samples(sampled_at DESC);
     CREATE INDEX IF NOT EXISTS idx_app_samples_proc_at ON app_samples(process_name, sampled_at);
+
+    -- applications: process_name 単位で「何のアプリか」 を AI 分類するカタログ。
+    -- domain_catalog と同じパターン。
+    -- kind は以下のいずれか (UI 側 enum):
+    --   game     — ゲーム (= 🎮 ゲームタブに集計、 「仕事時間」 にはカウントしない)
+    --   work     — 仕事系 (= IDE / オフィスツール / ターミナル等、 仕事時間にカウント)
+    --   browser  — ブラウザ (= Chrome / Edge 等)
+    --   messaging— Discord / Slack / Teams 等
+    --   media    — 動画 / 音楽プレイヤー
+    --   creative — Photoshop / Blender / DAW 等
+    --   other    — 上記に当てはまらない
+    CREATE TABLE IF NOT EXISTS applications (
+      process_name  TEXT PRIMARY KEY,
+      name          TEXT,
+      kind          TEXT,
+      description   TEXT,
+      icon_url      TEXT,
+      user_edited   INTEGER NOT NULL DEFAULT 0,
+      status        TEXT NOT NULL DEFAULT 'pending',
+      error         TEXT,
+      classified_at TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_applications_kind ON applications(kind);
+    CREATE INDEX IF NOT EXISTS idx_applications_status ON applications(status);
 
     -- Steam recently-played スナップショット。 1 時間おきに Web API で取得して
     -- 各 game 行を 1 つ insert。 集計 (今日の Steam プレイ時間) は同じ appid の
@@ -1939,6 +1964,93 @@ export function listDomainCatalogWithCounts(db: Db, { limit = 500, search }: { l
 
 export function deleteDomainCatalog(db: Db, domain: string): void {
   db.prepare(`DELETE FROM domain_catalog WHERE domain = ?`).run(domain);
+}
+
+// ── applications (exe classification) ------------------------------------
+
+export function getApplication(db: Db, processName: string): ApplicationRow | null {
+  return (db.prepare(`SELECT * FROM applications WHERE process_name = ?`).get(processName) as ApplicationRow | undefined) ?? null;
+}
+
+export function listApplications(db: Db, { limit = 500 }: { limit?: number } = {}): ApplicationRow[] {
+  return db.prepare(`
+    SELECT * FROM applications
+    ORDER BY (status = 'done') DESC, classified_at DESC, process_name ASC
+    LIMIT ?
+  `).all(limit) as ApplicationRow[];
+}
+
+export function listApplicationsByKind(db: Db, kind: string): ApplicationRow[] {
+  return db.prepare(`
+    SELECT * FROM applications WHERE kind = ? AND status = 'done'
+  `).all(kind) as ApplicationRow[];
+}
+
+/** bulk fetch — process_name 集合 → row map */
+export function getApplicationsMap(db: Db, processNames: string[]): Map<string, ApplicationRow> {
+  if (!processNames.length) return new Map();
+  const placeholders = processNames.map(() => '?').join(',');
+  const rows = db.prepare(`SELECT * FROM applications WHERE process_name IN (${placeholders})`).all(...processNames) as ApplicationRow[];
+  return new Map(rows.map(r => [r.process_name, r]));
+}
+
+export function insertApplicationPending(db: Db, processName: string): void {
+  db.prepare(`INSERT OR IGNORE INTO applications (process_name, status) VALUES (?, 'pending')`).run(processName);
+}
+
+export interface ApplicationPatch {
+  name?: string | null;
+  kind?: string | null;
+  description?: string | null;
+  icon_url?: string | null;
+  status?: string | null;
+  error?: string | null;
+}
+
+export function setApplication(db: Db, processName: string, patch: ApplicationPatch): void {
+  // user_edited=1 のとき AI 分類は値を上書きしない (domain_catalog と同じ)。
+  db.prepare(`
+    UPDATE applications
+       SET name = CASE WHEN user_edited = 1 THEN name ELSE COALESCE(?, name) END,
+           kind = CASE WHEN user_edited = 1 THEN kind ELSE COALESCE(?, kind) END,
+           description = CASE WHEN user_edited = 1 THEN description ELSE COALESCE(?, description) END,
+           icon_url = COALESCE(?, icon_url),
+           status = COALESCE(?, status),
+           error = ?,
+           classified_at = datetime('now')
+     WHERE process_name = ?
+  `).run(
+    patch.name ?? null,
+    patch.kind ?? null,
+    patch.description ?? null,
+    patch.icon_url ?? null,
+    patch.status ?? null,
+    patch.error ?? null,
+    processName,
+  );
+}
+
+export interface ApplicationUserPatch {
+  name?: string | null;
+  kind?: string | null;
+  description?: string | null;
+}
+
+export function updateApplicationUser(db: Db, processName: string, patch: ApplicationUserPatch): void {
+  db.prepare(`
+    UPDATE applications
+       SET name = COALESCE(?, name),
+           kind = COALESCE(?, kind),
+           description = COALESCE(?, description),
+           user_edited = 1,
+           status = 'done',
+           classified_at = datetime('now')
+     WHERE process_name = ?
+  `).run(patch.name ?? null, patch.kind ?? null, patch.description ?? null, processName);
+}
+
+export function deleteApplication(db: Db, processName: string): void {
+  db.prepare(`DELETE FROM applications WHERE process_name = ?`).run(processName);
 }
 
 // ── server events (uptime / downtime / lifecycle) -------------------------

--- a/server/db/types/application.ts
+++ b/server/db/types/application.ts
@@ -1,0 +1,30 @@
+// applications — process_name 単位の「何のアプリか」 分類カタログ。
+// domain_catalog と同じパターン (= 取り込まれるたびに AI 分類 → user_edited=1
+// なら手動値を保護)。
+
+export type AppKind =
+  | 'game'      // ゲーム (= 🎮 ゲームタブに集計、 仕事時間にはカウントしない)
+  | 'work'      // IDE / オフィス / ターミナル等 (= 仕事時間にカウント)
+  | 'browser'   // Chrome / Edge / Firefox 等
+  | 'messaging' // Discord / Slack / Teams 等
+  | 'media'     // 動画 / 音楽プレイヤー
+  | 'creative'  // Photoshop / Blender / DAW 等
+  | 'other';
+
+export const APP_KINDS: ReadonlyArray<AppKind> = [
+  'game', 'work', 'browser', 'messaging', 'media', 'creative', 'other',
+];
+
+export interface ApplicationRow {
+  process_name: string;
+  name: string | null;
+  kind: AppKind | string | null;
+  description: string | null;
+  icon_url: string | null;
+  /** 1 のとき auto-classify は値を上書きしない */
+  user_edited: 0 | 1;
+  /** 'pending' | 'done' | 'error' */
+  status: string;
+  error: string | null;
+  classified_at: string | null;
+}

--- a/server/db/types/index.ts
+++ b/server/db/types/index.ts
@@ -22,3 +22,4 @@ export * from './push.js';
 export * from './wordcloud.js';
 export * from './stopwords.js';
 export * from './note.js';
+export * from './application.js';

--- a/server/index.ts
+++ b/server/index.ts
@@ -172,7 +172,7 @@ app.route('/', makeNoteRouter({ db, htmlDir: HTML_DIR }));
 app.route('/', makeConfigRouter({
   db, port: PORT, dataDir: DATA_DIR,
   onMcpAutostartChange: (enabled) => mcp.sync(enabled),
-  onActivitySettingsChange: () => configureActivitySamplers(db),
+  onActivitySettingsChange: () => configureActivitySamplers(db, { maybeQueueApplication: queues.maybeQueueApplication }),
   summaryQueue: queues.summaryQueue,
   cloudQueue: queues.cloudQueue,
   digQueue: queues.digQueue,
@@ -286,7 +286,7 @@ startSchedulers({
 
 // ── activity samplers (PC アプリ + Steam) ─────────────────────────────────
 // feature flag が OFF なら no-op (起動時 + 設定変更時に再構成)
-configureActivitySamplers(db);
+configureActivitySamplers(db, { maybeQueueApplication: queues.maybeQueueApplication });
 
 // ---- in-process MQTT subscriber (任意) ----------------------------------
 //

--- a/server/lib/activity-sampler.ts
+++ b/server/lib/activity-sampler.ts
@@ -20,11 +20,19 @@ const DEFAULT_STEAM_INTERVAL_MIN = 60;
 
 let appTimer: ReturnType<typeof setInterval> | null = null;
 let steamTimer: ReturnType<typeof setInterval> | null = null;
+let _maybeQueueApp: ((processName: string, recentTitles?: string[]) => void) | null = null;
 
-export function configureActivitySamplers(db: Db): void {
+export interface ActivitySamplerDeps {
+  /** 新規 process_name を AI 分類するため queues.maybeQueueApplication を渡す。
+   *  渡さなくても sampling 自体は動く (= 分類はスキップ)。 */
+  maybeQueueApplication?: (processName: string, recentTitles?: string[]) => void;
+}
+
+export function configureActivitySamplers(db: Db, deps: ActivitySamplerDeps = {}): void {
   // 都度 clear → 設定に応じて再 schedule
   if (appTimer) { clearInterval(appTimer); appTimer = null; }
   if (steamTimer) { clearInterval(steamTimer); steamTimer = null; }
+  if (deps.maybeQueueApplication) _maybeQueueApp = deps.maybeQueueApplication;
 
   const priv = privacySettings(db);
   const settings = getAppSettings(db);
@@ -59,6 +67,10 @@ export async function sampleAppOnce(db: Db, sampleIntervalSec: number): Promise<
       INSERT INTO app_samples (sampled_at, process_name, window_title, sample_interval_sec)
       VALUES (datetime('now'), ?, ?, ?)
     `).run(fg.process_name, fg.window_title, sampleIntervalSec);
+    // 新規 process_name なら AI 分類を enqueue (= applications カタログ)
+    if (_maybeQueueApp) {
+      _maybeQueueApp(fg.process_name, fg.window_title ? [fg.window_title] : undefined);
+    }
   } catch (e) {
     console.warn('[activity] app sample insert failed:', (e as Error).message);
   }

--- a/server/lib/queues.ts
+++ b/server/lib/queues.ts
@@ -25,9 +25,11 @@ import {
   upsertWeekly, listDiariesInRange,
   getDiarySettings,
   countBookmarksInRange, countVisitEventsInRange, countActivityEventsInRange,
+  insertApplicationPending, getApplication, setApplication,
 } from '../db.js';
 import { summarizeWithClaude } from '../claude.js';
 import { classifyDomain, shouldSkipDomain } from '../domain-catalog.js';
+import { classifyApplication } from '../app-catalog.js';
 import { fetchPageMetadata } from '../page-metadata.js';
 import { extractWordCloud } from '../wordcloud.js';
 import { analyzeMealPhoto, estimateCaloriesFromName } from '../meals.js';
@@ -126,6 +128,7 @@ export interface QueueBundle {
   digQueue: FifoQueue;
   diaryQueue: FifoQueue;
   weeklyQueue: FifoQueue;
+  applicationCatalogQueue: FifoQueue;
   // タスク投入ヘルパ
   enqueueSummary: (id: number) => void;
   enqueueCloud: (id: number, args: { docs: string; label: string }) => void;
@@ -136,6 +139,7 @@ export interface QueueBundle {
   enqueueCalorieEstimate: (mealId: number, additionIdx: number, foodName: string) => void;
   maybeQueuePageMetadata: (url: string) => void;
   maybeQueueDomain: (url: string) => void;
+  maybeQueueApplication: (processName: string, recentTitles?: string[]) => void;
   /** ブクマ要約 push の batch flush (process exit 等の手動起動用) */
   flushBookmarkSummaryPush: () => void;
 }
@@ -150,6 +154,7 @@ export function makeQueues(deps: QueuesDeps): QueueBundle {
   const pageMetadataQueue = new FifoQueue();
   const mealVisionQueue = new FifoQueue();
   const digQueue = new FifoQueue();
+  const applicationCatalogQueue = new FifoQueue();
   const diaryQueue = new FifoQueue();
   const weeklyQueue = new FifoQueue();
 
@@ -298,6 +303,38 @@ export function makeQueues(deps: QueuesDeps): QueueBundle {
         error: null,
       });
     }, { kind: 'domain', domain, title: domain });
+  }
+
+  // ── application catalog (= process_name → AI 分類) ────────────────────
+  //
+  // app_samples insert 時に「初めて見た process_name」 だったら enqueue。
+  // 既に done / pending / error の row があれば skip。 短時間に同じ process が
+  // 何度も sample されても 1 度しか走らない (= INSERT OR IGNORE で行を作って
+  // 既存なら何もしない)。
+  function maybeQueueApplication(processName: string, recentTitles?: string[]): void {
+    const pn = (processName || '').trim();
+    if (!pn) return;
+    if (getApplication(db, pn)) return;
+    insertApplicationPending(db, pn);
+    applicationCatalogQueue.enqueue(async () => {
+      try {
+        const result = await classifyApplication({
+          processName: pn,
+          recentTitles,
+          platform: process.platform,
+        });
+        setApplication(db, pn, {
+          name: result.name,
+          kind: result.kind,
+          description: result.description,
+          status: 'done',
+          error: null,
+        });
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        setApplication(db, pn, { status: 'error', error: msg.slice(0, 500) });
+      }
+    }, { kind: 'application', processName: pn, title: pn });
   }
 
   // ── meal vision ───────────────────────────────────────────────────────
@@ -666,6 +703,7 @@ export function makeQueues(deps: QueuesDeps): QueueBundle {
     digQueue,
     diaryQueue,
     weeklyQueue,
+    applicationCatalogQueue,
     enqueueSummary,
     enqueueCloud,
     enqueueDig,
@@ -675,6 +713,7 @@ export function makeQueues(deps: QueuesDeps): QueueBundle {
     enqueueCalorieEstimate,
     maybeQueuePageMetadata,
     maybeQueueDomain,
+    maybeQueueApplication,
     flushBookmarkSummaryPush: bookmarkPusher.flush,
   };
 }

--- a/server/llm.ts
+++ b/server/llm.ts
@@ -8,13 +8,15 @@ export type LlmTaskName =
   | 'summarize' | 'dig' | 'dig_preview' | 'cloud_extract' | 'cloud_validate'
   | 'domain_classify' | 'page_summary'
   | 'diary_work' | 'diary_highlights' | 'diary_weekly'
-  | 'meal_vision' | 'meal_calorie';
+  | 'meal_vision' | 'meal_calorie'
+  | 'app_classify';
 
 export const TASKS: LlmTaskName[] = [
   'summarize', 'dig', 'dig_preview', 'cloud_extract', 'cloud_validate',
   'domain_classify', 'page_summary',
   'diary_work', 'diary_highlights', 'diary_weekly',
   'meal_vision', 'meal_calorie',
+  'app_classify',
 ];
 
 const TASK_DEFAULT_MODELS: Partial<Record<LlmTaskName, string>> = {
@@ -25,6 +27,7 @@ const TASK_DEFAULT_MODELS: Partial<Record<LlmTaskName, string>> = {
   diary_weekly: 'claude-opus-4-7[1m]',
   meal_vision: 'sonnet',
   meal_calorie: 'sonnet',
+  app_classify: 'sonnet',
 };
 
 export type LlmProviderKey = 'algorithm' | 'claude' | 'codex' | 'gemini' | 'openai';

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -651,6 +651,7 @@
           <button class="wl-subtab" data-sub="dig">🔎 ディグ</button>
           <button class="wl-subtab" data-sub="tracks">🗺 軌跡</button>
           <button class="wl-subtab" data-sub="activity">💻 アプリ</button>
+          <button class="wl-subtab" data-sub="games">🎮 ゲーム</button>
         </nav>
 
         <section id="wlScheduleView" class="wl-sub">
@@ -749,6 +750,18 @@
               </div>
             </div>
           </div>
+          <!-- 仕事時間サマリ (applications.kind='work' な samples の合計) -->
+          <div class="wl-activity-summary" id="wlActivityWorkSummary"></div>
+        </section>
+
+        <!-- 🎮 ゲームログ — Steam スナップショット + applications.kind='game' な samples の混合タイムライン -->
+        <section id="wlGamesView" class="wl-sub hidden">
+          <div class="wl-activity-disabled hidden" id="wlGamesDisabled">
+            <p>🎮 ゲームログには「Steam プレイ統計」 か「PC アプリ使用統計 + applications.kind='game'」 のどちらかが必要です。 <strong>設定 → 🚦 AI 自動処理</strong> で有効化してください。</p>
+          </div>
+          <div class="wl-summary-row" id="wlGamesSummary"></div>
+          <ul id="wlGamesList" class="wl-list"></ul>
+          <div id="wlGamesEmpty" class="queue-empty hidden">この日のゲームログはありません。</div>
         </section>
       </div>
 

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -7670,6 +7670,7 @@ const WL_SUB_VIEWS = {
   dig: 'wlDigView',
   tracks: 'tracksView',
   activity: 'wlActivityView',
+  games: 'wlGamesView',
 };
 
 // データベースタブのサブビュー一覧 (旧 'external' は軌跡タブに統合)
@@ -7775,6 +7776,7 @@ async function loadWorklog() {
   if (sub === 'dig') return loadWorklogDig(date);
   if (sub === 'tracks') return loadTracks();
   if (sub === 'activity') return loadWorklogActivityCard(date);
+  if (sub === 'games') return loadWorklogGamesView(date);
   if (WL_KIND_BY_SUB[sub]) {
     await loadWorklogActivity(date, sub);
     if (sub === 'gemini') await loadGeminiWebResearchLogs(date);
@@ -7828,6 +7830,66 @@ async function saveActivityCredentials() {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
+}
+
+interface WorkTimeRow {
+  date: string;
+  work_total_sec: number;
+  work_total_min: number;
+  work_samples: number;
+  by_kind: Array<{ kind: string; total_sec: number; samples: number }>;
+}
+interface GameLogRow {
+  source: 'steam' | 'app';
+  occurred_at: string;
+  title: string;
+  duration_min?: number;
+  detail?: string;
+  appid?: number;
+  img_icon_url?: string | null;
+}
+
+async function loadWorklogGamesView(date: string) {
+  const disabled = $('wlGamesDisabled');
+  const empty = $('wlGamesEmpty');
+  const list = $('wlGamesList');
+  const summary = $('wlGamesSummary');
+  // settings 読んで案内出し分け
+  let settings: ActivitySettings | null = null;
+  try { settings = await api('/api/activity/settings') as ActivitySettings; } catch { /* swallow */ }
+  if (disabled) disabled.classList.toggle('hidden', !!(settings && (settings.app_sampling || settings.steam_enabled)));
+  try {
+    const r = await api(`/api/activity/games?date=${encodeURIComponent(date)}`) as { date: string; items: GameLogRow[] };
+    if (summary) summary.innerHTML = '';
+    if (list) list.innerHTML = '';
+    if (!r.items?.length) {
+      empty?.classList.remove('hidden');
+      return;
+    }
+    empty?.classList.add('hidden');
+    const totalMin = r.items.reduce((a, b) => a + (b.duration_min ?? 0), 0);
+    if (summary && totalMin > 0) {
+      summary.innerHTML = `<div class="muted">合計 ${totalMin} 分 / ${r.items.length} 件</div>`;
+    }
+    if (list) {
+      list.innerHTML = r.items.map((it) => {
+        const badge = it.source === 'steam'
+          ? '<span class="wl-game-badge wl-game-badge-steam">Steam</span>'
+          : '<span class="wl-game-badge wl-game-badge-app">App</span>';
+        const time = new Date(it.occurred_at.replace(' ', 'T') + 'Z').toLocaleTimeString();
+        const dur = it.duration_min != null ? `${it.duration_min} 分` : '';
+        const detail = it.detail ? `<span class="muted">${escapeHtml(it.detail)}</span>` : '';
+        return `<li class="wl-list-row wl-game-row">
+          ${badge}
+          <span class="wl-list-title">${escapeHtml(it.title)}</span>
+          <span class="wl-list-meta muted">${dur} ・ ${time}</span>
+          ${detail}
+        </li>`;
+      }).join('');
+    }
+  } catch (e) {
+    if (summary) summary.innerHTML = `<div class="muted">取得失敗: ${escapeHtml((e as Error).message)}</div>`;
+  }
 }
 
 async function loadWorklogActivityCard(date: string) {
@@ -7904,6 +7966,37 @@ async function loadWorklogActivityCard(date: string) {
   } else {
     steamEmpty?.classList.remove('hidden');
     if (steamHint) steamHint.textContent = '(features.activity.steam.enabled が OFF)';
+  }
+
+  // 仕事時間サマリ (applications.kind='work' な samples の合計 + kind 別内訳)
+  const sum = $('wlActivityWorkSummary');
+  if (sum) {
+    if (!settings?.app_sampling) {
+      sum.innerHTML = '';
+    } else {
+      try {
+        const w = await api(`/api/activity/work-time?date=${encodeURIComponent(date)}`) as WorkTimeRow;
+        const kindLabels: Record<string, string> = {
+          work: '💼 仕事', game: '🎮 ゲーム', browser: '🌐 ブラウザ',
+          messaging: '💬 メッセージ', media: '🎬 メディア',
+          creative: '🎨 クリエイティブ', other: '❓ その他',
+        };
+        const breakdown = (w.by_kind || []).map((b) => {
+          const min = Math.round((b.total_sec || 0) / 60);
+          return `<span class="wl-kind-stat">${kindLabels[b.kind] || b.kind}: ${min}分</span>`;
+        }).join(' ・ ');
+        const wm = w.work_total_min || 0;
+        const hh = Math.floor(wm / 60);
+        const mm = wm % 60;
+        sum.innerHTML = `
+          <div class="wl-worktime-headline">💼 仕事時間 (kind=work): <strong>${hh}h${mm}m</strong></div>
+          <div class="wl-worktime-breakdown muted">${breakdown}</div>
+          <div class="muted" style="font-size:11px;margin-top:4px">※ applications カタログで kind が判定済みの行のみ集計</div>
+        `;
+      } catch (e) {
+        sum.innerHTML = `<div class="muted">仕事時間取得失敗: ${escapeHtml((e as Error).message)}</div>`;
+      }
+    }
   }
 }
 

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -5263,6 +5263,15 @@ dialog.loc-edit-modal[open] {
 .wl-activity-card .wl-list-meta { font-size: 11px; white-space: nowrap; }
 .wl-activity-card .wl-activity-actions { margin-top: 8px; display: flex; gap: 6px; }
 .wl-activity-disabled { background: var(--accent-bg, #fff8c5); border: 1px solid var(--border); border-radius: 6px; padding: 10px 12px; margin-bottom: 8px; font-size: 12px; }
+.wl-activity-summary { margin-top: 12px; padding: 10px 12px; border: 1px solid var(--border); border-radius: 8px; background: var(--panel, var(--card)); }
+.wl-worktime-headline { font-size: 14px; margin-bottom: 4px; }
+.wl-worktime-breakdown { font-size: 12px; }
+.wl-kind-stat { display: inline-block; padding: 1px 6px; border-radius: 4px; background: var(--accent-bg, transparent); margin: 1px 0; }
+/* 🎮 ゲームログのバッジ */
+.wl-game-row { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+.wl-game-badge { font-size: 10px; padding: 1px 6px; border-radius: 4px; font-weight: 600; }
+.wl-game-badge-steam { background: #1b2838; color: #66c0f4; }
+.wl-game-badge-app { background: var(--accent-bg, #eef); color: var(--text); border: 1px solid var(--border); }
 @media (max-width: 760px) {
   .wl-activity-row { grid-template-columns: 1fr; }
 }

--- a/server/routes/activity.ts
+++ b/server/routes/activity.ts
@@ -3,11 +3,16 @@
 
 import { Hono, type Context } from 'hono';
 import type BetterSqlite3 from 'better-sqlite3';
-import { getAppSettings, setAppSettings } from '../db.js';
+import {
+  getAppSettings, setAppSettings,
+  listApplications, getApplication, setApplication, updateApplicationUser,
+  insertApplicationPending,
+} from '../db.js';
 import { privacySettings } from '../lib/privacy.js';
 import {
   sampleAppOnce, sampleSteamOnce, configureActivitySamplers,
 } from '../lib/activity-sampler.js';
+import { classifyApplication } from '../app-catalog.js';
 
 type Db = BetterSqlite3.Database;
 
@@ -74,6 +79,188 @@ export function makeActivityRouter(deps: ActivityRouterDeps): Hono {
     const sec = Math.max(5, Number(settings['activity.app_sample_sec'] ?? 30));
     await sampleAppOnce(db, sec);
     return c.json({ ok: true });
+  });
+
+  // ── applications カタログ (process_name → AI 分類) ────────────────
+  // GET /api/activity/applications  - 全件
+  r.get('/api/activity/applications', (c: Context) => {
+    const items = listApplications(db, { limit: 1000 });
+    return c.json({ items });
+  });
+
+  // PATCH /api/activity/applications/:processName — ユーザ手動編集
+  r.patch('/api/activity/applications/:processName', async (c: Context) => {
+    const processName = decodeURIComponent(c.req.param('processName') ?? '');
+    if (!processName) return c.json({ error: 'processName required' }, 400);
+    if (!getApplication(db, processName)) {
+      // pending を作成して update_user で上書き
+      insertApplicationPending(db, processName);
+    }
+    const body = await c.req.json().catch(() => ({})) as { name?: unknown; kind?: unknown; description?: unknown };
+    updateApplicationUser(db, processName, {
+      name: typeof body.name === 'string' ? body.name : undefined,
+      kind: typeof body.kind === 'string' ? body.kind : undefined,
+      description: typeof body.description === 'string' ? body.description : undefined,
+    });
+    return c.json({ application: getApplication(db, processName) });
+  });
+
+  // POST /api/activity/applications/:processName/classify-now — 手動 trigger
+  r.post('/api/activity/applications/:processName/classify-now', async (c: Context) => {
+    const processName = decodeURIComponent(c.req.param('processName') ?? '');
+    if (!processName) return c.json({ error: 'processName required' }, 400);
+    insertApplicationPending(db, processName);
+    try {
+      const result = await classifyApplication({ processName, platform: process.platform });
+      setApplication(db, processName, {
+        name: result.name,
+        kind: result.kind,
+        description: result.description,
+        status: 'done',
+        error: null,
+      });
+      return c.json({ application: getApplication(db, processName) });
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setApplication(db, processName, { status: 'error', error: msg.slice(0, 500) });
+      return c.json({ application: getApplication(db, processName), error: msg }, 502);
+    }
+  });
+
+  // ── 🎮 ゲームログ ─────────────────────────────────────────────
+  // GET /api/activity/games?date=YYYY-MM-DD
+  //   Steam スナップショット (source=steam) + applications.kind='game' な
+  //   app_samples (source=app) を時系列マージして返す。
+  interface GameLogRow {
+    source: 'steam' | 'app';
+    occurred_at: string;
+    title: string;       // 表示名
+    duration_min?: number;
+    detail?: string;
+    appid?: number;
+    img_icon_url?: string | null;
+  }
+  r.get('/api/activity/games', (c: Context) => {
+    const dateRaw = c.req.query('date');
+    const date = (typeof dateRaw === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(dateRaw))
+      ? dateRaw
+      : new Date().toISOString().slice(0, 10);
+
+    // 1) Steam — 当日に取られた snapshot を時系列で
+    const steamRows = db.prepare(`
+      SELECT sampled_at, appid, name, playtime_2weeks_min, playtime_forever_min, img_icon_url
+      FROM steam_activity
+      WHERE date(sampled_at, 'localtime') = ?
+      ORDER BY sampled_at ASC
+    `).all(date) as Array<{
+      sampled_at: string; appid: number; name: string;
+      playtime_2weeks_min: number | null; playtime_forever_min: number | null;
+      img_icon_url: string | null;
+    }>;
+
+    // 同じ appid 内で snapshot 間の playtime_forever_min 差分 (= その日の追加プレイ時間)
+    const byApp = new Map<number, typeof steamRows>();
+    for (const row of steamRows) {
+      if (!byApp.has(row.appid)) byApp.set(row.appid, []);
+      byApp.get(row.appid)!.push(row);
+    }
+    const games: GameLogRow[] = [];
+    for (const [appid, rows] of byApp) {
+      // この appid の当日の playtime 増分 = (最新 - 最古) の forever_min 差
+      const first = rows[0]!;
+      const last = rows[rows.length - 1]!;
+      const delta = (last.playtime_forever_min ?? 0) - (first.playtime_forever_min ?? 0);
+      if (delta > 0) {
+        games.push({
+          source: 'steam',
+          occurred_at: last.sampled_at,
+          title: last.name,
+          duration_min: delta,
+          detail: `Steam (${appid})`,
+          appid,
+          img_icon_url: last.img_icon_url,
+        });
+      } else {
+        // snapshot 1 件のみ / 増分 0: 「観測されているがプレイ時間なし」 として
+        // playtime_2weeks_min が大きい (= 最近遊んでた) なら参考表示
+        const p2 = last.playtime_2weeks_min ?? 0;
+        if (p2 > 0) {
+          games.push({
+            source: 'steam',
+            occurred_at: last.sampled_at,
+            title: last.name,
+            duration_min: undefined,
+            detail: `Steam (${appid}) — 直近 2 週: ${p2}分`,
+            appid,
+            img_icon_url: last.img_icon_url,
+          });
+        }
+      }
+    }
+
+    // 2) applications.kind='game' な process_name の当日サンプルを集計
+    const appGameRows = db.prepare(`
+      SELECT s.process_name,
+             SUM(s.sample_interval_sec) AS total_sec,
+             MAX(s.sampled_at)           AS last_at,
+             a.name AS app_name
+      FROM app_samples s
+      JOIN applications a ON a.process_name = s.process_name
+      WHERE date(s.sampled_at, 'localtime') = ?
+        AND a.kind = 'game'
+        AND a.status = 'done'
+      GROUP BY s.process_name
+      ORDER BY total_sec DESC
+    `).all(date) as Array<{ process_name: string; total_sec: number; last_at: string; app_name: string | null }>;
+    for (const row of appGameRows) {
+      games.push({
+        source: 'app',
+        occurred_at: row.last_at,
+        title: row.app_name || row.process_name,
+        duration_min: Math.round(row.total_sec / 60),
+        detail: row.process_name,
+      });
+    }
+
+    // 時系列 (occurred_at) 降順で並べ替え
+    games.sort((a, b) => b.occurred_at.localeCompare(a.occurred_at));
+    return c.json({ date, items: games });
+  });
+
+  // GET /api/activity/work-time?date=YYYY-MM-DD
+  //   applications.kind='work' な process_name の当日合計サンプル時間。
+  r.get('/api/activity/work-time', (c: Context) => {
+    const dateRaw = c.req.query('date');
+    const date = (typeof dateRaw === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(dateRaw))
+      ? dateRaw
+      : new Date().toISOString().slice(0, 10);
+    const row = db.prepare(`
+      SELECT COALESCE(SUM(s.sample_interval_sec), 0) AS total_sec,
+             COUNT(*)                                AS samples
+      FROM app_samples s
+      JOIN applications a ON a.process_name = s.process_name
+      WHERE date(s.sampled_at, 'localtime') = ?
+        AND a.kind = 'work'
+        AND a.status = 'done'
+    `).get(date) as { total_sec: number; samples: number };
+    // kind 別の内訳も返す (UI でカード分類するため)
+    const byKind = db.prepare(`
+      SELECT a.kind,
+             COALESCE(SUM(s.sample_interval_sec), 0) AS total_sec,
+             COUNT(*)                                AS samples
+      FROM app_samples s
+      JOIN applications a ON a.process_name = s.process_name
+      WHERE date(s.sampled_at, 'localtime') = ?
+        AND a.status = 'done'
+      GROUP BY a.kind
+    `).all(date) as Array<{ kind: string; total_sec: number; samples: number }>;
+    return c.json({
+      date,
+      work_total_sec: row.total_sec,
+      work_total_min: Math.round(row.total_sec / 60),
+      work_samples: row.samples,
+      by_kind: byKind,
+    });
   });
 
   // ── Steam ─────────────────────────────────────────────────────────


### PR DESCRIPTION
> base = main、 内容は #138 を passenger に含みます。 #138 マージで diff が clean になります。

## Summary

ユーザ要望:
1. ログに「🎮 ゲーム」 タブを作り、 リスト表示 + Steam 行に [Steam] バッジ
2. DB「アプリケーション」 を用意し、 ドメイン辞書と同じく exe を AI 分類
3. kind='game' のアプリは ゲームログに参入、 kind='work' は仕事時間に換算

## 変更点

### DB
- \`applications\` (process_name PK, name, kind, description, icon_url, user_edited, status, error, classified_at)
- kind: \`game | work | browser | messaging | media | creative | other\`

### Backend
- \`server/app-catalog.ts\` — \`classifyApplication()\` (LLM task=app_classify、 sonnet default)
- \`server/db.ts\` に CRUD ヘルパ (domain_catalog と対称)
- \`server/lib/queues.ts\` に \`applicationCatalogQueue\` + \`maybeQueueApplication\`
- \`server/lib/activity-sampler.ts\` の sampleAppOnce が新規 process_name を見たら自動で AI 分類 enqueue
- \`server/routes/activity.ts\`:
  - \`GET /api/activity/applications\` — カタログ全件
  - \`PATCH /api/activity/applications/:processName\` — 手動編集 (user_edited=1 で AI 上書き保護)
  - \`POST /api/activity/applications/:processName/classify-now\` — 手動 trigger
  - **\`GET /api/activity/games?date=...\`** — Steam スナップショット差分 + applications.kind='game' な samples を時系列マージ
  - **\`GET /api/activity/work-time?date=...\`** — kind='work' な samples 合計 + kind 別内訳

### Frontend
- worklog に「🎮 ゲーム」 サブタブ
  - Steam 行: [Steam] バッジ
  - applications.kind='game' な samples: [App] バッジ
- 「💻 アプリ」 タブの末尾に「💼 仕事時間」 summary 追加 (= kind 別内訳バー付き)

## Test plan
- [ ] 💻 アプリ + 🎮 Steam を ON、 30 秒待つ
- [ ] AI 分類が完了したら applications カタログに kind が埋まる (\`GET /api/activity/applications\`)
- [ ] ゲームタブ → Steam 行が [Steam] バッジ付きで出る
- [ ] kind='game' の non-Steam ゲームを起動 → 数十秒後に分類済み → 同じタブに [App] バッジで出る
- [ ] kind='work' の IDE / ターミナル使用中 → 仕事時間 summary が増える
- [ ] 手動編集 PATCH → user_edited=1 になり、 次回 AI 分類が走っても上書きされない

🤖 Generated with [Claude Code](https://claude.com/claude-code)