### PR TITLE
feat(ui): キューを top-level タブに昇格 (DB サブタブから外す)

### DIFF
--- a/server/public/index.html
+++ b/server/public/index.html
@@ -308,6 +308,10 @@
           <button class="tab" data-tab="transit">
             <span class="tab-label" data-full="🚆 交通" data-short="🚆 交通">🚆 交通</span>
           </button>
+          <button class="tab" data-tab="queue">
+            <span class="tab-label" data-full="⚙ キュー" data-short="⚙ キュー">⚙ キュー</span>
+            <span id="tabQueueBadge" class="tab-count hidden">0</span>
+          </button>
           <!-- マルチビューはトップバーのマルチスイッチからのみアクセス。
                機能タブからは外す (PC/スマホ共通)。 -->
         </div>
@@ -660,7 +664,6 @@
           <button class="wl-subtab" data-db-sub="domain">🏷 ドメイン</button>
           <button class="wl-subtab" data-db-sub="workplace">🗺️ 作業場所</button>
           <button class="wl-subtab" data-db-sub="apps">💻 アプリ</button>
-          <button class="wl-subtab" data-db-sub="queue">⚙ キュー <span id="dbQueueBadge" class="tab-count hidden">0</span></button>
         </nav>
       </div>
 
@@ -1774,6 +1777,6 @@
       <button id="aiSettingsSave">保存</button>
     </div>
   </div>
-  <script src="app.js?v=20260513i"></script>
+  <script src="app.js?v=20260513j"></script>
 </body>
 </html>

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -978,20 +978,20 @@ async function refreshQueue() {
     if (totalDepth === 0) totalDepth = snap.depth || 0;
     const badge = $('queueBadge');
     const tabCount = $('tabQueueCount');
-    const dbBadge = $('dbQueueBadge');
+    const tabBadge = $('tabQueueBadge'); // queue が top-level タブに昇格 (2026-05-13)
     if (totalDepth > 0) {
       badge.classList.remove('hidden');
       tabCount?.classList.remove('hidden');
-      dbBadge?.classList.remove('hidden');
+      tabBadge?.classList.remove('hidden');
       $('queueCount').textContent = String(totalDepth);
       if (tabCount) tabCount.textContent = String(totalDepth);
-      if (dbBadge) dbBadge.textContent = String(totalDepth);
+      if (tabBadge) tabBadge.textContent = String(totalDepth);
     } else {
       badge.classList.add('hidden');
       tabCount?.classList.add('hidden');
-      dbBadge?.classList.add('hidden');
+      tabBadge?.classList.add('hidden');
     }
-    if (state.tab === 'database' && state.database?.sub === 'queue') renderQueue();
+    if (state.tab === 'queue') renderQueue();
     return totalDepth;
   } catch { return 0; }
 }
@@ -1113,7 +1113,7 @@ function jobLabel(item) {
 // 日付を持たない sub (queue / external) と物データ (bookmarks / dict / domain / workplace) は database 配下。
 // meals は top-level タブ。
 const WORKLOG_REDIRECT_TABS = new Set(['tracks']);
-const DATABASE_REDIRECT_TABS = new Set(['bookmarks', 'dict', 'domain', 'workplace', 'queue', 'external']);
+const DATABASE_REDIRECT_TABS = new Set(['bookmarks', 'dict', 'domain', 'workplace', 'external']);
 
 function switchTab(tab) {
   if (WORKLOG_REDIRECT_TABS.has(tab)) {
@@ -1146,6 +1146,7 @@ function switchTab(tab) {
   $('mealsView')?.classList.toggle('hidden', tab !== 'meals');
   $('reviewView')?.classList.toggle('hidden', tab !== 'review');
   $('transitView')?.classList.toggle('hidden', tab !== 'transit');
+  $('queueView')?.classList.toggle('hidden', tab !== 'queue');
   $('notesView')?.classList.toggle('hidden', tab !== 'notes');
   $('tasksView')?.classList.toggle('hidden', tab !== 'tasks');
   $('implView')?.classList.toggle('hidden', tab !== 'impl');
@@ -1163,6 +1164,7 @@ function switchTab(tab) {
   if (tab === 'meals') loadMeals();
   if (tab === 'review') loadReviewRepos();
   if (tab === 'transit') loadTransit();
+  if (tab === 'queue') renderQueue();
   if (tab === 'notes') void notesLoad();
   if (tab === 'tasks') loadTasks();
   if (tab === 'impl') loadImplementationNotes();
@@ -4898,7 +4900,7 @@ setInterval(async () => {
   const depth = await refreshQueue();
   await refreshVisitsBadge();
   if (depth > 0 || state.bookmarks.some(b => b.status === 'pending')) load();
-  if (state.tab === 'database' && state.database?.sub === 'queue') renderQueue();
+  if (state.tab === 'queue') renderQueue();
 }, 2000);
 refreshQueue();
 refreshVisitsBadge();
@@ -7956,7 +7958,6 @@ const DB_SUB_VIEWS = {
   domain: 'domainView',
   workplace: 'workplaceView',
   apps: 'appsView',
-  queue: 'queueView',
 };
 
 state.database = state.database || { sub: 'bookmarks' };
@@ -7990,7 +7991,6 @@ function switchDatabaseSub(sub) {
   if (sub === 'domain') loadDomainCatalog();
   if (sub === 'workplace') loadWorkLocations().catch(console.warn);
   if (sub === 'apps') loadApplicationsCatalog().catch(console.warn);
-  if (sub === 'queue') renderQueue();
 }
 
 interface ApplicationCatalogRow {


### PR DESCRIPTION
ユーザ要望: 「キューはトップレベルメニューに昇格」

## 変更点

- main tabs に `data-tab="queue"` ボタン追加 + バッジ `tabQueueBadge`
- databaseSubtabs から `data-db-sub="queue"` を削除
- `switchTab` に queueView の hidden 切替 + renderQueue 呼出
- `DB_SUB_VIEWS` / `switchDatabaseSub` / `DATABASE_REDIRECT_TABS` から queue 関連を削除
- `refreshQueue` の badge 切替を `dbQueueBadge` → `tabQueueBadge` にリネーム

cache buster: style.css v=20260513j, app.js v=20260513h。

🤖 Generated with [Claude Code](https://claude.com/claude-code)