### PR TITLE
refactor(review): タブをデータベース内に移動 + カード形式 + リポをカテゴリ化

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -412,6 +412,20 @@ export function openDb(dbPath: string): Db {
       not_found       INTEGER NOT NULL DEFAULT 0
     );
 
+    -- レビュー対象リポジトリ。 ludiars-review skill (= cloud routine) が
+    -- iterate するリスト。 起動時に LUDIARS_ROOT 配下の git clone を seed し、
+    -- ユーザは UI から任意のローカルパスを足せる。 format_key は将来カスタム
+    -- フォーマットを追加するための拡張点 (現状は 'aiformat' のみ)。
+    CREATE TABLE IF NOT EXISTS review_targets (
+      id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      name        TEXT NOT NULL UNIQUE,
+      local_path  TEXT NOT NULL UNIQUE,
+      format_key  TEXT NOT NULL DEFAULT 'aiformat',
+      enabled     INTEGER NOT NULL DEFAULT 1,
+      created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_review_targets_enabled ON review_targets(enabled);
+
     CREATE TABLE IF NOT EXISTS push_subscriptions (
       id          INTEGER PRIMARY KEY AUTOINCREMENT,
       endpoint    TEXT NOT NULL UNIQUE,
@@ -2308,6 +2322,75 @@ export function gameUsageForDate(db: Db, dateStr: string, limit = 20): GameUsage
     ORDER BY minutes_played DESC
     LIMIT ?
   `).all(dateStr, limit) as GameUsageRow[];
+}
+
+// ─── review_targets ──────────────────────────────────────────────────────────
+export interface ReviewTargetRow {
+  id: number;
+  name: string;
+  local_path: string;
+  format_key: string;
+  enabled: number;          // 1 or 0
+  created_at: string;
+}
+
+export function listReviewTargets(db: Db, { enabledOnly = false }: { enabledOnly?: boolean } = {}): ReviewTargetRow[] {
+  const where = enabledOnly ? 'WHERE enabled = 1' : '';
+  return db.prepare(`
+    SELECT id, name, local_path, format_key, enabled, created_at
+    FROM review_targets
+    ${where}
+    ORDER BY name ASC
+  `).all() as ReviewTargetRow[];
+}
+
+export function getReviewTargetByName(db: Db, name: string): ReviewTargetRow | undefined {
+  return db.prepare(
+    `SELECT id, name, local_path, format_key, enabled, created_at
+     FROM review_targets WHERE name = ?`,
+  ).get(name) as ReviewTargetRow | undefined;
+}
+
+export function insertReviewTarget(
+  db: Db,
+  { name, local_path, format_key = 'aiformat' }: { name: string; local_path: string; format_key?: string },
+): number {
+  const r = db.prepare(
+    `INSERT INTO review_targets (name, local_path, format_key) VALUES (?, ?, ?)`,
+  ).run(name, local_path, format_key);
+  return Number(r.lastInsertRowid);
+}
+
+/** 既存があれば何もしない (= INSERT OR IGNORE)。 戻り値: 新規に挿入したら true */
+export function insertReviewTargetIfMissing(
+  db: Db,
+  { name, local_path, format_key = 'aiformat' }: { name: string; local_path: string; format_key?: string },
+): boolean {
+  const r = db.prepare(
+    `INSERT OR IGNORE INTO review_targets (name, local_path, format_key) VALUES (?, ?, ?)`,
+  ).run(name, local_path, format_key);
+  return r.changes > 0;
+}
+
+export function updateReviewTarget(
+  db: Db,
+  id: number,
+  patch: { name?: string; local_path?: string; format_key?: string; enabled?: 0 | 1 },
+): void {
+  const set: string[] = [];
+  const args: unknown[] = [];
+  if (typeof patch.name === 'string') { set.push('name = ?'); args.push(patch.name); }
+  if (typeof patch.local_path === 'string') { set.push('local_path = ?'); args.push(patch.local_path); }
+  if (typeof patch.format_key === 'string') { set.push('format_key = ?'); args.push(patch.format_key); }
+  if (patch.enabled === 0 || patch.enabled === 1) { set.push('enabled = ?'); args.push(patch.enabled); }
+  if (set.length === 0) return;
+  args.push(id);
+  db.prepare(`UPDATE review_targets SET ${set.join(', ')} WHERE id = ?`).run(...args);
+}
+
+export function deleteReviewTarget(db: Db, id: number): boolean {
+  const r = db.prepare(`DELETE FROM review_targets WHERE id = ?`).run(id);
+  return r.changes > 0;
 }
 
 export function activityEventsForDate(db: Db, dateStr: string): ActivityEventParsed[] {

--- a/server/db.ts
+++ b/server/db.ts
@@ -2250,6 +2250,66 @@ export interface ActivityEventParsed extends Omit<ActivityEventRow, 'ingested_at
  * 内部集計 (hourly bucket / kind 別件数) で全部欲しい時用。
  * UI のリスト表示には activityEventsPage を使うこと。
  */
+/** 当日 (local) のフォアグラウンドアプリ使用時間を process_name 単位で集計する。
+ *  applications カタログ (AI 分類済) に LEFT JOIN して name / kind / icon_url を返す。
+ *  total_sec = 全 sample 区間の合計、 active_sec = input_active=1 のみの合計。
+ *  上位 50 件 (total_sec 降順) で打ち切る。 */
+export interface AppUsageRow {
+  process_name: string;
+  name: string | null;
+  kind: string | null;
+  icon_url: string | null;
+  total_sec: number;
+  active_sec: number;
+  samples: number;
+}
+export function appUsageForDate(db: Db, dateStr: string, limit = 50): AppUsageRow[] {
+  return db.prepare(`
+    SELECT
+      s.process_name,
+      app.name        AS name,
+      app.kind        AS kind,
+      app.icon_url    AS icon_url,
+      CAST(COALESCE(SUM(s.sample_interval_sec), 0) AS INTEGER) AS total_sec,
+      CAST(COALESCE(SUM(CASE WHEN s.input_active = 1 THEN s.sample_interval_sec ELSE 0 END), 0) AS INTEGER) AS active_sec,
+      COUNT(*) AS samples
+    FROM app_samples s
+    LEFT JOIN applications app ON app.process_name = s.process_name
+    WHERE date(s.sampled_at, 'localtime') = ?
+    GROUP BY s.process_name, app.name, app.kind, app.icon_url
+    ORDER BY total_sec DESC
+    LIMIT ?
+  `).all(dateStr, limit) as AppUsageRow[];
+}
+
+/** 当日 (local) の Steam ゲームプレイ時間を appid 別に集計する。
+ *  playtime_forever_min の MAX - MIN を「その日にプレイした分」 とみなす
+ *  (= Steam が回した間の delta が露出されるカラム)。 Steam がその日まったく
+ *  起動しなかった appid は 0 件で含まれない。 1 分以上プレイした行のみ。 */
+export interface GameUsageRow {
+  appid: number;
+  name: string | null;
+  minutes_played: number;
+  first_at: string;
+  last_at: string;
+}
+export function gameUsageForDate(db: Db, dateStr: string, limit = 20): GameUsageRow[] {
+  return db.prepare(`
+    SELECT
+      appid,
+      MAX(name) AS name,
+      CAST(MAX(playtime_forever_min) - MIN(playtime_forever_min) AS INTEGER) AS minutes_played,
+      MIN(sampled_at) AS first_at,
+      MAX(sampled_at) AS last_at
+    FROM steam_activity
+    WHERE date(sampled_at, 'localtime') = ?
+    GROUP BY appid
+    HAVING MAX(playtime_forever_min) - MIN(playtime_forever_min) > 0
+    ORDER BY minutes_played DESC
+    LIMIT ?
+  `).all(dateStr, limit) as GameUsageRow[];
+}
+
 export function activityEventsForDate(db: Db, dateStr: string): ActivityEventParsed[] {
   const rows = db.prepare(`
     SELECT id, kind, occurred_at, source, ref_id, content, metadata_json

--- a/server/diary.ts
+++ b/server/diary.ts
@@ -9,7 +9,9 @@ import {
   visitEventsForDate, getDomainCatalogMap, digSessionsForDate,
   listServerEventsForDate, listGpsLocationsForDate, listMealsForDate,
   getAppSettings, activityEventsForDate,
+  appUsageForDate, gameUsageForDate,
 } from './db.js';
+import type { AppUsageRow, GameUsageRow } from './db.js';
 import { runLlm } from './llm.js';
 import type { VisitEventRow } from './db/types/visit.js';
 import type { ActivityKind } from './db/types/activity.js';
@@ -248,11 +250,40 @@ export interface AggregatedDay {
   meals_pfc_label: string | null;
   caloric_balance: CaloricBalance | null;
   activity: ActivitySummary;
+  apps: AppUsageSummary | null;
+  games: GameUsageSummary | null;
   sources: {
     visit_events: number;
     page_visits: number;
     activity_events: number;
   };
+}
+
+export interface AppUsageItem {
+  process_name: string;
+  display_name: string;
+  kind: string | null;
+  minutes: number;
+  active_minutes: number;
+}
+export interface AppUsageKindTotal { kind: string; minutes: number; active_minutes: number }
+export interface AppUsageSummary {
+  total_minutes: number;
+  active_minutes: number;
+  by_kind: AppUsageKindTotal[];
+  top: AppUsageItem[];
+}
+
+export interface GameUsageItem {
+  appid: number;
+  name: string;
+  minutes: number;
+  first_at: string;
+  last_at: string;
+}
+export interface GameUsageSummary {
+  total_minutes: number;
+  items: GameUsageItem[];
 }
 
 /**
@@ -469,6 +500,13 @@ export function aggregateDay(
   const allActivity = activityEventsForDate(db, dateStr) as ActivityEventWithMetadata[];
   const activity = summarizeActivityForDate(allActivity, activityLimit ?? null);
 
+  // アプリ使用 (フォアグラウンドプロセスの秒積算) と Steam ゲーム時間。
+  // どちらも 0 件のときは null を返して prompt 側で「(なし)」 にする。
+  const appsRaw = appUsageForDate(db, dateStr) as AppUsageRow[];
+  const gamesRaw = gameUsageForDate(db, dateStr) as GameUsageRow[];
+  const apps = summarizeAppUsage(appsRaw);
+  const games = summarizeGameUsage(gamesRaw);
+
   return {
     date: dateStr,
     total_events: totalEvents,
@@ -493,12 +531,119 @@ export function aggregateDay(
       gpsDistanceM: gps?.distance_meters ?? 0,
     }),
     activity,
+    apps,
+    games,
     sources: {
       visit_events: events.length,
       page_visits: pageVisitsContribution,
       activity_events: allActivity.length,
     },
   };
+}
+
+function summarizeAppUsage(rows: AppUsageRow[]): AppUsageSummary | null {
+  if (!rows.length) return null;
+  // 短すぎる (= 30 秒未満) は誤検出が多いので捨てる。
+  const filtered = rows.filter((r) => r.total_sec >= 30);
+  if (!filtered.length) return null;
+  const items: AppUsageItem[] = filtered.map((r) => ({
+    process_name: r.process_name,
+    display_name: r.name?.trim() || r.process_name,
+    kind: r.kind || null,
+    minutes: Math.round(r.total_sec / 60),
+    active_minutes: Math.round(r.active_sec / 60),
+  })).filter((it) => it.minutes >= 1);
+  if (!items.length) return null;
+  const kindMap = new Map<string, { minutes: number; active_minutes: number }>();
+  for (const it of items) {
+    const k = it.kind || 'unknown';
+    const cur = kindMap.get(k) ?? { minutes: 0, active_minutes: 0 };
+    cur.minutes += it.minutes;
+    cur.active_minutes += it.active_minutes;
+    kindMap.set(k, cur);
+  }
+  const by_kind: AppUsageKindTotal[] = [...kindMap.entries()]
+    .map(([kind, v]) => ({ kind, minutes: v.minutes, active_minutes: v.active_minutes }))
+    .sort((a, b) => b.minutes - a.minutes);
+  const totalMinutes = items.reduce((s, it) => s + it.minutes, 0);
+  const activeMinutes = items.reduce((s, it) => s + it.active_minutes, 0);
+  return {
+    total_minutes: totalMinutes,
+    active_minutes: activeMinutes,
+    by_kind,
+    top: items.slice(0, 15),
+  };
+}
+
+function summarizeGameUsage(rows: GameUsageRow[]): GameUsageSummary | null {
+  if (!rows.length) return null;
+  const items: GameUsageItem[] = rows
+    .filter((r) => r.minutes_played >= 1)
+    .map((r) => ({
+      appid: r.appid,
+      name: r.name?.trim() || `appid:${r.appid}`,
+      minutes: r.minutes_played,
+      first_at: r.first_at,
+      last_at: r.last_at,
+    }));
+  if (!items.length) return null;
+  return {
+    total_minutes: items.reduce((s, it) => s + it.minutes, 0),
+    items,
+  };
+}
+
+function formatMinutes(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return '0m';
+  if (n < 60) return `${n}m`;
+  const h = Math.floor(n / 60);
+  const m = n % 60;
+  return m === 0 ? `${h}h` : `${h}h ${m}m`;
+}
+
+const APP_KIND_LABEL: Record<string, string> = {
+  game: '🎮 ゲーム',
+  work: '💼 仕事',
+  browser: '🌐 ブラウザ',
+  messaging: '💬 メッセージ',
+  media: '🎬 メディア',
+  creative: '🎨 クリエイティブ',
+  other: '❓ その他',
+  unknown: '❔ 未分類',
+};
+
+function formatAppsBlock(apps: AppUsageSummary | null | undefined): string {
+  if (!apps || apps.top.length === 0) return '(アプリ使用記録なし)';
+  const lines: string[] = [];
+  lines.push(`合計フォアグラウンド時間: ${formatMinutes(apps.total_minutes)} (入力アクティブ: ${formatMinutes(apps.active_minutes)})`);
+  if (apps.by_kind.length > 0) {
+    const kindStr = apps.by_kind
+      .filter((k) => k.minutes >= 1)
+      .map((k) => `${APP_KIND_LABEL[k.kind] || k.kind} ${formatMinutes(k.minutes)}`)
+      .join(' / ');
+    if (kindStr) lines.push(`カテゴリ別: ${kindStr}`);
+  }
+  lines.push('上位アプリ:');
+  for (const it of apps.top) {
+    const tag = APP_KIND_LABEL[it.kind || 'unknown'] || it.kind || '';
+    const act = it.active_minutes > 0 && it.active_minutes !== it.minutes
+      ? ` (入力 ${formatMinutes(it.active_minutes)})` : '';
+    lines.push(`- ${tag} ${it.display_name}: ${formatMinutes(it.minutes)}${act}`);
+  }
+  return lines.join('\n');
+}
+
+function formatGamesBlock(games: GameUsageSummary | null | undefined): string {
+  if (!games || games.items.length === 0) return '(プレイ記録なし)';
+  const lines: string[] = [];
+  lines.push(`合計プレイ時間: ${formatMinutes(games.total_minutes)} (Steam playtime_forever の delta)`);
+  for (const g of games.items) {
+    const startHH = g.first_at?.slice(11, 16);
+    const endHH = g.last_at?.slice(11, 16);
+    const span = (startHH && endHH && startHH !== endHH) ? ` (${startHH}〜${endHH})` : '';
+    lines.push(`- 🎮 ${g.name}: ${formatMinutes(g.minutes)}${span}`);
+  }
+  return lines.join('\n');
 }
 
 /**
@@ -1067,9 +1212,11 @@ interface WorkContentPromptArgs {
   totalEvents: number;
   totalDomains: number;
   activityCounts: string | null;
+  appsBlock: string;
+  gamesBlock: string;
 }
 
-const WORK_CONTENT_PROMPT = ({ dateStr, urlList, activityList, totalEvents, totalDomains, activityCounts }: WorkContentPromptArgs): string => [
+const WORK_CONTENT_PROMPT = ({ dateStr, urlList, activityList, totalEvents, totalDomains, activityCounts, appsBlock, gamesBlock }: WorkContentPromptArgs): string => [
   `あなたは ${dateStr} の「作業内容」セクションを書きます。`,
   'ブラウザ閲覧履歴 (URL + 時刻) と開発活動 (git commit / Claude Code への指示) を両方読み、',
   '**大まかな時間帯**で何をしていたかを 1 文でまとめ、',
@@ -1130,6 +1277,18 @@ const WORK_CONTENT_PROMPT = ({ dateStr, urlList, activityList, totalEvents, tota
   '',
   '開発活動 (時刻 + イベント):',
   activityList || '(なし)',
+  '',
+  'アプリ使用 (フォアグラウンド時間、 入力アクティブ秒):',
+  appsBlock,
+  '',
+  'ゲームプレイ (Steam playtime delta):',
+  gamesBlock,
+  '',
+  '※ アプリ / ゲーム情報は時間帯まとめの根拠として使う。 例:',
+  '  - 🎮 ゲーム合計が長い時間帯 → 「ゲームをしていた」 として 1 ブロック',
+  '  - 💼 仕事 / 🎨 クリエイティブ系アプリの時間 → 作業として扱う (URL の薄い日でも作業時間として認める)',
+  '  - 「主な作業」 に具体アプリ名 (VSCode / Photoshop / 特定ゲーム名) を入れて良い',
+  '  - WORK_MINUTES の見積もりにアプリ入力アクティブ秒も考慮する (= 仕事系アプリの active_min は作業時間)。 ゲームは作業に含めない。',
 ].join('\n');
 
 export interface WorkMinutesExtraction {
@@ -1317,6 +1476,12 @@ const HIGHLIGHTS_PROMPT = ({ dateStr, workContent, githubByRepo, bookmarkSummary
   '## 入力 3b: ローカル開発活動 (git commit + Claude Code 指示)',
   formatActivityBlock(metrics.activity),
   '',
+  '## 入力 3c: アプリ使用 (フォアグラウンド時間)',
+  formatAppsBlock(metrics.apps),
+  '',
+  '## 入力 3d: ゲームプレイ (Steam playtime delta)',
+  formatGamesBlock(metrics.games),
+  '',
   '## 入力 4: 当日のディグ調査 (検索 + 取得した情報源)',
   (digs && digs.length > 0)
     ? digs.map(d => {
@@ -1438,6 +1603,8 @@ export async function generateWorkContent({
     totalEvents: metrics.total_events,
     totalDomains: metrics.unique_domains,
     activityCounts,
+    appsBlock: formatAppsBlock(metrics.apps),
+    gamesBlock: formatGamesBlock(metrics.games),
   });
   const prompt = appendMemoAndImprove(base, { globalMemo, improve });
   const raw = await runLlm({ task: 'diary_work', prompt, timeoutMs });

--- a/server/index.ts
+++ b/server/index.ts
@@ -101,6 +101,23 @@ for (const m of listPendingMeals(db, { limit: 50 })) {
   queues.enqueueMealVision(m.id);
 }
 
+// 起動時に pending 日記があれば再投入。 diaryQueue は in-memory なので、
+// 真夜中 cron が走った直後に server が再起動すると stage 0 だけ済んだ
+// status='pending' な行が残ったままになる。 直近 14 日ぶんを限度に拾う
+// (古すぎる pending は metrics 元データが失われている可能性があるので諦める)。
+{
+  const pendingDiaries = db.prepare(
+    `SELECT date FROM diary_entries
+     WHERE status = 'pending'
+       AND date >= date('now', '-14 days', 'localtime')
+     ORDER BY date DESC`,
+  ).all() as { date: string }[];
+  if (pendingDiaries.length > 0) {
+    console.log(`[startup] re-queuing ${pendingDiaries.length} pending diary job(s): ${pendingDiaries.map((d) => d.date).join(', ')}`);
+    for (const { date } of pendingDiaries) queues.enqueueDiary(date);
+  }
+}
+
 // ── App ──────────────────────────────────────────────────────────────────
 const app = new Hono();
 app.use('/api/*', cors({ origin: '*', allowMethods: ['GET', 'POST', 'PATCH', 'DELETE', 'OPTIONS'] }));

--- a/server/index.ts
+++ b/server/index.ts
@@ -55,7 +55,7 @@ import { makeNoteRouter } from './routes/note.js';
 import { makeConfigRouter } from './routes/config.js';
 import { makeMultiRouter } from './routes/multi.js';
 import { makeMiscRouter } from './routes/misc.js';
-import { makeReviewRouter } from './routes/review.js';
+import { makeReviewRouter, seedReviewTargets } from './routes/review.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PORT = Number(process.env.MEMORIA_PORT ?? 5180);
@@ -116,6 +116,18 @@ for (const m of listPendingMeals(db, { limit: 50 })) {
     console.log(`[startup] re-queuing ${pendingDiaries.length} pending diary job(s): ${pendingDiaries.map((d) => d.date).join(', ')}`);
     for (const { date } of pendingDiaries) queues.enqueueDiary(date);
   }
+}
+
+// レビュー対象を LUDIARS clone から自動 seed (= 既存に追加するだけで、 ユーザが
+// UI で追加した行は触らない)。
+try {
+  const seedResult = seedReviewTargets(db);
+  if (seedResult.seeded > 0) {
+    console.log(`[startup] seeded ${seedResult.seeded} review target(s) from LUDIARS clones (${seedResult.skipped} skipped)`);
+  }
+} catch (e) {
+  const msg = e instanceof Error ? e.message : String(e);
+  console.warn(`[startup] review target seed failed: ${msg}`);
 }
 
 // ── App ──────────────────────────────────────────────────────────────────
@@ -207,7 +219,7 @@ app.route('/', makeMultiRouter({
   triggerResolveAsync: ws.triggerResolveAsync,
 }));
 app.route('/', makeMiscRouter({ db, htmlDir: HTML_DIR, bulkSaveDeps }));
-app.route('/', makeReviewRouter());
+app.route('/', makeReviewRouter({ db }));
 
 // ---- static UI ------------------------------------------------------------
 

--- a/server/lib/queues.ts
+++ b/server/lib/queues.ts
@@ -596,6 +596,8 @@ export function makeQueues(deps: QueuesDeps): QueueBundle {
           highlights: ctx.highlights,
           digs,
           activity: ctx.metrics?.activity ?? null,
+          apps: ctx.metrics?.apps ?? null,
+          games: ctx.metrics?.games ?? null,
         });
         upsertDiary(db, {
           date: dateStr,
@@ -730,9 +732,19 @@ interface ComposeSummaryArgs {
     kinds?: Partial<Record<string, number>>;
     items?: { occurred_at?: string | null; kind: string; source?: string | null; content?: string | null }[];
   } | null;
+  apps?: {
+    total_minutes: number;
+    active_minutes: number;
+    by_kind: { kind: string; minutes: number; active_minutes: number }[];
+    top: { display_name: string; kind: string | null; minutes: number; active_minutes: number }[];
+  } | null;
+  games?: {
+    total_minutes: number;
+    items: { name: string; minutes: number; first_at: string; last_at: string }[];
+  } | null;
 }
 
-function composeDiarySummary({ workContent, githubByRepo, highlights, digs, activity }: ComposeSummaryArgs): string {
+function composeDiarySummary({ workContent, githubByRepo, highlights, digs, activity, apps, games }: ComposeSummaryArgs): string {
   const parts: string[] = [];
   if (workContent) parts.push(`## 作業内容\n${workContent.trim()}`);
   if (digs && digs.length > 0) {
@@ -763,6 +775,28 @@ function composeDiarySummary({ workContent, githubByRepo, highlights, digs, acti
       ? `\n- … ほか ${(activity.items ?? []).length - 10} 件`
       : '';
     parts.push(`## 開発活動\n合計: ${head}\n${items.join('\n')}${tail}`);
+  }
+  if (apps && apps.top.length > 0) {
+    const fmt = (m: number) => m < 60 ? `${m}m` : `${Math.floor(m / 60)}h ${m % 60}m`.replace(' 0m', '');
+    const kindStr = (apps.by_kind || [])
+      .filter((k) => k.minutes >= 1)
+      .slice(0, 6)
+      .map((k) => `${k.kind} ${fmt(k.minutes)}`)
+      .join(' / ');
+    const topLines = apps.top.slice(0, 8).map((it) =>
+      `- ${it.display_name} (${it.kind || '?'}): ${fmt(it.minutes)}`
+    );
+    parts.push(`## アプリ使用 (${fmt(apps.total_minutes)})${kindStr ? `\n${kindStr}` : ''}\n${topLines.join('\n')}`);
+  }
+  if (games && games.items.length > 0) {
+    const fmt = (m: number) => m < 60 ? `${m}m` : `${Math.floor(m / 60)}h ${m % 60}m`.replace(' 0m', '');
+    const lines = games.items.map((g) => {
+      const startHH = g.first_at?.slice(11, 16);
+      const endHH = g.last_at?.slice(11, 16);
+      const span = (startHH && endHH && startHH !== endHH) ? ` (${startHH}〜${endHH})` : '';
+      return `- 🎮 ${g.name}: ${fmt(g.minutes)}${span}`;
+    });
+    parts.push(`## ゲームプレイ (${fmt(games.total_minutes)})\n${lines.join('\n')}`);
   }
   if (highlights) parts.push(`## ハイライト\n${highlights.trim()}`);
   return parts.join('\n\n');

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -302,11 +302,9 @@
           <button class="tab" data-tab="meals">
             <span class="tab-label" data-full="🍽 食事" data-short="🍽 食事">🍽 食事</span>
           </button>
-          <button class="tab" data-tab="review">
-            <span class="tab-label" data-full="🔍 レビュー" data-short="🔍 レビュ">🔍 レビュー</span>
-          </button>
           <!-- マルチビューはトップバーのマルチスイッチからのみアクセス。
-               機能タブからは外す (PC/スマホ共通)。 -->
+               機能タブからは外す (PC/スマホ共通)。
+               🔍 レビュー はデータベースタブのサブタブ (data-db-sub="review") へ移動。 -->
         </div>
         <button type="button" id="tabMoreBtn" class="tab tab-more-btn" aria-haspopup="true" aria-expanded="false" hidden>⋯</button>
         <ul id="tabMoreMenu" class="tab-more-menu" hidden role="menu"></ul>
@@ -646,6 +644,7 @@
           <button class="wl-subtab" data-db-sub="domain">🏷 ドメイン</button>
           <button class="wl-subtab" data-db-sub="workplace">🗺️ 作業場所</button>
           <button class="wl-subtab" data-db-sub="apps">💻 アプリ</button>
+          <button class="wl-subtab" data-db-sub="review">🔍 レビュー</button>
           <button class="wl-subtab" data-db-sub="queue">⚙ キュー <span id="dbQueueBadge" class="tab-count hidden">0</span></button>
         </nav>
       </div>
@@ -869,20 +868,29 @@
 
       <div id="reviewView" class="hidden">
         <div class="bookmarks-toolbar">
-          <span class="muted">LUDIARS 全サービスの AIFormat レビュー (skill `ludiars-review` が生成)</span>
+          <span class="muted">LUDIARS 全サービスの AIFormat レビュー (skill <code>/ludiars-review</code> が生成)</span>
           <span class="grow"></span>
+          <button id="reviewBackBtn" class="ghost" type="button" hidden>← 一覧に戻る</button>
           <button id="reviewRefresh" class="ghost" type="button">更新</button>
         </div>
-        <div class="bookmarks-layout">
-          <aside class="bookmarks-categories" id="reviewRepoList">
+        <div id="reviewListLayout" class="bookmarks-layout">
+          <aside class="bookmarks-categories" id="reviewCategoriesPanel">
             <h3>リポジトリ</h3>
-            <ul id="reviewRepoUl"></ul>
+            <ul id="reviewCategoryList"></ul>
           </aside>
           <div class="bookmarks-main">
-            <div id="reviewDetail" class="muted" style="padding:16px">
-              左のリポジトリを選択するとレビューが表示されます。
-            </div>
+            <div id="reviewCards" class="cards"></div>
+            <div id="reviewEmpty" class="empty hidden">レビューが見つかりません。 <code>/ludiars-review</code> を実行してください。</div>
           </div>
+        </div>
+        <div id="reviewDetailLayout" class="hidden">
+          <div style="padding:8px 16px;display:flex;gap:12px;align-items:center;flex-wrap:wrap;border-bottom:1px solid var(--border)">
+            <strong id="reviewDetailRepo"></strong>
+            <label class="muted">日付 <select id="reviewDateSel"></select></label>
+            <a id="reviewFixPrLink" href="#" target="_blank" rel="noopener" hidden>🔧 修正 PR</a>
+          </div>
+          <nav class="tabs" id="reviewFileTabs" style="padding:0 16px"></nav>
+          <pre id="reviewBody" style="padding:16px;white-space:pre-wrap;font-family:var(--mono, monospace);font-size:13px;line-height:1.5">読み込み中…</pre>
         </div>
       </div>
 

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -9,7 +9,7 @@
   <title>Memoria</title>
   <link rel="manifest" href="manifest.webmanifest" />
   <link rel="apple-touch-icon" href="icon-192.svg" />
-  <link rel="stylesheet" href="style.css?v=20260513g" />
+  <link rel="stylesheet" href="style.css?v=20260513h" />
 </head>
 <body>
   <header class="topbar">
@@ -302,9 +302,11 @@
           <button class="tab" data-tab="meals">
             <span class="tab-label" data-full="🍽 食事" data-short="🍽 食事">🍽 食事</span>
           </button>
+          <button class="tab" data-tab="review">
+            <span class="tab-label" data-full="🔍 レビュー" data-short="🔍 レビュ">🔍 レビュー</span>
+          </button>
           <!-- マルチビューはトップバーのマルチスイッチからのみアクセス。
-               機能タブからは外す (PC/スマホ共通)。
-               🔍 レビュー はデータベースタブのサブタブ (data-db-sub="review") へ移動。 -->
+               機能タブからは外す (PC/スマホ共通)。 -->
         </div>
         <button type="button" id="tabMoreBtn" class="tab tab-more-btn" aria-haspopup="true" aria-expanded="false" hidden>⋯</button>
         <ul id="tabMoreMenu" class="tab-more-menu" hidden role="menu"></ul>
@@ -645,7 +647,6 @@
           <button class="wl-subtab" data-db-sub="domain">🏷 ドメイン</button>
           <button class="wl-subtab" data-db-sub="workplace">🗺️ 作業場所</button>
           <button class="wl-subtab" data-db-sub="apps">💻 アプリ</button>
-          <button class="wl-subtab" data-db-sub="review">🔍 レビュー</button>
           <button class="wl-subtab" data-db-sub="queue">⚙ キュー <span id="dbQueueBadge" class="tab-count hidden">0</span></button>
         </nav>
       </div>
@@ -869,9 +870,10 @@
 
       <div id="reviewView" class="hidden">
         <div class="bookmarks-toolbar">
-          <span class="muted">LUDIARS 全サービスの AIFormat レビュー (skill <code>/ludiars-review</code> が生成)</span>
+          <span class="muted">AIFormat レビュー (skill <code>/ludiars-review</code> が生成)</span>
           <span class="grow"></span>
           <button id="reviewBackBtn" class="ghost" type="button" hidden>← 一覧に戻る</button>
+          <button id="reviewAddTargetBtn" class="ghost" type="button" title="レビュー対象リポを追加">+ 追加</button>
           <button id="reviewRefresh" class="ghost" type="button">更新</button>
         </div>
         <div id="reviewListLayout">
@@ -1235,6 +1237,34 @@
     <ul id="dictLinks" class="dict-links"></ul>
   </div>
 
+  <div id="reviewTargetModal" class="dict-detail modal-panel hidden">
+    <div class="dict-detail-head">
+      <h3 style="margin:0;flex:1">🔍 レビュー対象リポを追加</h3>
+      <button id="reviewTargetSaveBtn">保存</button>
+      <button id="reviewTargetCloseBtn" class="modal-close" title="閉じる">×</button>
+    </div>
+    <p class="muted" style="margin:8px 0;font-size:12px">
+      ローカルにある git clone をレビュー対象として登録します。 cloud routine
+      <code>ludiars-review-daily</code> は登録済の対象を読み、 指定フォーマットに
+      従って <code>review/&lt;date&gt;/</code> を生成します。
+    </p>
+    <h4>表示名</h4>
+    <input id="reviewTargetName" type="text" placeholder="例: Memoria" />
+    <h4>ローカルパス</h4>
+    <input id="reviewTargetPath" type="text" placeholder="例: E:/Document/Ars/Memoria" />
+    <p class="muted" style="font-size:11px;margin:4px 0">
+      LUDIARS_ROOT (既定 <code>E:/Document/Ars</code>) からの相対パスでも、 絶対パスでも可。
+    </p>
+    <h4>フォーマット</h4>
+    <select id="reviewTargetFormat">
+      <option value="aiformat">AIFormat (5 観点 + 総合)</option>
+    </select>
+    <p class="muted" style="font-size:11px;margin:4px 0">
+      現在は AIFormat のみ。 カスタムフォーマットは将来対応。
+    </p>
+    <div id="reviewTargetError" class="muted" style="margin-top:8px;font-size:11px;color:#c0392b" hidden></div>
+  </div>
+
   <div id="appsDetail" class="dict-detail modal-panel hidden">
     <div class="dict-detail-head">
       <input id="appsKey" type="text" placeholder="process_name" disabled />
@@ -1519,6 +1549,6 @@
       <button id="aiSettingsSave">保存</button>
     </div>
   </div>
-  <script src="app.js?v=20260513e"></script>
+  <script src="app.js?v=20260513f"></script>
 </body>
 </html>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -9,7 +9,7 @@
   <title>Memoria</title>
   <link rel="manifest" href="manifest.webmanifest" />
   <link rel="apple-touch-icon" href="icon-192.svg" />
-  <link rel="stylesheet" href="style.css?v=20260513f" />
+  <link rel="stylesheet" href="style.css?v=20260513g" />
 </head>
 <body>
   <header class="topbar">
@@ -886,11 +886,13 @@
         </div>
         <div id="reviewDetailLayout" class="hidden">
           <div class="review-detail-bar">
-            <strong id="reviewDetailRepo"></strong>
-            <label class="muted">日付 <select id="reviewDateSel"></select></label>
-            <a id="reviewFixPrLink" href="#" target="_blank" rel="noopener" hidden>🔧 修正 PR</a>
+            <div class="review-detail-title-row">
+              <h2 id="reviewDetailRepo" class="review-detail-title"></h2>
+              <a id="reviewFixPrLink" class="review-pr-badge" href="#" target="_blank" rel="noopener" hidden>🔧 修正 PR</a>
+            </div>
+            <label class="review-detail-date muted">日付 <select id="reviewDateSel"></select></label>
           </div>
-          <nav class="tabs" id="reviewFileTabs"></nav>
+          <nav class="tabs review-file-tabs" id="reviewFileTabs"></nav>
           <div id="reviewBody" class="review-body">読み込み中…</div>
         </div>
       </div>
@@ -1517,6 +1519,6 @@
       <button id="aiSettingsSave">保存</button>
     </div>
   </div>
-  <script src="app.js?v=20260513d"></script>
+  <script src="app.js?v=20260513e"></script>
 </body>
 </html>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -9,7 +9,7 @@
   <title>Memoria</title>
   <link rel="manifest" href="manifest.webmanifest" />
   <link rel="apple-touch-icon" href="icon-192.svg" />
-  <link rel="stylesheet" href="style.css?v=20260513b" />
+  <link rel="stylesheet" href="style.css?v=20260513c" />
 </head>
 <body>
   <header class="topbar">

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -9,7 +9,7 @@
   <title>Memoria</title>
   <link rel="manifest" href="manifest.webmanifest" />
   <link rel="apple-touch-icon" href="icon-192.svg" />
-  <link rel="stylesheet" href="style.css?v=20260513d" />
+  <link rel="stylesheet" href="style.css?v=20260513e" />
 </head>
 <body>
   <header class="topbar">
@@ -628,13 +628,14 @@
            ドメイン辞書と同じ構造 (= 自動分類 + 手動上書き)。
            data: app_samples (= sampling 元) / applications (= AI 分類済 row) -->
       <div id="appsView" class="hidden">
-        <div class="apps-bar">
+        <div class="dict-bar">
+          <input id="appsSearch" type="search" placeholder="プロセス名・表示名・説明で検索" />
           <span id="appsCount" class="muted"></span>
           <span class="grow"></span>
           <button id="appsRefresh" class="ghost" title="再読込">↻</button>
         </div>
-        <div id="appsEmpty" class="queue-empty hidden">applications カタログがまだ空です。 設定 → 🚦 AI 自動処理 で「💻 PC アプリ使用統計」 を ON にすると、 サンプリングされた process_name が AI 分類されてここに表示されます。</div>
-        <ul id="appsList" class="apps-list"></ul>
+        <div id="appsEmpty" class="dict-empty hidden">applications カタログがまだ空です。 設定 → 🚦 AI 自動処理 で「💻 PC アプリ使用統計」 を ON にすると、 サンプリングされた process_name が AI 分類されてここに表示されます。</div>
+        <ul id="appsList" class="dict-list pin-grid"></ul>
       </div>
 
       <div id="databaseView" class="hidden">
@@ -1232,6 +1233,36 @@
     <ul id="dictLinks" class="dict-links"></ul>
   </div>
 
+  <div id="appsDetail" class="dict-detail modal-panel hidden">
+    <div class="dict-detail-head">
+      <input id="appsKey" type="text" placeholder="process_name" disabled />
+      <button id="appsSaveBtn">保存</button>
+      <button id="appsReclassifyBtn" class="ghost" title="AI に再分類させる">↻ 再分類</button>
+      <button id="appsDetailClose" class="modal-close" title="閉じる">×</button>
+    </div>
+    <div id="appsStatusRow" class="domain-stats">
+      <span class="domain-stat"><b id="appsStatusBadge">—</b><br>状態</span>
+      <span class="domain-stat"><b id="appsEditedBadge">—</b><br>編集済み</span>
+      <span class="domain-stat"><b id="appsClassifiedAt">—</b><br>分類日時</span>
+    </div>
+    <h4>表示名</h4>
+    <input id="appsName" type="text" placeholder="(未分類)" />
+    <h4>種類</h4>
+    <select id="appsKind">
+      <option value="">--</option>
+      <option value="game">🎮 ゲーム</option>
+      <option value="work">💼 仕事</option>
+      <option value="browser">🌐 ブラウザ</option>
+      <option value="messaging">💬 メッセージ</option>
+      <option value="media">🎬 メディア</option>
+      <option value="creative">🎨 クリエイティブ</option>
+      <option value="other">❓ その他</option>
+    </select>
+    <h4>説明</h4>
+    <textarea id="appsDesc" rows="3" placeholder="このアプリの 1〜2 文の説明"></textarea>
+    <div id="appsErrorRow" class="muted" style="margin-top:8px;font-size:11px" hidden></div>
+  </div>
+
   <div id="domainDetail" class="dict-detail modal-panel hidden">
     <div class="dict-detail-head">
       <input id="domainKey" type="text" placeholder="ドメイン" disabled />
@@ -1486,6 +1517,6 @@
       <button id="aiSettingsSave">保存</button>
     </div>
   </div>
-  <script src="app.js?v=20260513b"></script>
+  <script src="app.js?v=20260513c"></script>
 </body>
 </html>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -9,7 +9,7 @@
   <title>Memoria</title>
   <link rel="manifest" href="manifest.webmanifest" />
   <link rel="apple-touch-icon" href="icon-192.svg" />
-  <link rel="stylesheet" href="style.css?v=20260513a" />
+  <link rel="stylesheet" href="style.css?v=20260513b" />
 </head>
 <body>
   <header class="topbar">
@@ -1486,6 +1486,6 @@
       <button id="aiSettingsSave">保存</button>
     </div>
   </div>
-  <script src="app.js?v=20260513a"></script>
+  <script src="app.js?v=20260513b"></script>
 </body>
 </html>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -9,7 +9,7 @@
   <title>Memoria</title>
   <link rel="manifest" href="manifest.webmanifest" />
   <link rel="apple-touch-icon" href="icon-192.svg" />
-  <link rel="stylesheet" href="style.css?v=20260503c" />
+  <link rel="stylesheet" href="style.css?v=20260513a" />
 </head>
 <body>
   <header class="topbar">
@@ -1486,6 +1486,6 @@
       <button id="aiSettingsSave">保存</button>
     </div>
   </div>
-  <script src="app.js?v=20260508f"></script>
+  <script src="app.js?v=20260513a"></script>
 </body>
 </html>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -9,7 +9,7 @@
   <title>Memoria</title>
   <link rel="manifest" href="manifest.webmanifest" />
   <link rel="apple-touch-icon" href="icon-192.svg" />
-  <link rel="stylesheet" href="style.css?v=20260513c" />
+  <link rel="stylesheet" href="style.css?v=20260513d" />
 </head>
 <body>
   <header class="topbar">

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -9,7 +9,7 @@
   <title>Memoria</title>
   <link rel="manifest" href="manifest.webmanifest" />
   <link rel="apple-touch-icon" href="icon-192.svg" />
-  <link rel="stylesheet" href="style.css?v=20260513e" />
+  <link rel="stylesheet" href="style.css?v=20260513f" />
 </head>
 <body>
   <header class="topbar">
@@ -874,24 +874,24 @@
           <button id="reviewBackBtn" class="ghost" type="button" hidden>← 一覧に戻る</button>
           <button id="reviewRefresh" class="ghost" type="button">更新</button>
         </div>
-        <div id="reviewListLayout" class="bookmarks-layout">
-          <aside class="bookmarks-categories" id="reviewCategoriesPanel">
-            <h3>リポジトリ</h3>
-            <ul id="reviewCategoryList"></ul>
-          </aside>
-          <div class="bookmarks-main">
-            <div id="reviewCards" class="cards"></div>
-            <div id="reviewEmpty" class="empty hidden">レビューが見つかりません。 <code>/ludiars-review</code> を実行してください。</div>
+        <div id="reviewListLayout">
+          <div class="review-filter-bar">
+            <label class="muted">リポジトリ
+              <select id="reviewRepoMenu"></select>
+            </label>
+            <span id="reviewListCount" class="muted"></span>
           </div>
+          <div id="reviewCards" class="cards"></div>
+          <div id="reviewEmpty" class="dict-empty hidden">レビューが見つかりません。 <code>/ludiars-review</code> を実行してください。</div>
         </div>
         <div id="reviewDetailLayout" class="hidden">
-          <div style="padding:8px 16px;display:flex;gap:12px;align-items:center;flex-wrap:wrap;border-bottom:1px solid var(--border)">
+          <div class="review-detail-bar">
             <strong id="reviewDetailRepo"></strong>
             <label class="muted">日付 <select id="reviewDateSel"></select></label>
             <a id="reviewFixPrLink" href="#" target="_blank" rel="noopener" hidden>🔧 修正 PR</a>
           </div>
-          <nav class="tabs" id="reviewFileTabs" style="padding:0 16px"></nav>
-          <pre id="reviewBody" style="padding:16px;white-space:pre-wrap;font-family:var(--mono, monospace);font-size:13px;line-height:1.5">読み込み中…</pre>
+          <nav class="tabs" id="reviewFileTabs"></nav>
+          <div id="reviewBody" class="review-body">読み込み中…</div>
         </div>
       </div>
 
@@ -1517,6 +1517,6 @@
       <button id="aiSettingsSave">保存</button>
     </div>
   </div>
-  <script src="app.js?v=20260513c"></script>
+  <script src="app.js?v=20260513d"></script>
 </body>
 </html>

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -157,6 +157,7 @@ declare global {
 // notes module — esa / DocBase 風 WYSIWYG エディタ。
 // switchTab('notes') で loadNotes() を呼ぶ。
 import { loadNotes as notesLoad } from './notes/index.js';
+import { renderMarkdownBlock } from './markdown-block.js';
 
 // 起動チュートリアル / ページヘルプ drawer。 app.ts 肥大化対策で分離。
 // PAGE_HELP の本文を増やす場合は page-help.ts を編集する。
@@ -10086,42 +10087,36 @@ async function loadReviewRepos() {
   showReviewList();
   const cards = document.getElementById('reviewCards');
   const empty = document.getElementById('reviewEmpty');
-  const catUl = document.getElementById('reviewCategoryList');
-  if (!cards || !catUl) return;
+  if (!cards) return;
   try {
     const r = await api('/api/review/repos');
     reviewState.items = (r.items || []).slice().sort((a, b) =>
       (b.latest_date || '').localeCompare(a.latest_date || ''));
-    renderReviewCategories();
+    renderReviewMenu();
     renderReviewCards();
   } catch (e) {
     cards.innerHTML = '';
     empty?.classList.add('hidden');
-    catUl.innerHTML = `<li class="hint">読み込みエラー: ${escapeHtml(e.message)}</li>`;
+    const menu = document.getElementById('reviewRepoMenu');
+    if (menu) menu.innerHTML = `<option>読み込みエラー: ${escapeHtml(e.message)}</option>`;
   }
 }
 
-function renderReviewCategories() {
-  const ul = document.getElementById('reviewCategoryList');
-  if (!ul) return;
+function renderReviewMenu() {
+  const sel = document.getElementById('reviewRepoMenu') as HTMLSelectElement | null;
+  const count = document.getElementById('reviewListCount');
+  if (!sel) return;
   const total = reviewState.items.length;
-  const allClass = reviewState.filterRepo === null ? ' active' : '';
-  let html = `<li><a href="#" data-review-cat="" class="cat-link${allClass}">全て <span class="tab-count">${total}</span></a></li>`;
-  html += reviewState.items.map((it) => {
-    const active = reviewState.filterRepo === it.repo ? ' active' : '';
+  const opts = [`<option value="">全て (${total})</option>`];
+  for (const it of reviewState.items) {
     const warn = (it.critical_count > 0 || it.high_count > 0) ? ' ⚠' : '';
-    return `<li><a href="#" data-review-cat="${escapeHtml(it.repo)}" class="cat-link${active}">${escapeHtml(it.repo)}${warn} <span class="tab-count">1</span></a></li>`;
-  }).join('');
-  ul.innerHTML = html;
-  ul.querySelectorAll('a[data-review-cat]').forEach((a) => {
-    a.addEventListener('click', (ev) => {
-      ev.preventDefault();
-      const repo = a.getAttribute('data-review-cat') || '';
-      reviewState.filterRepo = repo || null;
-      renderReviewCategories();
-      renderReviewCards();
-    });
-  });
+    opts.push(`<option value="${escapeHtml(it.repo)}"${reviewState.filterRepo === it.repo ? ' selected' : ''}>${escapeHtml(it.repo)}${warn}</option>`);
+  }
+  sel.innerHTML = opts.join('');
+  if (count) {
+    const shown = reviewState.filterRepo ? 1 : total;
+    count.textContent = `${shown} / ${total} 件`;
+  }
 }
 
 function renderReviewCards() {
@@ -10143,16 +10138,20 @@ function renderReviewCards() {
     const date = it.latest_date ? `<small class="muted">${escapeHtml(it.latest_date)}</small>` : '';
     const warn = (it.critical_count > 0 || it.high_count > 0)
       ? `<small style="color:#d97706">⚠ Critical ${it.critical_count} / High ${it.high_count}</small>` : '';
-    const pr = it.fix_pr
-      ? `<small><a href="${escapeHtml(it.fix_pr)}" target="_blank" rel="noopener" onclick="event.stopPropagation()">🔧 修正 PR</a></small>` : '';
+    // 「現在アクティブな要修正 PR 数」 = latest.json.fix_pr が non-null なら 1。
+    // 履歴 (= 過去日付の fix_pr) を追跡する仕組みは未実装なので暫定で 0 / 1。
+    const activePrCount = it.fix_pr ? 1 : 0;
+    const prBadge = activePrCount > 0
+      ? `<a class="badge review-pr-badge" href="${escapeHtml(it.fix_pr || '#')}" target="_blank" rel="noopener" onclick="event.stopPropagation()" title="要修正 PR を開く">🔧 ${activePrCount}</a>`
+      : '';
     return `
-      <article class="card" data-review-card="${escapeHtml(it.repo)}" style="cursor:pointer">
-        <header class="card-head">
-          <strong>AIFormat レビュー</strong>
-          <span class="badge category">${escapeHtml(it.repo)}</span>
+      <article class="card review-card" data-review-card="${escapeHtml(it.repo)}">
+        <header class="review-card-head">
+          <strong class="review-card-repo">${escapeHtml(it.repo)}</strong>
+          ${prBadge}
         </header>
-        <div class="card-meta" style="display:flex;gap:8px;flex-wrap:wrap;align-items:center;margin-top:6px">
-          ${score} ${date} ${warn} ${pr}
+        <div class="review-card-meta">
+          ${score} ${date} ${warn}
         </div>
       </article>`;
   }).join('');
@@ -10227,10 +10226,14 @@ async function loadReviewFile() {
   const body = document.getElementById('reviewBody');
   if (!body || !reviewState.selected || !reviewState.currentDate) return;
   const url = `/api/review/repos/${encodeURIComponent(reviewState.selected)}/${reviewState.currentDate}/${reviewState.currentFile}`;
+  body.textContent = '読み込み中…';
   try {
     const res = await fetch(url);
     if (!res.ok) { body.textContent = `${res.status}: ${await res.text()}`; return; }
-    body.textContent = await res.text();
+    const md = await res.text();
+    // 見出し + テーブル + リスト + 段落 + コードフェンスを HTML に。
+    // インラインは notes/markdown.ts:renderInline を流用 (bold / italic / code / link)。
+    body.innerHTML = renderMarkdownBlock(md);
   } catch (e) {
     body.textContent = `読み込みエラー: ${e.message}`;
   }
@@ -10238,6 +10241,12 @@ async function loadReviewFile() {
 
 document.getElementById('reviewRefresh')?.addEventListener('click', () => void loadReviewRepos());
 document.getElementById('reviewBackBtn')?.addEventListener('click', () => showReviewList());
+document.getElementById('reviewRepoMenu')?.addEventListener('change', (ev) => {
+  const v = (ev.target as HTMLSelectElement).value;
+  reviewState.filterRepo = v || null;
+  renderReviewMenu();
+  renderReviewCards();
+});
 document.getElementById('reviewDateSel')?.addEventListener('change', (ev) => {
   reviewState.currentDate = ev.target.value;
   void loadReviewFile();

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -11687,6 +11687,33 @@ document.getElementById('topbarHelpBtn')?.addEventListener('click', () => {
   openHelpFor(state.tab as string);
 });
 
+// topbar (ページの頭) をタップで最上部にスクロール。 iOS のステータスバー
+// タップ慣習と同じ。 内部にボタンを含むので、 button / interactive 要素を
+// クリックしたときは伝播させない (= scroll しない)。
+function scrollPageToTop() {
+  const opts: ScrollToOptions = { top: 0, behavior: 'smooth' };
+  window.scrollTo(opts);
+  // Memoria のメイン scroll container は `.layout > .content`。
+  document.querySelector('.layout > .content')?.scrollTo(opts);
+  // 各タブ内部に独自スクロール container を持つビューも先頭に戻す
+  // (notes-pane / notes-comments / bookmarks-main / mealsList 等)。
+  const selectors = [
+    '.notes-pane', '.notes-comments', '.notes-sidebar',
+    '.bookmarks-main', '.bookmarks-categories',
+    '#cards', '#mealsList', '#reviewCards', '#reviewBody',
+    '#diaryView', '#trendsView', '#recommendView', '#digView', '#tasksView', '#implView',
+  ];
+  document.querySelectorAll(selectors.join(',')).forEach((el) => {
+    if ((el as HTMLElement).scrollTop > 0) (el as HTMLElement).scrollTop = 0;
+  });
+}
+document.querySelector('.topbar')?.addEventListener('click', (ev) => {
+  // ボタン / リンク / 設定パネル等のインタラクティブ要素をクリックしたときは無視
+  const target = ev.target as HTMLElement | null;
+  if (target?.closest('button, a, input, select, textarea, [role="button"]')) return;
+  scrollPageToTop();
+});
+
 
 // ── Legatus WS client (loopback ws://127.0.0.1:17320/ws) ─────────────
 // 接続状態 / MQTT 受信 / relay 成否を live で取り込む。

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -1054,7 +1054,7 @@ function jobLabel(item) {
 // 日付を持たない sub (queue / external) と物データ (bookmarks / dict / domain / workplace) は database 配下。
 // meals は top-level タブ。
 const WORKLOG_REDIRECT_TABS = new Set(['tracks']);
-const DATABASE_REDIRECT_TABS = new Set(['bookmarks', 'dict', 'domain', 'workplace', 'queue', 'external', 'review']);
+const DATABASE_REDIRECT_TABS = new Set(['bookmarks', 'dict', 'domain', 'workplace', 'queue', 'external']);
 
 function switchTab(tab) {
   if (WORKLOG_REDIRECT_TABS.has(tab)) {
@@ -1085,6 +1085,7 @@ function switchTab(tab) {
   $('digView').classList.toggle('hidden', tab !== 'dig');
   $('diaryView').classList.toggle('hidden', tab !== 'diary');
   $('mealsView')?.classList.toggle('hidden', tab !== 'meals');
+  $('reviewView')?.classList.toggle('hidden', tab !== 'review');
   $('notesView')?.classList.toggle('hidden', tab !== 'notes');
   $('tasksView')?.classList.toggle('hidden', tab !== 'tasks');
   $('implView')?.classList.toggle('hidden', tab !== 'impl');
@@ -1100,6 +1101,7 @@ function switchTab(tab) {
   if (tab === 'dig') loadDigHistory();
   if (tab === 'diary') loadDiary();
   if (tab === 'meals') loadMeals();
+  if (tab === 'review') loadReviewRepos();
   if (tab === 'notes') void notesLoad();
   if (tab === 'tasks') loadTasks();
   if (tab === 'impl') loadImplementationNotes();
@@ -4673,12 +4675,13 @@ function hideModal(panelId) {
   const dictOpen = !$('dictDetail').classList.contains('hidden');
   const domOpen  = !$('domainDetail').classList.contains('hidden');
   const appsOpen = $('appsDetail') ? !$('appsDetail').classList.contains('hidden') : false;
+  const reviewTgtOpen = $('reviewTargetModal') ? !$('reviewTargetModal').classList.contains('hidden') : false;
   const taskOpen = $('taskEditorModal') ? !$('taskEditorModal').classList.contains('hidden') : false;
   const implOpen = $('implEditorModal') ? !$('implEditorModal').classList.contains('hidden') : false;
   const workOpen = $('workplaceEditorModal') ? !$('workplaceEditorModal').classList.contains('hidden') : false;
   const apOpen = $('agentProjectEditor') ? !$('agentProjectEditor').classList.contains('hidden') : false;
   const arOpen = $('agentRunModal') ? !$('agentRunModal').classList.contains('hidden') : false;
-  $('modalBackdrop').hidden = !(dictOpen || domOpen || appsOpen || taskOpen || implOpen || workOpen || apOpen || arOpen);
+  $('modalBackdrop').hidden = !(dictOpen || domOpen || appsOpen || reviewTgtOpen || taskOpen || implOpen || workOpen || apOpen || arOpen);
 }
 function closeAllModals() {
   state.dictDetail = null;
@@ -4688,6 +4691,7 @@ function closeAllModals() {
   hideModal('dictDetail');
   hideModal('domainDetail');
   if ($('appsDetail')) hideModal('appsDetail');
+  if ($('reviewTargetModal')) hideModal('reviewTargetModal');
   hideModal('taskEditorModal');
   hideModal('implEditorModal');
   hideModal('workplaceEditorModal');
@@ -7679,7 +7683,6 @@ const DB_SUB_VIEWS = {
   domain: 'domainView',
   workplace: 'workplaceView',
   apps: 'appsView',
-  review: 'reviewView',
   queue: 'queueView',
 };
 
@@ -7714,7 +7717,6 @@ function switchDatabaseSub(sub) {
   if (sub === 'domain') loadDomainCatalog();
   if (sub === 'workplace') loadWorkLocations().catch(console.warn);
   if (sub === 'apps') loadApplicationsCatalog().catch(console.warn);
-  if (sub === 'review') loadReviewRepos();
   if (sub === 'queue') renderQueue();
 }
 
@@ -10247,6 +10249,46 @@ document.getElementById('reviewRepoMenu')?.addEventListener('change', (ev) => {
   renderReviewMenu();
   renderReviewCards();
 });
+
+// ── レビュー対象の追加モーダル ─────────────────────────────────
+function openReviewTargetModal() {
+  ($('reviewTargetName') as HTMLInputElement).value = '';
+  ($('reviewTargetPath') as HTMLInputElement).value = '';
+  ($('reviewTargetFormat') as HTMLSelectElement).value = 'aiformat';
+  const err = $('reviewTargetError');
+  if (err) { err.hidden = true; err.textContent = ''; }
+  showModal('reviewTargetModal');
+}
+
+async function submitReviewTarget() {
+  const name = ($('reviewTargetName') as HTMLInputElement).value.trim();
+  const local_path = ($('reviewTargetPath') as HTMLInputElement).value.trim();
+  const format_key = ($('reviewTargetFormat') as HTMLSelectElement).value;
+  const err = $('reviewTargetError');
+  const showErr = (msg: string) => { if (err) { err.textContent = `⚠ ${msg}`; err.hidden = false; } };
+  if (!name) return showErr('表示名を入力してください');
+  if (!local_path) return showErr('ローカルパスを入力してください');
+  try {
+    const res = await fetch('/api/review/targets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, local_path, format_key }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({})) as { error?: string };
+      return showErr(body.error || `${res.status}`);
+    }
+    hideModal('reviewTargetModal');
+    flashToast('レビュー対象を追加しました');
+    await loadReviewRepos();
+  } catch (e) {
+    showErr((e as Error).message);
+  }
+}
+
+$('reviewAddTargetBtn')?.addEventListener('click', openReviewTargetModal);
+$('reviewTargetSaveBtn')?.addEventListener('click', () => void submitReviewTarget());
+$('reviewTargetCloseBtn')?.addEventListener('click', () => hideModal('reviewTargetModal'));
 document.getElementById('reviewDateSel')?.addEventListener('change', (ev) => {
   reviewState.currentDate = ev.target.value;
   void loadReviewFile();

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -4671,19 +4671,22 @@ function hideModal(panelId) {
   // If neither panel is open after this hide, drop the backdrop too.
   const dictOpen = !$('dictDetail').classList.contains('hidden');
   const domOpen  = !$('domainDetail').classList.contains('hidden');
+  const appsOpen = $('appsDetail') ? !$('appsDetail').classList.contains('hidden') : false;
   const taskOpen = $('taskEditorModal') ? !$('taskEditorModal').classList.contains('hidden') : false;
   const implOpen = $('implEditorModal') ? !$('implEditorModal').classList.contains('hidden') : false;
   const workOpen = $('workplaceEditorModal') ? !$('workplaceEditorModal').classList.contains('hidden') : false;
   const apOpen = $('agentProjectEditor') ? !$('agentProjectEditor').classList.contains('hidden') : false;
   const arOpen = $('agentRunModal') ? !$('agentRunModal').classList.contains('hidden') : false;
-  $('modalBackdrop').hidden = !(dictOpen || domOpen || taskOpen || implOpen || workOpen || apOpen || arOpen);
+  $('modalBackdrop').hidden = !(dictOpen || domOpen || appsOpen || taskOpen || implOpen || workOpen || apOpen || arOpen);
 }
 function closeAllModals() {
   state.dictDetail = null;
   state.domainDetail = null;
   state.taskDetail = null;
+  appsState.selected = null;
   hideModal('dictDetail');
   hideModal('domainDetail');
+  if ($('appsDetail')) hideModal('appsDetail');
   hideModal('taskEditorModal');
   hideModal('implEditorModal');
   hideModal('workplaceEditorModal');
@@ -7736,84 +7739,135 @@ const APP_KIND_LABELS: Record<string, string> = {
   other: '❓ その他',
 };
 
+// ── アプリカタログ (カード形式) ─────────────────────────────────────
+// ドメインタブと同じ pin-grid カードレイアウト。 詳細編集は appsDetail モーダル。
+const appsState = { items: [] as ApplicationCatalogRow[], search: '', selected: null as string | null };
+
 async function loadApplicationsCatalog() {
   const list = $('appsList');
-  const empty = $('appsEmpty');
   const count = $('appsCount');
   if (!list) return;
   try {
     const r = await api('/api/activity/applications') as { items: ApplicationCatalogRow[] };
-    const items = r.items || [];
-    if (count) count.textContent = `${items.length} 件`;
-    if (items.length === 0) {
-      empty?.classList.remove('hidden');
-      list.innerHTML = '';
-      return;
-    }
-    empty?.classList.add('hidden');
-    list.innerHTML = items.map((it) => {
-      const kindOptions = Object.entries(APP_KIND_LABELS).map(([k, label]) =>
-        `<option value="${k}"${it.kind === k ? ' selected' : ''}>${label}</option>`
-      ).join('');
-      const statusBadge = it.status === 'done' ? '✓' : it.status === 'error' ? '⚠' : '⟳';
-      const edited = it.user_edited ? '<span class="apps-edited" title="手動編集済み">✎</span>' : '';
-      return `<li class="apps-row" data-process="${escapeHtml(it.process_name)}">
-        <div class="apps-row-head">
-          <span class="apps-status">${statusBadge}</span>
-          <code class="apps-process">${escapeHtml(it.process_name)}</code>
-          ${edited}
-          <span class="grow"></span>
-          <button class="ghost apps-reclassify" data-process="${escapeHtml(it.process_name)}" title="AI 分類を再実行">↻ 再分類</button>
-        </div>
-        <div class="apps-row-body">
-          <label class="apps-field">
-            <span>名前</span>
-            <input class="apps-name" type="text" value="${escapeHtml(it.name || '')}" placeholder="(未分類)" />
-          </label>
-          <label class="apps-field">
-            <span>種類</span>
-            <select class="apps-kind">
-              <option value="">--</option>
-              ${kindOptions}
-            </select>
-          </label>
-          <label class="apps-field apps-field-wide">
-            <span>説明</span>
-            <input class="apps-desc" type="text" value="${escapeHtml(it.description || '')}" placeholder="(未分類)" />
-          </label>
-        </div>
-        ${it.error ? `<div class="apps-error muted">⚠ ${escapeHtml(it.error)}</div>` : ''}
-      </li>`;
-    }).join('');
-    // 行ごとに save (blur で自動保存) + 再分類ボタン配線
-    list.querySelectorAll<HTMLLIElement>('.apps-row').forEach((row) => {
-      const processName = row.dataset.process || '';
-      const save = async () => {
-        const name = (row.querySelector<HTMLInputElement>('.apps-name')?.value || '').trim();
-        const kind = row.querySelector<HTMLSelectElement>('.apps-kind')?.value || '';
-        const description = (row.querySelector<HTMLInputElement>('.apps-desc')?.value || '').trim();
-        try {
-          await api(`/api/activity/applications/${encodeURIComponent(processName)}`, {
-            method: 'PATCH',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name, kind, description }),
-          });
-        } catch (e) { console.warn('app patch failed:', (e as Error).message); }
-      };
-      row.querySelector('.apps-name')?.addEventListener('blur', save);
-      row.querySelector('.apps-desc')?.addEventListener('blur', save);
-      row.querySelector('.apps-kind')?.addEventListener('change', save);
-      row.querySelector('.apps-reclassify')?.addEventListener('click', async () => {
-        try {
-          await api(`/api/activity/applications/${encodeURIComponent(processName)}/classify-now`, { method: 'POST' });
-          await loadApplicationsCatalog();
-        } catch (e) { alert(`再分類失敗: ${(e as Error).message}`); }
-      });
-    });
+    appsState.items = r.items || [];
+    if (count) count.textContent = `${appsState.items.length} 件`;
+    renderAppsList();
   } catch (e) {
     if (count) count.textContent = `取得失敗: ${(e as Error).message}`;
   }
 }
+
+function renderAppsList() {
+  const list = $('appsList');
+  const empty = $('appsEmpty');
+  if (!list || !empty) return;
+  const q = appsState.search.trim().toLowerCase();
+  const filtered = q
+    ? appsState.items.filter((it) =>
+        it.process_name.toLowerCase().includes(q) ||
+        (it.name || '').toLowerCase().includes(q) ||
+        (it.description || '').toLowerCase().includes(q))
+    : appsState.items;
+  if (filtered.length === 0) {
+    list.innerHTML = '';
+    empty.classList.remove('hidden');
+    return;
+  }
+  empty.classList.add('hidden');
+  list.innerHTML = filtered.map((it) => {
+    const kindLabel = it.kind ? (APP_KIND_LABELS[it.kind] || it.kind) : '';
+    const kindBadge = kindLabel ? `<span class="apps-kind-badge">${escapeHtml(kindLabel)}</span>` : '';
+    const desc = (it.description || '').trim();
+    const status = it.status === 'done' ? '' : it.status === 'error' ? '⚠ 分類失敗' : '⟳ 分類待ち';
+    const edited = it.user_edited ? ' ✎' : '';
+    return `<li class="dict-item${appsState.selected === it.process_name ? ' selected' : ''}" data-app="${escapeHtml(it.process_name)}">
+      <div class="dict-term">${escapeHtml(it.name?.trim() || it.process_name)}${edited} ${kindBadge}</div>
+      <div class="dict-snippet">${escapeHtml(desc.slice(0, 320)) || '<span class="muted">(未分類)</span>'}</div>
+      <div class="dict-meta">
+        <code style="font-size:11px">${escapeHtml(it.process_name)}</code>
+        <span>${escapeHtml(status)}</span>
+      </div>
+    </li>`;
+  }).join('');
+  list.querySelectorAll<HTMLLIElement>('.dict-item').forEach((li) => {
+    li.addEventListener('click', () => {
+      const pn = li.dataset.app;
+      if (pn) openAppDetail(pn);
+    });
+  });
+}
+
+function openAppDetail(processName: string) {
+  const it = appsState.items.find((x) => x.process_name === processName);
+  if (!it) return;
+  appsState.selected = processName;
+  renderAppsList();
+  showModal('appsDetail');
+  ($('appsKey') as HTMLInputElement).value = it.process_name;
+  ($('appsName') as HTMLInputElement).value = it.name || '';
+  ($('appsKind') as HTMLSelectElement).value = it.kind || '';
+  ($('appsDesc') as HTMLTextAreaElement).value = it.description || '';
+  const statusBadge = $('appsStatusBadge');
+  if (statusBadge) statusBadge.textContent = it.status || '—';
+  const editedBadge = $('appsEditedBadge');
+  if (editedBadge) editedBadge.textContent = it.user_edited ? '✓' : '—';
+  const classifiedAt = $('appsClassifiedAt');
+  if (classifiedAt) classifiedAt.textContent = it.classified_at ? new Date(it.classified_at).toLocaleString() : '—';
+  const errRow = $('appsErrorRow');
+  if (errRow) {
+    if (it.error) {
+      errRow.textContent = `⚠ ${it.error}`;
+      errRow.hidden = false;
+    } else {
+      errRow.hidden = true;
+    }
+  }
+}
+
+async function saveAppDetail() {
+  const pn = ($('appsKey') as HTMLInputElement | null)?.value;
+  if (!pn) return;
+  const name = (($('appsName') as HTMLInputElement).value || '').trim();
+  const kind = ($('appsKind') as HTMLSelectElement).value || '';
+  const description = (($('appsDesc') as HTMLTextAreaElement).value || '').trim();
+  try {
+    await api(`/api/activity/applications/${encodeURIComponent(pn)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, kind, description }),
+    });
+    await loadApplicationsCatalog();
+    flashToast('アプリを保存しました');
+  } catch (e) {
+    alert(`保存失敗: ${(e as Error).message}`);
+  }
+}
+
+async function reclassifyApp() {
+  const pn = ($('appsKey') as HTMLInputElement | null)?.value;
+  if (!pn) return;
+  try {
+    await api(`/api/activity/applications/${encodeURIComponent(pn)}/classify-now`, { method: 'POST' });
+    await loadApplicationsCatalog();
+    openAppDetail(pn);
+    flashToast('再分類をキューに積みました');
+  } catch (e) {
+    alert(`再分類失敗: ${(e as Error).message}`);
+  }
+}
+
+$('appsSaveBtn')?.addEventListener('click', () => void saveAppDetail());
+$('appsReclassifyBtn')?.addEventListener('click', () => void reclassifyApp());
+$('appsDetailClose')?.addEventListener('click', () => {
+  appsState.selected = null;
+  hideModal('appsDetail');
+  renderAppsList();
+});
+$('appsRefresh')?.addEventListener('click', () => void loadApplicationsCatalog());
+$('appsSearch')?.addEventListener('input', (ev) => {
+  appsState.search = (ev.target as HTMLInputElement).value;
+  renderAppsList();
+});
 
 // 日付ベースの sub かどうか (date toolbar / summary 表示の有無)
 const WL_DATE_BASED = new Set(['schedule', 'github', 'claude', 'gemini', 'codex', 'browsing', 'dig', 'tracks', 'activity', 'games']);

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -1053,7 +1053,7 @@ function jobLabel(item) {
 // 日付を持たない sub (queue / external) と物データ (bookmarks / dict / domain / workplace) は database 配下。
 // meals は top-level タブ。
 const WORKLOG_REDIRECT_TABS = new Set(['tracks']);
-const DATABASE_REDIRECT_TABS = new Set(['bookmarks', 'dict', 'domain', 'workplace', 'queue', 'external']);
+const DATABASE_REDIRECT_TABS = new Set(['bookmarks', 'dict', 'domain', 'workplace', 'queue', 'external', 'review']);
 
 function switchTab(tab) {
   if (WORKLOG_REDIRECT_TABS.has(tab)) {
@@ -1084,7 +1084,6 @@ function switchTab(tab) {
   $('digView').classList.toggle('hidden', tab !== 'dig');
   $('diaryView').classList.toggle('hidden', tab !== 'diary');
   $('mealsView')?.classList.toggle('hidden', tab !== 'meals');
-  $('reviewView')?.classList.toggle('hidden', tab !== 'review');
   $('notesView')?.classList.toggle('hidden', tab !== 'notes');
   $('tasksView')?.classList.toggle('hidden', tab !== 'tasks');
   $('implView')?.classList.toggle('hidden', tab !== 'impl');
@@ -1100,7 +1099,6 @@ function switchTab(tab) {
   if (tab === 'dig') loadDigHistory();
   if (tab === 'diary') loadDiary();
   if (tab === 'meals') loadMeals();
-  if (tab === 'review') loadReviewRepos();
   if (tab === 'notes') void notesLoad();
   if (tab === 'tasks') loadTasks();
   if (tab === 'impl') loadImplementationNotes();
@@ -7677,6 +7675,7 @@ const DB_SUB_VIEWS = {
   domain: 'domainView',
   workplace: 'workplaceView',
   apps: 'appsView',
+  review: 'reviewView',
   queue: 'queueView',
 };
 
@@ -7711,6 +7710,7 @@ function switchDatabaseSub(sub) {
   if (sub === 'domain') loadDomainCatalog();
   if (sub === 'workplace') loadWorkLocations().catch(console.warn);
   if (sub === 'apps') loadApplicationsCatalog().catch(console.warn);
+  if (sub === 'review') loadReviewRepos();
   if (sub === 'queue') renderQueue();
 }
 
@@ -10005,8 +10005,11 @@ document.addEventListener('click', (ev) => {
   }).catch(() => {});
 });
 
-// ── review (LUDIARS AIFormat レビュー閲覧) ────────────────────────────────
-const reviewState = { repos: [], selected: null, dates: [], currentDate: null, currentFile: 'REVIEW.md' };
+// ── review (LUDIARS AIFormat レビュー閲覧、 DB タブ内サブタブ) ─────────────
+//
+// 一覧 = カード形式 (1 カード = 1 リポの最新レビュー)、 リポ = 左サイドの
+// カテゴリとして運用 (= bookmarks タブと同じレイアウト)。 カードをクリックで
+// 詳細ビュー (日付セレクト + 6 ファイルタブ) に切替。
 const REVIEW_FILES_UI = [
   ['REVIEW.md', '総合'],
   ['REVIEW_DESIGN.md', '設計'],
@@ -10015,82 +10018,155 @@ const REVIEW_FILES_UI = [
   ['REVIEW_MISSING_FEATURES.md', '不足機能'],
   ['REVIEW_QUALITY.md', '品質'],
 ];
+const reviewState = {
+  items: [],
+  filterRepo: null,            // null = 全カテゴリ
+  selected: null,
+  dates: [],
+  currentDate: null,
+  currentFile: 'REVIEW.md',
+  fixPr: null,
+};
 
 async function loadReviewRepos() {
-  const ul = document.getElementById('reviewRepoUl');
-  if (!ul) return;
+  showReviewList();
+  const cards = document.getElementById('reviewCards');
+  const empty = document.getElementById('reviewEmpty');
+  const catUl = document.getElementById('reviewCategoryList');
+  if (!cards || !catUl) return;
   try {
     const r = await api('/api/review/repos');
-    reviewState.repos = r.items || [];
-    if (reviewState.repos.length === 0) {
-      ul.innerHTML = '<li class="muted">レビューが見つかりません。 <code>/ludiars-review</code> を実行してください。</li>';
-      return;
-    }
-    ul.innerHTML = reviewState.repos.map((it) => {
-      const score = it.weighted_score ? `<span class="badge">${escapeHtml(it.weighted_score)}</span>` : '';
-      const date = it.latest_date ? `<small class="muted">${escapeHtml(it.latest_date)}</small>` : '';
-      const warn = (it.critical_count > 0 || it.high_count > 0)
-        ? `<small style="color:#d97706">⚠ C${it.critical_count}/H${it.high_count}</small>` : '';
-      return `<li><a href="#" data-review-repo="${escapeHtml(it.repo)}">${escapeHtml(it.repo)}</a> ${score} ${date} ${warn}</li>`;
-    }).join('');
-    ul.querySelectorAll('a[data-review-repo]').forEach((a) => {
-      a.addEventListener('click', (ev) => {
-        ev.preventDefault();
-        const repo = a.getAttribute('data-review-repo');
-        if (repo) void loadReviewDetail(repo);
-      });
-    });
+    reviewState.items = (r.items || []).slice().sort((a, b) =>
+      (b.latest_date || '').localeCompare(a.latest_date || ''));
+    renderReviewCategories();
+    renderReviewCards();
   } catch (e) {
-    ul.innerHTML = `<li class="hint">読み込みエラー: ${escapeHtml(e.message)}</li>`;
+    cards.innerHTML = '';
+    empty?.classList.add('hidden');
+    catUl.innerHTML = `<li class="hint">読み込みエラー: ${escapeHtml(e.message)}</li>`;
   }
 }
 
-async function loadReviewDetail(repo) {
-  const detail = document.getElementById('reviewDetail');
-  if (!detail) return;
-  detail.innerHTML = '<div class="muted" style="padding:16px">読み込み中…</div>';
+function renderReviewCategories() {
+  const ul = document.getElementById('reviewCategoryList');
+  if (!ul) return;
+  const total = reviewState.items.length;
+  const allClass = reviewState.filterRepo === null ? ' active' : '';
+  let html = `<li><a href="#" data-review-cat="" class="cat-link${allClass}">全て <span class="tab-count">${total}</span></a></li>`;
+  html += reviewState.items.map((it) => {
+    const active = reviewState.filterRepo === it.repo ? ' active' : '';
+    const warn = (it.critical_count > 0 || it.high_count > 0) ? ' ⚠' : '';
+    return `<li><a href="#" data-review-cat="${escapeHtml(it.repo)}" class="cat-link${active}">${escapeHtml(it.repo)}${warn} <span class="tab-count">1</span></a></li>`;
+  }).join('');
+  ul.innerHTML = html;
+  ul.querySelectorAll('a[data-review-cat]').forEach((a) => {
+    a.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      const repo = a.getAttribute('data-review-cat') || '';
+      reviewState.filterRepo = repo || null;
+      renderReviewCategories();
+      renderReviewCards();
+    });
+  });
+}
+
+function renderReviewCards() {
+  const cards = document.getElementById('reviewCards');
+  const empty = document.getElementById('reviewEmpty');
+  if (!cards || !empty) return;
+  const filtered = reviewState.filterRepo
+    ? reviewState.items.filter((it) => it.repo === reviewState.filterRepo)
+    : reviewState.items;
+  if (filtered.length === 0) {
+    cards.innerHTML = '';
+    empty.classList.remove('hidden');
+    return;
+  }
+  empty.classList.add('hidden');
+  cards.innerHTML = filtered.map((it) => {
+    const score = it.weighted_score
+      ? `<span class="badge" title="総合評価">⭐ ${escapeHtml(it.weighted_score)}</span>` : '';
+    const date = it.latest_date ? `<small class="muted">${escapeHtml(it.latest_date)}</small>` : '';
+    const warn = (it.critical_count > 0 || it.high_count > 0)
+      ? `<small style="color:#d97706">⚠ Critical ${it.critical_count} / High ${it.high_count}</small>` : '';
+    const pr = it.fix_pr
+      ? `<small><a href="${escapeHtml(it.fix_pr)}" target="_blank" rel="noopener" onclick="event.stopPropagation()">🔧 修正 PR</a></small>` : '';
+    return `
+      <article class="card" data-review-card="${escapeHtml(it.repo)}" style="cursor:pointer">
+        <header class="card-head">
+          <strong>AIFormat レビュー</strong>
+          <span class="badge category">${escapeHtml(it.repo)}</span>
+        </header>
+        <div class="card-meta" style="display:flex;gap:8px;flex-wrap:wrap;align-items:center;margin-top:6px">
+          ${score} ${date} ${warn} ${pr}
+        </div>
+      </article>`;
+  }).join('');
+  cards.querySelectorAll('article[data-review-card]').forEach((c) => {
+    c.addEventListener('click', () => {
+      const repo = c.getAttribute('data-review-card');
+      if (repo) void openReviewDetail(repo);
+    });
+  });
+}
+
+async function openReviewDetail(repo) {
   try {
     const r = await api(`/api/review/repos/${encodeURIComponent(repo)}`);
     reviewState.selected = repo;
     reviewState.dates = r.dates || [];
     reviewState.currentDate = r.dates?.[0] ?? null;
+    reviewState.currentFile = 'REVIEW.md';
+    reviewState.fixPr = r.latest?.fix_pr ?? null;
     if (!reviewState.currentDate) {
-      detail.innerHTML = `<div class="hint">${escapeHtml(repo)}: レビューフォルダはありますが日付ディレクトリが見つかりません。</div>`;
+      alert(`${repo}: レビューフォルダはありますが日付ディレクトリが見つかりません。`);
       return;
     }
-    renderReviewDetail();
+    showReviewDetail();
+    renderReviewDetailHeader();
+    await loadReviewFile();
   } catch (e) {
-    detail.innerHTML = `<div class="hint">読み込みエラー: ${escapeHtml(e.message)}</div>`;
+    alert(`読み込みエラー: ${e.message}`);
   }
 }
 
-async function renderReviewDetail() {
-  const detail = document.getElementById('reviewDetail');
-  if (!detail || !reviewState.selected || !reviewState.currentDate) return;
-  const dateOptions = reviewState.dates.map((d) =>
+function showReviewList() {
+  document.getElementById('reviewListLayout')?.classList.remove('hidden');
+  document.getElementById('reviewDetailLayout')?.classList.add('hidden');
+  document.getElementById('reviewBackBtn')?.setAttribute('hidden', '');
+}
+
+function showReviewDetail() {
+  document.getElementById('reviewListLayout')?.classList.add('hidden');
+  document.getElementById('reviewDetailLayout')?.classList.remove('hidden');
+  document.getElementById('reviewBackBtn')?.removeAttribute('hidden');
+}
+
+function renderReviewDetailHeader() {
+  const repoEl = document.getElementById('reviewDetailRepo');
+  const dateSel = document.getElementById('reviewDateSel');
+  const fileTabs = document.getElementById('reviewFileTabs');
+  const fixLink = document.getElementById('reviewFixPrLink');
+  if (!repoEl || !dateSel || !fileTabs || !fixLink) return;
+  repoEl.textContent = reviewState.selected || '';
+  dateSel.innerHTML = reviewState.dates.map((d) =>
     `<option value="${escapeHtml(d)}"${d === reviewState.currentDate ? ' selected' : ''}>${escapeHtml(d)}</option>`).join('');
-  const fileTabs = REVIEW_FILES_UI.map(([f, label]) =>
-    `<button type="button" class="tab${f === reviewState.currentFile ? ' active' : ''}" data-review-file="${f}">${escapeHtml(label)}</button>`).join('');
-  detail.innerHTML = `
-    <div style="padding:8px 16px;display:flex;gap:12px;align-items:center;flex-wrap:wrap;border-bottom:1px solid var(--border)">
-      <strong>${escapeHtml(reviewState.selected)}</strong>
-      <label class="muted">日付 <select id="reviewDateSel">${dateOptions}</select></label>
-    </div>
-    <nav class="tabs" style="padding:0 16px">${fileTabs}</nav>
-    <pre id="reviewBody" style="padding:16px;white-space:pre-wrap;font-family:var(--mono, monospace);font-size:13px;line-height:1.5">読み込み中…</pre>`;
-  document.getElementById('reviewDateSel')?.addEventListener('change', (ev) => {
-    reviewState.currentDate = ev.target.value;
-    void loadReviewFile();
-  });
-  detail.querySelectorAll('button[data-review-file]').forEach((b) => {
+  fileTabs.innerHTML = REVIEW_FILES_UI.map(([f, label]) =>
+    `<button type="button" class="tab${f === reviewState.currentFile ? ' active' : ''}" data-review-file="${escapeHtml(f)}">${escapeHtml(label)}</button>`).join('');
+  if (reviewState.fixPr) {
+    fixLink.setAttribute('href', reviewState.fixPr);
+    fixLink.removeAttribute('hidden');
+  } else {
+    fixLink.setAttribute('hidden', '');
+  }
+  fileTabs.querySelectorAll('button[data-review-file]').forEach((b) => {
     b.addEventListener('click', () => {
       reviewState.currentFile = b.getAttribute('data-review-file') || 'REVIEW.md';
-      detail.querySelectorAll('button[data-review-file]').forEach((x) =>
+      fileTabs.querySelectorAll('button[data-review-file]').forEach((x) =>
         x.classList.toggle('active', x.getAttribute('data-review-file') === reviewState.currentFile));
       void loadReviewFile();
     });
   });
-  await loadReviewFile();
 }
 
 async function loadReviewFile() {
@@ -10107,6 +10183,11 @@ async function loadReviewFile() {
 }
 
 document.getElementById('reviewRefresh')?.addEventListener('click', () => void loadReviewRepos());
+document.getElementById('reviewBackBtn')?.addEventListener('click', () => showReviewList());
+document.getElementById('reviewDateSel')?.addEventListener('change', (ev) => {
+  reviewState.currentDate = ev.target.value;
+  void loadReviewFile();
+});
 
 async function loadMeals() {
   const list = document.getElementById('mealsList');

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -11714,6 +11714,28 @@ document.querySelector('.topbar')?.addEventListener('click', (ev) => {
   scrollPageToTop();
 });
 
+// iOS の status-bar tap (= 「画面最上部に戻る」 ジェスチャ) を捕まえる。
+// body には CSS で min-height: calc(100vh + 1px) を入れて 1px の scroll
+// バッファを作っており、 ここでは初期位置を scrollTop=1 にしておく。
+// status-bar tap → iOS が window を scrollTop=0 に戻そうとする → scroll
+// イベント発火 → scrollPageToTop() を呼んで .content も先頭に戻し、
+// window は再び 1 に戻して次の tap に備える。
+(function setupStatusBarTapToTop() {
+  if (!window.matchMedia('(max-width: 760px)').matches) return;
+  // 起動直後に 1px ぶん下にずらしておく (= status-bar tap 検出の土俵)
+  const park = () => window.scrollTo(0, 1);
+  requestAnimationFrame(() => requestAnimationFrame(park));
+  let pending: ReturnType<typeof setTimeout> | null = null;
+  window.addEventListener('scroll', () => {
+    if (window.scrollY !== 0) return;
+    // window が 0 に戻った = status-bar tap (or 初回ロード時の同期問題)。
+    // .content も連動して先頭へ。
+    scrollPageToTop();
+    if (pending !== null) clearTimeout(pending);
+    pending = setTimeout(() => { park(); pending = null; }, 250);
+  }, { passive: true });
+})();
+
 
 // ── Legatus WS client (loopback ws://127.0.0.1:17320/ws) ─────────────
 // 接続状態 / MQTT 受信 / relay 成否を live で取り込む。

--- a/server/public/src/markdown-block.ts
+++ b/server/public/src/markdown-block.ts
@@ -1,0 +1,182 @@
+// Block-level markdown → HTML renderer (見出し + テーブル + リスト + 段落 + 引用 + コードフェンス)。
+//
+// レビュー閲覧 (AIFormat REVIEW_*.md) で使う想定。 ノートの block 編集
+// (block_type を DB が持つ) とは別軸で、 ここでは「Markdown ファイル全体を
+// 一括で HTML に変換する」 用途。
+//
+// インライン (**bold**, *italic*, `code`, [text](url)) は notes/markdown.ts の
+// renderInline をそのまま流用する。
+
+import { renderInline } from './notes/markdown.js';
+import { escapeHtml } from './notes/sanitize.js';
+
+export function renderMarkdownBlock(md: string): string {
+  if (!md) return '';
+  const lines = md.replace(/\r\n/g, '\n').split('\n');
+  const out: string[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // ─── コードフェンス ``` ───
+    const fence = /^```(\S*)\s*$/.exec(line);
+    if (fence) {
+      const lang = fence[1];
+      i++;
+      const codeLines: string[] = [];
+      while (i < lines.length && !/^```\s*$/.test(lines[i])) {
+        codeLines.push(lines[i]);
+        i++;
+      }
+      if (i < lines.length) i++; // skip closing ```
+      const langAttr = lang ? ` data-lang="${escapeHtml(lang)}"` : '';
+      out.push(`<pre class="md-code"${langAttr}><code>${escapeHtml(codeLines.join('\n'))}</code></pre>`);
+      continue;
+    }
+
+    // ─── 見出し # / ## / ... / ###### ───
+    const heading = /^(#{1,6})\s+(.+?)\s*#*$/.exec(line);
+    if (heading) {
+      const level = heading[1].length;
+      out.push(`<h${level} class="md-h${level}">${renderInline(heading[2])}</h${level}>`);
+      i++;
+      continue;
+    }
+
+    // ─── 水平線 --- / *** ───
+    if (/^\s*([-*_])\s*\1\s*\1[-*_\s]*$/.test(line)) {
+      out.push('<hr class="md-hr">');
+      i++;
+      continue;
+    }
+
+    // ─── パイプテーブル ───
+    // 1 行目: | col1 | col2 |
+    // 2 行目: |------|------|  または :----:  / -----:
+    if (isPipeTableRow(line) && i + 1 < lines.length && isTableSeparator(lines[i + 1])) {
+      const headerCells = splitTableRow(line);
+      const aligns = parseAligns(lines[i + 1]);
+      i += 2;
+      const bodyRows: string[][] = [];
+      while (i < lines.length && isPipeTableRow(lines[i])) {
+        bodyRows.push(splitTableRow(lines[i]));
+        i++;
+      }
+      out.push(buildTable(headerCells, aligns, bodyRows));
+      continue;
+    }
+
+    // ─── 引用 > ───
+    if (/^>\s?/.test(line)) {
+      const quoteLines: string[] = [];
+      while (i < lines.length && /^>\s?/.test(lines[i])) {
+        quoteLines.push(lines[i].replace(/^>\s?/, ''));
+        i++;
+      }
+      out.push(`<blockquote class="md-blockquote">${quoteLines.map((l) => renderInline(l)).join('<br>')}</blockquote>`);
+      continue;
+    }
+
+    // ─── 順序なしリスト - / * / + ───
+    if (/^\s*[-*+]\s+/.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^\s*[-*+]\s+/.test(lines[i])) {
+        items.push(lines[i].replace(/^\s*[-*+]\s+/, ''));
+        i++;
+      }
+      out.push(`<ul class="md-ul">${items.map((it) => `<li>${renderInline(it)}</li>`).join('')}</ul>`);
+      continue;
+    }
+
+    // ─── 順序付きリスト 1. 2. ───
+    if (/^\s*\d+\.\s+/.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^\s*\d+\.\s+/.test(lines[i])) {
+        items.push(lines[i].replace(/^\s*\d+\.\s+/, ''));
+        i++;
+      }
+      out.push(`<ol class="md-ol">${items.map((it) => `<li>${renderInline(it)}</li>`).join('')}</ol>`);
+      continue;
+    }
+
+    // ─── 空行 ───
+    if (line.trim() === '') { i++; continue; }
+
+    // ─── 段落 (空行 / 別ブロックまで連結) ───
+    const paraLines: string[] = [line];
+    i++;
+    while (
+      i < lines.length &&
+      lines[i].trim() !== '' &&
+      !/^(#{1,6})\s+/.test(lines[i]) &&
+      !/^```/.test(lines[i]) &&
+      !/^>\s?/.test(lines[i]) &&
+      !/^\s*[-*+]\s+/.test(lines[i]) &&
+      !/^\s*\d+\.\s+/.test(lines[i]) &&
+      !(isPipeTableRow(lines[i]) && i + 1 < lines.length && isTableSeparator(lines[i + 1]))
+    ) {
+      paraLines.push(lines[i]);
+      i++;
+    }
+    out.push(`<p class="md-p">${renderInline(paraLines.join(' '))}</p>`);
+  }
+
+  return out.join('\n');
+}
+
+// ─── table helpers ────────────────────────────────────────────────────────
+
+function isPipeTableRow(line: string): boolean {
+  // 少なくとも 1 つの `|` を内側に含む行 (= cell が 2 つ以上)。
+  // 例: `| a | b |` / `a | b` / `| a |`
+  if (!line.includes('|')) return false;
+  const inner = line.trim().replace(/^\|/, '').replace(/\|$/, '');
+  return inner.includes('|');
+}
+
+function isTableSeparator(line: string): boolean {
+  // 全 cell が `:?-+:?` 形式 (空白可) であること。
+  if (!isPipeTableRow(line)) return false;
+  const cells = splitTableRow(line);
+  if (cells.length === 0) return false;
+  return cells.every((c) => /^:?-{3,}:?$/.test(c.trim()) || /^:?-+:?$/.test(c.trim()));
+}
+
+function splitTableRow(line: string): string[] {
+  return line.trim().replace(/^\|/, '').replace(/\|$/, '').split('|').map((c) => c.trim());
+}
+
+function parseAligns(sep: string): ('left' | 'center' | 'right' | null)[] {
+  return splitTableRow(sep).map((c) => {
+    const t = c.trim();
+    const left = t.startsWith(':');
+    const right = t.endsWith(':');
+    if (left && right) return 'center';
+    if (right) return 'right';
+    if (left) return 'left';
+    return null;
+  });
+}
+
+function buildTable(
+  header: string[],
+  aligns: ('left' | 'center' | 'right' | null)[],
+  body: string[][],
+): string {
+  const head = `<thead><tr>${header.map((h, i) => {
+    const a = aligns[i] ? ` style="text-align:${aligns[i]}"` : '';
+    return `<th${a}>${renderInline(h)}</th>`;
+  }).join('')}</tr></thead>`;
+  const cols = header.length;
+  const bodyHtml = body.map((row) => {
+    // セル数が足りない / 多い場合は padding / 打ち切り
+    const cells = row.slice(0, cols);
+    while (cells.length < cols) cells.push('');
+    return `<tr>${cells.map((c, i) => {
+      const a = aligns[i] ? ` style="text-align:${aligns[i]}"` : '';
+      return `<td${a}>${renderInline(c)}</td>`;
+    }).join('')}</tr>`;
+  }).join('');
+  return `<table class="md-table">${head}<tbody>${bodyHtml}</tbody></table>`;
+}

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -5201,9 +5201,14 @@ dialog.loc-edit-modal[open] {
 .wl-subtab.active {
   color: var(--text);
   background: var(--card);
-  border-color: var(--accent);
-  border-bottom: 1px solid var(--card);
-  margin-bottom: -1px;
+  /* top/left/right だけ accent 化、 bottom は inactive と同じ透明のまま。
+   * 以前は `border-bottom: 1px solid var(--card); margin-bottom: -1px;` で
+   * コンテナの border-bottom と継ぎ目なく繋ぐ trick を使っていたが、
+   * 切替時に box geometry が 1px 変化して行全体がガタついていたため
+   * 視覚マージは捨てる (= active タブの下にもコンテナのグレー線が見える)。 */
+  border-top-color: var(--accent);
+  border-left-color: var(--accent);
+  border-right-color: var(--accent);
 }
 
 .wl-sub { padding: 12px; }

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -5297,26 +5297,28 @@ dialog.loc-edit-modal[open] {
 .wl-worktime-headline { font-size: 14px; margin-bottom: 4px; }
 .wl-worktime-breakdown { font-size: 12px; }
 .wl-kind-stat { display: inline-block; padding: 1px 6px; border-radius: 4px; background: var(--accent-bg, transparent); margin: 1px 0; }
-/* 💻 アプリケーションカタログ (Database → アプリ) */
-.apps-bar { display: flex; align-items: center; gap: 8px; margin: 8px 0; }
-.apps-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 6px; }
-.apps-row { padding: 8px 12px; border: 1px solid var(--border); border-radius: 6px; background: var(--panel, var(--card)); display: flex; flex-direction: column; gap: 6px; }
-.apps-row-head { display: flex; align-items: center; gap: 8px; font-size: 12px; }
-.apps-status { font-size: 14px; }
-.apps-process { background: var(--bg, transparent); padding: 1px 6px; border-radius: 3px; font-size: 12px; }
-.apps-edited { color: var(--accent, #2a6df4); font-size: 11px; }
-.apps-reclassify { font-size: 11px; padding: 2px 8px; }
-.apps-row-body { display: grid; grid-template-columns: minmax(120px, 1fr) minmax(120px, 1fr) 2fr; gap: 8px; }
-.apps-field { display: flex; flex-direction: column; font-size: 11px; gap: 2px; }
-.apps-field span { color: var(--muted); }
-.apps-field input, .apps-field select { font-size: 12px; padding: 3px 6px; width: 100%; box-sizing: border-box; }
-.apps-error { font-size: 11px; }
-@media (max-width: 760px) {
-  .apps-row-body { grid-template-columns: 1fr; }
+/* 💻 アプリケーションカタログ (Database → アプリ)
+ * カード形式 (= ドメインタブと同じ .dict-list.pin-grid + .dict-item)。
+ * 詳細編集は appsDetail モーダル。 */
+.apps-kind-badge {
+  display: inline-block;
+  font-size: 10px;
+  padding: 1px 6px;
+  margin-left: 4px;
+  border-radius: 999px;
+  background: var(--accent-bg, #eef);
+  color: var(--text);
+  border: 1px solid var(--border);
+  white-space: nowrap;
+  vertical-align: middle;
+  font-weight: 500;
 }
 
 /* 🎮 ゲームログのバッジ */
+
+/* 🎮 ゲームログのバッジ */
 .wl-game-row { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+/* ─── 旧 apps-* (vertical row レイアウト) は 2026-05-13 にカード化で廃止 ─── */
 .wl-game-badge { font-size: 10px; padding: 1px 6px; border-radius: 4px; font-weight: 600; }
 .wl-game-badge-steam { background: #1b2838; color: #66c0f4; }
 .wl-game-badge-app { background: var(--accent-bg, #eef); color: var(--text); border: 1px solid var(--border); }

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -19,6 +19,16 @@ body {
   font-size: 14px;
 }
 
+/* iOS の status-bar tap (= 最上部に戻すジェスチャ) は window を scrollTop=0
+ * に向けて scroll させる動作。 Memoria は実スクロールが `.layout > .content`
+ * 側にあるため、 window が常に 0 のままだと status-bar tap で何も起きない。
+ * mobile では body に 1px だけ余白を持たせて window scroll が成立する状態を
+ * 作り、 起動時に scrollTo(0, 1) で待機させておく (app.ts の setup 側)。
+ * 見た目への影響は 1px ぶん下にスクロール可能になるだけで実用上ゼロ。 */
+@media (max-width: 760px) {
+  body { min-height: calc(100vh + 1px); }
+}
+
 .topbar {
   display: flex;
   align-items: center;

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -5174,7 +5174,10 @@ dialog.loc-edit-modal[open] {
 .wl-subtab {
   background: transparent;
   border: 1px solid var(--border);
-  border-bottom: none;
+  /* inactive にも透明な border-bottom を持たせて高さを active と揃える。
+   * 以前は `border-bottom: none` で active 時に 1px 高さが変わり、
+   * タップごとに行全体が上下にガタついていた。 */
+  border-bottom: 1px solid transparent;
   border-radius: 6px 6px 0 0;
   padding: 6px 12px;
   font-size: 13px;

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -6039,6 +6039,13 @@ dialog.loc-edit-modal[open] {
     overflow: hidden;   /* sidebar の transform: translateX(-100%) を内部に閉じる */
     min-height: 60vh;   /* sidebar が absolute なので layout に高さを与える */
   }
+  /* mobile では sidebar が position: absolute でグリッド外なので、
+   * non-open 状態でも pane を 1fr 維持する (親の 1100px ルール
+   * `grid-template-columns: 0 minmax(0,1fr)` が pane を幅 0 の
+   * 1 列目に詰め込んでしまうのを上書き)。 ページ幅 = pane 幅。 */
+  .notes-layout:not(.notes-sidebar-open) {
+    grid-template-columns: 1fr;
+  }
   .notes-sidebar {
     position: absolute;
     top: 0;

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -5319,6 +5319,133 @@ dialog.loc-edit-modal[open] {
 /* 🎮 ゲームログのバッジ */
 .wl-game-row { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
 /* ─── 旧 apps-* (vertical row レイアウト) は 2026-05-13 にカード化で廃止 ─── */
+
+/* 🔍 レビュータブ (DB サブタブ) ──────────────────────────────────────── */
+.review-filter-bar {
+  display: flex; align-items: center; gap: 12px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+.review-filter-bar select {
+  font-size: 13px;
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--panel);
+}
+.review-detail-bar {
+  padding: 8px 16px;
+  display: flex; gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+  border-bottom: 1px solid var(--border);
+}
+#reviewFileTabs { padding: 0 16px; }
+.review-card {
+  cursor: pointer;
+  padding: 12px 14px;
+}
+.review-card-head {
+  display: flex; align-items: center; gap: 8px;
+  margin-bottom: 4px;
+}
+.review-card-repo {
+  font-size: 14px;
+  font-weight: 700;
+  flex: 1;
+  word-break: break-word;
+}
+.review-card-meta {
+  display: flex; gap: 8px; flex-wrap: wrap; align-items: center;
+  font-size: 11px;
+}
+.review-pr-badge {
+  display: inline-flex; align-items: center; gap: 2px;
+  background: #fff5e1; color: #8a5a00;
+  border: 1px solid #f0c97a;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  text-decoration: none;
+}
+.review-pr-badge:hover { filter: brightness(0.95); }
+
+/* markdown body (見出し / 段落 / テーブル / リスト / 引用 / コードフェンス) */
+.review-body {
+  padding: 16px;
+  font-size: 14px;
+  line-height: 1.65;
+  color: var(--text);
+  overflow-y: auto;
+  max-width: 100%;
+}
+.review-body .md-h1 { font-size: 22px; font-weight: 700; margin: 18px 0 10px; border-bottom: 2px solid var(--border); padding-bottom: 6px; }
+.review-body .md-h2 { font-size: 18px; font-weight: 700; margin: 16px 0 8px; border-bottom: 1px solid var(--border); padding-bottom: 4px; }
+.review-body .md-h3 { font-size: 16px; font-weight: 700; margin: 14px 0 6px; color: var(--accent); }
+.review-body .md-h4 { font-size: 14px; font-weight: 700; margin: 12px 0 4px; }
+.review-body .md-h5 { font-size: 13px; font-weight: 700; margin: 10px 0 4px; }
+.review-body .md-h6 { font-size: 12px; font-weight: 700; margin: 10px 0 4px; color: var(--muted); }
+.review-body .md-p { margin: 6px 0; }
+.review-body .md-ul, .review-body .md-ol { margin: 6px 0; padding-left: 24px; }
+.review-body .md-ul li, .review-body .md-ol li { margin: 2px 0; }
+.review-body .md-blockquote {
+  margin: 10px 0;
+  padding: 6px 12px;
+  border-left: 3px solid var(--accent);
+  background: var(--accent-bg);
+  color: var(--text);
+  font-style: normal;
+}
+.review-body .md-hr {
+  border: 0;
+  border-top: 1px solid var(--border);
+  margin: 16px 0;
+}
+.review-body .md-code {
+  background: #2a2f3a;
+  color: #e6e9ef;
+  padding: 10px 12px;
+  border-radius: 6px;
+  font-size: 12px;
+  line-height: 1.5;
+  overflow-x: auto;
+}
+.review-body code {
+  background: var(--accent-bg);
+  color: var(--text);
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-size: 0.92em;
+  font-family: ui-monospace, "Cascadia Code", "Consolas", "Menlo", monospace;
+}
+.review-body .md-table {
+  border-collapse: collapse;
+  margin: 10px 0;
+  font-size: 13px;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+  display: block;
+}
+.review-body .md-table thead { background: var(--accent-bg); }
+.review-body .md-table th, .review-body .md-table td {
+  border: 1px solid var(--border);
+  padding: 6px 10px;
+  text-align: left;
+  vertical-align: top;
+}
+.review-body .md-table th { font-weight: 700; }
+.review-body a { color: var(--accent); }
+@media (max-width: 760px) {
+  .review-body { padding: 12px; font-size: 13px; }
+  .review-body .md-h1 { font-size: 20px; }
+  .review-body .md-h2 { font-size: 16px; }
+  .review-body .md-h3 { font-size: 15px; }
+  .review-body .md-table { font-size: 12px; }
+  .review-body .md-table th, .review-body .md-table td { padding: 5px 8px; }
+}
 .wl-game-badge { font-size: 10px; padding: 1px 6px; border-radius: 4px; font-weight: 600; }
 .wl-game-badge-steam { background: #1b2838; color: #66c0f4; }
 .wl-game-badge-app { background: var(--accent-bg, #eef); color: var(--text); border: 1px solid var(--border); }

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -5335,13 +5335,45 @@ dialog.loc-edit-modal[open] {
   background: var(--panel);
 }
 .review-detail-bar {
-  padding: 8px 16px;
-  display: flex; gap: 12px;
-  align-items: center;
-  flex-wrap: wrap;
+  padding: 14px 18px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
   border-bottom: 1px solid var(--border);
 }
-#reviewFileTabs { padding: 0 16px; }
+.review-detail-title-row {
+  display: flex; align-items: center; gap: 12px;
+  flex-wrap: wrap;
+}
+.review-detail-title {
+  margin: 0;
+  font-size: 26px;
+  font-weight: 700;
+  line-height: 1.25;
+  word-break: break-word;
+  flex: 1;
+}
+.review-detail-date {
+  font-size: 12px;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.review-detail-date select {
+  font-size: 13px;
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--panel);
+}
+.review-file-tabs {
+  padding: 8px 16px 0;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 0;
+}
+@media (max-width: 760px) {
+  .review-detail-bar { padding: 12px 14px 8px; }
+  .review-detail-title { font-size: 22px; }
+  .review-file-tabs { padding: 6px 12px 0; }
+}
 .review-card {
   cursor: pointer;
   padding: 12px 14px;

--- a/server/routes/review.ts
+++ b/server/routes/review.ts
@@ -1,14 +1,29 @@
-// /api/review/* — LUDIARS 全リポの review/ フォルダを横断閲覧する。
+// /api/review/* — レビュー対象 (`review_targets` テーブル) と、 各ターゲットの
+// ローカル clone にある `review/<YYYY-MM-DD>/` 配下のファイルを返す API。
 //
-// Skill `ludiars-review` が各リポの `review/<YYYY-MM-DD>/REVIEW_*.md` と
-// `review/latest.json` を書き出す。 このルータはそれをファイルシステム
-// 経由でそのまま返すだけ (DB は使わない)。
+// データソース:
+//   - SQLite テーブル `review_targets` で 「どのリポを対象に listing するか」 を管理
+//   - 各ターゲットの local_path 配下 `review/` フォルダから日付ディレクトリ・
+//     latest.json・各 REVIEW_*.md を読む
+//
+// 起動時に `LUDIARS_ROOT` (= E:/Document/Ars) を走査して LUDIARS clone を
+// 自動 seed する (init.ts から `seedReviewTargets` を呼ぶ)。
 
 import { Hono, type Context } from 'hono';
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { execSync } from 'node:child_process';
+import { join, resolve, isAbsolute } from 'node:path';
+import type BetterSqlite3 from 'better-sqlite3';
+import {
+  listReviewTargets, getReviewTargetByName, insertReviewTarget,
+  insertReviewTargetIfMissing, updateReviewTarget, deleteReviewTarget,
+  type ReviewTargetRow,
+} from '../db.js';
+
+type Db = BetterSqlite3.Database;
 
 const LUDIARS_ROOT = resolve(process.env.LUDIARS_ROOT ?? 'E:/Document/Ars');
+const SUPPORTED_FORMATS = new Set(['aiformat']);
 
 const REVIEW_FILES = [
   'REVIEW.md',
@@ -30,13 +45,6 @@ interface LatestJson {
   fix_pr?: string | null;
 }
 
-function safeRepoName(name: string): string | null {
-  // path traversal 防止 — 英数字 / ハイフン / アンダースコア / ドットのみ許可、 先頭ドット禁止
-  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(name)) return null;
-  if (name.includes('..')) return null;
-  return name;
-}
-
 function safeDate(s: string): string | null {
   return /^\d{4}-\d{2}-\d{2}$/.test(s) ? s : null;
 }
@@ -45,18 +53,23 @@ function safeFile(name: string): ReviewFile | null {
   return (REVIEW_FILES as readonly string[]).includes(name) ? (name as ReviewFile) : null;
 }
 
-function reviewDir(repo: string): string {
-  return join(LUDIARS_ROOT, repo, 'review');
+/** ターゲットの local_path を絶対パスに解決 (= 相対なら LUDIARS_ROOT 起点)。 */
+function resolveTargetPath(target: ReviewTargetRow): string {
+  return isAbsolute(target.local_path) ? target.local_path : resolve(LUDIARS_ROOT, target.local_path);
 }
 
-function readLatest(repo: string): LatestJson | null {
-  const p = join(reviewDir(repo), 'latest.json');
+function reviewDir(target: ReviewTargetRow): string {
+  return join(resolveTargetPath(target), 'review');
+}
+
+function readLatest(target: ReviewTargetRow): LatestJson | null {
+  const p = join(reviewDir(target), 'latest.json');
   if (!existsSync(p)) return null;
   try { return JSON.parse(readFileSync(p, 'utf8')) as LatestJson; } catch { return null; }
 }
 
-function listDates(repo: string): string[] {
-  const dir = reviewDir(repo);
+function listDates(target: ReviewTargetRow): string[] {
+  const dir = reviewDir(target);
   if (!existsSync(dir)) return [];
   return readdirSync(dir)
     .filter((n) => safeDate(n) && statSync(join(dir, n)).isDirectory())
@@ -64,56 +77,142 @@ function listDates(repo: string): string[] {
     .reverse();
 }
 
-function listReviewedRepos(): string[] {
-  if (!existsSync(LUDIARS_ROOT)) return [];
-  const out: string[] = [];
-  for (const name of readdirSync(LUDIARS_ROOT)) {
-    if (!safeRepoName(name)) continue;
-    const dir = reviewDir(name);
-    if (!existsSync(dir) || !statSync(dir).isDirectory()) continue;
-    // review/ フォルダがあっても日付サブディレクトリが 1 件も無い場合は
-    // 一覧に出さない (= Actio と Actio.cocoiru のように同一 remote の別 clone で
-    // pull タイミングがずれて空の review/ だけが残っている worktree 対策)。
-    const hasDates = readdirSync(dir).some(
-      (n) => safeDate(n) && statSync(join(dir, n)).isDirectory(),
-    );
-    if (hasDates) out.push(name);
+/** 起動時に LUDIARS_ROOT 配下の git clone を walk し、 github.com/LUDIARS/<Name>
+ *  remote を持つものを review_targets に挿入する。 既存はスキップ。 */
+export function seedReviewTargets(db: Db): { seeded: number; skipped: number } {
+  if (!existsSync(LUDIARS_ROOT)) return { seeded: 0, skipped: 0 };
+  let seeded = 0;
+  let skipped = 0;
+  // 同じ remote URL の別 clone (worktree / fork) を排除するため、 URL でユニーク化
+  const seenUrls = new Set<string>();
+  for (const name of readdirSync(LUDIARS_ROOT).sort()) {
+    const full = join(LUDIARS_ROOT, name);
+    let stat;
+    try { stat = statSync(full); } catch { continue; }
+    if (!stat.isDirectory()) continue;
+    let url = '';
+    try {
+      url = execSync('git config --get remote.origin.url', { cwd: full, stdio: ['ignore', 'pipe', 'ignore'] })
+        .toString().trim();
+    } catch { continue; }
+    if (!/github\.com[/:]LUDIARS\//i.test(url)) continue;
+    if (seenUrls.has(url)) { skipped++; continue; }
+    seenUrls.add(url);
+    const inserted = insertReviewTargetIfMissing(db, {
+      name,
+      local_path: full,
+      format_key: 'aiformat',
+    });
+    if (inserted) seeded++; else skipped++;
   }
-  return out.sort();
+  return { seeded, skipped };
 }
 
-export function makeReviewRouter(): Hono {
+export interface ReviewRouterDeps { db: Db }
+
+export function makeReviewRouter(deps: ReviewRouterDeps): Hono {
+  const { db } = deps;
   const r = new Hono();
 
+  // ── target CRUD ────────────────────────────────────────────────────────
+  r.get('/api/review/targets', (c: Context) => {
+    const items = listReviewTargets(db);
+    return c.json({ items, ludiars_root: LUDIARS_ROOT, formats: [...SUPPORTED_FORMATS] });
+  });
+
+  r.post('/api/review/targets', async (c: Context) => {
+    const body = await c.req.json().catch(() => null) as {
+      name?: unknown; local_path?: unknown; format_key?: unknown;
+    } | null;
+    const name = typeof body?.name === 'string' ? body.name.trim() : '';
+    let local_path = typeof body?.local_path === 'string' ? body.local_path.trim() : '';
+    const format_key = typeof body?.format_key === 'string' ? body.format_key.trim() : 'aiformat';
+    if (!name) return c.json({ error: 'name required' }, 400);
+    if (!local_path) return c.json({ error: 'local_path required' }, 400);
+    if (!SUPPORTED_FORMATS.has(format_key)) return c.json({ error: `unsupported format: ${format_key}` }, 400);
+    // 相対なら LUDIARS_ROOT 起点で絶対化して存在を確認
+    const abs = isAbsolute(local_path) ? local_path : resolve(LUDIARS_ROOT, local_path);
+    if (!existsSync(abs)) return c.json({ error: `local_path not found: ${abs}` }, 400);
+    if (!statSync(abs).isDirectory()) return c.json({ error: 'local_path is not a directory' }, 400);
+    // 同名・同 path をブロック
+    if (getReviewTargetByName(db, name)) return c.json({ error: `name already taken: ${name}` }, 409);
+    try {
+      const id = insertReviewTarget(db, { name, local_path: abs, format_key });
+      return c.json({ id, name, local_path: abs, format_key }, 201);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return c.json({ error: `insert failed: ${msg}` }, 500);
+    }
+  });
+
+  r.patch('/api/review/targets/:id', async (c: Context) => {
+    const id = Number(c.req.param('id'));
+    if (!Number.isFinite(id)) return c.json({ error: 'invalid id' }, 400);
+    const body = await c.req.json().catch(() => ({})) as {
+      name?: unknown; local_path?: unknown; format_key?: unknown; enabled?: unknown;
+    };
+    const patch: { name?: string; local_path?: string; format_key?: string; enabled?: 0 | 1 } = {};
+    if (typeof body.name === 'string') patch.name = body.name.trim();
+    if (typeof body.local_path === 'string') patch.local_path = body.local_path.trim();
+    if (typeof body.format_key === 'string') {
+      if (!SUPPORTED_FORMATS.has(body.format_key)) return c.json({ error: 'unsupported format' }, 400);
+      patch.format_key = body.format_key;
+    }
+    if (body.enabled === true || body.enabled === 1) patch.enabled = 1;
+    if (body.enabled === false || body.enabled === 0) patch.enabled = 0;
+    updateReviewTarget(db, id, patch);
+    return c.json({ ok: true });
+  });
+
+  r.delete('/api/review/targets/:id', (c: Context) => {
+    const id = Number(c.req.param('id'));
+    if (!Number.isFinite(id)) return c.json({ error: 'invalid id' }, 400);
+    const ok = deleteReviewTarget(db, id);
+    return c.json({ ok });
+  });
+
+  // ── public listing API (= レビューカード一覧) ─────────────────────────
   r.get('/api/review/repos', (c: Context) => {
-    const items = listReviewedRepos().map((repo) => {
-      const latest = readLatest(repo);
-      return {
-        repo,
-        latest_date: latest?.date ?? null,
-        weighted_score: latest?.weighted_score ?? null,
-        critical_count: latest?.critical_count ?? 0,
-        high_count: latest?.high_count ?? 0,
-        fix_pr: latest?.fix_pr ?? null,
-      };
-    });
+    const targets = listReviewTargets(db, { enabledOnly: true });
+    const items = targets
+      .map((t) => {
+        const dates = listDates(t);
+        const latest = readLatest(t);
+        return {
+          repo: t.name,
+          target_id: t.id,
+          local_path: resolveTargetPath(t),
+          format_key: t.format_key,
+          has_dates: dates.length > 0,
+          latest_date: latest?.date ?? (dates[0] ?? null),
+          weighted_score: latest?.weighted_score ?? null,
+          critical_count: latest?.critical_count ?? 0,
+          high_count: latest?.high_count ?? 0,
+          fix_pr: latest?.fix_pr ?? null,
+        };
+      })
+      // 日付ディレクトリ無しのターゲットは UI 側で 「未生成」 表示にしたいが、
+      // とりあえず latest.json も無いものは抑制 (= まだレビュー走ってない repo は出さない)。
+      .filter((it) => it.has_dates);
     return c.json({ items, root: LUDIARS_ROOT });
   });
 
   r.get('/api/review/repos/:repo', (c: Context) => {
-    const repo = safeRepoName(c.req.param('repo') ?? '');
-    if (!repo) return c.json({ error: 'invalid repo' }, 400);
-    const dates = listDates(repo);
-    const latest = readLatest(repo);
-    return c.json({ repo, dates, latest });
+    const repo = c.req.param('repo') ?? '';
+    const target = getReviewTargetByName(db, repo);
+    if (!target) return c.json({ error: 'not_found' }, 404);
+    const dates = listDates(target);
+    const latest = readLatest(target);
+    return c.json({ repo: target.name, dates, latest, format_key: target.format_key });
   });
 
   r.get('/api/review/repos/:repo/:date/:file', (c: Context) => {
-    const repo = safeRepoName(c.req.param('repo') ?? '');
+    const repo = c.req.param('repo') ?? '';
     const date = safeDate(c.req.param('date') ?? '');
     const file = safeFile(c.req.param('file') ?? '');
-    if (!repo || !date || !file) return c.json({ error: 'invalid path' }, 400);
-    const p = join(reviewDir(repo), date, file);
+    const target = getReviewTargetByName(db, repo);
+    if (!target || !date || !file) return c.json({ error: 'invalid path' }, 400);
+    const p = join(reviewDir(target), date, file);
     if (!existsSync(p)) return c.json({ error: 'not_found' }, 404);
     const text = readFileSync(p, 'utf8');
     return c.body(text, 200, { 'Content-Type': 'text/markdown; charset=utf-8' });

--- a/server/routes/review.ts
+++ b/server/routes/review.ts
@@ -125,7 +125,7 @@ export function makeReviewRouter(deps: ReviewRouterDeps): Hono {
       name?: unknown; local_path?: unknown; format_key?: unknown;
     } | null;
     const name = typeof body?.name === 'string' ? body.name.trim() : '';
-    let local_path = typeof body?.local_path === 'string' ? body.local_path.trim() : '';
+    const local_path = typeof body?.local_path === 'string' ? body.local_path.trim() : '';
     const format_key = typeof body?.format_key === 'string' ? body.format_key.trim() : 'aiformat';
     if (!name) return c.json({ error: 'name required' }, 400);
     if (!local_path) return c.json({ error: 'local_path required' }, 400);

--- a/server/routes/review.ts
+++ b/server/routes/review.ts
@@ -70,7 +70,14 @@ function listReviewedRepos(): string[] {
   for (const name of readdirSync(LUDIARS_ROOT)) {
     if (!safeRepoName(name)) continue;
     const dir = reviewDir(name);
-    if (existsSync(dir) && statSync(dir).isDirectory()) out.push(name);
+    if (!existsSync(dir) || !statSync(dir).isDirectory()) continue;
+    // review/ フォルダがあっても日付サブディレクトリが 1 件も無い場合は
+    // 一覧に出さない (= Actio と Actio.cocoiru のように同一 remote の別 clone で
+    // pull タイミングがずれて空の review/ だけが残っている worktree 対策)。
+    const hasDates = readdirSync(dir).some(
+      (n) => safeDate(n) && statSync(join(dir, n)).isDirectory(),
+    );
+    if (hasDates) out.push(name);
   }
   return out.sort();
 }


### PR DESCRIPTION
## Summary

🔍 レビューを top-level タブから **データベースタブ内のサブタブ** に格下げ、 UI を **カード形式 + リポをカテゴリとして運用** に変更。

- 上部メインタブから 🔍 レビューを削除
- databaseSubtabs に `data-db-sub="review"` 追加 (📚 ブクマ / 📖 辞書 / 🏷 ドメイン / 🗺️ 作業場所 / 💻 アプリ / **🔍 レビュー** / ⚙ キュー)
- 一覧: 1 リポ 1 カードで「タイトル + リポ + 総合スコア + ⚠ Critical/High 数 + 🔧 修正 PR」 のみ抽出
- 左サイドのカテゴリ = リポ一覧 (全て / 各リポ)。 クリックでフィルタ
- カードクリック → 日付セレクト + 6 ファイルタブの詳細ビュー、 「← 一覧に戻る」 で復帰

## 旧 state の救済

`DATABASE_REDIRECT_TABS` に `'review'` を追加したので、 localStorage の旧 `state.tab='review'` も自動でデータベースタブ → review サブに redirect される。

## Test plan

- [ ] データベースタブで 🔍 レビューサブを開くとリポ一覧 + カードが表示される
- [ ] カテゴリ「全て」 + 各リポ切替が動く
- [ ] カードクリックで詳細ビュー、 ← 戻るで一覧復帰
- [ ] 日付セレクト切替で過去レビューが見られる
- [ ] 🔧 修正 PR リンクが新しいタブで開く

## 連動

- 朝 5:07 JST の cloud routine [\`ludiars-review-daily\`](https://claude.ai/code/routines/trig_01QHgXWxTbLSsMWXoTHKAUq4) が AIFormat レビュー PR + AUTOFIX.md を生成。 ローカルで pull するとこの UI で表示される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)