### PR TITLE
feat(multi): Hub への Bearer を Cernere user_for_project token に切替 (memory only)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -212,6 +212,25 @@ const httpServer = serve({ fetch: app.fetch, port: PORT }, (info) => {
   console.log(`  claude bin: ${CLAUDE_BIN}`);
 });
 
+// 起動時の Cernere project-token 事前取得 — 「起動時に必ず認証を通す」 ポリシー。
+// 接続済みサーバごとに user-JWT → Cernere /api/auth/project-token → memory cache。
+// 失敗してもプロセスは落とさず、 該当 Hub への次の操作で再試行される。
+void import('./local/multi-client.js').then(async ({ readMultiServers, isConnected }) => {
+  const { getProjectTokenForHub } = await import('./lib/cernere-session.js');
+  const projectKey = process.env.CERNERE_PROJECT_KEY ?? 'memoria';
+  const { servers } = readMultiServers(db);
+  for (const s of servers) {
+    const state = { ...s, label: s.label } as const;
+    if (!isConnected(state as never)) continue;
+    try {
+      await getProjectTokenForHub(s.url, s.jwt as string, projectKey);
+      console.log(`[cernere] startup auth ok — hub=${s.url} project=${projectKey}`);
+    } catch (e) {
+      console.warn(`[cernere] startup auth failed — hub=${s.url}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+});
+
 // 起動時に未解決 GPS の backfill を 1 batch だけ走らせる. listen 直後でなく
 // 5 秒遅延させて、 Memoria 起動直後のバタつき (server / WS / RAG init) と
 // 重ならないようにする. API key 未設定なら全件 'failed' で帰すので副作用なし.

--- a/server/lib/cernere-session.ts
+++ b/server/lib/cernere-session.ts
@@ -1,0 +1,116 @@
+/**
+ * Cernere project-token のメモリ専用キャッシュ。
+ *
+ * Memoria local backend は Cernere に永続的な long-lived service secret を持たない。
+ * 代わりに、 ログイン中ユーザの user-JWT を Cernere `/api/auth/project-token` に渡して
+ * 「このユーザの memoria-hub 向け short-lived token」 を都度受け取り、 in-memory のみで
+ * 保持する。 プロセス再起動で消える / disk に出ない / user・AI ともに値を直接見ない。
+ *
+ * Cernere 側エンドポイント:
+ *   POST /api/auth/project-token
+ *   Authorization: Bearer <user-JWT>
+ *   body: { project_key: "memoria" }
+ *   → { accessToken, expiresIn, projectKey, userId }
+ */
+
+const REFRESH_LEEWAY_SEC = 60;
+const CERNERE_BASE_URL = (process.env.CERNERE_BASE_URL ?? 'http://localhost:8080').replace(/\/$/, '');
+
+interface CachedToken {
+  accessToken: string;
+  expSec: number;
+  projectKey: string;
+  userId: string;
+}
+
+/** key = hubUrl (末尾 `/` 無し). 1 user-context あたり 1 entry。 */
+const cache = new Map<string, CachedToken>();
+/** 同時呼び出しを 1 本にまとめる */
+const inflight = new Map<string, Promise<CachedToken>>();
+
+function nowSec(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+function decodeExp(token: string): number | null {
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  try {
+    const p = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+    return typeof p.exp === 'number' ? p.exp : null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchProjectToken(userJwt: string, projectKey: string): Promise<CachedToken> {
+  const res = await fetch(`${CERNERE_BASE_URL}/api/auth/project-token`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${userJwt}`,
+    },
+    body: JSON.stringify({ project_key: projectKey }),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Cernere /api/auth/project-token failed: ${res.status} ${body.slice(0, 200)}`);
+  }
+  const data = await res.json() as {
+    accessToken: string; expiresIn?: number; projectKey: string; userId: string;
+  };
+  const exp = decodeExp(data.accessToken) ?? (nowSec() + (data.expiresIn ?? 3600));
+  return { accessToken: data.accessToken, expSec: exp, projectKey: data.projectKey, userId: data.userId };
+}
+
+/**
+ * `hubUrl` 向けの project-token をメモリから返す。 期限切れなら Cernere に再要求。
+ *
+ * @param hubUrl       Hub の base URL (例 `http://localhost:5280`). キャッシュキー。
+ * @param userJwt      Cernere user JWT (ログイン中ユーザの accessToken)。 backend memory にあるもの。
+ * @param projectKey   Cernere managed_projects.key (例 `memoria`)
+ */
+export async function getProjectTokenForHub(
+  hubUrl: string,
+  userJwt: string,
+  projectKey: string,
+): Promise<string> {
+  const key = hubUrl.replace(/\/$/, '');
+  const hit = cache.get(key);
+  if (hit && hit.expSec - REFRESH_LEEWAY_SEC > nowSec()) return hit.accessToken;
+  const pending = inflight.get(key);
+  if (pending) return (await pending).accessToken;
+
+  const task = (async () => {
+    try {
+      const t = await fetchProjectToken(userJwt, projectKey);
+      cache.set(key, t);
+      return t;
+    } finally {
+      inflight.delete(key);
+    }
+  })();
+  inflight.set(key, task);
+  return (await task).accessToken;
+}
+
+/** 401/403 を受けたら呼んで次回再取得を強制する。 */
+export function invalidateProjectToken(hubUrl: string): void {
+  cache.delete(hubUrl.replace(/\/$/, ''));
+}
+
+/** 全 Hub の cache を捨てる (disconnect 時)。 */
+export function clearAllProjectTokens(): void {
+  cache.clear();
+  inflight.clear();
+}
+
+/** 状況確認用 — token 値そのものは絶対に出さない。 */
+export function getCacheSummary(): Array<{ hubUrl: string; projectKey: string; userId: string; expSec: number }> {
+  return Array.from(cache.entries()).map(([hubUrl, t]) => ({
+    hubUrl,
+    projectKey: t.projectKey,
+    userId: t.userId,
+    expSec: t.expSec,
+  }));
+}

--- a/server/local/multi-client.ts
+++ b/server/local/multi-client.ts
@@ -9,6 +9,14 @@
 // one-entry list with that URL active.
 import type BetterSqlite3 from 'better-sqlite3';
 import { getAppSettings, setAppSettings } from '../db/index.js';
+import { getProjectTokenForHub, invalidateProjectToken } from '../lib/cernere-session.js';
+
+/**
+ * Hub への Bearer に使う project-token を Cernere から取得 (memory-cached)。
+ * Cernere unreachable 等で失敗したら fall-through せず throw する — 「起動時に
+ * 必ず認証を通す」 ポリシーに従い、 user-JWT を Hub に直送りはしない。
+ */
+const CERNERE_PROJECT_KEY = process.env.CERNERE_PROJECT_KEY ?? 'memoria';
 
 type Db = BetterSqlite3.Database;
 
@@ -246,9 +254,10 @@ export async function multiFetch<T = Record<string, unknown>>(
 ): Promise<T> {
   if (!isConnected(state)) throw new Error('not connected to a multi server');
   const url = `${state.url.replace(/\/$/, '')}${path}`;
+  const bearer = await getProjectTokenForHub(state.url, state.jwt, CERNERE_PROJECT_KEY);
   const headers: Record<string, string> = {
     ...(init.headers || {}),
-    'Authorization': `Bearer ${state.jwt}`,
+    'Authorization': `Bearer ${bearer}`,
     'X-Memoria-Origin': 'local',
   };
   if (init.body && !headers['Content-Type']) headers['Content-Type'] = 'application/json';
@@ -257,6 +266,7 @@ export async function multiFetch<T = Record<string, unknown>>(
   let body: unknown;
   try { body = text ? JSON.parse(text) : null; } catch { body = text; }
   if (!res.ok) {
+    if (res.status === 401 || res.status === 403) invalidateProjectToken(state.url);
     const msg = (body && typeof body === 'object' && 'error' in body && typeof (body as { error: unknown }).error === 'string')
       ? (body as { error: string }).error
       : `HTTP ${res.status}`;

--- a/server/multi/docker-compose.yml
+++ b/server/multi/docker-compose.yml
@@ -46,6 +46,9 @@ services:
       CERNERE_SERVICE_CODE: ${CERNERE_SERVICE_CODE:-memoria-hub}
       CERNERE_SERVICE_SECRET: ${CERNERE_SERVICE_SECRET}
       SERVICE_JWT_SECRET: ${SERVICE_JWT_SECRET}
+      # Hub の authMiddleware が Bearer JWT を HS256 検証するための共有鍵。
+      # Cernere の JWT_SECRET と必ず同値にする (Infisical 経由で揃えるのが本筋)。
+      CERNERE_JWT_SECRET: ${CERNERE_JWT_SECRET}
       MEMORIA_HUB_ALLOWED_ORIGINS: ${MEMORIA_HUB_ALLOWED_ORIGINS}
     ports:
       - "${MEMORIA_HUB_HOST_PORT:-5280}:5280"

--- a/server/routes/multi.ts
+++ b/server/routes/multi.ts
@@ -30,7 +30,10 @@ import { resolveUnresolvedBatch, getResolverDebug } from '../lib/place-resolver.
 import { fetchPageHtml } from '../lib/fetch-page.js';
 import { featureEnabled } from '../lib/privacy.js';
 import { checkIngestKey } from '../lib/ingest-auth.js';
+import { getProjectTokenForHub } from '../lib/cernere-session.js';
 import type { LocationBroadcastPoint, PlaceResolveResult } from '../lib/ws-locations.js';
+
+const CERNERE_PROJECT_KEY = process.env.CERNERE_PROJECT_KEY ?? 'memoria';
 
 type Db = BetterSqlite3.Database;
 
@@ -161,10 +164,17 @@ export function makeMultiRouter(deps: MultiRouterDeps): Hono {
     }
     const qs = new URL(c.req.url).search;
     const upstream = `${state.url.replace(/\/$/, '')}${path}${qs}`;
+    let bearer: string;
+    try {
+      bearer = await getProjectTokenForHub(state.url, state.jwt, CERNERE_PROJECT_KEY);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return c.json({ error: `cernere project-token failed: ${msg}` }, 502);
+    }
     const init: RequestInit & { headers: Record<string, string> } = {
       method,
       headers: {
-        'Authorization': `Bearer ${state.jwt}`,
+        'Authorization': `Bearer ${bearer}`,
         'Accept': 'application/json',
       },
     };


### PR DESCRIPTION
## Summary
- Memoria local backend が Memoria Hub を叩く際、 これまで raw な user-JWT をそのまま Bearer に乗せていたのを、 Cernere `POST /api/auth/project-token` で発行する **per-(user, project) short-lived token** 経由に変更。
- 取得した token は backend process の **memory のみ** に保持。 SQLite / Infisical / log には書き出さない。 ユーザも AI も値を直接見ない設計。
- 起動時に「接続済みサーバ」 ごとに project-token を eager fetch (= 「起動時に必ず認証を通す」)。 401/403 を受けたら自動 invalidate → 次回呼び出しで再取得。

## 変更点
- 新: `server/lib/cernere-session.ts` — Hub URL をキーにした in-memory token cache。 同時呼び出しは inflight でまとめる。 expiry 60 秒前 refresh。
- `server/local/multi-client.ts` (`multiFetch`) — Bearer を project-token に差し替え。
- `server/routes/multi.ts` (`proxyMulti`) — 同上。 Cernere 不到達なら 502。
- `server/index.ts` 起動 hook — 接続済みサーバごとに project-token を pre-warm。
- `server/multi/docker-compose.yml` — `CERNERE_JWT_SECRET` の env pass-through 追加 (今まで `.env` に書いても container に届かなかった bug fix)。

## Env
- `CERNERE_BASE_URL`  既定 `http://localhost:8080`
- `CERNERE_PROJECT_KEY`  既定 `memoria`

## 依存
- LUDIARS/Cernere#89 (`POST /api/auth/project-token` 実装) を先にマージする必要あり。 マージ前は Cernere 不到達 → proxy/share が 502 になる。

## Test plan
- [ ] 既存の `/api/multi/connect` → `/api/multi/finish` で user-JWT 保存 → backend log に `[cernere] startup auth ok` が出る (restart 後)
- [ ] `/api/multi/share` で bookmark/dig/dict/impl/work-location を共有して 200
- [ ] `/api/multi/proxy/api/shared/bookmarks` で 200 (project-token 経由)
- [ ] Cernere を停止して `/api/multi/share` → 502 (cernere project-token failed) が出る
- [ ] Hub の docker-compose recreate 後、 `docker exec multi-hub-1 env | grep CERNERE_JWT_SECRET` で値が見える

🤖 Generated with [Claude Code](https://claude.com/claude-code)