### PR TITLE
feat(database): 「💻 アプリ」 サブタブ + worklog activity/games の date toolbar 表示

### DIFF
--- a/server/public/index.html
+++ b/server/public/index.html
@@ -623,12 +623,26 @@
         <div id="queueHistory" class="queue-history-list"></div>
       </div>
 
+      <!-- 💻 アプリ (Application catalog) — process_name 単位の AI 分類カタログ。
+           ドメイン辞書と同じ構造 (= 自動分類 + 手動上書き)。
+           data: app_samples (= sampling 元) / applications (= AI 分類済 row) -->
+      <div id="appsView" class="hidden">
+        <div class="apps-bar">
+          <span id="appsCount" class="muted"></span>
+          <span class="grow"></span>
+          <button id="appsRefresh" class="ghost" title="再読込">↻</button>
+        </div>
+        <div id="appsEmpty" class="queue-empty hidden">applications カタログがまだ空です。 設定 → 🚦 AI 自動処理 で「💻 PC アプリ使用統計」 を ON にすると、 サンプリングされた process_name が AI 分類されてここに表示されます。</div>
+        <ul id="appsList" class="apps-list"></ul>
+      </div>
+
       <div id="databaseView" class="hidden">
         <nav class="worklog-subtabs" id="databaseSubtabs">
           <button class="wl-subtab active" data-db-sub="bookmarks">📚 ブックマーク</button>
           <button class="wl-subtab" data-db-sub="dict">📖 辞書</button>
           <button class="wl-subtab" data-db-sub="domain">🏷 ドメイン</button>
           <button class="wl-subtab" data-db-sub="workplace">🗺️ 作業場所</button>
+          <button class="wl-subtab" data-db-sub="apps">💻 アプリ</button>
           <button class="wl-subtab" data-db-sub="queue">⚙ キュー <span id="dbQueueBadge" class="tab-count hidden">0</span></button>
         </nav>
       </div>

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -7674,6 +7674,7 @@ const DB_SUB_VIEWS = {
   dict: 'dictView',
   domain: 'domainView',
   workplace: 'workplaceView',
+  apps: 'appsView',
   queue: 'queueView',
 };
 
@@ -7707,11 +7708,113 @@ function switchDatabaseSub(sub) {
   if (sub === 'dict') loadDictionary();
   if (sub === 'domain') loadDomainCatalog();
   if (sub === 'workplace') loadWorkLocations().catch(console.warn);
+  if (sub === 'apps') loadApplicationsCatalog().catch(console.warn);
   if (sub === 'queue') renderQueue();
 }
 
+interface ApplicationCatalogRow {
+  process_name: string;
+  name: string | null;
+  kind: string | null;
+  description: string | null;
+  icon_url: string | null;
+  user_edited: 0 | 1;
+  status: string;
+  error: string | null;
+  classified_at: string | null;
+}
+
+const APP_KIND_LABELS: Record<string, string> = {
+  game: '🎮 ゲーム',
+  work: '💼 仕事',
+  browser: '🌐 ブラウザ',
+  messaging: '💬 メッセージ',
+  media: '🎬 メディア',
+  creative: '🎨 クリエイティブ',
+  other: '❓ その他',
+};
+
+async function loadApplicationsCatalog() {
+  const list = $('appsList');
+  const empty = $('appsEmpty');
+  const count = $('appsCount');
+  if (!list) return;
+  try {
+    const r = await api('/api/activity/applications') as { items: ApplicationCatalogRow[] };
+    const items = r.items || [];
+    if (count) count.textContent = `${items.length} 件`;
+    if (items.length === 0) {
+      empty?.classList.remove('hidden');
+      list.innerHTML = '';
+      return;
+    }
+    empty?.classList.add('hidden');
+    list.innerHTML = items.map((it) => {
+      const kindOptions = Object.entries(APP_KIND_LABELS).map(([k, label]) =>
+        `<option value="${k}"${it.kind === k ? ' selected' : ''}>${label}</option>`
+      ).join('');
+      const statusBadge = it.status === 'done' ? '✓' : it.status === 'error' ? '⚠' : '⟳';
+      const edited = it.user_edited ? '<span class="apps-edited" title="手動編集済み">✎</span>' : '';
+      return `<li class="apps-row" data-process="${escapeHtml(it.process_name)}">
+        <div class="apps-row-head">
+          <span class="apps-status">${statusBadge}</span>
+          <code class="apps-process">${escapeHtml(it.process_name)}</code>
+          ${edited}
+          <span class="grow"></span>
+          <button class="ghost apps-reclassify" data-process="${escapeHtml(it.process_name)}" title="AI 分類を再実行">↻ 再分類</button>
+        </div>
+        <div class="apps-row-body">
+          <label class="apps-field">
+            <span>名前</span>
+            <input class="apps-name" type="text" value="${escapeHtml(it.name || '')}" placeholder="(未分類)" />
+          </label>
+          <label class="apps-field">
+            <span>種類</span>
+            <select class="apps-kind">
+              <option value="">--</option>
+              ${kindOptions}
+            </select>
+          </label>
+          <label class="apps-field apps-field-wide">
+            <span>説明</span>
+            <input class="apps-desc" type="text" value="${escapeHtml(it.description || '')}" placeholder="(未分類)" />
+          </label>
+        </div>
+        ${it.error ? `<div class="apps-error muted">⚠ ${escapeHtml(it.error)}</div>` : ''}
+      </li>`;
+    }).join('');
+    // 行ごとに save (blur で自動保存) + 再分類ボタン配線
+    list.querySelectorAll<HTMLLIElement>('.apps-row').forEach((row) => {
+      const processName = row.dataset.process || '';
+      const save = async () => {
+        const name = (row.querySelector<HTMLInputElement>('.apps-name')?.value || '').trim();
+        const kind = row.querySelector<HTMLSelectElement>('.apps-kind')?.value || '';
+        const description = (row.querySelector<HTMLInputElement>('.apps-desc')?.value || '').trim();
+        try {
+          await api(`/api/activity/applications/${encodeURIComponent(processName)}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name, kind, description }),
+          });
+        } catch (e) { console.warn('app patch failed:', (e as Error).message); }
+      };
+      row.querySelector('.apps-name')?.addEventListener('blur', save);
+      row.querySelector('.apps-desc')?.addEventListener('blur', save);
+      row.querySelector('.apps-kind')?.addEventListener('change', save);
+      row.querySelector('.apps-reclassify')?.addEventListener('click', async () => {
+        try {
+          await api(`/api/activity/applications/${encodeURIComponent(processName)}/classify-now`, { method: 'POST' });
+          await loadApplicationsCatalog();
+        } catch (e) { alert(`再分類失敗: ${(e as Error).message}`); }
+      });
+    });
+  } catch (e) {
+    if (count) count.textContent = `取得失敗: ${(e as Error).message}`;
+  }
+}
+
 // 日付ベースの sub かどうか (date toolbar / summary 表示の有無)
-const WL_DATE_BASED = new Set(['schedule', 'github', 'claude', 'gemini', 'codex', 'browsing', 'dig', 'tracks']);
+const WL_DATE_BASED = new Set(['schedule', 'github', 'claude', 'gemini', 'codex', 'browsing', 'dig', 'tracks', 'activity', 'games']);
 
 const WL_KIND_BY_SUB = {
   github: 'git_commit',
@@ -7745,6 +7848,7 @@ migrateDatabaseSubViews();
 document.querySelectorAll('#databaseSubtabs [data-db-sub]').forEach(btn => {
   btn.addEventListener('click', () => switchDatabaseSub(btn.dataset.dbSub));
 });
+$('appsRefresh')?.addEventListener('click', () => void loadApplicationsCatalog());
 
 function switchWorklogSub(sub) {
   if (!WL_SUB_VIEWS[sub]) return;

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -5279,6 +5279,24 @@ dialog.loc-edit-modal[open] {
 .wl-worktime-headline { font-size: 14px; margin-bottom: 4px; }
 .wl-worktime-breakdown { font-size: 12px; }
 .wl-kind-stat { display: inline-block; padding: 1px 6px; border-radius: 4px; background: var(--accent-bg, transparent); margin: 1px 0; }
+/* 💻 アプリケーションカタログ (Database → アプリ) */
+.apps-bar { display: flex; align-items: center; gap: 8px; margin: 8px 0; }
+.apps-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 6px; }
+.apps-row { padding: 8px 12px; border: 1px solid var(--border); border-radius: 6px; background: var(--panel, var(--card)); display: flex; flex-direction: column; gap: 6px; }
+.apps-row-head { display: flex; align-items: center; gap: 8px; font-size: 12px; }
+.apps-status { font-size: 14px; }
+.apps-process { background: var(--bg, transparent); padding: 1px 6px; border-radius: 3px; font-size: 12px; }
+.apps-edited { color: var(--accent, #2a6df4); font-size: 11px; }
+.apps-reclassify { font-size: 11px; padding: 2px 8px; }
+.apps-row-body { display: grid; grid-template-columns: minmax(120px, 1fr) minmax(120px, 1fr) 2fr; gap: 8px; }
+.apps-field { display: flex; flex-direction: column; font-size: 11px; gap: 2px; }
+.apps-field span { color: var(--muted); }
+.apps-field input, .apps-field select { font-size: 12px; padding: 3px 6px; width: 100%; box-sizing: border-box; }
+.apps-error { font-size: 11px; }
+@media (max-width: 760px) {
+  .apps-row-body { grid-template-columns: 1fr; }
+}
+
 /* 🎮 ゲームログのバッジ */
 .wl-game-row { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
 .wl-game-badge { font-size: 10px; padding: 1px 6px; border-radius: 4px; font-weight: 600; }


### PR DESCRIPTION
## Summary

ユーザ報告:
1. **ログのアプリとゲームが遷移できない** — date toolbar が消えて見えなくなる問題
2. **データベースに「アプリ」 がない** — #139 で applications カタログを実装したが UI が無かった

## 修正

### 1. データベース → 💻 アプリ サブタブ
- データベースタブに新規サブタブ追加 (ドメインの隣)
- \`#appsView\` で process_name 単位のカード一覧
  - status badge / process_name / 「↻ 再分類」 ボタン
  - name / kind (select 7 種類) / description のインライン編集 (blur で自動保存 → user_edited=1)
  - エラーは行末に表示
- \`DB_SUB_VIEWS.apps = 'appsView'\`
- \`switchDatabaseSub('apps')\` → \`loadApplicationsCatalog()\`

### 2. worklog の activity / games で date toolbar が消える問題
- 旧 \`WL_DATE_BASED\` に activity / games が無く、 サブタブ選択時に dateBar が hidden になっていた
- 両 sub に **date 別表示** があるので WL_DATE_BASED に追加 → date toolbar が出る

## Test plan
- [ ] データベース → 💻 アプリ で applications 一覧が出る
- [ ] 名前 / kind / 説明 を編集 → blur で自動保存、 再リロードしても保持
- [ ] 「↻ 再分類」 で AI 分類が再走り、 結果が反映
- [ ] ✎ マーカーが手動編集行に出る (= user_edited=1)
- [ ] worklog → 💻 アプリ / 🎮 ゲーム で date toolbar が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)