### PR TITLE
feat(hub): PASETO v4 verifier + HS256 fallback + aud / displayName (Phase 1)

### DIFF
--- a/server/multi/.env.example
+++ b/server/multi/.env.example
@@ -33,10 +33,21 @@ CERNERE_SERVICE_SECRET=replace-me
 # (将来 Cernere /ws/service が実装されたら使う)
 SERVICE_JWT_SECRET=replace-with-a-long-random-string
 
-# Cernere の JWT_SECRET と共有する。
-# 当面の認証経路は Cernere accessToken を Hub がローカル HMAC 検証する形 (RFC 7519
-# `sub` claim を userId として読む)。 Cernere の .env の JWT_SECRET と必ず一致させる。
+# [DEPRECATED / 互換期間] Cernere の JWT_SECRET と共有する HS256 fallback。
+# PASETO v4 移行 (Issue LUDIARS/Cernere#91) 完了後は不要。 当面 2 週間は
+# 旧 client (HS256) を受け付けるために残す。 cutover 後に削除する。
 CERNERE_JWT_SECRET=replace-with-cernere-jwt-secret
+
+# PASETO v4 検証用 (Cernere Phase 1)。 Hub は Cernere の public key を以下
+# endpoint から起動時 + 6h 毎に fetch して in-memory cache に持つ。
+# CERNERE_BASE_URL: Hub が Cernere に到達できる URL。 server-to-server (LAN /
+# private). public URL でも可。
+CERNERE_BASE_URL=http://localhost:8080
+
+# MEMORIA_HUB_PUBLIC_URL: Hub 自身の公開 URL (= PASETO の aud claim 検証用)。
+# Cernere から発行された token の aud と一致しないと拒否する。
+# 未設定だと aud 検証は skip され warn ログが出る (= 一時的な互換動作)。
+MEMORIA_HUB_PUBLIC_URL=https://hub.memoria.example.com
 
 # CORS — Memoria local SPA からのアクセスを許可するオリジン
 MEMORIA_HUB_ALLOWED_ORIGINS=http://localhost:5180

--- a/server/multi/index.js
+++ b/server/multi/index.js
@@ -86,6 +86,12 @@ void adapter; // 将来 isRevoked check 等に使う想定
 const CERNERE_JWT_SECRET = process.env.CERNERE_JWT_SECRET ?? '';
 const IS_DEV = process.env.NODE_ENV !== 'production';
 
+// PASETO v4 (Phase 1 / Cernere Issue #91)。 起動時 + 6h 毎に Cernere の
+// /.well-known/cernere-public-key を fetch して in-memory cache に持つ。
+import { verifyPaseto, startPublicKeyRefreshLoop, getCachedKidList } from './paseto-verifier.js';
+startPublicKeyRefreshLoop();
+console.log(`[hub] PASETO public key refresh loop started (cernere: ${process.env.CERNERE_BASE_URL || 'http://localhost:8080'})`);
+
 function verifyCernereJwt(token) {
   if (!CERNERE_JWT_SECRET) return null;
   const parts = token.split('.');
@@ -108,10 +114,28 @@ const authMiddleware = async (c, next) => {
   const auth = c.req.header('authorization') ?? c.req.header('Authorization') ?? '';
   const m = auth.match(/^Bearer\s+(.+)$/i);
   if (m) {
-    const v = verifyCernereJwt(m[1]);
+    const raw = m[1];
+    // PASETO v4 (新、 Cernere の signProjectToken が発行) を優先検証
+    if (raw.startsWith('v4.public.')) {
+      const p = await verifyPaseto(raw);
+      if (p?.userId) {
+        c.set('userId', p.userId);
+        c.set('userRole', p.role);
+        if (p.displayName) c.set('userName', p.displayName);
+        c.set('tokenAlg', 'EdDSA');
+        return next();
+      }
+      // PASETO 形式だが検証失敗 → fallback には流さず即拒否 (= forge 防止)
+      console.warn(`[auth] PASETO token verify failed (cached kids: ${getCachedKidList().join(',') || '(empty)'})`);
+      return c.json({ error: 'unauthorized', detail: 'paseto verify failed' }, 401);
+    }
+    // 旧 HS256 (= 互換期間中の legacy client)
+    const v = verifyCernereJwt(raw);
     if (v?.userId) {
       c.set('userId', v.userId);
       c.set('userRole', v.role);
+      c.set('tokenAlg', 'HS256');
+      console.warn(`[auth] deprecated HS256 token used (user=${v.userId.slice(0, 8)}) — migrate to PASETO`);
       return next();
     }
   }

--- a/server/multi/package-lock.json
+++ b/server/multi/package-lock.json
@@ -12,6 +12,7 @@
         "@ludiars/cernere-id-cache": "file:../../../Cernere/packages/id-cache",
         "@ludiars/cernere-service-adapter": "file:../../../Cernere/packages/service-adapter",
         "hono": "^4.6.10",
+        "paseto": "^3.1.4",
         "pg": "^8.13.1",
         "ws": "^8.20.0"
       }
@@ -71,6 +72,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/paseto": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/paseto/-/paseto-3.1.4.tgz",
+      "integrity": "sha512-BifaKKu+MS9b/vTgFMC6Q8uLUMqw8VtYgl4qODJWb6Jqt+dTKn8XH9EftJZx+6wxF4ELBbKdH33DZa4inMYVcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/pg": {

--- a/server/multi/package.json
+++ b/server/multi/package.json
@@ -14,6 +14,7 @@
     "@ludiars/cernere-id-cache": "file:../../../Cernere/packages/id-cache",
     "@ludiars/cernere-service-adapter": "file:../../../Cernere/packages/service-adapter",
     "hono": "^4.6.10",
+    "paseto": "^3.1.4",
     "pg": "^8.13.1",
     "ws": "^8.20.0"
   }

--- a/server/multi/paseto-verifier.js
+++ b/server/multi/paseto-verifier.js
@@ -1,0 +1,105 @@
+// Hub 側 PASETO v4 検証 (Cernere Phase 1 — Issue LUDIARS/Cernere#91)。
+//
+// Cernere は GET /.well-known/cernere-public-key で public key を公開する。
+// 起動時 + 6h 毎に fetch して in-memory cache に持ち、 Bearer token の
+// 検証を完全に local で行う (= Cernere 不到達でも検証は continue 可能)。
+//
+// 旧 HS256 (= 互換期間) の検証は index.js の verifyCernereJwt がそのまま残る。
+// ここでは PASETO 検証のみを行う。
+
+import { V4 } from 'paseto';
+
+const CERNERE_BASE_URL = process.env.CERNERE_BASE_URL || 'http://localhost:8080';
+const HUB_PUBLIC_URL = process.env.MEMORIA_HUB_PUBLIC_URL || '';
+// 6 時間ごと refresh + 起動時 1 回。
+const REFRESH_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+/** keyCache: kid → { key (Buffer), fetched_at } */
+const keyCache = new Map();
+let refreshTimer = null;
+
+export function getCachedKidList() {
+  return [...keyCache.keys()];
+}
+
+export async function refreshPublicKeys() {
+  try {
+    const res = await fetch(`${CERNERE_BASE_URL}/.well-known/cernere-public-key`);
+    if (!res.ok) throw new Error(`fetch failed: ${res.status}`);
+    const body = await res.json();
+    const keys = Array.isArray(body?.keys) ? body.keys : [];
+    let added = 0;
+    for (const k of keys) {
+      if (!k?.kid || !k?.public_key) continue;
+      const buf = Buffer.from(k.public_key, 'base64');
+      if (buf.length !== 32) {
+        console.warn(`[paseto] skipped kid=${k.kid} (public_key length=${buf.length}, expected 32)`);
+        continue;
+      }
+      keyCache.set(k.kid, { key: buf, fetched_at: Date.now() });
+      added++;
+    }
+    console.log(`[paseto] public key cache refreshed: ${added} key(s) total=${keyCache.size}`);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.warn(`[paseto] refresh failed: ${msg} (cache size: ${keyCache.size})`);
+  }
+}
+
+export function startPublicKeyRefreshLoop() {
+  void refreshPublicKeys();
+  if (refreshTimer) clearInterval(refreshTimer);
+  refreshTimer = setInterval(() => {
+    void refreshPublicKeys();
+  }, REFRESH_INTERVAL_MS);
+  refreshTimer.unref?.();
+}
+
+/** PASETO v4 token を検証して claims を返す。 失敗時は null。
+ *  検証項目:
+ *    - PASETO header から kid 抽出、 cache lookup
+ *    - V4 signature verify
+ *    - aud === HUB_PUBLIC_URL (= 別 hub への replay 防止)
+ *    - exp > now、 iat < now + 30sec (= clock skew)
+ *    - kind === "user_for_project"
+ */
+export async function verifyPaseto(token) {
+  if (typeof token !== 'string') return null;
+  // v4.public.<base64...><.footer> 形式のみ受け付ける (= HS256 token は始まりが異なる)。
+  if (!token.startsWith('v4.public.')) return null;
+
+  // PASETO の footer (= JSON with kid) を覗き見るために decode のみ実行する。
+  // paseto ライブラリは V4.verify に渡す前段で kid を取り出す API を提供していないので、
+  // 全 cached key を順に試す方式で動かす (= key 数は 1-3 程度なので OK)。
+  for (const [kid, entry] of keyCache.entries()) {
+    try {
+      const result = await V4.verify(token, entry.key, {
+        complete: true,
+        audience: HUB_PUBLIC_URL || undefined,
+      });
+      const payload = result?.payload ?? result;
+      if (!payload || typeof payload !== 'object') continue;
+      if (payload.kind !== 'user_for_project') {
+        console.warn(`[paseto] rejected: kind=${payload.kind} kid=${kid}`);
+        return null;
+      }
+      // audience が optional な場合 (= HUB_PUBLIC_URL 未設定で起動) はここで warn 出す。
+      if (!HUB_PUBLIC_URL) {
+        console.warn('[paseto] MEMORIA_HUB_PUBLIC_URL not set — aud check skipped');
+      }
+      return {
+        userId: typeof payload.sub === 'string' ? payload.sub : null,
+        role: typeof payload.role === 'string' ? payload.role : 'general',
+        displayName: typeof payload.displayName === 'string' ? payload.displayName : null,
+        projectKey: typeof payload.projectKey === 'string' ? payload.projectKey : null,
+        kid,
+        jti: typeof payload.jti === 'string' ? payload.jti : null,
+        exp: typeof payload.exp === 'number' ? payload.exp : null,
+      };
+    } catch (e) {
+      // kid 違い or invalid → 次の key を試す
+      void e;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
Phase 1 (Issue [LUDIARS/Cernere#91](https://github.com/LUDIARS/Cernere/issues/91)) の Memoria Hub 側。
[LUDIARS/Cernere#92](https://github.com/LUDIARS/Cernere/pull/92) (PASETO 発行) とペアの PR。

## Summary

Cernere が発行した PASETO v4 token を **Hub が公開鍵で local 検証** できるようにする。 これで HS256 共有 secret 時代の 「Hub 漏洩 = token 偽造能力漏洩」 を解消。 旧 HS256 は 2 週間の互換期間中は fallback として受け付ける。

## 変更点

- 新規 `server/multi/paseto-verifier.js`
  - 起動時 + 6h 毎に `GET <CERNERE_BASE_URL>/.well-known/cernere-public-key`
  - in-memory cache (kid → public key)
  - `verifyPaseto(token)`: v4.public.\* token を cached key で検証
  - `aud` claim と `MEMORIA_HUB_PUBLIC_URL` を一致確認
- `server/multi/index.js` authMiddleware:
  - Bearer が `v4.public.` で始まれば **PASETO 経路** (= 厳格、 fallback なし)
  - そうでなければ旧 HS256 verifyCernereJwt (= warn ログ付き)
  - displayName が PASETO claim にあれば `c.set('userName', ...)` 経由でカードに反映
- `server/multi/.env.example`:
  - `CERNERE_JWT_SECRET` を `[DEPRECATED / 互換期間]` とマーク
  - 新規: `CERNERE_BASE_URL`, `MEMORIA_HUB_PUBLIC_URL`
- 依存: `paseto@^3` 追加

## 動作確認の流れ

1. Cernere PR #92 を merge して keypair を env に設定、 起動
2. この PR を merge して Hub に `CERNERE_BASE_URL` / `MEMORIA_HUB_PUBLIC_URL` を設定、 起動
3. Hub 起動ログに `[paseto] public key cache refreshed: 1 key(s)` が出る
4. Memoria local 側はまだ PASETO 未対応のため、 暫定で HS256 fallback で動作 (warn ログあり)
5. 別 PR で Memoria local が PASETO 経路を使うようにする

## Test plan

- [ ] Cernere 起動後 `GET /.well-known/cernere-public-key` で public key が返る
- [ ] Hub 起動ログに `[paseto] public key cache refreshed` が出る
- [ ] PASETO token (Cernere に hub_url 渡して取得) で `/api/me` → 200 + displayName が response に
- [ ] HS256 token (legacy) で `/api/me` → 200 + warn ログ `deprecated HS256 token used`
- [ ] 別 hub_url を aud に入れた PASETO で → 401 `paseto verify failed`
- [ ] PASETO 形式だが signature 改竄 → 401 (HS256 fallback には流れない)

## 関連

- Cernere PR #92: PASETO 発行 + well-known endpoint
- Memoria 次の PR: local の `getProjectTokenForHub` に `hub_url` 追加
- Issue LUDIARS/Cernere#91 — Phase 1 設計全体
- Issue LUDIARS/Cernere#90 — Phase 2 (mTLS) 設計

🤖 Generated with [Claude Code](https://claude.com/claude-code)