### PR TITLE
feat(activity): Steam appid → name 解決 + applications に同時登録

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -400,8 +400,8 @@ export function openDb(dbPath: string): Db {
     -- Steam Store API (= keyless) で appid → name を解決するキャッシュ。
     -- VDF fallback で uninstalled な appid は appmanifest_<appid>.acf が無いので
     -- 「appid:XXXXX」 にしか出来ない。 起動後に Store API で resolve して
-    -- このテーブルに入れる → 以後の表示で name を上書き。 30 日でリフレッシュ。
-    -- not_found=1 は Store API が 404/false を返した (= delisted や private) 印。
+    -- このテーブルに入れる → 以後の表示で name を上書き。 一度解決した name は
+    -- 永続化する (= 再取得しない)。 not_found=1 (= delisted/private) のみ 7 日後に再試行。
     CREATE TABLE IF NOT EXISTS steam_apps_cache (
       appid           INTEGER PRIMARY KEY,
       name            TEXT,
@@ -2120,17 +2120,19 @@ export function upsertSteamAppCache(db: Db, appid: number, patch: SteamAppCacheP
   );
 }
 
-/** 30 日経過した行 + 未解決 (not_found=0 だが name が null) は stale 扱い */
+/** キャッシュ未解決の appid を steam_activity から拾う。
+ *  - キャッシュ row 自体が無い appid
+ *  - 過去 not_found=1 で記録されたが name が後で復活する可能性があるので、 7 日経った
+ *    not_found のみ再試行 (= 完全に永続化、 ただし delisted 復帰は拾う)
+ *  解決済 (name あり) はもう再取得しない (= ゲーム名は永続化)。 */
 export function listStaleAppidsFromActivity(db: Db, limit = 100): number[] {
   const rows = db.prepare(`
     SELECT DISTINCT sa.appid
     FROM steam_activity sa
     LEFT JOIN steam_apps_cache c ON c.appid = sa.appid
     WHERE
-      -- まだキャッシュ自体が無い
       c.appid IS NULL
-      -- もしくは 30 日以上前のフレッシュなものを再確認 (not_found=1 を含む)
-      OR julianday('now') - julianday(c.fetched_at) > 30
+      OR (c.not_found = 1 AND julianday('now') - julianday(c.fetched_at) > 7)
     ORDER BY sa.id DESC
     LIMIT ?
   `).all(limit) as Array<{ appid: number }>;

--- a/server/db.ts
+++ b/server/db.ts
@@ -397,6 +397,21 @@ export function openDb(dbPath: string): Db {
     CREATE INDEX IF NOT EXISTS idx_steam_activity_at ON steam_activity(sampled_at DESC);
     CREATE INDEX IF NOT EXISTS idx_steam_activity_app ON steam_activity(appid, sampled_at);
 
+    -- Steam Store API (= keyless) で appid → name を解決するキャッシュ。
+    -- VDF fallback で uninstalled な appid は appmanifest_<appid>.acf が無いので
+    -- 「appid:XXXXX」 にしか出来ない。 起動後に Store API で resolve して
+    -- このテーブルに入れる → 以後の表示で name を上書き。 30 日でリフレッシュ。
+    -- not_found=1 は Store API が 404/false を返した (= delisted や private) 印。
+    CREATE TABLE IF NOT EXISTS steam_apps_cache (
+      appid           INTEGER PRIMARY KEY,
+      name            TEXT,
+      header_image    TEXT,
+      type            TEXT,
+      short_desc      TEXT,
+      fetched_at      TEXT NOT NULL DEFAULT (datetime('now')),
+      not_found       INTEGER NOT NULL DEFAULT 0
+    );
+
     CREATE TABLE IF NOT EXISTS push_subscriptions (
       id          INTEGER PRIMARY KEY AUTOINCREMENT,
       endpoint    TEXT NOT NULL UNIQUE,
@@ -2051,6 +2066,75 @@ export function updateApplicationUser(db: Db, processName: string, patch: Applic
 
 export function deleteApplication(db: Db, processName: string): void {
   db.prepare(`DELETE FROM applications WHERE process_name = ?`).run(processName);
+}
+
+// ── steam_apps_cache (Store API resolved appid → name) -------------------
+
+export interface SteamAppCacheRow {
+  appid: number;
+  name: string | null;
+  header_image: string | null;
+  type: string | null;
+  short_desc: string | null;
+  fetched_at: string;
+  not_found: number;
+}
+
+export function getSteamAppCache(db: Db, appid: number): SteamAppCacheRow | null {
+  return (db.prepare(`SELECT * FROM steam_apps_cache WHERE appid = ?`).get(appid) as SteamAppCacheRow | undefined) ?? null;
+}
+
+export function getSteamAppsCacheMap(db: Db, appids: number[]): Map<number, SteamAppCacheRow> {
+  if (!appids.length) return new Map();
+  const placeholders = appids.map(() => '?').join(',');
+  const rows = db.prepare(`SELECT * FROM steam_apps_cache WHERE appid IN (${placeholders})`).all(...appids) as SteamAppCacheRow[];
+  return new Map(rows.map(r => [r.appid, r]));
+}
+
+export interface SteamAppCachePatch {
+  name?: string | null;
+  header_image?: string | null;
+  type?: string | null;
+  short_desc?: string | null;
+  not_found?: boolean;
+}
+
+export function upsertSteamAppCache(db: Db, appid: number, patch: SteamAppCachePatch): void {
+  db.prepare(`
+    INSERT INTO steam_apps_cache (appid, name, header_image, type, short_desc, fetched_at, not_found)
+    VALUES (?, ?, ?, ?, ?, datetime('now'), ?)
+    ON CONFLICT(appid) DO UPDATE SET
+      name = excluded.name,
+      header_image = excluded.header_image,
+      type = excluded.type,
+      short_desc = excluded.short_desc,
+      fetched_at = excluded.fetched_at,
+      not_found = excluded.not_found
+  `).run(
+    appid,
+    patch.name ?? null,
+    patch.header_image ?? null,
+    patch.type ?? null,
+    patch.short_desc ?? null,
+    patch.not_found ? 1 : 0,
+  );
+}
+
+/** 30 日経過した行 + 未解決 (not_found=0 だが name が null) は stale 扱い */
+export function listStaleAppidsFromActivity(db: Db, limit = 100): number[] {
+  const rows = db.prepare(`
+    SELECT DISTINCT sa.appid
+    FROM steam_activity sa
+    LEFT JOIN steam_apps_cache c ON c.appid = sa.appid
+    WHERE
+      -- まだキャッシュ自体が無い
+      c.appid IS NULL
+      -- もしくは 30 日以上前のフレッシュなものを再確認 (not_found=1 を含む)
+      OR julianday('now') - julianday(c.fetched_at) > 30
+    ORDER BY sa.id DESC
+    LIMIT ?
+  `).all(limit) as Array<{ appid: number }>;
+  return rows.map(r => r.appid);
 }
 
 // ── server events (uptime / downtime / lifecycle) -------------------------

--- a/server/lib/activity-sampler.ts
+++ b/server/lib/activity-sampler.ts
@@ -58,6 +58,12 @@ export function configureActivitySamplers(db: Db, deps: ActivitySamplerDeps = {}
     steamTimer = setInterval(() => { void sampleSteamOnce(db); }, steamMin * 60_000);
     steamTimer.unref?.();
     console.log(`[activity] steam sampler started — interval ${steamMin}m`);
+    // 起動時に未解決 appid (= 既存の `appid:XXXXX` rows) を resolve 走らせる。
+    // snapshot insert 後にも fire-and-forget で走るが、 新規 snapshot が無くても
+    // 過去ぶんを後追いで埋められるようにここでも 1 度叩く。
+    void resolveUnresolvedSteamApps(db).catch((e) => {
+      console.warn('[activity] steam app resolve (boot) failed:', (e as Error).message);
+    });
   }
 }
 

--- a/server/lib/activity-sampler.ts
+++ b/server/lib/activity-sampler.ts
@@ -8,9 +8,16 @@
 
 import type BetterSqlite3 from 'better-sqlite3';
 import { getForegroundApp } from './app-activity-sampler.js';
-import { getRecentlyPlayedGames, type SteamGameSnapshot } from './steam-client.js';
+import { fetchAppDetails, getRecentlyPlayedGames, type SteamGameSnapshot } from './steam-client.js';
 import { getRecentlyPlayedFromVdf } from './steam-vdf.js';
-import { getAppSettings } from '../db.js';
+import {
+  getAppSettings,
+  getApplication,
+  insertApplicationPending,
+  listStaleAppidsFromActivity,
+  setApplication,
+  upsertSteamAppCache,
+} from '../db.js';
 import { privacySettings } from './privacy.js';
 
 type Db = BetterSqlite3.Database;
@@ -125,5 +132,98 @@ export async function sampleSteamOnce(db: Db): Promise<{ source: 'api' | 'vdf' |
   } catch (e) {
     console.warn('[activity] steam snapshot insert failed:', (e as Error).message);
   }
+
+  // VDF 経路は uninstalled な appid の name が「appid:XXXXX」 になる。
+  // Store API (= keyless) で resolve してキャッシュ + applications にも反映する。
+  // ここは await しても OK だが UX のため snapshot insert を先に返したいので fire-and-forget。
+  void resolveUnresolvedSteamApps(db).catch((e) => {
+    console.warn('[activity] steam app resolve failed:', (e as Error).message);
+  });
+
   return { source, count: games.length };
+}
+
+// ── Steam Store API で appid → name 解決 ───────────────────────────────
+//
+// 動作:
+//   1. steam_activity に存在するが steam_apps_cache が無い (= 未解決) appid を抽出
+//   2. 1 つずつ Store API を叩く (rate-limit 配慮で 600ms 間隔)
+//   3. 結果を steam_apps_cache に upsert
+//   4. 同時に applications テーブルにも `steam:<appid>` の row を作る
+//      (= ゲームリスト / アプリ一覧から横断的に見えるように)
+//
+// 1 回の呼び出しで最大 RESOLVE_BATCH_LIMIT 件まで処理する。
+
+const RESOLVE_BATCH_LIMIT = 30;
+const RESOLVE_INTERVAL_MS = 600;
+
+export async function resolveUnresolvedSteamApps(db: Db): Promise<{ resolved: number; notFound: number; errors: number }> {
+  const appids = listStaleAppidsFromActivity(db, RESOLVE_BATCH_LIMIT);
+  if (appids.length === 0) return { resolved: 0, notFound: 0, errors: 0 };
+
+  let resolved = 0;
+  let notFound = 0;
+  let errors = 0;
+
+  for (let i = 0; i < appids.length; i++) {
+    const appid = appids[i]!;
+    const r = await fetchAppDetails(appid);
+    if (!r.ok) {
+      errors++;
+      console.debug(`[activity] steam appdetails ${appid} error:`, r.error);
+    } else if (r.notFound) {
+      notFound++;
+      upsertSteamAppCache(db, appid, { not_found: true });
+    } else if (r.details) {
+      resolved++;
+      upsertSteamAppCache(db, appid, {
+        name: r.details.name,
+        header_image: r.details.header_image,
+        type: r.details.type,
+        short_desc: r.details.short_description,
+        not_found: false,
+      });
+      registerSteamApplication(db, appid, r.details.name, r.details.type, r.details.short_description, r.details.header_image);
+      // steam_activity 側の name も上書き (= appid:XXXXX → 正式名)
+      try {
+        db.prepare(`UPDATE steam_activity SET name = ? WHERE appid = ? AND name LIKE 'appid:%'`).run(r.details.name, appid);
+      } catch (e) {
+        console.debug('[activity] steam_activity name update failed:', (e as Error).message);
+      }
+    }
+    if (i < appids.length - 1) {
+      await new Promise((res) => setTimeout(res, RESOLVE_INTERVAL_MS));
+    }
+  }
+  if (resolved || notFound || errors) {
+    console.log(`[activity] steam resolve — resolved=${resolved} notFound=${notFound} errors=${errors}`);
+  }
+  return { resolved, notFound, errors };
+}
+
+/** Steam appid を applications テーブルに登録 / 更新する。
+ *  process_name には `steam:<appid>` を使う (exe 名と衝突しない) 。
+ *  Store API の `type` が game/demo なら kind='game'、 その他は 'other'。 */
+function registerSteamApplication(
+  db: Db,
+  appid: number,
+  name: string,
+  type: string,
+  shortDesc: string | null,
+  headerImage: string | null,
+): void {
+  const processName = `steam:${appid}`;
+  const kind = (type === 'game' || type === 'demo') ? 'game' : 'other';
+  // 既存行が無ければ pending を作って setApplication で埋める (user_edited=1 は触らない)
+  if (!getApplication(db, processName)) {
+    insertApplicationPending(db, processName);
+  }
+  setApplication(db, processName, {
+    name,
+    kind,
+    description: shortDesc,
+    icon_url: headerImage,
+    status: 'done',
+    error: null,
+  });
 }

--- a/server/lib/steam-client.ts
+++ b/server/lib/steam-client.ts
@@ -76,3 +76,67 @@ export async function getRecentlyPlayedGames(
     return { ok: false, error: `steam api: ${msg}`, games: [] };
   }
 }
+
+// ── Store API (= keyless) で appid → name 解決 ──────────────────────────
+//
+// localconfig.vdf の appid のうち steamapps/appmanifest_<appid>.acf が無い
+// (= uninstalled) ものは VDF からは name を出せない。 そこで公開 Store API
+// で resolve する。 こちらは API key 不要。
+//
+// 仕様 (rate limit など): https://wiki.teamfortress.com/wiki/User:RJackson/StorefrontAPI
+// 体感で 1 req/sec 程度なら問題なし。 呼び出し側で連投しない。
+
+export interface SteamStoreAppDetails {
+  appid: number;
+  name: string;
+  type: string;                    // 'game' | 'dlc' | 'demo' | 'tool' | 'music' | ...
+  header_image: string | null;
+  short_description: string | null;
+}
+
+export interface FetchAppDetailsResult {
+  ok: boolean;
+  error?: string;
+  /** Store API が `success: false` (= delisted/private) を明示で返した */
+  notFound?: boolean;
+  details?: SteamStoreAppDetails;
+}
+
+export async function fetchAppDetails(
+  appid: number,
+  opts: { timeoutMs?: number; lang?: string } = {},
+): Promise<FetchAppDetailsResult> {
+  if (!Number.isFinite(appid) || appid <= 0) {
+    return { ok: false, error: 'invalid appid' };
+  }
+  const lang = (opts.lang || 'japanese').trim();
+  const url = `https://store.steampowered.com/api/appdetails?appids=${appid}&l=${encodeURIComponent(lang)}`;
+  try {
+    const res = await fetch(url, {
+      headers: { 'Accept': 'application/json' },
+      signal: AbortSignal.timeout(opts.timeoutMs ?? 10_000),
+    });
+    if (!res.ok) return { ok: false, error: `store api ${res.status}` };
+    const json = await res.json() as Record<string, unknown>;
+    const entry = json?.[String(appid)] as { success?: boolean; data?: Record<string, unknown> } | undefined;
+    if (!entry) return { ok: false, error: 'store api: empty response' };
+    if (entry.success === false) return { ok: true, notFound: true };
+    const data = entry.data;
+    if (!data || typeof data !== 'object') return { ok: false, error: 'store api: missing data' };
+    const name = typeof data.name === 'string' ? data.name : '';
+    if (!name) return { ok: false, error: 'store api: missing name' };
+    return {
+      ok: true,
+      details: {
+        appid,
+        name,
+        type: typeof data.type === 'string' ? data.type : 'game',
+        header_image: typeof data.header_image === 'string' ? data.header_image : null,
+        short_description: typeof data.short_description === 'string' ? data.short_description : null,
+      },
+    };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: `store api: ${msg}` };
+  }
+}

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -749,6 +749,7 @@
               <div id="wlActivitySteamEmpty" class="queue-empty hidden">Steam の snapshot はまだありません。 ON 後 1 時間以内 (もしくは「いますぐ取得」 ボタン) で表示されます。</div>
               <div class="wl-activity-actions">
                 <button id="wlActivitySteamSampleNow" class="ghost" type="button">🔄 いますぐ取得</button>
+                <button id="wlActivitySteamResolveNow" class="ghost" type="button" title="未インストールのゲームを Steam Store API で解決し、 名前を埋めます">🏷️ 名前を解決</button>
               </div>
             </div>
           </div>

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -8402,6 +8402,23 @@ $('wlActivitySteamSampleNow')?.addEventListener('click', async () => {
     if (btn) { btn.disabled = false; btn.textContent = '🔄 いますぐ取得'; }
   }
 });
+$('wlActivitySteamResolveNow')?.addEventListener('click', async () => {
+  const btn = $('wlActivitySteamResolveNow') as HTMLButtonElement | null;
+  if (btn) { btn.disabled = true; btn.textContent = '解決中…'; }
+  try {
+    const r = await api('/api/activity/steam/resolve-now', { method: 'POST' }) as { resolved: number; notFound: number; errors: number };
+    alert(`Steam 名前解決 — ${r.resolved} 件解決 / ${r.notFound} 件見つからず / ${r.errors} 件エラー`);
+    if (state.tab === 'worklog' && state.worklog?.sub === 'activity') {
+      void loadWorklogActivityCard(state.worklog.date);
+    } else if (state.tab === 'worklog' && state.worklog?.sub === 'games') {
+      void loadWorklogGamesView(state.worklog.date);
+    }
+  } catch (e) {
+    alert(`Steam 名前解決失敗: ${(e as Error).message}`);
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = '🏷️ 名前を解決'; }
+  }
+});
 $('wlGeminiWebSaveBtn')?.addEventListener('click', () => {
   saveGeminiWebResearchLog().catch((e) => {
     console.error(e);

--- a/server/routes/activity.ts
+++ b/server/routes/activity.ts
@@ -11,6 +11,7 @@ import {
 import { privacySettings } from '../lib/privacy.js';
 import {
   sampleAppOnce, sampleSteamOnce, configureActivitySamplers,
+  resolveUnresolvedSteamApps,
 } from '../lib/activity-sampler.js';
 import { classifyApplication } from '../app-catalog.js';
 
@@ -146,12 +147,19 @@ export function makeActivityRouter(deps: ActivityRouterDeps): Hono {
       ? dateRaw
       : new Date().toISOString().slice(0, 10);
 
-    // 1) Steam — 当日に取られた snapshot を時系列で
+    // 1) Steam — 当日に取られた snapshot を時系列で。
+    //    steam_apps_cache に解決済 name があれば優先 (= VDF 由来の `appid:XXXXX` を上書き)
     const steamRows = db.prepare(`
-      SELECT sampled_at, appid, name, playtime_2weeks_min, playtime_forever_min, img_icon_url
-      FROM steam_activity
-      WHERE date(sampled_at, 'localtime') = ?
-      ORDER BY sampled_at ASC
+      SELECT sa.sampled_at,
+             sa.appid,
+             COALESCE(NULLIF(c.name, ''), sa.name) AS name,
+             sa.playtime_2weeks_min,
+             sa.playtime_forever_min,
+             COALESCE(sa.img_icon_url, c.header_image) AS img_icon_url
+      FROM steam_activity sa
+      LEFT JOIN steam_apps_cache c ON c.appid = sa.appid
+      WHERE date(sa.sampled_at, 'localtime') = ?
+      ORDER BY sa.sampled_at ASC
     `).all(date) as Array<{
       sampled_at: string; appid: number; name: string;
       playtime_2weeks_min: number | null; playtime_forever_min: number | null;
@@ -268,13 +276,18 @@ export function makeActivityRouter(deps: ActivityRouterDeps): Hono {
   //   uniq して返す (= 最新の playtime_2weeks_min 順)
   r.get('/api/activity/steam/recent', (c: Context) => {
     const rows = db.prepare(`
-      SELECT appid, name, playtime_2weeks_min, playtime_forever_min,
-             img_icon_url, sampled_at
-      FROM steam_activity
-      WHERE id IN (
+      SELECT sa.appid,
+             COALESCE(NULLIF(c.name, ''), sa.name) AS name,
+             sa.playtime_2weeks_min,
+             sa.playtime_forever_min,
+             COALESCE(sa.img_icon_url, c.header_image) AS img_icon_url,
+             sa.sampled_at
+      FROM steam_activity sa
+      LEFT JOIN steam_apps_cache c ON c.appid = sa.appid
+      WHERE sa.id IN (
         SELECT MAX(id) FROM steam_activity GROUP BY appid
       )
-      ORDER BY COALESCE(playtime_2weeks_min, 0) DESC, sampled_at DESC
+      ORDER BY COALESCE(sa.playtime_2weeks_min, 0) DESC, sa.sampled_at DESC
       LIMIT 50
     `).all() as SteamDayRow[];
     return c.json({ items: rows });
@@ -283,6 +296,12 @@ export function makeActivityRouter(deps: ActivityRouterDeps): Hono {
   // POST /api/activity/steam/sample-now — 手動 snapshot 取得
   r.post('/api/activity/steam/sample-now', async (c: Context) => {
     const r2 = await sampleSteamOnce(db);
+    return c.json(r2);
+  });
+
+  // POST /api/activity/steam/resolve-now — Store API で未解決 appid を resolve
+  r.post('/api/activity/steam/resolve-now', async (c: Context) => {
+    const r2 = await resolveUnresolvedSteamApps(db);
     return c.json(r2);
   });
 


### PR DESCRIPTION
## Summary
- VDF fallback で uninstalled な Steam ゲームの name が「`appid:4216070`」 のままだった問題を解消
- Steam Store API (= keyless) で appid → name を resolve し `steam_apps_cache` に保存 (30 日 TTL)
- 同時に `applications` テーブルへも `steam:<appid>` で登録 (kind='game') — ログ / ゲームタブ / アプリ DB から横断的に名前が見える
- 既存の `steam_activity` 側の name も「`appid:`」 のものは正式名に上書き
- UI: 「🏷️ 名前を解決」 ボタンを Steam カードに追加 (= 手動 resolve)

## 仕組み
1. `sampleSteamOnce` snapshot 後に `resolveUnresolvedSteamApps(db)` を fire-and-forget で呼ぶ
2. `steam_activity` にあるが `steam_apps_cache` に無い (or 30 日以上前の) appid を最大 30 件抽出
3. Store API を 600ms 間隔で叩いて name / type / header_image / short_description を取得
4. `steam_apps_cache` + `applications` (process_name=`steam:<appid>`) に upsert
5. 表示クエリは `steam_activity LEFT JOIN steam_apps_cache` で name を上書き

## Test plan
- [ ] Memoria 起動後、 Steam サンプルが取れた状態で「🏷️ 名前を解決」 を押す → uninstalled ゲームの「`appid:XXXXX`」 が正式名に置き換わる
- [ ] データベース → アプリ で `steam:<appid>` 行が kind=game で並ぶ
- [ ] 30 日経過すると自動で再 resolve される (= 改名対応)
- [ ] private / delisted な appid は `not_found=1` で再リトライされない

🤖 Generated with [Claude Code](https://claude.com/claude-code)