### PR TITLE
fix(ui): token ●●●● placeholder + npm start に prestart hook (radius_m 保存 bug の真因対処)

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "prestart": "npm run build:frontend",
     "start": "tsx --env-file-if-exists=.env --env-file-if-exists=../.env index.ts",
+    "predev": "npm run build:frontend",
     "dev": "tsx watch --env-file-if-exists=.env --env-file-if-exists=../.env index.ts",
     "owntracks": "tsx --env-file-if-exists=.env --env-file-if-exists=../.env owntracks-server.js",
     "owntracks:dev": "tsx watch --env-file-if-exists=.env --env-file-if-exists=../.env owntracks-server.js",

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -9,7 +9,7 @@
   <title>Memoria</title>
   <link rel="manifest" href="manifest.webmanifest" />
   <link rel="apple-touch-icon" href="icon-192.svg" />
-  <link rel="stylesheet" href="style.css?v=20260513h" />
+  <link rel="stylesheet" href="style.css?v=20260513i" />
 </head>
 <body>
   <header class="topbar">
@@ -1549,6 +1549,6 @@
       <button id="aiSettingsSave">保存</button>
     </div>
   </div>
-  <script src="app.js?v=20260513f"></script>
+  <script src="app.js?v=20260513g"></script>
 </body>
 </html>

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -850,6 +850,16 @@ function escapeHtml(s) {
   }[c]));
 }
 
+// password 系 input の placeholder を 「設定されてるか」 で切り替える。
+// 値は server から戻ってこない (security best practice) ので、 input の value は
+// 空のまま、 placeholder で「●●●● (設定済み)」 を視覚的に出す。
+// 文字数は実値と一致しない (= 安全)。
+function setTokenPlaceholder(elementId: string, isSet: boolean, emptyPlaceholder: string): void {
+  const el = $(elementId) as HTMLInputElement | null;
+  if (!el) return;
+  el.placeholder = isSet ? '●●●●●●●●●●●● (設定済み・ 再入力で上書き)' : emptyPlaceholder;
+}
+
 // ---- wire up ---------------------------------------------------------------
 
 $('search').addEventListener('input', (e) => {
@@ -3730,6 +3740,7 @@ async function openDiarySettings() {
     const s = await api('/api/diary/settings');
     $('diaryGhUser').value = s.github_user || '';
     $('diaryGhRepos').value = s.github_repos || '';
+    setTokenPlaceholder('diaryGhToken', !!s.github_token_set, 'ghp_...');
     $('diaryGhTokenStatus').textContent = s.github_token_set ? '✓ token 設定済み (再入力で上書き)' : '(未設定)';
   } catch (e) { console.error(e); }
 }
@@ -4788,6 +4799,7 @@ async function openAiSettings() {
     $('aiBinCodex').value  = cfg.bins?.codex  || '';
     $('aiGitBashPath').value = cfg.git_bash_path || '';
     $('aiOpenaiKey').value = '';
+    setTokenPlaceholder('aiOpenaiKey', !!cfg.openai_api_key_set, 'sk-...');
     $('aiOpenaiModel').value = cfg.openai_model || '';
     $('aiOpenaiKeyStatus').textContent = cfg.openai_api_key_set ? '✓ API key 設定済み (再入力で上書き)' : '(未設定)';
     if ($('aiDiaryGlobalMemo')) $('aiDiaryGlobalMemo').value = cfg.diary_global_memo || '';
@@ -4818,6 +4830,7 @@ async function openAiSettings() {
       try {
         const m = await api('/api/maps/config');
         $('mapsApiKey').value = '';
+        setTokenPlaceholder('mapsApiKey', !!m.hasKey, 'AIzaSy...');
         $('mapsApiKeyStatus').textContent = m.hasKey
           ? '✓ 設定済み (再入力で上書き / 空欄保存は維持)'
           : '(未設定)';
@@ -7990,6 +8003,7 @@ async function loadActivityCredentials() {
   const r = await api('/api/activity/settings') as ActivitySettings;
   const k = $('activitySteamApiKey') as HTMLInputElement | null;
   if (k) k.value = ''; // password なので raw 値は返さない
+  setTokenPlaceholder('activitySteamApiKey', !!r.steam_api_key_set, '未設定 = VDF fallback');
   const ks = $('activitySteamApiKeyStatus');
   if (ks) ks.textContent = r.steam_api_key_set ? '✓ API key 設定済み (再入力で上書き、 空欄保存は維持)' : '(未設定 — VDF fallback で動く)';
   const sid = $('activitySteamId') as HTMLInputElement | null;


### PR DESCRIPTION
## Summary

ユーザ報告 2 件をまとめて対処:

1. **「GPS 誤差許容半径 が保存されない」** (PR #150 のあと) の真因:
  - `server/public/app.js` は \`.gitignore\` (= build artifact、 tracked しない)
  - これまで `npm start` は frontend を build しない設計
  - → ユーザが pull した直後は古い app.js のまま動作、 新 source の UI 変更が反映されない
  - **修正**: \`prestart\` / \`predev\` hook を package.json に追加 → `npm start` 時に必ず build:frontend を走らせる

2. **「token が設定されているか UI でパッと見分からない」**:
  - これまで `_set` フラグはあったが status text (`✓ 設定済み (再入力で上書き)`) でのみ表示、 input field 自体は空欄
  - → 入力欄に値が入っていないように見える
  - **修正**: input の `placeholder` を 「●●●●●●●●●●●● (設定済み・ 再入力で上書き)」 に切り替え。 値は server から返さない (security)、 placeholder の文字数は実値と一致させない

## 変更点

### prestart hook
\`\`\`json
"prestart": "npm run build:frontend",
"start": "tsx ...",
"predev": "npm run build:frontend",
"dev": "tsx watch ..."
\`\`\`

毎回 esbuild で bundle するので 50ms 程度遅くなるだけ。

### token placeholder
新 helper:
\`\`\`ts
function setTokenPlaceholder(elementId, isSet, emptyPlaceholder) {
  const el = $(elementId) as HTMLInputElement | null;
  if (!el) return;
  el.placeholder = isSet ? '●●●●●●●●●●●● (設定済み・ 再入力で上書き)' : emptyPlaceholder;
}
\`\`\`

呼出箇所 4:
- \`aiOpenaiKey\` (OpenAI API key)
- \`mapsApiKey\` (Google Maps API key)
- \`diaryGhToken\` (GitHub PAT)
- \`activitySteamApiKey\` (Steam Web API key)

### cache buster
- style.css v=20260513i
- app.js v=20260513g

## Test plan

- [ ] `git pull` した後 `npm start` で frontend が自動 build される (ログに esbuild の `Done in ...ms`)
- [ ] 既存 token を設定済みのまま開くと placeholder が `●●●●●●●●●●●● (設定済み・ 再入力で上書き)` になる
- [ ] 未設定の token は元の placeholder (`sk-...` 等)
- [ ] 設定済み token を空欄保存しても値は維持される (= 既存挙動と同じ)
- [ ] radius_m が PR #150 通り正常に保存される (= prestart 経由で新 bundle が当たる)

🤖 Generated with [Claude Code](https://claude.com/claude-code)