### PR TITLE
fix(diary): LLM タイムアウトを 180s/240s → 600s に延長

### DIFF
--- a/server/diary.ts
+++ b/server/diary.ts
@@ -1589,7 +1589,7 @@ export interface GenerateWorkContentArgs {
  * 適切に推定されるようにする。
  */
 export async function generateWorkContent({
-  db, dateStr, metrics, globalMemo, improve, timeoutMs = 180_000,
+  db, dateStr, metrics, globalMemo, improve, timeoutMs = 600_000,
 }: GenerateWorkContentArgs): Promise<WorkMinutesExtraction> {
   const urlList = buildUrlList(db, dateStr);
   const activityList = buildActivityList(metrics.activity);
@@ -1664,7 +1664,7 @@ export interface GenerateHighlightsArgs {
 /** Stage 3: Opus 1M (default) integrates work content + bookmark count + commits + dig into highlights. */
 export async function generateHighlights({
   dateStr, workContent, githubByRepo, bookmarkSummary, digs, notes, metrics,
-  globalMemo, improve, timeoutMs = 240_000,
+  globalMemo, improve, timeoutMs = 600_000,
 }: GenerateHighlightsArgs): Promise<string> {
   const base = HIGHLIGHTS_PROMPT({
     dateStr, workContent, githubByRepo, bookmarkSummary, digs, notes, metrics,


### PR DESCRIPTION
ユーザ要望: 「日記のタイムアウトが 180000ms なので 600000ms とかにする」

## 変更点

- `generateWorkContent` (Sonnet / diary_work): 180_000 → **600_000** (10 min)
- `generateHighlights` (Opus / diary_highlights): 240_000 → **600_000** (10 min)

長文コミット連発日や活動量の多い日に Sonnet 出力 / Opus 統合プロンプトが膨らんで timeout で落ちるケースを救う。

PR #149 で GitHub fetch (30s/12s → 60s) は対応済み、 今回は LLM 側。

🤖 Generated with [Claude Code](https://claude.com/claude-code)