### PR TITLE
feat: リポジトリ ウォッチ一覧 (📦 リポジトリ タブ)

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -532,6 +532,35 @@ export function openDb(dbPath: string): Db {
     CREATE INDEX IF NOT EXISTS idx_recommendation_runs_started
       ON recommendation_runs(started_at DESC);
 
+    -- ウォッチ対象のソース管理リポジトリ。 PR / Issue / デフォルトブランチの
+    -- 最終更新を一覧するためのレジストリ。 内部ビューアは持たず、 表示は
+    -- すべて元のホスティング先 (GitHub 等) へリンクするだけ。
+    -- provider は将来 GitHub 以外 (gitlab / bitbucket / gitea ...) を足す
+    -- ための拡張点 (現状は 'github' のみ実装)。
+    -- 各 *_count / last_commit_* / fetched_at / fetch_error はホスティング先
+    -- API レート制限を避けるための直近フェッチのキャッシュ。 表示は常に
+    -- このキャッシュから行い、 refresh で明示的に取り直す。
+    CREATE TABLE IF NOT EXISTS repo_watch (
+      id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+      provider            TEXT NOT NULL DEFAULT 'github',
+      owner               TEXT NOT NULL,
+      name                TEXT NOT NULL,
+      html_url            TEXT NOT NULL,
+      default_branch      TEXT,
+      open_pr_count       INTEGER,
+      open_issue_count    INTEGER,
+      last_commit_sha     TEXT,
+      last_commit_message TEXT,
+      last_commit_url     TEXT,
+      last_commit_at      TEXT,
+      fetched_at          TEXT,
+      fetch_error         TEXT,
+      sort_order          INTEGER NOT NULL DEFAULT 0,
+      created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE(provider, owner, name)
+    );
+    CREATE INDEX IF NOT EXISTS idx_repo_watch_sort ON repo_watch(sort_order, id);
+
     CREATE TABLE IF NOT EXISTS push_subscriptions (
       id          INTEGER PRIMARY KEY AUTOINCREMENT,
       endpoint    TEXT NOT NULL UNIQUE,
@@ -2571,6 +2600,104 @@ export function updateReviewTarget(
 export function deleteReviewTarget(db: Db, id: number): boolean {
   const r = db.prepare(`DELETE FROM review_targets WHERE id = ?`).run(id);
   return r.changes > 0;
+}
+
+// ─── repo_watch (ソース管理リポジトリのウォッチ一覧) ──────────────────────────
+export interface RepoWatchRow {
+  id: number;
+  provider: string;
+  owner: string;
+  name: string;
+  html_url: string;
+  default_branch: string | null;
+  open_pr_count: number | null;
+  open_issue_count: number | null;
+  last_commit_sha: string | null;
+  last_commit_message: string | null;
+  last_commit_url: string | null;
+  last_commit_at: string | null;
+  fetched_at: string | null;
+  fetch_error: string | null;
+  sort_order: number;
+  created_at: string;
+}
+
+const REPO_WATCH_COLS = `
+  id, provider, owner, name, html_url, default_branch,
+  open_pr_count, open_issue_count,
+  last_commit_sha, last_commit_message, last_commit_url, last_commit_at,
+  fetched_at, fetch_error, sort_order, created_at
+`;
+
+export function listRepoWatch(db: Db): RepoWatchRow[] {
+  return db.prepare(
+    `SELECT ${REPO_WATCH_COLS} FROM repo_watch ORDER BY sort_order ASC, id ASC`,
+  ).all() as RepoWatchRow[];
+}
+
+export function getRepoWatch(db: Db, id: number): RepoWatchRow | undefined {
+  return db.prepare(
+    `SELECT ${REPO_WATCH_COLS} FROM repo_watch WHERE id = ?`,
+  ).get(id) as RepoWatchRow | undefined;
+}
+
+/** 新規登録。 (provider, owner, name) が重複する場合は UNIQUE 制約で throw。 */
+export function insertRepoWatch(
+  db: Db,
+  { provider = 'github', owner, name, html_url, default_branch = null }:
+    { provider?: string; owner: string; name: string; html_url: string; default_branch?: string | null },
+): number {
+  const max = db.prepare(`SELECT COALESCE(MAX(sort_order), -1) AS m FROM repo_watch`).get() as { m: number };
+  const r = db.prepare(
+    `INSERT INTO repo_watch (provider, owner, name, html_url, default_branch, sort_order)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(provider, owner, name, html_url, default_branch, max.m + 1);
+  return Number(r.lastInsertRowid);
+}
+
+export function deleteRepoWatch(db: Db, id: number): boolean {
+  const r = db.prepare(`DELETE FROM repo_watch WHERE id = ?`).run(id);
+  return r.changes > 0;
+}
+
+/** 直近フェッチのキャッシュ列を更新する。 fetch 成否どちらでも呼ぶ。 */
+export function updateRepoWatchStats(
+  db: Db,
+  id: number,
+  stats: {
+    default_branch?: string | null;
+    open_pr_count?: number | null;
+    open_issue_count?: number | null;
+    last_commit_sha?: string | null;
+    last_commit_message?: string | null;
+    last_commit_url?: string | null;
+    last_commit_at?: string | null;
+    fetch_error?: string | null;
+  },
+): void {
+  db.prepare(
+    `UPDATE repo_watch SET
+       default_branch      = ?,
+       open_pr_count       = ?,
+       open_issue_count    = ?,
+       last_commit_sha     = ?,
+       last_commit_message = ?,
+       last_commit_url     = ?,
+       last_commit_at      = ?,
+       fetched_at          = datetime('now'),
+       fetch_error         = ?
+     WHERE id = ?`,
+  ).run(
+    stats.default_branch ?? null,
+    stats.open_pr_count ?? null,
+    stats.open_issue_count ?? null,
+    stats.last_commit_sha ?? null,
+    stats.last_commit_message ?? null,
+    stats.last_commit_url ?? null,
+    stats.last_commit_at ?? null,
+    stats.fetch_error ?? null,
+    id,
+  );
 }
 
 export function activityEventsForDate(db: Db, dateStr: string): ActivityEventParsed[] {

--- a/server/index.ts
+++ b/server/index.ts
@@ -60,6 +60,7 @@ import { makeConfigRouter } from './routes/config.js';
 import { makeMultiRouter } from './routes/multi.js';
 import { makeMiscRouter } from './routes/misc.js';
 import { makeReviewRouter, seedReviewTargets } from './routes/review.js';
+import { makeRepoRouter } from './routes/repo.js';
 import { seedStationsIfEmpty } from './lib/transit-stations-seed.js';
 import { makeWeatherRouter } from './routes/weather.js';
 import { makeTransitRouter } from './routes/transit.js';
@@ -297,6 +298,7 @@ app.route('/', makeMultiRouter({
 }));
 app.route('/', makeMiscRouter({ db, htmlDir: HTML_DIR, bulkSaveDeps }));
 app.route('/', makeReviewRouter({ db }));
+app.route('/', makeRepoRouter({ db }));
 app.route('/', makeWeatherRouter({ db }));
 app.route('/', makeTransitRouter({ db }));
 app.route('/', makeStalenessRouter({ db }));

--- a/server/lib/repo-watch.ts
+++ b/server/lib/repo-watch.ts
@@ -1,0 +1,205 @@
+// repo_watch のソース管理プロバイダ連携。
+//
+// 役割は 2 つだけ:
+//   1. ユーザ入力 (URL / owner/name) を { provider, owner, name, html_url } に正規化
+//   2. プロバイダ API を叩いて 「PR / Issue / デフォルトブランチ最終更新」 の
+//      サマリを取得 (= repo_watch のキャッシュ列に焼くための値)
+//
+// 内部ビューアは持たない方針なので、 ここで取るのは一覧表示に必要な
+// 件数・最終コミットだけ。 詳細はすべて html_url 系リンクで元の
+// ホスティング先へ飛ばす。
+//
+// provider は現状 'github' のみ。 GitLab / Bitbucket / Gitea などを足す時は
+// PROVIDERS と fetchRepoStats の switch に分岐を追加する (DB スキーマと
+// ルータは provider 非依存に書いてある)。
+
+export type RepoProvider = 'github';
+
+/** 実装済みプロバイダ。 UI のセレクトはここから生成する。 */
+export const REPO_PROVIDERS: ReadonlyArray<{ key: RepoProvider; label: string }> = [
+  { key: 'github', label: 'GitHub' },
+];
+
+export interface ParsedRepo {
+  provider: RepoProvider;
+  owner: string;
+  name: string;
+  html_url: string;
+}
+
+export interface RepoStats {
+  default_branch: string | null;
+  open_pr_count: number | null;
+  open_issue_count: number | null;
+  last_commit_sha: string | null;
+  last_commit_message: string | null;
+  last_commit_url: string | null;
+  last_commit_at: string | null;
+  /** 取得に失敗した場合の理由 (= 部分的にしか取れなかった時も入れる)。 成功なら null。 */
+  fetch_error: string | null;
+}
+
+/**
+ * ユーザ入力を正規化する。 受け付ける形:
+ *   - https://github.com/owner/name             (.git / 末尾スラッシュ / 余分なパスは無視)
+ *   - github.com/owner/name
+ *   - git@github.com:owner/name.git
+ *   - owner/name                                 (= GitHub と見なす)
+ *
+ * 解釈できなければ { error } を返す。
+ */
+export function parseRepoInput(raw: string): ParsedRepo | { error: string } {
+  const input = (raw || '').trim();
+  if (!input) return { error: 'リポジトリ URL または owner/name を入力してください' };
+
+  // git@github.com:owner/name.git
+  const ssh = input.match(/^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/i);
+  if (ssh) return makeGithub(ssh[1], ssh[2]);
+
+  // http(s)://github.com/owner/name/...  または  github.com/owner/name
+  const urlLike = input.match(/^(?:https?:\/\/)?(?:www\.)?github\.com\/([^/]+)\/([^/#?]+)/i);
+  if (urlLike) return makeGithub(urlLike[1], urlLike[2]);
+
+  // owner/name (スキームなし)
+  const shorthand = input.match(/^([A-Za-z0-9][\w.-]*)\/([A-Za-z0-9][\w.-]*?)(?:\.git)?$/);
+  if (shorthand) return makeGithub(shorthand[1], shorthand[2]);
+
+  return { error: 'GitHub の URL か owner/name 形式で入力してください' };
+}
+
+function makeGithub(owner: string, name: string): ParsedRepo {
+  const o = owner.trim();
+  const n = name.trim().replace(/\.git$/i, '');
+  return { provider: 'github', owner: o, name: n, html_url: `https://github.com/${o}/${n}` };
+}
+
+/** provider に応じてサマリを取得する。 例外は投げず、 失敗は fetch_error に入れて返す。 */
+export async function fetchRepoStats(
+  repo: { provider: string; owner: string; name: string },
+  token: string | null,
+): Promise<RepoStats> {
+  if (repo.provider === 'github') {
+    return fetchGithubRepoStats(repo.owner, repo.name, token);
+  }
+  return { ...EMPTY_STATS, fetch_error: `未対応の provider: ${repo.provider}` };
+}
+
+const EMPTY_STATS: RepoStats = {
+  default_branch: null,
+  open_pr_count: null,
+  open_issue_count: null,
+  last_commit_sha: null,
+  last_commit_message: null,
+  last_commit_url: null,
+  last_commit_at: null,
+  fetch_error: null,
+};
+
+interface GithubRepoResponse {
+  default_branch?: string;
+  open_issues_count?: number;   // issue + PR の合算
+}
+interface GithubCommitResponse {
+  sha?: string;
+  html_url?: string;
+  commit?: { message?: string; committer?: { date?: string }; author?: { date?: string } };
+}
+interface GithubSearchResponse {
+  total_count?: number;
+}
+
+/**
+ * GitHub REST v3 でリポジトリのサマリを取る。
+ *   - GET /repos/{o}/{n}                      → default_branch, open_issues_count
+ *   - GET /repos/{o}/{n}/commits?sha=&per_page=1 → デフォルトブランチ最終コミット
+ *   - GET /search/issues?q=...is:pr is:open    → open PR 件数
+ *     (Issue 件数 = open_issues_count - PR 件数。 GitHub の open_issues_count は
+ *      PR も含むため)
+ *
+ * token があれば Authorization に載せる (rate limit 緩和 + private 対応)。
+ * 無くても public repo は取得できる。
+ */
+async function fetchGithubRepoStats(
+  owner: string,
+  name: string,
+  token: string | null,
+): Promise<RepoStats> {
+  const headers: Record<string, string> = {
+    'Accept': 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': 'Memoria-repo-watch',
+  };
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+
+  const slug = `${owner}/${name}`;
+  const get = async (url: string): Promise<{ ok: true; data: unknown } | { ok: false; error: string }> => {
+    try {
+      const res = await fetch(url, { headers });
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        return { ok: false, error: `GitHub API ${res.status}: ${body.slice(0, 200)}` };
+      }
+      return { ok: true, data: await res.json() };
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : String(e) };
+    }
+  };
+
+  // 1. repo メタ — ここが落ちたら致命的 (= リポジトリ自体が見えない)。
+  const repoRes = await get(`https://api.github.com/repos/${slug}`);
+  if (!repoRes.ok) return { ...EMPTY_STATS, fetch_error: repoRes.error };
+  const repo = repoRes.data as GithubRepoResponse;
+  const defaultBranch = repo.default_branch ?? null;
+  const openIssuesAndPrs = typeof repo.open_issues_count === 'number' ? repo.open_issues_count : null;
+
+  const errors: string[] = [];
+
+  // 2. デフォルトブランチ最終コミット (best-effort)。
+  let lastCommitSha: string | null = null;
+  let lastCommitMessage: string | null = null;
+  let lastCommitUrl: string | null = null;
+  let lastCommitAt: string | null = null;
+  if (defaultBranch) {
+    const commitsRes = await get(
+      `https://api.github.com/repos/${slug}/commits?sha=${encodeURIComponent(defaultBranch)}&per_page=1`,
+    );
+    if (commitsRes.ok && Array.isArray(commitsRes.data) && commitsRes.data.length > 0) {
+      const c = commitsRes.data[0] as GithubCommitResponse;
+      lastCommitSha = c.sha ?? null;
+      lastCommitMessage = (c.commit?.message ?? '').split('\n')[0] || null;
+      lastCommitUrl = c.html_url ?? (lastCommitSha ? `https://github.com/${slug}/commit/${lastCommitSha}` : null);
+      lastCommitAt = c.commit?.committer?.date ?? c.commit?.author?.date ?? null;
+    } else if (!commitsRes.ok) {
+      errors.push(`commits: ${commitsRes.error}`);
+    }
+  }
+
+  // 3. open PR 件数 (best-effort, search API)。 Issue 件数はそこから逆算。
+  let openPrCount: number | null = null;
+  let openIssueCount: number | null = null;
+  const searchRes = await get(
+    `https://api.github.com/search/issues?q=${encodeURIComponent(`repo:${slug} is:pr is:open`)}&per_page=1`,
+  );
+  if (searchRes.ok) {
+    const s = searchRes.data as GithubSearchResponse;
+    openPrCount = typeof s.total_count === 'number' ? s.total_count : null;
+    if (openPrCount != null && openIssuesAndPrs != null) {
+      openIssueCount = Math.max(0, openIssuesAndPrs - openPrCount);
+    }
+  } else {
+    errors.push(`PR count: ${searchRes.error}`);
+    // search が落ちても open_issues_count (issue+PR 合算) は出しておく。
+    openIssueCount = openIssuesAndPrs;
+  }
+
+  return {
+    default_branch: defaultBranch,
+    open_pr_count: openPrCount,
+    open_issue_count: openIssueCount,
+    last_commit_sha: lastCommitSha,
+    last_commit_message: lastCommitMessage,
+    last_commit_url: lastCommitUrl,
+    last_commit_at: lastCommitAt,
+    fetch_error: errors.length > 0 ? errors.join(' / ') : null,
+  };
+}

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -305,6 +305,9 @@
           <button class="tab" data-tab="review">
             <span class="tab-label" data-full="🔍 レビュー" data-short="🔍 レビュ">🔍 レビュー</span>
           </button>
+          <button class="tab" data-tab="repos">
+            <span class="tab-label" data-full="📦 リポジトリ" data-short="📦 リポ">📦 リポジトリ</span>
+          </button>
           <button class="tab" data-tab="transit">
             <span class="tab-label" data-full="🚆 交通" data-short="🚆 交通">🚆 交通</span>
           </button>
@@ -965,6 +968,24 @@
         </div>
       </div>
 
+      <div id="reposView" class="hidden">
+        <div class="bookmarks-toolbar">
+          <span class="muted">📦 ウォッチ中のリポジトリ — PR / Issue / デフォルトブランチ最終更新</span>
+          <span class="grow"></span>
+          <button id="repoAddBtn" class="ghost" type="button" title="リポジトリを追加">+ 追加</button>
+          <button id="repoRefreshAllBtn" class="ghost" type="button" title="全リポのサマリを取り直す">更新</button>
+        </div>
+        <p id="repoTokenHint" class="muted" style="font-size:11px;margin:0 0 8px;display:none">
+          GitHub PAT が未設定です。 public リポは取得できますが、 private リポや
+          rate limit 緩和には <code>日記</code> 設定の GitHub トークンを設定してください。
+        </p>
+        <div id="repoList" class="cards"></div>
+        <div id="repoEmpty" class="dict-empty hidden">
+          ウォッチ中のリポジトリはありません。 「+ 追加」 から GitHub の URL か
+          <code>owner/name</code> を登録してください。
+        </div>
+      </div>
+
       <div id="transitView" class="hidden">
         <div class="bookmarks-toolbar">
           <span class="muted">🚆 経路検索 (Google Maps へ) / 乗車記録</span>
@@ -1491,6 +1512,27 @@
       現在は AIFormat のみ。 カスタムフォーマットは将来対応。
     </p>
     <div id="reviewTargetError" class="muted" style="margin-top:8px;font-size:11px;color:#c0392b" hidden></div>
+  </div>
+
+  <div id="repoWatchModal" class="dict-detail modal-panel hidden foundation-form">
+    <div class="dict-detail-head">
+      <h3 style="margin:0;flex:1">📦 リポジトリを追加</h3>
+      <button id="repoWatchSaveBtn">追加</button>
+      <button id="repoWatchCloseBtn" class="modal-close" title="閉じる">×</button>
+    </div>
+    <p class="muted" style="margin:8px 0;font-size:12px">
+      ウォッチ対象のリポジトリを登録します。 PR / Issue / デフォルトブランチの
+      最終更新を一覧表示し、 各項目は GitHub へリンクします (内部ビューアは
+      ありません)。
+    </p>
+    <label class="simple-field" style="margin-top:8px">
+      <span>リポジトリ URL または owner/name</span>
+      <input id="repoWatchUrl" type="text" placeholder="例: https://github.com/LUDIARS/Memoria  または  LUDIARS/Memoria" />
+    </label>
+    <p class="muted" style="font-size:11px;margin:4px 0">
+      現在は GitHub のみ対応。 GitHub 以外のバージョン管理は今後対応予定です。
+    </p>
+    <div id="repoWatchError" class="muted" style="margin-top:8px;font-size:11px;color:#c0392b" hidden></div>
   </div>
 
   <div id="appsDetail" class="dict-detail modal-panel hidden foundation-form">

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -1145,6 +1145,7 @@ function switchTab(tab) {
   $('diaryView').classList.toggle('hidden', tab !== 'diary');
   $('mealsView')?.classList.toggle('hidden', tab !== 'meals');
   $('reviewView')?.classList.toggle('hidden', tab !== 'review');
+  $('reposView')?.classList.toggle('hidden', tab !== 'repos');
   $('transitView')?.classList.toggle('hidden', tab !== 'transit');
   $('queueView')?.classList.toggle('hidden', tab !== 'queue');
   $('notesView')?.classList.toggle('hidden', tab !== 'notes');
@@ -1163,6 +1164,7 @@ function switchTab(tab) {
   if (tab === 'diary') loadDiary();
   if (tab === 'meals') loadMeals();
   if (tab === 'review') loadReviewRepos();
+  if (tab === 'repos') loadRepoWatch();
   if (tab === 'transit') loadTransit();
   if (tab === 'queue') renderQueue();
   if (tab === 'notes') void notesLoad();
@@ -11016,6 +11018,231 @@ $('reviewTargetCloseBtn')?.addEventListener('click', () => hideModal('reviewTarg
 document.getElementById('reviewDateSel')?.addEventListener('change', (ev) => {
   reviewState.currentDate = ev.target.value;
   void loadReviewFile();
+});
+
+// ── 📦 リポジトリ ウォッチ一覧 ────────────────────────────────────────────
+//
+// 登録した GitHub リポの PR / Issue / デフォルトブランチ最終更新を一覧する。
+// 内部ビューアは持たず、 すべての項目は GitHub への外部リンク。 サマリは
+// サーバ側 (repo_watch テーブル) にキャッシュされ、 「更新」 で取り直す。
+interface RepoWatchItem {
+  id: number;
+  provider: string;
+  owner: string;
+  name: string;
+  html_url: string;
+  default_branch: string | null;
+  open_pr_count: number | null;
+  open_issue_count: number | null;
+  last_commit_sha: string | null;
+  last_commit_message: string | null;
+  last_commit_url: string | null;
+  last_commit_at: string | null;
+  fetched_at: string | null;
+  fetch_error: string | null;
+}
+const repoWatchState: { items: RepoWatchItem[]; tokenSet: boolean } = { items: [], tokenSet: false };
+
+/** ざっくり相対時刻 ("3時間前" 等)。 不正値や未来は fmtDate にフォールバック。 */
+function repoFmtAgo(s: string | null): string {
+  if (!s) return '—';
+  const d = new Date(s.includes('T') ? s : s.replace(' ', 'T') + 'Z');
+  const ms = Date.now() - d.getTime();
+  if (Number.isNaN(ms)) return s;
+  if (ms < 0) return fmtDate(s);
+  const min = Math.floor(ms / 60000);
+  if (min < 1) return 'たった今';
+  if (min < 60) return `${min}分前`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}時間前`;
+  const day = Math.floor(hr / 24);
+  if (day < 30) return `${day}日前`;
+  const mon = Math.floor(day / 30);
+  if (mon < 12) return `${mon}ヶ月前`;
+  return `${Math.floor(mon / 12)}年前`;
+}
+
+async function loadRepoWatch() {
+  const list = document.getElementById('repoList');
+  const empty = document.getElementById('repoEmpty');
+  if (!list) return;
+  try {
+    const r = await api('/api/repos') as { items?: RepoWatchItem[]; token_set?: boolean };
+    repoWatchState.items = r.items || [];
+    repoWatchState.tokenSet = !!r.token_set;
+    renderRepoWatch();
+  } catch (e) {
+    list.innerHTML = '';
+    empty?.classList.add('hidden');
+    list.innerHTML = `<p class="muted">読み込みエラー: ${escapeHtml((e as Error).message)}</p>`;
+  }
+}
+
+function renderRepoWatch() {
+  const list = document.getElementById('repoList');
+  const empty = document.getElementById('repoEmpty');
+  const hint = document.getElementById('repoTokenHint');
+  if (!list || !empty) return;
+  if (hint) hint.style.display = repoWatchState.tokenSet ? 'none' : '';
+  if (repoWatchState.items.length === 0) {
+    list.innerHTML = '';
+    empty.classList.remove('hidden');
+    return;
+  }
+  empty.classList.add('hidden');
+  list.innerHTML = repoWatchState.items.map((it) => {
+    const slug = `${it.owner}/${it.name}`;
+    const branch = it.default_branch || 'main';
+    const prCount = it.open_pr_count == null ? '—' : String(it.open_pr_count);
+    const issueCount = it.open_issue_count == null ? '—' : String(it.open_issue_count);
+    const prLink = `${it.html_url}/pulls`;
+    const issueLink = `${it.html_url}/issues`;
+    const branchLink = `${it.html_url}/commits/${encodeURIComponent(branch)}`;
+    const commitMsg = it.last_commit_message
+      ? escapeHtml(it.last_commit_message)
+      : '<span class="muted">コミット情報なし</span>';
+    const commitWhen = it.last_commit_at
+      ? `<a href="${escapeHtml(it.last_commit_url || branchLink)}" target="_blank" rel="noopener" title="${escapeHtml(fmtDate(it.last_commit_at))}">${escapeHtml(repoFmtAgo(it.last_commit_at))}</a>`
+      : '<span class="muted">—</span>';
+    const fetched = it.fetched_at
+      ? `<span class="muted" style="font-size:11px" title="${escapeHtml(fmtDate(it.fetched_at))}">サマリ取得: ${escapeHtml(repoFmtAgo(it.fetched_at))}</span>`
+      : '';
+    const err = it.fetch_error
+      ? `<div class="muted" style="font-size:11px;color:#c0392b;margin-top:4px">⚠ ${escapeHtml(it.fetch_error)}</div>`
+      : '';
+    return `
+      <article class="card repo-watch-card">
+        <header class="repo-watch-head">
+          <a class="repo-watch-slug" href="${escapeHtml(it.html_url)}" target="_blank" rel="noopener">
+            <strong>${escapeHtml(slug)}</strong>
+          </a>
+          <span class="grow"></span>
+          <button class="ghost repo-refresh-btn" type="button" data-repo-id="${it.id}" title="このリポを更新">↻</button>
+          <button class="ghost repo-delete-btn" type="button" data-repo-id="${it.id}" title="一覧から削除">✕</button>
+        </header>
+        <div class="repo-watch-stats">
+          <a class="repo-watch-stat" href="${escapeHtml(prLink)}" target="_blank" rel="noopener">
+            <span class="repo-watch-stat-num">${escapeHtml(prCount)}</span>
+            <span class="repo-watch-stat-label">Open PR</span>
+          </a>
+          <a class="repo-watch-stat" href="${escapeHtml(issueLink)}" target="_blank" rel="noopener">
+            <span class="repo-watch-stat-num">${escapeHtml(issueCount)}</span>
+            <span class="repo-watch-stat-label">Open Issue</span>
+          </a>
+        </div>
+        <div class="repo-watch-branch">
+          <a href="${escapeHtml(branchLink)}" target="_blank" rel="noopener" title="デフォルトブランチのコミット一覧"><code>${escapeHtml(branch)}</code></a>
+          <span class="repo-watch-commit-msg">${commitMsg}</span>
+          <span class="repo-watch-commit-when">${commitWhen}</span>
+        </div>
+        <div class="repo-watch-foot">${fetched}</div>
+        ${err}
+      </article>`;
+  }).join('');
+}
+
+// ── 追加モーダル ──────────────────────────────────────────────────────────
+function openRepoWatchModal() {
+  const input = $('repoWatchUrl') as HTMLInputElement | null;
+  if (input) input.value = '';
+  const err = $('repoWatchError');
+  if (err) { err.hidden = true; err.textContent = ''; }
+  showModal('repoWatchModal');
+  input?.focus();
+}
+
+async function submitRepoWatch() {
+  const url = (($('repoWatchUrl') as HTMLInputElement | null)?.value || '').trim();
+  const err = $('repoWatchError');
+  const showErr = (msg: string) => { if (err) { err.textContent = `⚠ ${msg}`; err.hidden = false; } };
+  if (!url) return showErr('リポジトリ URL または owner/name を入力してください');
+  try {
+    const res = await fetch('/api/repos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({})) as { error?: string };
+      return showErr(body.error || `${res.status}`);
+    }
+    hideModal('repoWatchModal');
+    flashToast('リポジトリを追加しました');
+    await loadRepoWatch();
+  } catch (e) {
+    showErr((e as Error).message);
+  }
+}
+
+async function refreshRepoWatch(id: number) {
+  try {
+    const res = await fetch(`/api/repos/${id}/refresh`, { method: 'POST' });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({})) as { error?: string };
+      flashToast(`更新失敗: ${body.error || res.status}`);
+      return;
+    }
+    const { item } = await res.json() as { item: RepoWatchItem };
+    const idx = repoWatchState.items.findIndex((r) => r.id === id);
+    if (idx >= 0) repoWatchState.items[idx] = item;
+    renderRepoWatch();
+  } catch (e) {
+    flashToast(`更新失敗: ${(e as Error).message}`);
+  }
+}
+
+async function deleteRepoWatch(id: number) {
+  const it = repoWatchState.items.find((r) => r.id === id);
+  if (it && !confirm(`「${it.owner}/${it.name}」 を一覧から削除しますか?`)) return;
+  try {
+    const res = await fetch(`/api/repos/${id}`, { method: 'DELETE' });
+    if (!res.ok) { flashToast(`削除失敗: ${res.status}`); return; }
+    repoWatchState.items = repoWatchState.items.filter((r) => r.id !== id);
+    renderRepoWatch();
+    flashToast('削除しました');
+  } catch (e) {
+    flashToast(`削除失敗: ${(e as Error).message}`);
+  }
+}
+
+async function refreshAllRepoWatch() {
+  const btn = $('repoRefreshAllBtn') as HTMLButtonElement | null;
+  if (btn) { btn.disabled = true; btn.textContent = '更新中…'; }
+  try {
+    const res = await fetch('/api/repos/refresh', { method: 'POST' });
+    if (res.ok) {
+      const { items } = await res.json() as { items: RepoWatchItem[] };
+      repoWatchState.items = items;
+      renderRepoWatch();
+      flashToast('全リポを更新しました');
+    } else {
+      flashToast(`更新失敗: ${res.status}`);
+    }
+  } catch (e) {
+    flashToast(`更新失敗: ${(e as Error).message}`);
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = '更新'; }
+  }
+}
+
+$('repoAddBtn')?.addEventListener('click', openRepoWatchModal);
+$('repoRefreshAllBtn')?.addEventListener('click', () => void refreshAllRepoWatch());
+$('repoWatchSaveBtn')?.addEventListener('click', () => void submitRepoWatch());
+$('repoWatchCloseBtn')?.addEventListener('click', () => hideModal('repoWatchModal'));
+$('repoWatchUrl')?.addEventListener('keydown', (ev) => {
+  if ((ev as KeyboardEvent).key === 'Enter') { ev.preventDefault(); void submitRepoWatch(); }
+});
+document.getElementById('repoList')?.addEventListener('click', (ev) => {
+  const target = ev.target as HTMLElement;
+  const refreshBtn = target.closest('.repo-refresh-btn') as HTMLElement | null;
+  if (refreshBtn) {
+    void refreshRepoWatch(Number(refreshBtn.dataset.repoId));
+    return;
+  }
+  const deleteBtn = target.closest('.repo-delete-btn') as HTMLElement | null;
+  if (deleteBtn) {
+    void deleteRepoWatch(Number(deleteBtn.dataset.repoId));
+  }
 });
 
 // ── transit (Ekispert 経路検索 + 乗車記録 + 運行情報) ─────────────────────

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -6716,3 +6716,32 @@ dialog.loc-edit-modal[open] {
   .ncb-toolbar { gap: 6px; }
   .ncb-tool-group { padding: 0 2px; }
 }
+
+/* ── 📦 リポジトリ ウォッチ一覧 ─────────────────────────────────────────── */
+.repo-watch-card { padding: 12px 14px; display: flex; flex-direction: column; gap: 8px; }
+.repo-watch-head { display: flex; align-items: center; gap: 6px; }
+.repo-watch-slug { text-decoration: none; color: inherit; word-break: break-all; }
+.repo-watch-slug:hover strong { color: var(--accent); }
+.repo-watch-head .ghost { padding: 2px 7px; font-size: 12px; line-height: 1.4; }
+.repo-watch-stats { display: flex; gap: 8px; }
+.repo-watch-stat {
+  flex: 1; display: flex; flex-direction: column; align-items: center;
+  gap: 1px; padding: 6px 4px;
+  background: var(--bg); border: 1px solid var(--border); border-radius: 8px;
+  text-decoration: none; color: inherit;
+}
+.repo-watch-stat:hover { border-color: var(--accent); background: var(--accent-bg); }
+.repo-watch-stat-num { font-size: 18px; font-weight: 700; }
+.repo-watch-stat-label { font-size: 10px; color: var(--muted); }
+.repo-watch-branch {
+  display: flex; flex-wrap: wrap; align-items: baseline; gap: 6px;
+  font-size: 12px;
+}
+.repo-watch-branch code {
+  background: var(--bg); border: 1px solid var(--border);
+  border-radius: 4px; padding: 1px 5px; font-size: 11px;
+}
+.repo-watch-commit-msg { flex: 1; min-width: 120px; word-break: break-word; }
+.repo-watch-commit-when { color: var(--muted); white-space: nowrap; }
+.repo-watch-commit-when a { color: var(--muted); }
+.repo-watch-foot { min-height: 0; }

--- a/server/routes/repo.ts
+++ b/server/routes/repo.ts
@@ -1,0 +1,113 @@
+// /api/repos/* — ソース管理リポジトリのウォッチ一覧 (`repo_watch` テーブル)。
+//
+// 目的は 「登録したリポの PR / Issue / デフォルトブランチ最終更新を 1 画面で
+// 見渡す」 こと。 内部ビューアは持たず、 フロントの表示はすべて GitHub への
+// 外部リンク。 ここで提供するのは:
+//   - GET    /api/repos              一覧 (キャッシュ済サマリ込み)
+//   - POST   /api/repos              URL / owner/name から追加 + 初回フェッチ
+//   - DELETE /api/repos/:id          削除
+//   - POST   /api/repos/:id/refresh  1 件だけサマリ取り直し
+//   - POST   /api/repos/refresh      全件サマリ取り直し (直列 + 軽い間隔)
+//
+// GitHub PAT は diary 設定 (`diary_settings.github_token`) を流用する。
+// 無くても public repo は取得できる (rate limit は低くなる)。
+
+import { Hono, type Context } from 'hono';
+import type BetterSqlite3 from 'better-sqlite3';
+import {
+  listRepoWatch, getRepoWatch, insertRepoWatch, deleteRepoWatch,
+  updateRepoWatchStats, getDiarySettings, type RepoWatchRow,
+} from '../db.js';
+import { parseRepoInput, fetchRepoStats, REPO_PROVIDERS } from '../lib/repo-watch.js';
+
+type Db = BetterSqlite3.Database;
+
+export interface RepoRouterDeps { db: Db }
+
+/** diary 設定 or env から GitHub PAT を引く (どちらも無ければ null)。 */
+function githubToken(db: Db): string | null {
+  const s = getDiarySettings(db);
+  return s.github_token || process.env.MEMORIA_GH_TOKEN || null;
+}
+
+/** 1 件フェッチ → repo_watch のキャッシュ列を更新 → 最新行を返す。 */
+async function refreshOne(db: Db, row: RepoWatchRow): Promise<RepoWatchRow> {
+  const stats = await fetchRepoStats(row, githubToken(db));
+  updateRepoWatchStats(db, row.id, stats);
+  return getRepoWatch(db, row.id) ?? row;
+}
+
+export function makeRepoRouter(deps: RepoRouterDeps): Hono {
+  const { db } = deps;
+  const r = new Hono();
+
+  // ── 一覧 ────────────────────────────────────────────────────────────────
+  r.get('/api/repos', (c: Context) => {
+    return c.json({
+      items: listRepoWatch(db),
+      providers: REPO_PROVIDERS,
+      token_set: !!githubToken(db),
+    });
+  });
+
+  // ── 追加 ────────────────────────────────────────────────────────────────
+  // body: { url: string }  — URL でも owner/name でも可。 追加直後に 1 回
+  // フェッチして初期サマリを埋める (フェッチ失敗でも登録自体は成功扱い)。
+  r.post('/api/repos', async (c: Context) => {
+    const body = await c.req.json().catch(() => null) as { url?: unknown } | null;
+    const raw = typeof body?.url === 'string' ? body.url : '';
+    const parsed = parseRepoInput(raw);
+    if ('error' in parsed) return c.json({ error: parsed.error }, 400);
+
+    let id: number;
+    try {
+      id = insertRepoWatch(db, {
+        provider: parsed.provider,
+        owner: parsed.owner,
+        name: parsed.name,
+        html_url: parsed.html_url,
+      });
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (/UNIQUE/i.test(msg)) {
+        return c.json({ error: `登録済みです: ${parsed.owner}/${parsed.name}` }, 409);
+      }
+      return c.json({ error: `登録に失敗しました: ${msg}` }, 500);
+    }
+
+    const inserted = getRepoWatch(db, id);
+    if (!inserted) return c.json({ error: 'insert succeeded but row not found' }, 500);
+    const row = await refreshOne(db, inserted);
+    return c.json({ item: row }, 201);
+  });
+
+  // ── 削除 ────────────────────────────────────────────────────────────────
+  r.delete('/api/repos/:id', (c: Context) => {
+    const id = Number(c.req.param('id'));
+    if (!Number.isFinite(id)) return c.json({ error: 'invalid id' }, 400);
+    return c.json({ ok: deleteRepoWatch(db, id) });
+  });
+
+  // ── 1 件サマリ更新 ──────────────────────────────────────────────────────
+  r.post('/api/repos/:id/refresh', async (c: Context) => {
+    const id = Number(c.req.param('id'));
+    if (!Number.isFinite(id)) return c.json({ error: 'invalid id' }, 400);
+    const row = getRepoWatch(db, id);
+    if (!row) return c.json({ error: 'not_found' }, 404);
+    return c.json({ item: await refreshOne(db, row) });
+  });
+
+  // ── 全件サマリ更新 ──────────────────────────────────────────────────────
+  // GitHub API のレート制限を踏まないよう直列 + 200ms 間隔。 件数が多い時は
+  // 数秒かかるが、 手動操作前提なので許容する。
+  r.post('/api/repos/refresh', async (c: Context) => {
+    const rows = listRepoWatch(db);
+    for (const row of rows) {
+      await refreshOne(db, row);
+      await new Promise((res) => setTimeout(res, 200));
+    }
+    return c.json({ items: listRepoWatch(db) });
+  });
+
+  return r;
+}


### PR DESCRIPTION
## 概要

登録した GitHub リポジトリの **PR / Issue / デフォルトブランチ最終更新内容・最終更新日** を 1 画面で一覧する機能を追加。一覧化が目的なので内部ビューアは持たず、表示はすべて GitHub への外部リンク。WebUI から追加・削除できる。

## 変更点

### バックエンド
- **`server/db.ts`** — `repo_watch` テーブル新設 + CRUD / キャッシュ更新ヘルパー。`provider` カラム (既定 `'github'`) で将来の非 GitHub 拡張に備える
- **`server/lib/repo-watch.ts`** (新規) — `parseRepoInput` (URL / `owner/name` 正規化) + `fetchRepoStats` (GitHub REST: デフォルトブランチ・最終コミット・open PR/Issue 件数)
- **`server/routes/repo.ts`** (新規) — `GET/POST /api/repos`、`DELETE /api/repos/:id`、`POST /api/repos/:id/refresh`、`POST /api/repos/refresh`。GitHub PAT は `diary_settings.github_token` を流用 (未設定でも public リポは取得可)
- **`server/index.ts`** — ルータを mount

### フロントエンド
- **`index.html`** — `📦 リポジトリ` タブ + `reposView` パネル + 追加モーダル
- **`app.ts`** — 一覧ロード / カード描画 / 追加・削除・更新ハンドラ。PR・Issue・ブランチ・コミットの各項目は GitHub への外部リンク
- **`style.css`** — `.repo-watch-*` スタイル

## 設計メモ

- フェッチ結果は `repo_watch` のキャッシュ列に保存し、表示は常にキャッシュから。`更新` ボタンで明示的に取り直す (GitHub API レート制限対策)
- 既存 DB は起動時の `CREATE TABLE IF NOT EXISTS` で自動マイグレーション
- Ars 配下リポは WebUI からの手動追加方針のためシード処理は入れていない

## 動作確認

- typecheck / lint / `build:frontend` すべて green
- `parseRepoInput`・`repo_watch` DB ヘルパー・GitHub 実フェッチ (LUDIARS/Memoria public) をスモークテスト済み

## 関連

- 非 GitHub バージョン管理への対応: #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)
