### PR TITLE
feat(workplace): 場所ごとの GPS 誤差半径 + 移動速度フィルタ

### DIFF
--- a/server/api/types/config.ts
+++ b/server/api/types/config.ts
@@ -18,6 +18,7 @@ export interface PrivacySettings {
   workplace_geo_enabled: boolean;
   workplace_auto_share_enabled: boolean;
   workplace_match_radius_m: number;     // 20-2000m
+  workplace_max_speed_kmh: number;      // 0-200, 0=disable speed filter
 }
 
 export type PrivacySettingsPatch = Partial<PrivacySettings>;

--- a/server/db.ts
+++ b/server/db.ts
@@ -539,6 +539,7 @@ export function openDb(dbPath: string): Db {
       tags           TEXT,
       wifi_ssids     TEXT,
       is_home        INTEGER NOT NULL DEFAULT 0,
+      radius_m       INTEGER,
       shareable      INTEGER NOT NULL DEFAULT 0,
       shared_at      TEXT,
       shared_origin  TEXT,
@@ -695,6 +696,12 @@ export function openDb(dbPath: string): Db {
   // 排他制御、 ここでは制約までは設けない)。
   if (wlCols.length > 0 && !wlCols.includes('is_home')) {
     db.exec(`ALTER TABLE work_locations ADD COLUMN is_home INTEGER NOT NULL DEFAULT 0`);
+  }
+  // radius_m: 場所ごとの GPS 誤差許容半径 (m)。 NULL の場合は global の
+  // `workplace_match_radius_m` 設定を使う。 都市公園 vs オフィスビルなど、
+  // 場所の物理的な大きさに応じて個別に設定できるようにする。
+  if (wlCols.length > 0 && !wlCols.includes('radius_m')) {
+    db.exec(`ALTER TABLE work_locations ADD COLUMN radius_m INTEGER`);
   }
 
   const mealsCols = (db.prepare(`PRAGMA table_info(meals)`).all() as { name: string }[]).map(c => c.name);
@@ -4090,6 +4097,8 @@ export interface InsertWorkLocationInput {
   /** 有線接続時のデフォルト workplace に使う */
   is_home?: boolean | 0 | 1;
   shareable?: boolean | 0 | 1;
+  /** GPS 誤差許容半径 (m)。 null/undefined なら global default を使う */
+  radius_m?: number | string | null;
 }
 
 export function insertWorkLocation(db: Db, loc: InsertWorkLocationInput): number {
@@ -4099,8 +4108,8 @@ export function insertWorkLocation(db: Db, loc: InsertWorkLocationInput): number
   }
   const info = db.prepare(`
     INSERT INTO work_locations
-      (name, address, latitude, longitude, description, url, tags, wifi_ssids, is_home, shareable)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      (name, address, latitude, longitude, description, url, tags, wifi_ssids, is_home, shareable, radius_m)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     loc.name,
     loc.address ?? null,
@@ -4112,6 +4121,7 @@ export function insertWorkLocation(db: Db, loc: InsertWorkLocationInput): number
     loc.wifi_ssids ?? null,
     loc.is_home ? 1 : 0,
     loc.shareable ? 1 : 0,
+    loc.radius_m == null ? null : Math.max(1, Math.min(50_000, Number(loc.radius_m) || 0)) || null,
   );
   return Number(info.lastInsertRowid);
 }
@@ -4123,7 +4133,7 @@ export function updateWorkLocation(db: Db, id: number, patch: Record<string, unk
   }
   const allowed = new Set([
     'name', 'address', 'latitude', 'longitude', 'description', 'url', 'tags',
-    'wifi_ssids', 'is_home',
+    'wifi_ssids', 'is_home', 'radius_m',
     'shareable', 'shared_at', 'shared_origin',
     'owner_user_id', 'owner_user_name',
   ]);

--- a/server/db/types/workplace.ts
+++ b/server/db/types/workplace.ts
@@ -18,6 +18,10 @@ export interface WorkLocationRow {
   /** 1 つだけ true にできる「自宅」 フラグ。 PC が有線接続のとき higher
    *  priority な信号 (GPS / WiFi) が無ければ、 ここを current に置く。 */
   is_home: 0 | 1;
+  /** 場所ごとの GPS 誤差許容半径 (m)。 NULL なら global default
+   *  (`workplace_match_radius_m`) を使う。 都市公園 vs オフィスビル等、
+   *  場所の物理的な大きさに応じて 1〜50_000m の範囲で設定可。 */
+  radius_m: number | null;
   shareable: 0 | 1;
   shared_at: string | null;
   shared_origin: string | null;

--- a/server/lib/privacy.ts
+++ b/server/lib/privacy.ts
@@ -23,6 +23,10 @@ export interface PrivacySettings {
   workplace_geo_enabled: boolean;
   workplace_auto_share_enabled: boolean;
   workplace_match_radius_m: number;
+  /** 移動速度の閾値 (km/h)。 これより速い瞬間速度の GPS 点は「移動中」 とみなして
+   *  workplace タグ付けの対象から外す (= 通り過ぎただけの場所を誤検出しない)。
+   *  既定 5 km/h。 0 にすると速度フィルタ無効。 */
+  workplace_max_speed_kmh: number;
   legatus_enabled: boolean;
   // AI 自動処理の opt-out 群。 すべて default true (= 現状維持) で、
   // ローカル運用ユーザは個別に OFF にして「素材は溜まる、 AI は呼ばない」
@@ -75,7 +79,10 @@ export function privacySettings(db: Db): PrivacySettings {
     workplace_auto_share_enabled: settingBool(s, 'features.workplace.share.enabled', false),
     // OwnTracks の locator displacement と整合させやすい 50m を既定に。
     // 屋内ビルや GPS が荒い環境では 100-200m に上げる。
+    // place ごとの radius_m が work_locations に設定されていればそちらが優先。
     workplace_match_radius_m: Number(s['features.workplace.match.radius_m'] ?? 50),
+    // 移動速度の閾値 (km/h)。 0 = フィルタ無効。 既定 5 km/h は徒歩上限近辺。
+    workplace_max_speed_kmh: Number(s['features.workplace.max_speed_kmh'] ?? 5),
     // Legatus 連携は明示 opt-in。 default OFF (= 旧 Legatus 同居 PC を持たないユーザは
     // 何も気にせず UI から消える)。
     legatus_enabled: settingBool(s, 'features.legatus.enabled', false),

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -5478,6 +5478,11 @@ let ensureMemoriaFeatureViews = function () {
             <span>🏠 自宅 (有線接続時のデフォルト)</span>
           </label>
           <small class="muted" style="margin-top:-4px">PC が有線で繋がっていて WiFi / GPS で他の場所が判定できないとき、 ここを current にします。 1 つだけ true にできます (= 別の場所を 🏠 にすると自動的に解除)。</small>
+          <label class="simple-field">
+            <span>GPS 誤差許容半径 (m、 空欄 = global 既定)</span>
+            <input id="workplaceEditorRadius" type="number" min="1" max="50000" step="1" placeholder="50 (空欄: 設定の既定値を使う)" />
+            <small class="muted">場所の物理的な大きさに応じて個別に設定。 例: 自宅 = 30m / 駅前広場 = 200m / 大学キャンパス = 500m。 0 や空欄なら全体設定の値 (設定 → プライバシー → 場所判定の半径) を使う。</small>
+          </label>
           <label class="simple-check-row">
             <input id="workplaceEditorShareable" type="checkbox" />
             <span>シェア可能にする</span>
@@ -5538,13 +5543,23 @@ let ensureMemoriaFeatureViews = function () {
       <label class="check-inline"><input id="workplaceAutoShareEnabled" type="checkbox" /> 作業場所が切り替わったとき Hub に共有する (オプトイン)</label>
       <label style="display:flex;align-items:center;gap:6px;margin-bottom:6px">マッチ半径 (作業場所判定 / 1 日の作業セッション検出):
         <input id="workplaceMatchRadiusM" type="number" min="20" max="2000" step="10" style="width:80px" />
-        m
+        m (= global 既定)
       </label>
       <p class="diary-settings-help" style="margin-top:6px">
         OwnTracks の locator displacement (移動 N m ごとに送信) と GPS の精度を考慮した距離。
         既定 50m。 OwnTracks 側を 50m に設定しているならここも 50-100m が目安。
         屋内ビル (室内 GPS オフセット) で取りこぼす場合は 100-200m に上げてください。
         この半径を超えた点で「離脱」と判定し、 セッションがそこで終了します。
+        場所ごとに <code>radius_m</code> を個別設定すると、 そちらが優先されます (= 作業場所編集画面で入力)。
+      </p>
+      <label style="display:flex;align-items:center;gap:6px;margin-bottom:6px">移動速度の閾値:
+        <input id="workplaceMaxSpeedKmh" type="number" min="0" max="200" step="1" style="width:80px" />
+        km/h
+      </label>
+      <p class="diary-settings-help" style="margin-top:6px">
+        これより速い瞬間速度 (= 直前 GPS 点との距離 / 時間差) の点は「移動中」とみなして
+        場所タグ付けの対象から外します。 通り過ぎただけの場所を誤検出しないため。
+        既定 5 km/h (= 徒歩速度の上限近辺)。 0 を入れるとフィルタ無効。
       </p>
       <p class="diary-settings-help" style="margin-top:6px">iOS で受け取る場合はホーム画面に追加 + 通知を許可してください。GPS 共有は Hub 接続済みのときのみ動作します。</p>`;
     footer.parentNode.insertBefore(sec, footer);
@@ -5805,6 +5820,7 @@ async function loadPrivacySettings() {
   if ($('workplaceGeoEnabled')) $('workplaceGeoEnabled').checked = !!s.workplace_geo_enabled;
   if ($('workplaceAutoShareEnabled')) $('workplaceAutoShareEnabled').checked = !!s.workplace_auto_share_enabled;
   if ($('workplaceMatchRadiusM')) $('workplaceMatchRadiusM').value = s.workplace_match_radius_m ?? 50;
+  if ($('workplaceMaxSpeedKmh')) $('workplaceMaxSpeedKmh').value = s.workplace_max_speed_kmh ?? 5;
   if ($('aiLegatusEnabled')) $('aiLegatusEnabled').checked = !!s.legatus_enabled;
   applyLegatusEnabled(!!s.legatus_enabled);
   // AI 自動処理 opt-out 群
@@ -5845,6 +5861,7 @@ async function savePrivacySettings() {
       workplace_geo_enabled: !!($('workplaceGeoEnabled')?.checked),
       workplace_auto_share_enabled: !!($('workplaceAutoShareEnabled')?.checked),
       workplace_match_radius_m: Number($('workplaceMatchRadiusM')?.value ?? 150),
+      workplace_max_speed_kmh: Number($('workplaceMaxSpeedKmh')?.value ?? 5),
       legatus_enabled: !!($('aiLegatusEnabled')?.checked),
       bookmarks_auto_summarize: !!($('aiAutoBookmarkSummarize')?.checked),
       page_metadata_auto_fetch: !!($('aiAutoPageMetadata')?.checked),
@@ -6461,6 +6478,7 @@ function openWorkplaceEditor(w = null) {
   $('workplaceEditorTags').value = w?.tags || '';
   if ($('workplaceEditorWifiSsids')) $('workplaceEditorWifiSsids').value = w?.wifi_ssids || '';
   if ($('workplaceEditorIsHome')) $('workplaceEditorIsHome').checked = !!w?.is_home;
+  if ($('workplaceEditorRadius')) $('workplaceEditorRadius').value = (w?.radius_m == null ? '' : String(w.radius_m));
   $('workplaceEditorDescription').value = w?.description || '';
   $('workplaceEditorShareable').checked = !!w?.shareable;
   // 「現在の WiFi を追加」 ボタンは server 側 /api/wifi/current が返してくれる
@@ -6988,6 +7006,12 @@ async function saveWorkLocationFromForm() {
     is_home: !!$('workplaceEditorIsHome')?.checked,
     description: $('workplaceEditorDescription')?.value.trim() || null,
     shareable: !!$('workplaceEditorShareable')?.checked,
+    radius_m: ((): number | null => {
+      const v = ($('workplaceEditorRadius')?.value || '').trim();
+      if (!v) return null;
+      const n = Number(v);
+      return Number.isFinite(n) && n > 0 ? n : null;
+    })(),
   };
   try {
     if (editId) {

--- a/server/routes/config.ts
+++ b/server/routes/config.ts
@@ -114,6 +114,7 @@ export function makeConfigRouter(deps: ConfigRouterDeps): Hono {
     if (typeof body.tasks_reminder_minute === 'number') patch['features.tasks.reminder.minute'] = String(Math.max(0, Math.min(59, Math.floor(body.tasks_reminder_minute))));
     if (typeof body.tasks_reminder_nuntius_url === 'string') patch['features.tasks.reminder.nuntius_url'] = body.tasks_reminder_nuntius_url.trim();
     if (typeof body.workplace_match_radius_m === 'number') patch['features.workplace.match.radius_m'] = String(Math.max(20, Math.min(2000, Math.floor(body.workplace_match_radius_m))));
+    if (typeof body.workplace_max_speed_kmh === 'number') patch['features.workplace.max_speed_kmh'] = String(Math.max(0, Math.min(200, body.workplace_max_speed_kmh)));
     if (Object.keys(patch).length) setAppSettings(db, patch);
     if (Object.prototype.hasOwnProperty.call(body, 'mcp_autostart_enabled')) {
       onMcpAutostartChange(privacySettings(db).mcp_autostart_enabled);

--- a/server/routes/workplace.ts
+++ b/server/routes/workplace.ts
@@ -94,7 +94,7 @@ export function makeWorkplaceRouter(deps: WorkplaceRouterDeps): Hono {
     const body = await c.req.json().catch(() => ({})) as
       { name?: unknown; address?: unknown; latitude?: unknown; longitude?: unknown;
         description?: unknown; url?: unknown; tags?: unknown; wifi_ssids?: unknown;
-        is_home?: unknown; shareable?: unknown };
+        is_home?: unknown; shareable?: unknown; radius_m?: unknown };
     const name = String(body.name ?? '').trim();
     if (!name) return c.json({ error: 'name required' }, 400);
     const id = insertWorkLocation(db, {
@@ -108,6 +108,7 @@ export function makeWorkplaceRouter(deps: WorkplaceRouterDeps): Hono {
       wifi_ssids: typeof body.wifi_ssids === 'string' ? body.wifi_ssids.trim() : null,
       is_home: !!body.is_home,
       shareable: !!body.shareable,
+      radius_m: body.radius_m == null || body.radius_m === '' ? null : Number(body.radius_m),
     });
     return c.json({ location: getWorkLocation(db, id) }, 201);
   });
@@ -118,7 +119,7 @@ export function makeWorkplaceRouter(deps: WorkplaceRouterDeps): Hono {
     const body = await c.req.json().catch(() => ({})) as
       { name?: unknown; address?: unknown; latitude?: unknown; longitude?: unknown;
         description?: unknown; url?: unknown; tags?: unknown; wifi_ssids?: unknown;
-        is_home?: unknown; shareable?: unknown };
+        is_home?: unknown; shareable?: unknown; radius_m?: unknown };
     const patch: Record<string, unknown> = {};
     if (typeof body.name === 'string') patch.name = body.name.trim();
     if (typeof body.address === 'string' || body.address === null) patch.address = body.address;
@@ -134,6 +135,12 @@ export function makeWorkplaceRouter(deps: WorkplaceRouterDeps): Hono {
     if (typeof body.wifi_ssids === 'string' || body.wifi_ssids === null) patch.wifi_ssids = body.wifi_ssids;
     if (typeof body.is_home === 'boolean') patch.is_home = body.is_home;
     if (typeof body.shareable === 'boolean') patch.shareable = body.shareable;
+    if (body.radius_m === null || body.radius_m === '' || body.radius_m === undefined) {
+      if ('radius_m' in body) patch.radius_m = null;
+    } else {
+      const r = Number(body.radius_m);
+      if (Number.isFinite(r) && r > 0) patch.radius_m = Math.max(1, Math.min(50_000, r));
+    }
     updateWorkLocation(db, id, patch);
     return c.json({ location: getWorkLocation(db, id) });
   });
@@ -207,16 +214,19 @@ export function makeWorkplaceRouter(deps: WorkplaceRouterDeps): Hono {
     if (!settings.workplace_geo_enabled) {
       return c.json({ error: 'workplace_geo disabled' }, 403);
     }
-    const radius = Math.max(20, Math.min(2000, Number(settings.workplace_match_radius_m) || 150));
+    const globalRadius = Math.max(20, Math.min(2000, Number(settings.workplace_match_radius_m) || 150));
 
-    // Find nearest workplace within radius.
+    // Find nearest workplace within its own radius (per-place `radius_m` column
+    // が NULL なら global default を使う)。 「最も近い」 は「正規化距離 d / r」
+    // ではなく「実距離 d」 で比較する (= 半径が大きい場所が必ず勝つわけではない)。
     const all = listWorkLocations(db, { limit: 500 });
     let matched: typeof all[number] | null = null;
     let matchedDist = Infinity;
     for (const w of all) {
       if (!Number.isFinite(w.latitude) || !Number.isFinite(w.longitude)) continue;
+      const r = (typeof w.radius_m === 'number' && w.radius_m > 0) ? w.radius_m : globalRadius;
       const d = haversineMeters({ lat, lng }, { lat: w.latitude as number, lng: w.longitude as number });
-      if (d <= radius && d < matchedDist) {
+      if (d <= r && d < matchedDist) {
         matched = w;
         matchedDist = d;
       }
@@ -415,14 +425,37 @@ export function makeWorkplaceRouter(deps: WorkplaceRouterDeps): Hono {
     }
 
     const settings = privacySettings(db);
-    const RADIUS_M = Math.max(20, Math.min(2000, Number(settings.workplace_match_radius_m) || 50));
+    const GLOBAL_RADIUS_M = Math.max(20, Math.min(2000, Number(settings.workplace_match_radius_m) || 50));
+    // 移動速度の閾値 (km/h)。 これより速い瞬間速度の GPS 点は「移動中」 と
+    // 見なして workplace タグ付けの対象から外す (= 通り過ぎただけの場所を誤検出しない)。
+    // 既定 5 km/h (= 徒歩速度上限近辺)。 0 にすると速度フィルタ無効。
+    const MAX_SPEED_KMH = Math.max(0, Number(settings.workplace_max_speed_kmh) || 5);
+    const MAX_SPEED_MPS = MAX_SPEED_KMH > 0 ? (MAX_SPEED_KMH * 1000) / 3600 : Infinity;
 
-    const tagged = points.map((p) => {
+    // 速度計算: 各点について「直前点との距離 / 時間差」 で瞬間速度を出す。
+    // 最初の点は速度不明 → 含める。
+    const tsMs = (s: string): number => {
+      const t = Date.parse(s.includes('T') ? s : s.replace(' ', 'T') + 'Z');
+      return Number.isFinite(t) ? t : 0;
+    };
+    const speedFiltered = points.map((p, i) => {
+      if (i === 0 || MAX_SPEED_MPS === Infinity) return { p, fast: false };
+      const prev = points[i - 1];
+      const d = distMeters({ lat: p.lat, lon: p.lon }, { lat: prev.lat, lon: prev.lon });
+      const dt = (tsMs(p.recorded_at) - tsMs(prev.recorded_at)) / 1000;
+      if (dt <= 0) return { p, fast: false };
+      const v = d / dt;
+      return { p, fast: v > MAX_SPEED_MPS };
+    });
+
+    const tagged = speedFiltered.map(({ p, fast }) => {
+      if (fast) return { recorded_at: p.recorded_at, workplace_id: null };
       let bestId: number | null = null;
       let bestDist = Infinity;
       for (const w of places) {
+        const r = (typeof w.radius_m === 'number' && w.radius_m > 0) ? w.radius_m : GLOBAL_RADIUS_M;
         const d = distMeters({ lat: p.lat, lon: p.lon }, { lat: w.latitude, lon: w.longitude });
-        if (d <= RADIUS_M && d < bestDist) {
+        if (d <= r && d < bestDist) {
           bestId = w.id;
           bestDist = d;
         }


### PR DESCRIPTION
## Summary

「場所ごとに大きさが異なるので GPS 誤差の許容範囲を m 単位で設定できる + 移動速度の閾値を設定できる」 を実装。 自宅 (30m) と大学キャンパス (500m) のような物理的に大きさが違う場所も正しく扱える。

## 変更点

### DB
- 新カラム `work_locations.radius_m` (INTEGER, nullable, 1〜50_000m)
  - NULL なら従来通り global `workplace_match_radius_m` を使う (= 後方互換)
- ALTER TABLE で既存 DB にも追加 (idempotent)

### 設定
- 新設定 `features.workplace.max_speed_kmh` (= 既定 5 km/h、 0 で無効)
- `PrivacySettings.workplace_max_speed_kmh` 追加

### マッチング (workplace.ts)
- **check-in** (\`POST /api/work-locations/checkin\`): 各 work location の `radius_m` (NULL → global) で円判定
- **GPS sessions** (\`GET /api/work-sessions\`):
  - 瞬間速度を「直前点との距離 ÷ 時間差」 で算出
  - `max_speed_kmh` より速い点は workplace タグ付け対象から除外 (= drive-by 抑止)
  - per-place radius も同じ仕組みで適用

### UI
- 作業場所編集モーダル: 「GPS 誤差許容半径 (m)」 入力。 空欄 → global 既定
- 設定 → プライバシー → 作業場所セクションに「移動速度の閾値 (km/h)」 入力
- マッチ半径の説明文に「場所ごとに radius_m を個別設定するとそちらが優先」 と注記

## Test plan

- [ ] 既存 work_locations は radius_m が NULL → 従来通り動作
- [ ] 編集モーダルで radius_m=30 を保存 → 該当場所のみ 30m で判定
- [ ] GPS 点が時速 30 km/h で通過 → タグ付けされない (workplace_id=null)
- [ ] max_speed_kmh=0 にすると速度フィルタ無効
- [ ] 作業場所判定が円判定 (= haversine 距離 ≤ radius) で動く

🤖 Generated with [Claude Code](https://claude.com/claude-code)