### PR TITLE
feat(ui): Multi-server switch をロゴ下に独立行で配置 + 「💡 やり方」 を設定に移動

### DIFF
--- a/server/public/index.html
+++ b/server/public/index.html
@@ -14,11 +14,9 @@
 <body>
   <header class="topbar">
     <div class="brand">Memoria</div>
-    <div id="multiSwitch" class="multi-switch" hidden></div>
     <button id="extensionBadge" type="button" class="ext-badge" hidden></button>
     <div id="queueBadge" class="queue-badge hidden" title="作業中ジョブ数">作業中 <span id="queueCount">0</span></div>
     <div class="topbar-controls">
-      <button id="howToBookmarkBtn" class="ghost topbar-howto" title="ブックマークの追加方法" hidden>💡 やり方</button>
       <button id="legatusBadge" class="ghost topbar-legatus" type="button" title="Legatus 接続状態" hidden>
         <span class="legatus-dot" data-state="unknown">●</span>
         <span class="legatus-label">Legatus</span>
@@ -27,6 +25,10 @@
       <button id="aiSettingsBtn" class="ghost topbar-settings" title="設定">⚙ 設定</button>
     </div>
   </header>
+
+  <!-- Multi-server (Memoria Hub) スイッチ — Memoria ロゴの下、 機能タブの上の独立行。
+       hub に 1 件も登録が無いときは hidden、 1 件以上で表示される。 -->
+  <div id="multiSwitch" class="multi-switch multi-switch-row" hidden></div>
 
   <!-- ── 起動チュートリアル (5 step wizard) ────────────────────────────
        初回起動時 (= app_settings.tutorial.completed_at が空) で自動表示。
@@ -1350,6 +1352,12 @@
           ON にすると <code>--hidden</code> フラグでウィンドウなし起動 → トレイアイコンだけ表示されます。 普段は OS スタートアップに登録するこの方式で十分。 「ログアウト中も動かしたい」 ような用途は将来 Windows サービス化を検討します (別 PR)。
         </p>
       </div>
+      <h4>📌 スマホでブックマークする方法</h4>
+      <p class="ai-settings-help">スマホには Chrome 拡張が使えないので、 Memoria を PWA 化して OS の共有メニューから保存します。 詳細手順:</p>
+      <div class="ai-settings-actions">
+        <button id="howToBookmarkBtnInSettings" class="ghost" type="button">💡 ブックマーク方法を表示</button>
+      </div>
+
       <h4>📱 通知 (WebPush)</h4>
       <p class="ai-settings-help">
         日記生成完了などをこの端末に通知します。

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -4459,20 +4459,15 @@ setupCategoriesDrawer();
 setupExtensionBadge();
 setupHowToBookmark();
 
-// 💡 やり方 button — only shows on mobile (no Chrome extension available).
+// 💡 やり方 (スマホでブックマークする方法) — 旧 topbar の howToBookmarkBtn は
+// 廃止し、 設定 → 🔔 通知 / 端末 内の howToBookmarkBtnInSettings に移動。
+// モバイル幅でしか出さない自動表示も止め、 設定からいつでも開ける形に。
 function setupHowToBookmark() {
-  const btn = $('howToBookmarkBtn');
+  const btn = $('howToBookmarkBtnInSettings');
   const overlay = $('howToBookmarkOverlay');
   const close = $('howToBookmarkClose');
-  if (!btn || !overlay) return;
-  // Show only when viewport is mobile-ish — desktop uses the Chrome
-  // extension, so this prompt isn't relevant.
-  function syncVisibility() {
-    btn.hidden = window.innerWidth > 760;
-  }
-  syncVisibility();
-  window.addEventListener('resize', syncVisibility);
-  btn.addEventListener('click', () => { overlay.hidden = false; });
+  if (!overlay) return;
+  btn?.addEventListener('click', () => { overlay.hidden = false; });
   close?.addEventListener('click', () => { overlay.hidden = true; });
   overlay.addEventListener('click', (e) => {
     if (e.target === overlay) overlay.hidden = true;

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -58,7 +58,8 @@ body {
 .topbar-controls { display: flex; gap: 8px; margin-left: auto; align-items: center; }
 .topbar-settings { margin-left: auto; }
 
-/* Multi-server switch — registered remote pills next to the brand. */
+/* Multi-server switch — registered remote pills. v0.x までは topbar 内
+ * (brand 隣) に置いていたが、 ロゴ下の独立行 (.multi-switch-row) に移動。 */
 .multi-switch {
   display: flex;
   gap: 4px;
@@ -67,6 +68,17 @@ body {
   margin-left: 8px;
 }
 .multi-switch[hidden] { display: none; }
+/* 機能タブ上の独立行版 — Memoria ロゴの下に出る横スクロール可能なバー */
+.multi-switch-row {
+  margin: 0;
+  padding: 6px 12px;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+.multi-switch-row::-webkit-scrollbar { height: 4px; }
+.multi-switch-row::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
 .multi-switch .ms-pill {
   background: var(--bg);
   border: 1px solid var(--border);


### PR DESCRIPTION
## Summary

1. **Multi-server (Memoria Hub) スイッチをロゴ下の独立行に移動**
   - 旧: topbar 内 \`<div class=\"brand\">Memoria</div>\` の直右に並ぶ
   - 新: topbar 外、 機能タブの直上 (\`.multi-switch-row\` で横スクロール対応のバー)
   - 利点: hub 切替が常に視認できる / topbar が混雑しない / hub 未登録時は従来通り hidden

2. **「💡 やり方」 (= スマホでブックマークする方法) を topbar から設定内に移動**
   - 旧: topbar に mobile width で自動表示
   - 新: 設定 → 🔔 通知 / 端末 → 「📌 スマホでブックマークする方法」 セクション の「💡 ブックマーク方法を表示」 ボタン
   - 利点: 設定からいつでも開ける / topbar がさらにスッキリ

## Test plan

- [ ] hub に 1 件以上登録 → ロゴ下に独立行で pill が出る
- [ ] hub 未登録 → 独立行は hidden
- [ ] スマホ width で開いても topbar に 💡 やり方 が出ない
- [ ] 設定 → 🔔 通知 / 端末 で 「💡 ブックマーク方法を表示」 を押すと既存 modal が開く

🤖 Generated with [Claude Code](https://claude.com/claude-code)