### PR TITLE
feat(hooks): 文字化け対策込みの git post-commit hook + setup script + ユーザ設定 doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,16 @@ UI 設定が無い限り使うのは port / data dir くらい。
 | `MEMORIA_WIFI_INTERVAL_SEC` | `600` | WiFi 位置の実行間隔 |
 | `MEMORIA_LEGATUS_WS` | (off) | `on` で旧 Legatus 経由 subscriber を opt-in (通常は内蔵 broker のみ) |
 
+## ユーザがやる必要のある設定
+
+各機能を使うには「ユーザ側で鍵を入れる / hook をインストールする」 など必須。
+全部まとめた一覧 → [docs/setup/user-setup.md](docs/setup/user-setup.md)。
+
+特によく聞かれるもの:
+- git post-commit hook (= ローカル commit を活動ログに) → [docs/setup/git-hooks.md](docs/setup/git-hooks.md)
+- Claude Code prompt hook → `server/hooks/claude-code-prompt.mjs` の冒頭コメント参照
+- GitHub PAT / Steam ID / OwnTracks key / LLM provider → アプリの設定パネル
+
 ## ライセンス
 
 MIT

--- a/docs/setup/git-hooks.md
+++ b/docs/setup/git-hooks.md
@@ -1,0 +1,91 @@
+# git post-commit hook の導入
+
+Memoria は commit を「開発活動」 として記録し、 日記 / 週報の根拠にする。
+git の `post-commit` hook を設定すると、 commit するたびに Memoria local backend
+の `POST /api/activity/event` が呼ばれて `activity_events.kind='git_commit'` 行が
+追加される。
+
+## 自動セットアップ (推奨)
+
+```bash
+# Memoria repo のルートで:
+node server/hooks/setup.mjs
+
+# 既に global の core.hooksPath を別用途で使ってる場合は repo ごとに入れる:
+node server/hooks/setup.mjs --repo /path/to/your-repo
+
+# 何が実行されるか確認するだけ (手動でやる人向け):
+node server/hooks/setup.mjs --print
+```
+
+これで以下が起きる:
+
+1. `~/.memoria-hooks/` に `post-commit` (shell shim) と `post-commit.mjs` (Node 本体) をコピー
+2. `git config --global core.hooksPath ~/.memoria-hooks` を設定
+3. 動作確認用の dummy commit でも記録される
+
+既に別の global hook を使っている場合 (例: メモリの `feedback_8686_git_hooks_ignore.md`
+で言及されている別ツール用の hook) は、 setup.mjs は **警告して中止** する。
+共存させたい場合は手動で:
+
+```bash
+# 既存 hooks dir のパスを確認
+git config --global core.hooksPath
+
+# その dir に Memoria hooks をコピー (上書き注意)
+cp server/hooks/post-commit     <existing-hooks-dir>/post-commit-memoria
+cp server/hooks/post-commit.mjs <existing-hooks-dir>/
+# 既存 post-commit から `<existing-hooks-dir>/post-commit-memoria` を呼ぶラッパに改修
+```
+
+## 動作確認
+
+```bash
+# どこかの git repo で
+git commit --allow-empty -m "test memoria hook"
+
+# Memoria backend (npm run dev) のログに以下が出れば成功
+# [http] {... method: "POST", path: "/api/activity/event", status: 200 ...}
+```
+
+stdout/stderr に hook 関連のメッセージが出てしまう場合は、 `MEMORIA_GIT_HOOK_DEBUG=0`
+で抑制 (default も silent)。
+
+## トラブルシュート
+
+### コミットメッセージが文字化けする
+
+Windows の OEM code page (= Shift-JIS) が悪さしているはず。 hook は
+`git -c i18n.logoutputencoding=utf-8` を内部で使うので、 通常は UTF-8 で
+送信される。 それでも化ける場合:
+
+1. PowerShell / git-bash 双方で `git log -1` の表示が正しいか確認
+2. `MEMORIA_GIT_HOOK_DEBUG=1 node server/hooks/post-commit.mjs` を実行して
+   どの段階で化けるかを切り分け
+3. Memoria 受信側で 化けていれば `routes/visit.ts` の JSON parse 周りを疑う
+
+### Memoria backend に届かない
+
+- `curl -i http://localhost:5180/health` で疎通確認
+- backend の起動順 (= Memoria が落ちてる時間帯の commit は記録されない、 仕様)
+- `MEMORIA_URL` 環境変数が正しいか (`export MEMORIA_URL=http://192.168.x.x:5180` 等)
+
+## AI に頼む場合のプロンプト例
+
+このリポジトリには AI 担当者に貼るだけで導入できるテンプレートを用意してある。
+
+```text
+Memoria の git post-commit hook を私の環境に導入してください。
+
+このリポジトリの server/hooks/ に setup.mjs / post-commit / post-commit.mjs が
+あるので、以下の前提に従って導入手順を実行 (or 案内) してください:
+
+- 私の OS は <Windows / macOS / Linux>
+- 既存の global git hook の使用状況: <未使用 / 8686 系の noise hook を使ってる / 別ツール>
+- 既に Memoria local backend が <http://localhost:5180> で動いている
+- 動作確認は dummy commit で Memoria backend ログに POST 200 が見えること
+
+setup.mjs を直接実行できる環境なら自動セットアップ、 共存が必要なら手動 merge の
+手順を提示してください。 設定後、 私のターミナルで実行すべきコマンドを 1 つずつ
+提示し、 私が承認するごとに次へ進めてください (= 一括実行はしない)。
+```

--- a/docs/setup/user-setup.md
+++ b/docs/setup/user-setup.md
@@ -1,0 +1,59 @@
+# ユーザが手動で設定する必要があるもの
+
+Memoria は単体で動くが、 外部サービス / 自分の端末 と連携する機能は **ユーザが
+鍵やパス / 個別 hook 等を設定しないと取得できない**。 ここでは「ユーザがやらない限り
+Memoria には来ないデータ」 を 1 箇所にまとめる。
+
+| 種別 | 必要設定 | 設定先 | 取れるデータ |
+|---|---|---|---|
+| **GitHub commits** | Personal Access Token (classic 推奨) | 設定 → 📝 日記 → GitHub 連携 | 日記 / 週報の commit 集計 |
+| **git ローカル post-commit** | hook の install ([git-hooks.md](./git-hooks.md)) | global core.hooksPath or per-repo | ローカル commit (= push 前) を活動として記録 |
+| **Claude Code prompt** | UserPromptSubmit hook ([claude-code-prompt.mjs](../../server/hooks/claude-code-prompt.mjs)) | `~/.claude/settings.json` の hooks | Claude Code への指示を「開発活動」 として記録 |
+| **OwnTracks GPS 軌跡** | iPhone OwnTracks → MQTT key | 軌跡タブ → 🔑 key → OwnTracks の設定 | 移動軌跡 / 作業場所自動判定 |
+| **Steam ゲームプレイ** | Steam ID (+ optional Web API key) | 設定 → 🔌 連携 → Steam | ゲームタイトル + playtime 自動取得 |
+| **Google Geolocation API** | API key | 環境変数 `MEMORIA_GOOGLE_GEOLOCATION_API_KEY` | PC の WiFi スキャン → 概略位置 |
+| **WiFi 位置 (Electron 限定)** | Electron 実行 (= Windows のみ自動) | デスクトップアプリ起動 | 起動端末の WiFi SSID から作業場所 |
+| **Web Push 通知** | ブラウザの通知許可 + PWA インストール (iOS) | 起動チュートリアル / 設定 → 🔔 | 日記完了 / ディグ完了等の push |
+| **Cernere SSO (Multi server)** | Cernere ログイン | 設定 → 📦 データ / Hub → マルチサーバ接続 | 辞書 / dig / ブクマ / 実装自慢 / 作業場所 を Hub に共有 |
+| **LLM プロバイダ** | OpenAI API key or Claude CLI / Gemini CLI / Codex CLI のインストール | 設定 → 🤖 AI | 要約 / dig / 日記 / 食事解析等 |
+| **claude CLI (Windows)** | `CLAUDE_CODE_GIT_BASH_PATH` 環境変数 | `.bashrc` / `setx` 等 | Memoria Server から claude CLI 呼び出し |
+| **Steam app name 解決** | API key 不要 (= keyless Store API) | 自動 (=設定不要) | uninstalled な appid の name 解決 |
+| **iOS PWA 通知** | Memoria を「ホーム画面に追加」 してアプリ起動 | iOS Safari → 共有 → ホーム画面に追加 | iOS で通知許可ダイアログを出すための前提 (iOS 16.4+) |
+| **Memoria Hub への接続** | (Cernere SSO + 同左) + マルチサーバ URL | 設定 → マルチサーバ → 接続 | Hub から各種データ download / share |
+| **食事写真の Vision 解析** | LLM provider のうち vision 対応モデル | 設定 → 🤖 AI → meal_vision task | 食事写真 → 食品 / カロリー推定 |
+| **Steam 起動間隔** | 設定 → 連携 → Steam → 取得間隔 (分) | 設定 | 短くするほど精度↑ / 通信量↑ |
+| **環境変数 (server)** | `MEMORIA_PORT` / `MEMORIA_DATA` / `MEMORIA_CLAUDE_BIN` / `MEMORIA_DIG_CONCURRENCY` 等 | shell env / .env | 各 default の上書き |
+
+## 一気にやる場合の順番
+
+1. Memoria local backend 起動 (`npm run dev`、 `desktop` or 手動)
+2. ブラウザで `http://localhost:5180` を開いて起動チュートリアル
+3. 設定 → 🤖 AI → 1 つでも provider を選ぶ
+4. 設定 → 🔌 連携 → GitHub PAT / Steam ID を入れる
+5. `node server/hooks/setup.mjs` で git post-commit hook 導入 ([git-hooks.md](./git-hooks.md))
+6. `~/.claude/settings.json` に Claude Code hook を追加
+7. (任意) Cernere ログイン → マルチサーバ接続
+8. (任意) iOS で「ホーム画面に追加」 → 通知許可
+9. (任意) OwnTracks 設定 → GPS 軌跡
+
+それぞれ独立に設定可能。 手を抜いた箇所は単にその機能のデータが入らないだけで、
+他機能は通常通り動く。
+
+## AI に頼む場合のプロンプト例 (= 全部委託)
+
+```text
+Memoria を私の環境にフルセットアップしてください。 docs/setup/user-setup.md
+を参照し、 以下の前提で進めてください:
+
+- OS: <Windows / macOS / Linux>
+- 既に Memoria local backend は <http://localhost:5180> で動作している
+- 使う LLM provider: <claude CLI / OpenAI API / その他>
+- GitHub PAT は <持っている / これから作る>
+- Steam: <使う / 使わない>
+- OwnTracks: <使う / 使わない>
+- iOS PWA: <使う / 使わない>
+- マルチサーバ: <使う / 使わない>
+
+1 ステップずつ、 私が確認 (= 「次へ」 と返す) してから次に進めてください。
+途中で API key 等を求められたら私が手動で入れます。
+```

--- a/server/hooks/post-commit
+++ b/server/hooks/post-commit
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Memoria git post-commit shim.
+#
+# 内容は server/hooks/post-commit.mjs (Node 実装) に丸投げ。
+# git は拡張子のない実行ファイル (`post-commit`) を呼ぶ必要があるので、
+# この shell スクリプトが薄い wrapper として存在する。
+#
+# 環境変数:
+#   MEMORIA_HOOK_DIR — このスクリプトと post-commit.mjs が同じ場所にある前提で、
+#                      自動解決される。 明示したい場合のみ設定。
+
+set -e
+SCRIPT_DIR="${MEMORIA_HOOK_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+exec node "$SCRIPT_DIR/post-commit.mjs" "$@"

--- a/server/hooks/post-commit.mjs
+++ b/server/hooks/post-commit.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+// Memoria git post-commit hook.
+//
+// commit 直後に走らせて Memoria に `git_commit` activity event を送る。
+// `claude-code-prompt.mjs` と同じスタイル: 失敗は黙殺、 stdout/stderr 汚さない、
+// 1 秒タイムアウト。
+//
+// 文字化け対策:
+//   Windows 既定の OEM code page (= 932 / Shift-JIS) で git log の出力を
+//   そのまま curl --data に渡すと、 Memoria が UTF-8 として解釈して文字化けする。
+//   ここでは:
+//     - child_process.execFileSync で `git log -1 --format=...` を実行
+//     - encoding: 'utf8' を明示
+//     - GIT 自体には `-c i18n.logoutputencoding=utf-8` と `-c i18n.commitencoding=utf-8` を渡す
+//     - body は JSON.stringify で encode (= 確定 UTF-8)
+//
+// インストール:
+//   1) `~/.memoria-hooks/` に本ファイルを post-commit (拡張子なし) でコピー
+//      or symlink。 実行ビット必須 (`chmod +x`)。
+//   2) `git config --global core.hooksPath "$HOME/.memoria-hooks"` で全 repo 有効化。
+//      既に別 hook 運用がある場合は repo ごとに `.git/hooks/post-commit` に置く。
+//   3) Memoria local backend が起動していること (= MEMORIA_URL に到達できる)。
+//   docs/setup/git-hooks.md に手順詳細あり。
+//
+// 環境変数:
+//   MEMORIA_URL  — base URL (default http://localhost:5180)
+//   MEMORIA_GIT_HOOK_DEBUG — '1' で stderr に診断出力
+
+import { execFileSync } from "node:child_process";
+import { hostname, userInfo } from "node:os";
+
+const MEMORIA_URL = process.env.MEMORIA_URL || "http://localhost:5180";
+const TIMEOUT_MS = 1000;
+const DEBUG = process.env.MEMORIA_GIT_HOOK_DEBUG === "1";
+
+function dbg(msg) {
+  if (DEBUG) process.stderr.write(`[memoria-hook] ${msg}\n`);
+}
+
+function runGit(args) {
+  try {
+    return execFileSync(
+      "git",
+      ["-c", "i18n.logoutputencoding=utf-8", "-c", "i18n.commitencoding=utf-8", ...args],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], windowsHide: true },
+    ).trim();
+  } catch (e) {
+    dbg(`git ${args.join(" ")} failed: ${e && e.message}`);
+    return "";
+  }
+}
+
+async function main() {
+  // commit が無い (= rebase の途中とか) なら諦める
+  const sha = runGit(["rev-parse", "HEAD"]);
+  if (!sha || sha.length < 7) return;
+
+  // commit 情報 (UTF-8 強制)
+  const subject = runGit(["log", "-1", "--format=%s"]);
+  const body = runGit(["log", "-1", "--format=%B"]);
+  const author = runGit(["log", "-1", "--format=%an <%ae>"]);
+  const committedAt = runGit(["log", "-1", "--format=%cI"]);
+  const branch = runGit(["rev-parse", "--abbrev-ref", "HEAD"]);
+  const repoTop = runGit(["rev-parse", "--show-toplevel"]);
+  const remoteUrl = runGit(["config", "--get", "remote.origin.url"]);
+  const filesChangedRaw = runGit(["diff-tree", "--no-commit-id", "--name-only", "-r", sha]);
+  const filesChanged = filesChangedRaw ? filesChangedRaw.split(/\r?\n/).filter(Boolean) : [];
+
+  // 短く要約された 1 行 content (= 検索 / 一覧用)
+  const content = subject || `commit ${sha.slice(0, 7)}`;
+
+  // 詳細は metadata に。 個人情報的に問題ない範囲。
+  const metadata = {
+    sha,
+    branch,
+    repo: repoTop ? repoTop.replace(/\\/g, "/").split("/").slice(-1)[0] : null,
+    repo_path: repoTop,
+    remote_url: remoteUrl || null,
+    author,
+    committed_at: committedAt,
+    subject,
+    body: body && body !== subject ? body.slice(0, 4000) : null,
+    files_changed: filesChanged.slice(0, 200),
+    files_changed_total: filesChanged.length,
+    host: hostname(),
+    user: (() => { try { return userInfo().username; } catch { return null; } })(),
+  };
+
+  const payload = {
+    kind: "git_commit",
+    source: metadata.repo || metadata.repo_path || null,
+    ref_id: sha,
+    content,
+    occurred_at: committedAt || undefined,
+    metadata,
+  };
+
+  // 1 秒 timeout 付きの POST。 失敗は完全黙殺。
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(`${MEMORIA_URL}/api/activity/event`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+      body: JSON.stringify(payload),
+      signal: ctrl.signal,
+    });
+    dbg(`POST ${MEMORIA_URL}/api/activity/event → ${res.status}`);
+  } catch (e) {
+    dbg(`POST failed: ${e && e.message}`);
+    // intentional: commit を妨げない
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+void main().catch((e) => {
+  dbg(`unhandled: ${e && e.message}`);
+  process.exit(0);
+});

--- a/server/hooks/setup.mjs
+++ b/server/hooks/setup.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// Memoria git hooks のインストールヘルパー。
+//
+// 使い方:
+//   node server/hooks/setup.mjs [--global | --repo <path> | --print]
+//
+// オプション:
+//   --global         (default) ~/.memoria-hooks/ にコピーし、 git config --global
+//                    core.hooksPath をそこへ設定。 既存設定がある場合は警告して中止。
+//   --repo <path>    指定した repo の .git/hooks/post-commit にコピー (= 1 repo のみ)
+//   --force          既存ファイル / 既存設定があっても上書き
+//   --print          手動でやる人向け、 install するファイル一覧と実行コマンドを出すだけ
+//
+// 動作確認: 完了後に dummy commit を作ると Memoria backend のログに
+//   [http] {... method: "POST", path: "/api/activity/event", status: 200 ...}
+// が出る。 出ない場合は server/hooks/post-commit.mjs を直接実行して
+// デバッグ可 (MEMORIA_GIT_HOOK_DEBUG=1)。
+
+import { existsSync, readFileSync, writeFileSync, chmodSync, mkdirSync, copyFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execSync } from "node:child_process";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC_DIR = __dirname;
+const HOOKS = ["post-commit", "post-commit.mjs"];
+
+function args() {
+  const a = { mode: "global", force: false, repo: null, print: false };
+  const argv = process.argv.slice(2);
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--global") a.mode = "global";
+    else if (argv[i] === "--repo") { a.mode = "repo"; a.repo = argv[++i]; }
+    else if (argv[i] === "--force") a.force = true;
+    else if (argv[i] === "--print") a.print = true;
+    else if (argv[i] === "--help" || argv[i] === "-h") {
+      console.log(`Usage: node setup.mjs [--global | --repo <path> | --print] [--force]`);
+      process.exit(0);
+    }
+  }
+  return a;
+}
+
+function copyHook(srcDir, dstDir, force) {
+  mkdirSync(dstDir, { recursive: true });
+  for (const f of HOOKS) {
+    const src = join(srcDir, f);
+    const dst = join(dstDir, f);
+    if (existsSync(dst) && !force) {
+      // 既に同 size + 同 content ならスキップ
+      if (readFileSync(src).equals(readFileSync(dst))) {
+        console.log(`  ✓ ${f} (already up-to-date)`);
+        continue;
+      }
+      console.error(`  ⚠ ${dst} already exists. Use --force to overwrite.`);
+      process.exit(1);
+    }
+    copyFileSync(src, dst);
+    if (!f.endsWith(".mjs")) {
+      try { chmodSync(dst, 0o755); } catch { /* Windows: chmod は no-op */ }
+    }
+    console.log(`  → ${dst}`);
+  }
+}
+
+function setGlobalHooksPath(dstDir, force) {
+  let current = "";
+  try { current = execSync("git config --global core.hooksPath", { encoding: "utf8" }).trim(); } catch { /* unset */ }
+  if (current && current !== dstDir && !force) {
+    console.error(`⚠ git config --global core.hooksPath is already set to: ${current}`);
+    console.error("  Use --force to override, or copy server/hooks/* into the existing dir manually.");
+    process.exit(1);
+  }
+  execSync(`git config --global core.hooksPath "${dstDir}"`, { stdio: "inherit" });
+  console.log(`  → git config --global core.hooksPath ${dstDir}`);
+}
+
+function main() {
+  const a = args();
+  if (a.print) {
+    console.log("# 手動で git hook を入れる場合の手順:");
+    console.log("");
+    console.log("# 1. hooks dir を準備");
+    console.log("mkdir -p ~/.memoria-hooks");
+    console.log("");
+    console.log("# 2. Memoria の hooks ファイルをコピー");
+    console.log(`cp "${SRC_DIR}/post-commit"     ~/.memoria-hooks/`);
+    console.log(`cp "${SRC_DIR}/post-commit.mjs" ~/.memoria-hooks/`);
+    console.log("chmod +x ~/.memoria-hooks/post-commit");
+    console.log("");
+    console.log("# 3. git config に登録");
+    console.log("git config --global core.hooksPath ~/.memoria-hooks");
+    console.log("");
+    console.log("# 4. 動作確認 (適当な repo で commit して Memoria backend ログに POST が出るか)");
+    return;
+  }
+
+  if (a.mode === "global") {
+    const dst = join(homedir(), ".memoria-hooks");
+    console.log(`Installing Memoria git hooks to ${dst} ...`);
+    copyHook(SRC_DIR, dst, a.force);
+    setGlobalHooksPath(dst, a.force);
+    console.log("\n✓ Done. Test with a dummy commit in any repo; check the Memoria backend log.");
+  } else if (a.mode === "repo") {
+    if (!a.repo) { console.error("--repo requires a path"); process.exit(1); }
+    const repoAbs = resolve(a.repo);
+    const dst = join(repoAbs, ".git", "hooks");
+    if (!existsSync(dst)) { console.error(`Not a git repo (no ${dst})`); process.exit(1); }
+    console.log(`Installing to ${dst} ...`);
+    copyHook(SRC_DIR, dst, a.force);
+    console.log(`\n✓ Done. Test with a dummy commit in ${repoAbs}.`);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

ローカル commit を「開発活動」 として記録するための post-commit hook を Memoria 正式機能として提供。 これまではユーザ各自が curl で書く想定で **Windows + 日本語コミットメッセージで文字化け** するケースがあったため、 Node 実装に置き換えて構造的に解消。

ついでに「ユーザが設定しないと取れないデータ」 を 1 箇所に集約した doc も作成。

## 変更点

### 1. git hook 本体 (encoding-safe)
- `server/hooks/post-commit.mjs` — Node 実装、 `execFileSync` + `encoding: 'utf8'` + `git -c i18n.logoutputencoding=utf-8` で UTF-8 強制。 JSON.stringify で body encode。
- `server/hooks/post-commit` — shell shim (git は拡張子なし実行ファイルを要求するため)

### 2. インストール helper
- `node server/hooks/setup.mjs` で `~/.memoria-hooks/` にコピー + `git config --global core.hooksPath` を設定
- `--repo <path>` で per-repo インストールも可
- `--print` で手動派向けに手順を表示
- 既存 hooksPath との衝突は警告して中止 (`--force` で上書き)

### 3. doc
- `docs/setup/git-hooks.md` — 手順 + トラブルシュート + **AI に頼む用プロンプトテンプレ**
- `docs/setup/user-setup.md` — **「ユーザが設定しなければ取得できない情報」 を網羅表**:
  - GitHub PAT / Steam ID / OwnTracks key / WiFi 位置 / Cernere SSO / LLM provider
  - git post-commit / Claude Code UserPromptSubmit hook
  - 環境変数一覧 / iOS PWA / Multi server 接続
  - 各設定の「これをやらないと何が取れないか」 が一目で分かる

### 4. README にリンク追加

## Test plan

- [ ] `node server/hooks/setup.mjs --print` で手順が表示される
- [ ] `node server/hooks/setup.mjs` で `~/.memoria-hooks/` にコピーされ、 `git config --global core.hooksPath` が設定される
- [ ] dummy commit (日本語コミットメッセージ) → Memoria backend ログに POST 200、 DB の activity_events に正しく UTF-8 で記録
- [ ] Memoria backend 停止中の commit → 失敗黙殺、 commit 自体は通る
- [ ] `MEMORIA_GIT_HOOK_DEBUG=1` で stderr に診断が出る
- [ ] 既存 hooksPath 設定がある状態で setup → 警告 + 中止 (--force で続行可)

🤖 Generated with [Claude Code](https://claude.com/claude-code)