### PR TITLE
feat(review): 🔍 レビュータブ — AIFormat レビュー閲覧 (ludiars-review skill 連携)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -55,6 +55,7 @@ import { makeNoteRouter } from './routes/note.js';
 import { makeConfigRouter } from './routes/config.js';
 import { makeMultiRouter } from './routes/multi.js';
 import { makeMiscRouter } from './routes/misc.js';
+import { makeReviewRouter } from './routes/review.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PORT = Number(process.env.MEMORIA_PORT ?? 5180);
@@ -189,6 +190,7 @@ app.route('/', makeMultiRouter({
   triggerResolveAsync: ws.triggerResolveAsync,
 }));
 app.route('/', makeMiscRouter({ db, htmlDir: HTML_DIR, bulkSaveDeps }));
+app.route('/', makeReviewRouter());
 
 // ---- static UI ------------------------------------------------------------
 

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -302,6 +302,9 @@
           <button class="tab" data-tab="meals">
             <span class="tab-label" data-full="🍽 食事" data-short="🍽 食事">🍽 食事</span>
           </button>
+          <button class="tab" data-tab="review">
+            <span class="tab-label" data-full="🔍 レビュー" data-short="🔍 レビュ">🔍 レビュー</span>
+          </button>
           <!-- マルチビューはトップバーのマルチスイッチからのみアクセス。
                機能タブからは外す (PC/スマホ共通)。 -->
         </div>
@@ -861,6 +864,25 @@
         <div class="tracks-days">
           <h4>記録のある日</h4>
           <ul id="tracksDays" class="tracks-days-list"></ul>
+        </div>
+      </div>
+
+      <div id="reviewView" class="hidden">
+        <div class="bookmarks-toolbar">
+          <span class="muted">LUDIARS 全サービスの AIFormat レビュー (skill `ludiars-review` が生成)</span>
+          <span class="grow"></span>
+          <button id="reviewRefresh" class="ghost" type="button">更新</button>
+        </div>
+        <div class="bookmarks-layout">
+          <aside class="bookmarks-categories" id="reviewRepoList">
+            <h3>リポジトリ</h3>
+            <ul id="reviewRepoUl"></ul>
+          </aside>
+          <div class="bookmarks-main">
+            <div id="reviewDetail" class="muted" style="padding:16px">
+              左のリポジトリを選択するとレビューが表示されます。
+            </div>
+          </div>
         </div>
       </div>
 

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -1084,6 +1084,7 @@ function switchTab(tab) {
   $('digView').classList.toggle('hidden', tab !== 'dig');
   $('diaryView').classList.toggle('hidden', tab !== 'diary');
   $('mealsView')?.classList.toggle('hidden', tab !== 'meals');
+  $('reviewView')?.classList.toggle('hidden', tab !== 'review');
   $('notesView')?.classList.toggle('hidden', tab !== 'notes');
   $('tasksView')?.classList.toggle('hidden', tab !== 'tasks');
   $('implView')?.classList.toggle('hidden', tab !== 'impl');
@@ -1099,6 +1100,7 @@ function switchTab(tab) {
   if (tab === 'dig') loadDigHistory();
   if (tab === 'diary') loadDiary();
   if (tab === 'meals') loadMeals();
+  if (tab === 'review') loadReviewRepos();
   if (tab === 'notes') void notesLoad();
   if (tab === 'tasks') loadTasks();
   if (tab === 'impl') loadImplementationNotes();
@@ -10002,6 +10004,109 @@ document.addEventListener('click', (ev) => {
     setTimeout(() => { btn.textContent = orig; }, 1500);
   }).catch(() => {});
 });
+
+// ── review (LUDIARS AIFormat レビュー閲覧) ────────────────────────────────
+const reviewState = { repos: [], selected: null, dates: [], currentDate: null, currentFile: 'REVIEW.md' };
+const REVIEW_FILES_UI = [
+  ['REVIEW.md', '総合'],
+  ['REVIEW_DESIGN.md', '設計'],
+  ['REVIEW_VULNERABILITY.md', '脆弱性'],
+  ['REVIEW_IMPLEMENTATION.md', '実装'],
+  ['REVIEW_MISSING_FEATURES.md', '不足機能'],
+  ['REVIEW_QUALITY.md', '品質'],
+];
+
+async function loadReviewRepos() {
+  const ul = document.getElementById('reviewRepoUl');
+  if (!ul) return;
+  try {
+    const r = await api('/api/review/repos');
+    reviewState.repos = r.items || [];
+    if (reviewState.repos.length === 0) {
+      ul.innerHTML = '<li class="muted">レビューが見つかりません。 <code>/ludiars-review</code> を実行してください。</li>';
+      return;
+    }
+    ul.innerHTML = reviewState.repos.map((it) => {
+      const score = it.weighted_score ? `<span class="badge">${escapeHtml(it.weighted_score)}</span>` : '';
+      const date = it.latest_date ? `<small class="muted">${escapeHtml(it.latest_date)}</small>` : '';
+      const warn = (it.critical_count > 0 || it.high_count > 0)
+        ? `<small style="color:#d97706">⚠ C${it.critical_count}/H${it.high_count}</small>` : '';
+      return `<li><a href="#" data-review-repo="${escapeHtml(it.repo)}">${escapeHtml(it.repo)}</a> ${score} ${date} ${warn}</li>`;
+    }).join('');
+    ul.querySelectorAll('a[data-review-repo]').forEach((a) => {
+      a.addEventListener('click', (ev) => {
+        ev.preventDefault();
+        const repo = a.getAttribute('data-review-repo');
+        if (repo) void loadReviewDetail(repo);
+      });
+    });
+  } catch (e) {
+    ul.innerHTML = `<li class="hint">読み込みエラー: ${escapeHtml(e.message)}</li>`;
+  }
+}
+
+async function loadReviewDetail(repo) {
+  const detail = document.getElementById('reviewDetail');
+  if (!detail) return;
+  detail.innerHTML = '<div class="muted" style="padding:16px">読み込み中…</div>';
+  try {
+    const r = await api(`/api/review/repos/${encodeURIComponent(repo)}`);
+    reviewState.selected = repo;
+    reviewState.dates = r.dates || [];
+    reviewState.currentDate = r.dates?.[0] ?? null;
+    if (!reviewState.currentDate) {
+      detail.innerHTML = `<div class="hint">${escapeHtml(repo)}: レビューフォルダはありますが日付ディレクトリが見つかりません。</div>`;
+      return;
+    }
+    renderReviewDetail();
+  } catch (e) {
+    detail.innerHTML = `<div class="hint">読み込みエラー: ${escapeHtml(e.message)}</div>`;
+  }
+}
+
+async function renderReviewDetail() {
+  const detail = document.getElementById('reviewDetail');
+  if (!detail || !reviewState.selected || !reviewState.currentDate) return;
+  const dateOptions = reviewState.dates.map((d) =>
+    `<option value="${escapeHtml(d)}"${d === reviewState.currentDate ? ' selected' : ''}>${escapeHtml(d)}</option>`).join('');
+  const fileTabs = REVIEW_FILES_UI.map(([f, label]) =>
+    `<button type="button" class="tab${f === reviewState.currentFile ? ' active' : ''}" data-review-file="${f}">${escapeHtml(label)}</button>`).join('');
+  detail.innerHTML = `
+    <div style="padding:8px 16px;display:flex;gap:12px;align-items:center;flex-wrap:wrap;border-bottom:1px solid var(--border)">
+      <strong>${escapeHtml(reviewState.selected)}</strong>
+      <label class="muted">日付 <select id="reviewDateSel">${dateOptions}</select></label>
+    </div>
+    <nav class="tabs" style="padding:0 16px">${fileTabs}</nav>
+    <pre id="reviewBody" style="padding:16px;white-space:pre-wrap;font-family:var(--mono, monospace);font-size:13px;line-height:1.5">読み込み中…</pre>`;
+  document.getElementById('reviewDateSel')?.addEventListener('change', (ev) => {
+    reviewState.currentDate = ev.target.value;
+    void loadReviewFile();
+  });
+  detail.querySelectorAll('button[data-review-file]').forEach((b) => {
+    b.addEventListener('click', () => {
+      reviewState.currentFile = b.getAttribute('data-review-file') || 'REVIEW.md';
+      detail.querySelectorAll('button[data-review-file]').forEach((x) =>
+        x.classList.toggle('active', x.getAttribute('data-review-file') === reviewState.currentFile));
+      void loadReviewFile();
+    });
+  });
+  await loadReviewFile();
+}
+
+async function loadReviewFile() {
+  const body = document.getElementById('reviewBody');
+  if (!body || !reviewState.selected || !reviewState.currentDate) return;
+  const url = `/api/review/repos/${encodeURIComponent(reviewState.selected)}/${reviewState.currentDate}/${reviewState.currentFile}`;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) { body.textContent = `${res.status}: ${await res.text()}`; return; }
+    body.textContent = await res.text();
+  } catch (e) {
+    body.textContent = `読み込みエラー: ${e.message}`;
+  }
+}
+
+document.getElementById('reviewRefresh')?.addEventListener('click', () => void loadReviewRepos());
 
 async function loadMeals() {
   const list = document.getElementById('mealsList');

--- a/server/routes/review.ts
+++ b/server/routes/review.ts
@@ -1,0 +1,116 @@
+// /api/review/* — LUDIARS 全リポの review/ フォルダを横断閲覧する。
+//
+// Skill `ludiars-review` が各リポの `review/<YYYY-MM-DD>/REVIEW_*.md` と
+// `review/latest.json` を書き出す。 このルータはそれをファイルシステム
+// 経由でそのまま返すだけ (DB は使わない)。
+
+import { Hono, type Context } from 'hono';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const LUDIARS_ROOT = resolve(process.env.LUDIARS_ROOT ?? 'E:/Document/Ars');
+
+const REVIEW_FILES = [
+  'REVIEW.md',
+  'REVIEW_DESIGN.md',
+  'REVIEW_VULNERABILITY.md',
+  'REVIEW_IMPLEMENTATION.md',
+  'REVIEW_MISSING_FEATURES.md',
+  'REVIEW_QUALITY.md',
+] as const;
+
+type ReviewFile = typeof REVIEW_FILES[number];
+
+interface LatestJson {
+  date: string;
+  weighted_score?: string;
+  scores?: Record<string, string>;
+  critical_count?: number;
+  high_count?: number;
+  fix_pr?: string | null;
+}
+
+function safeRepoName(name: string): string | null {
+  // path traversal 防止 — 英数字 / ハイフン / アンダースコア / ドットのみ許可、 先頭ドット禁止
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(name)) return null;
+  if (name.includes('..')) return null;
+  return name;
+}
+
+function safeDate(s: string): string | null {
+  return /^\d{4}-\d{2}-\d{2}$/.test(s) ? s : null;
+}
+
+function safeFile(name: string): ReviewFile | null {
+  return (REVIEW_FILES as readonly string[]).includes(name) ? (name as ReviewFile) : null;
+}
+
+function reviewDir(repo: string): string {
+  return join(LUDIARS_ROOT, repo, 'review');
+}
+
+function readLatest(repo: string): LatestJson | null {
+  const p = join(reviewDir(repo), 'latest.json');
+  if (!existsSync(p)) return null;
+  try { return JSON.parse(readFileSync(p, 'utf8')) as LatestJson; } catch { return null; }
+}
+
+function listDates(repo: string): string[] {
+  const dir = reviewDir(repo);
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((n) => safeDate(n) && statSync(join(dir, n)).isDirectory())
+    .sort()
+    .reverse();
+}
+
+function listReviewedRepos(): string[] {
+  if (!existsSync(LUDIARS_ROOT)) return [];
+  const out: string[] = [];
+  for (const name of readdirSync(LUDIARS_ROOT)) {
+    if (!safeRepoName(name)) continue;
+    const dir = reviewDir(name);
+    if (existsSync(dir) && statSync(dir).isDirectory()) out.push(name);
+  }
+  return out.sort();
+}
+
+export function makeReviewRouter(): Hono {
+  const r = new Hono();
+
+  r.get('/api/review/repos', (c: Context) => {
+    const items = listReviewedRepos().map((repo) => {
+      const latest = readLatest(repo);
+      return {
+        repo,
+        latest_date: latest?.date ?? null,
+        weighted_score: latest?.weighted_score ?? null,
+        critical_count: latest?.critical_count ?? 0,
+        high_count: latest?.high_count ?? 0,
+        fix_pr: latest?.fix_pr ?? null,
+      };
+    });
+    return c.json({ items, root: LUDIARS_ROOT });
+  });
+
+  r.get('/api/review/repos/:repo', (c: Context) => {
+    const repo = safeRepoName(c.req.param('repo') ?? '');
+    if (!repo) return c.json({ error: 'invalid repo' }, 400);
+    const dates = listDates(repo);
+    const latest = readLatest(repo);
+    return c.json({ repo, dates, latest });
+  });
+
+  r.get('/api/review/repos/:repo/:date/:file', (c: Context) => {
+    const repo = safeRepoName(c.req.param('repo') ?? '');
+    const date = safeDate(c.req.param('date') ?? '');
+    const file = safeFile(c.req.param('file') ?? '');
+    if (!repo || !date || !file) return c.json({ error: 'invalid path' }, 400);
+    const p = join(reviewDir(repo), date, file);
+    if (!existsSync(p)) return c.json({ error: 'not_found' }, 404);
+    const text = readFileSync(p, 'utf8');
+    return c.body(text, 200, { 'Content-Type': 'text/markdown; charset=utf-8' });
+  });
+
+  return r;
+}


### PR DESCRIPTION
## Summary

LUDIARS 全リポの AIFormat レビュー (skill [`ludiars-review`](https://github.com/LUDIARS/AIFormat) が `review/<YYYY-MM-DD>/REVIEW_*.md` を生成) を Memoria 上で横断閲覧するタブを追加。

- 新ルータ `server/routes/review.ts` — `LUDIARS_ROOT` (既定 `E:/Document/Ars`) 配下の `<repo>/review/` を直接読む。 path traversal 対策込み。
- 🔍 レビュータブ + reviewView を追加。 左ペインにリポ一覧 (latest_date + 重み付きスコア + Critical/High 数 + fix_pr リンク)、 右ペインに日付セレクト + 6 ファイルタブ (総合 / 設計 / 脆弱性 / 実装 / 不足機能 / 品質)。

## 連動する scheduled routine

朝 5:07 JST の cloud routine [\`ludiars-review-daily\`](https://claude.ai/code/routines/trig_01QHgXWxTbLSsMWXoTHKAUq4) が各 LUDIARS リポに review PR を投げる。 ユーザがローカル \`git pull\` した後、 このタブから確認できる。

## API

| Method | Path | 説明 |
|---|---|---|
| GET | \`/api/review/repos\` | レビューがあるリポ一覧 + 各 latest.json サマリ |
| GET | \`/api/review/repos/:repo\` | 1 リポの日付一覧 + latest |
| GET | \`/api/review/repos/:repo/:date/:file\` | Markdown 本文 |

## Test plan

- [ ] サーバ起動後 \`GET /api/review/repos\` が空配列を返す (skill 未実行時)
- [ ] \`/ludiars-review Mm\` 等で local に \`review/\` フォルダを作った後、 タブで Memoria が表示される
- [ ] 日付セレクトを切り替えると過去レビューが見られる
- [ ] 不正な repo / date / file 名で 400 / 404 を返す (path traversal 対策)

🤖 Generated with [Claude Code](https://claude.com/claude-code)