### PR TITLE
feat(multi-client): project-token request に hub_url (= audience) を含める

### DIFF
--- a/server/lib/cernere-session.ts
+++ b/server/lib/cernere-session.ts
@@ -43,14 +43,21 @@ function decodeExp(token: string): number | null {
   }
 }
 
-async function fetchProjectToken(userJwt: string, projectKey: string): Promise<CachedToken> {
+async function fetchProjectToken(
+  userJwt: string,
+  projectKey: string,
+  hubUrl: string,
+): Promise<CachedToken> {
+  // Cernere Phase 1 (PR #92) で `hub_url` を audience に入れる仕様になった。
+  // 旧 Cernere は無視するので互換性あり。 新 Cernere は PASETO v4 で発行、
+  // aud claim が hub_url と一致する。
   const res = await fetch(`${CERNERE_BASE_URL}/api/auth/project-token`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'Authorization': `Bearer ${userJwt}`,
     },
-    body: JSON.stringify({ project_key: projectKey }),
+    body: JSON.stringify({ project_key: projectKey, hub_url: hubUrl }),
   });
   if (!res.ok) {
     const body = await res.text().catch(() => '');
@@ -83,7 +90,7 @@ export async function getProjectTokenForHub(
 
   const task = (async () => {
     try {
-      const t = await fetchProjectToken(userJwt, projectKey);
+      const t = await fetchProjectToken(userJwt, projectKey, key);
       cache.set(key, t);
       return t;
     } finally {


### PR DESCRIPTION
Phase 1 (Issue [LUDIARS/Cernere#91](https://github.com/LUDIARS/Cernere/issues/91)) の Memoria local 側。 [Cernere #92](https://github.com/LUDIARS/Cernere/pull/92) + [Memoria #146](https://github.com/LUDIARS/Memoria/pull/146) と組で動く。

## Summary

`fetchProjectToken` の POST body に `hub_url` を追加。 Cernere 側 (PR #92) は受け取った hub_url を PASETO の `aud` claim に入れて発行する。 旧 Cernere は body の余計フィールドを無視するので **完全に互換**。

## 変更点

- `server/lib/cernere-session.ts`:
  - `fetchProjectToken(userJwt, projectKey)` → `(userJwt, projectKey, hubUrl)`
  - body: `{ project_key, hub_url }` (hub_url 追加)
  - 呼び出し側 (`getProjectTokenForHub`) は既に hubUrl を持っているので、 そのまま渡す

## Test plan

- [ ] Cernere #92 を merge 後、 Memoria local backend を再起動
- [ ] 接続済みサーバの 1 つに対して share 操作 (例: bookmark share)
- [ ] Cernere 側 dev log で `auth.projectUserToken.issue` の `alg=EdDSA` と `audience=<hub url>` を確認
- [ ] Hub 側 (#146 merge 後) で「PASETO 経路、 displayName 取込」 のログ確認
- [ ] 旧 Cernere (= #92 未 merge) でも 同 API を叩いて HS256 token が返ってきて 200 で動作 (= 互換性)

## 関連

- Cernere PR #92: PASETO 発行 + well-known
- Memoria Hub PR #146: PASETO verifier + HS256 fallback
- Issue LUDIARS/Cernere#91: Phase 1 設計全体
- Issue LUDIARS/Cernere#90: Phase 2 (mTLS) 設計

## 次のステップ

3 PR (Cernere #92 / Memoria #146 / Memoria #147) を順に merge した後、 deployment 側で:
- Memoria Hub の Caddy / WAF に IP allowlist を入れる
- 2 週間運用してログから HS256 token 使用件数が 0 になるのを確認
- HS256 経路 (Cernere `auth-handler.ts` の legacy fallback + Memoria Hub の `verifyCernereJwt`) を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)