### PR TITLE
feat: 設定タブ再編 + 自動読み込み静音化 + リポカード/ダイアログ拡幅

### DIFF
--- a/server/lib/repo-watch.ts
+++ b/server/lib/repo-watch.ts
@@ -59,6 +59,27 @@ export interface RepoStats {
   fetch_error: string | null;
 }
 
+/** 「直近の作業 サマリ」 用の最小コミット情報。 fetchRepoRecentCommits の戻り値。 */
+export interface RepoCommit {
+  sha: string;
+  message: string;        // 1 行目だけ
+  html_url: string;
+  author: string | null;  // login 優先、 commit.author.name fallback
+  when: string | null;    // ISO 8601
+}
+
+/** プロバイダ非依存: 直近 N コミットを取る。 失敗時は { items: [], error } を返す。 */
+export async function fetchRepoRecentCommits(
+  repo: { provider: string; owner: string; name: string; default_branch?: string | null },
+  token: string | null,
+  limit: number,
+): Promise<{ items: RepoCommit[]; error: string | null }> {
+  if (repo.provider === 'github') {
+    return fetchGithubRecentCommits(repo.owner, repo.name, repo.default_branch ?? null, token, limit);
+  }
+  return { items: [], error: `未対応の provider: ${repo.provider}` };
+}
+
 /**
  * ユーザ入力を正規化する。 受け付ける形:
  *   - https://github.com/owner/name             (.git / 末尾スラッシュ / 余分なパスは無視)
@@ -326,5 +347,61 @@ async function fetchGithubRepoStats(
     items,
     ci,
     fetch_error: errors.length > 0 ? errors.join(' / ') : null,
+  };
+}
+
+/**
+ * GitHub REST v3 — デフォルトブランチの最新 N コミットだけ取る軽量版。
+ * カード「開いた」 時の lazy fetch 用 (= ユーザがそのリポを見たいと表明
+ * したタイミングだけ追加で API を叩く)。
+ *   - GET /repos/{o}/{n}/commits?sha=&per_page=N
+ * default_branch 未取得時は GitHub に決めさせる (sha 省略 = default を使う)。
+ */
+async function fetchGithubRecentCommits(
+  owner: string,
+  name: string,
+  defaultBranch: string | null,
+  token: string | null,
+  limit: number,
+): Promise<{ items: RepoCommit[]; error: string | null }> {
+  const headers: Record<string, string> = {
+    'Accept': 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': 'Memoria-repo-watch',
+  };
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  const per = Math.min(50, Math.max(1, limit));
+  const slug = `${owner}/${name}`;
+  const url = defaultBranch
+    ? `https://api.github.com/repos/${slug}/commits?sha=${encodeURIComponent(defaultBranch)}&per_page=${per}`
+    : `https://api.github.com/repos/${slug}/commits?per_page=${per}`;
+  try {
+    const res = await fetch(url, { headers });
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      return { items: [], error: `GitHub API ${res.status}: ${body.slice(0, 200)}` };
+    }
+    const data = await res.json() as GithubCommitResponseFull[];
+    const items: RepoCommit[] = data.map((c) => ({
+      sha: c.sha ?? '',
+      message: (c.commit?.message ?? '').split('\n')[0] || '',
+      html_url: c.html_url ?? (c.sha ? `https://github.com/${slug}/commit/${c.sha}` : ''),
+      author: c.author?.login ?? c.commit?.author?.name ?? null,
+      when: c.commit?.committer?.date ?? c.commit?.author?.date ?? null,
+    })).filter((c) => c.sha && c.html_url);
+    return { items, error: null };
+  } catch (e) {
+    return { items: [], error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+interface GithubCommitResponseFull {
+  sha?: string;
+  html_url?: string;
+  author?: { login?: string } | null;       // GitHub user (login あり)、 anon commit では null
+  commit?: {
+    message?: string;
+    author?: { name?: string; date?: string };
+    committer?: { date?: string };
   };
 }

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -1567,10 +1567,8 @@
     <nav class="settings-tabs" role="tablist">
       <button type="button" class="settings-tab active" data-stab="ai" role="tab">🤖 AI / モデル</button>
       <button type="button" class="settings-tab" data-stab="api" role="tab">🔌 連携 / API key</button>
-      <button type="button" class="settings-tab" data-stab="notif" role="tab">🔔 通知 / 端末</button>
       <button type="button" class="settings-tab" data-stab="profile" role="tab">🧍 プロフィール</button>
       <button type="button" class="settings-tab" data-stab="data" role="tab">📦 データ / Hub</button>
-      <button type="button" class="settings-tab" data-stab="runtime" role="tab">🛠 ランタイム</button>
     </nav>
 
     <!-- ── 🤖 AI / モデル ── -->
@@ -1584,16 +1582,6 @@
       <h4>🐚 Bash (Windows のみ)</h4>
       <p class="ai-settings-help">Claude CLI は内部で bash を呼び出します。Windows でデスクトップアプリから動かすときだけ git-bash の絶対パスを指定してください (例: <code>C:\Program Files\Git\bin\bash.exe</code>)。空欄なら環境変数 <code>CLAUDE_CODE_GIT_BASH_PATH</code> を尊重します。</p>
       <label>git-bash path: <input id="aiGitBashPath" type="text" placeholder="C:\\Program Files\\Git\\bin\\bash.exe" /></label>
-      <h4>📝 日記の常設メモ</h4>
-      <p class="ai-settings-help">日記生成時に毎回プロンプトに添える「常設メモ」。プロジェクトの背景・自分の役割・生成ルール (例: <code>Memoria は LUDIARS の個人ツール。曖昧な作業は推測で断定して書く</code>) などを書いておくと、毎日の日記の作業内容 / ハイライトに反映されます。空欄なら何も追加しません。</p>
-      <textarea id="aiDiaryGlobalMemo" rows="6" placeholder="例: 自分の役割は LUDIARS の AI/フルスタック開発。Memoria, Synergos, Cernere を主軸に動く。日記は事実+推測で書き、断定口調を維持。"></textarea>
-
-      <h4>🎓 はじめての Memoria</h4>
-      <p class="ai-settings-help">起動チュートリアル (5 step wizard) を再表示します。 すでに設定済みの項目はそのまま残り、 必要なものだけ確認できます。</p>
-      <div class="ai-settings-actions">
-        <button id="tutorialReopenBtn" type="button" class="ghost">🎓 はじめての Memoria を表示</button>
-        <span id="tutorialReopenStatus" class="ai-keystatus"></span>
-      </div>
 
       <h4>🚦 AI 自動処理 (opt-out)</h4>
       <p class="ai-settings-help">既定では「保存と同時に AI が要約 / 分類 / カロリー推定 / 日記生成」を自動で走らせます。 claude / OpenAI などをまだ設定していない場合や、 ローカル単体で「素材だけ溜める」 運用にしたいときは OFF にしてください。 OFF にしても各画面の「再要約」「再分析」「日記生成」 等の手動ボタンは引き続き使えます。</p>
@@ -1627,13 +1615,16 @@
           🎮 Steam プレイ統計 (= 1 時間おきに最近プレイした game を取得)
         </label>
       </div>
+    </section>
 
-      <h4>🎮 Steam Web API (オプション)</h4>
-      <p class="ai-settings-help">API key + SteamID を入れると <a href="https://api.steampowered.com/IPlayerService/GetRecentlyPlayedGames" target="_blank" rel="noopener">公式 GetRecentlyPlayedGames</a> で取得します。 未設定でも同じ PC に Steam が入っていればローカル VDF ファイルからフォールバックで取得 (= key 不要)。</p>
-      <label>Steam Web API Key: <input id="activitySteamApiKey" type="password" placeholder="未設定 = VDF fallback" autocomplete="off" /></label>
-      <span id="activitySteamApiKeyStatus" class="ai-keystatus"></span>
-      <label>SteamID64 (17 桁): <input id="activitySteamId" type="text" placeholder="76561198..." autocomplete="off" /></label>
-      <p class="ai-settings-help">API key: <a href="https://steamcommunity.com/dev/apikey" target="_blank" rel="noopener">steamcommunity.com/dev/apikey</a> で発行 (無料、 ドメインは <code>localhost</code> でも OK)。 SteamID64 は <a href="https://steamid.io/" target="_blank" rel="noopener">steamid.io</a> 等。 プロフィール公開設定が ON でないと空が返る。</p>
+    <!-- ── セットアップ手順 (移設): 🎓 はじめての Memoria ── -->
+    <section class="settings-tab-body hidden" data-stab="setup">
+      <h4>🎓 はじめての Memoria</h4>
+      <p class="ai-settings-help">起動チュートリアル (5 step wizard) を再表示します。 すでに設定済みの項目はそのまま残り、 必要なものだけ確認できます。</p>
+      <div class="ai-settings-actions">
+        <button id="tutorialReopenBtn" type="button" class="ghost">🎓 はじめての Memoria を表示</button>
+        <span id="tutorialReopenStatus" class="ai-keystatus"></span>
+      </div>
     </section>
 
     <!-- ── 🔌 連携 / API key ── -->
@@ -1706,10 +1697,17 @@
       </div>
       <p class="ai-settings-help">「🔧 gcloud から自動取得」は <code>gcloud services api-keys list</code> を叩いて active project の Maps key を引き当て、 そのまま設定に書き込みます (Maps API 制限の付いた key 優先 → 無制限 → その他)。 事前に <code>gcloud auth login</code> + <code>gcloud config set project &lt;ID&gt;</code> が必要。</p>
       <p class="ai-settings-help">優先順: <code>app_settings.maps.api_key</code> &gt; 環境変数 <code>GOOGLE_MAPS_API_KEY</code>。 ここで保存すれば DB 側に書かれ、 再起動不要で反映。</p>
+
+      <h4>🎮 Steam Web API (オプション)</h4>
+      <p class="ai-settings-help">API key + SteamID を入れると <a href="https://api.steampowered.com/IPlayerService/GetRecentlyPlayedGames" target="_blank" rel="noopener">公式 GetRecentlyPlayedGames</a> で取得します。 未設定でも同じ PC に Steam が入っていればローカル VDF ファイルからフォールバックで取得 (= key 不要)。</p>
+      <label>Steam Web API Key: <input id="activitySteamApiKey" type="password" placeholder="未設定 = VDF fallback" autocomplete="off" /></label>
+      <span id="activitySteamApiKeyStatus" class="ai-keystatus"></span>
+      <label>SteamID64 (17 桁): <input id="activitySteamId" type="text" placeholder="76561198..." autocomplete="off" /></label>
+      <p class="ai-settings-help">API key: <a href="https://steamcommunity.com/dev/apikey" target="_blank" rel="noopener">steamcommunity.com/dev/apikey</a> で発行 (無料、 ドメインは <code>localhost</code> でも OK)。 SteamID64 は <a href="https://steamid.io/" target="_blank" rel="noopener">steamid.io</a> 等。 プロフィール公開設定が ON でないと空が返る。</p>
     </section>
 
-    <!-- ── 🔔 通知 / 端末 ── -->
-    <section class="settings-tab-body hidden" data-stab="notif">
+    <!-- ── 🔒 プライバシー側 (移設): デスクトップ自動起動 + WebPush 通知 ── -->
+    <section class="settings-tab-body hidden" data-stab="privacy">
       <h4 id="aiDesktopHead" hidden>🖥 デスクトップアプリ</h4>
       <div id="aiDesktopSection" hidden>
         <p class="ai-settings-help">この Memoria は Electron デスクトップアプリの中で動いています。 ウィンドウの × はトレイ最小化、 サーバは常駐し続けます (Chrome 拡張 / モバイル PWA からのアクセスは継続)。 完全終了はトレイ右クリック → 「Memoria を終了」。</p>
@@ -1720,11 +1718,6 @@
         <p class="ai-settings-help" style="margin-top:6px">
           ON にすると <code>--hidden</code> フラグでウィンドウなし起動 → トレイアイコンだけ表示されます。 普段は OS スタートアップに登録するこの方式で十分。 「ログアウト中も動かしたい」 ような用途は将来 Windows サービス化を検討します (別 PR)。
         </p>
-      </div>
-      <h4>📌 スマホでブックマークする方法</h4>
-      <p class="ai-settings-help">スマホには Chrome 拡張が使えないので、 Memoria を PWA 化して OS の共有メニューから保存します。 詳細手順:</p>
-      <div class="ai-settings-actions">
-        <button id="howToBookmarkBtnInSettings" class="ghost" type="button">💡 ブックマーク方法を表示</button>
       </div>
 
       <h4>📱 通知 (WebPush)</h4>
@@ -1766,6 +1759,10 @@
           </select>
         </label>
       </div>
+
+      <h4>📝 日記の常設メモ</h4>
+      <p class="ai-settings-help">日記生成時に毎回プロンプトに添える「常設メモ」。プロジェクトの背景・自分の役割・生成ルール (例: <code>Memoria は LUDIARS の個人ツール。曖昧な作業は推測で断定して書く</code>) などを書いておくと、毎日の日記の作業内容 / ハイライトに反映されます。空欄なら何も追加しません。</p>
+      <textarea id="aiDiaryGlobalMemo" rows="6" placeholder="例: 自分の役割は LUDIARS の AI/フルスタック開発。Memoria, Synergos, Cernere を主軸に動く。日記は事実+推測で書き、断定口調を維持。"></textarea>
     </section>
 
     <!-- ── 📦 データ / Hub ── -->
@@ -1779,14 +1776,6 @@
         </label>
       </div>
 
-      <h4>🧹 メンテナンス</h4>
-      <p class="ai-settings-help">過去のアクセス記録に出てきたドメインのうち、まだドメイン辞書に登録されていないものを fetch + 分類キューに積みます。 force にすると既存行も再分類します (user_edited 列は保護)。</p>
-      <div class="ai-settings-actions">
-        <button id="recatalogAllBtn">アクセス記録から全ドメインを走査</button>
-        <button id="recatalogAllForceBtn" class="ghost" title="既存の辞書行も含めて全部再分類する">force 再分類</button>
-      </div>
-      <div id="recatalogAllStatus" class="multi-status"></div>
-
       <h4>🌐 マルチサーバ (Memoria Hub)</h4>
       <p class="ai-settings-help">辞書 / ディグ / ブックマークを共有できるハブを複数登録できます。各エントリは独立した Cernere ログインを持ち、左の topbar スイッチで個別 ON/OFF (複数同時 ON 可)。</p>
       <ul id="multiServersList" class="multi-servers"></ul>
@@ -1796,13 +1785,6 @@
         <button id="multiAddBtn">＋ 追加</button>
       </div>
       <div id="multiStatus" class="multi-status"></div>
-    </section>
-
-    <!-- ── 🛠 ランタイム ── -->
-    <section class="settings-tab-body hidden" data-stab="runtime">
-      <h4>🛠 ランタイム情報 (読み取り専用)</h4>
-      <p class="ai-settings-help">これらは起動時に決まる値で、変更には再起動が必要です。デスクトップアプリから自動で渡されます。</p>
-      <div id="aiRuntimeInfo" class="ai-runtime-info"></div>
     </section>
 
     <!-- ── 共通 footer (どの tab でも見える) ── -->

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -445,57 +445,64 @@ interface ApiResp extends Loose {
 
 // ── グローバル読み込みインジケータ ───────────────────────────────────────
 //
-// api() 経由の fetch が in-flight のあいだ、 画面上部に非ブロッキングな
-// 「⏳ 読み込み中…」 pill を出す。 pointer-events:none なので他の操作は
-// 一切妨げない。
+// api() 経由の fetch が in-flight のあいだ、 ロゴ (`.brand`) の横に小さな
+// スピナーを表示する。 pointer-events:none なので他の操作は一切妨げない。
 //
-// 250ms の遅延を入れてあるので:
-//   - 2 秒ごとの queue/visits poll や staleness ping のような速い fetch は
-//     出さない (= チラつかない)
-//   - diary 生成 / review file / transit 検索 等の重い読み込みだけ出る
+// `opts.silent: true` を渡すと表示しない (= 2 秒ごとの queue/visits poll や
+// staleness ping、 各種 setInterval ベースの定期 fetch 用 — ユーザに「定期
+// 自動読み込みで青い帯が点滅する」 ノイズを与えない)。
 let _apiInflight = 0;
-let _apiLoadingTimer: ReturnType<typeof setTimeout> | null = null;
 
-function showLoadingPill() {
-  let el = document.getElementById('memLoading');
-  if (!el) {
-    el = document.createElement('div');
-    el.id = 'memLoading';
-    el.className = 'mem-loading';
-    el.textContent = '⏳ 読み込み中…';
-    document.body.appendChild(el);
+function showLogoSpinner() {
+  const brand = document.querySelector('.brand');
+  if (!brand) return;
+  let sp = document.getElementById('brandSpinner');
+  if (!sp) {
+    sp = document.createElement('span');
+    sp.id = 'brandSpinner';
+    sp.className = 'brand-spinner';
+    sp.setAttribute('aria-hidden', 'true');
+    brand.appendChild(sp);
   }
-  el.classList.add('show');
+  sp.classList.add('show');
 }
-function hideLoadingPill() {
-  document.getElementById('memLoading')?.classList.remove('show');
+function hideLogoSpinner() {
+  document.getElementById('brandSpinner')?.classList.remove('show');
 }
 function apiInflightStart() {
   _apiInflight++;
-  if (_apiInflight === 1 && _apiLoadingTimer == null) {
-    _apiLoadingTimer = setTimeout(() => {
-      _apiLoadingTimer = null;
-      if (_apiInflight > 0) showLoadingPill();
-    }, 250);
-  }
+  if (_apiInflight === 1) showLogoSpinner();
 }
 function apiInflightEnd() {
   _apiInflight = Math.max(0, _apiInflight - 1);
-  if (_apiInflight === 0) {
-    if (_apiLoadingTimer != null) { clearTimeout(_apiLoadingTimer); _apiLoadingTimer = null; }
-    hideLoadingPill();
-  }
+  if (_apiInflight === 0) hideLogoSpinner();
 }
 
-async function api<T = ApiResp>(path: string, opts?: RequestInit): Promise<T> {
-  apiInflightStart();
+type ApiOpts = RequestInit & { silent?: boolean };
+async function api<T = ApiResp>(path: string, opts?: ApiOpts): Promise<T> {
+  const silent = !!opts?.silent;
+  if (!silent) apiInflightStart();
   try {
-    const res = await fetch(path, opts);
+    // RequestInit 側に silent を渡さないよう取り除く (fetch 仕様外プロパティ)
+    let fetchOpts: RequestInit | undefined = opts;
+    if (silent && opts) {
+      const { silent: _drop, ...rest } = opts;
+      fetchOpts = rest;
+    }
+    const res = await fetch(path, fetchOpts);
     if (!res.ok) throw new Error(`${res.status} ${await res.text().catch(()=>'')}`);
     return await res.json() as T;
   } finally {
-    apiInflightEnd();
+    if (!silent) apiInflightEnd();
   }
+}
+
+// 定期 poll / 自動 reload 用: api() を silent=true で叩く。 旧 setInterval 群が
+// `api(path)` 直接呼び出していたので、 silent 化を一括で塗り直すための薄い
+// ラッパ。 既存 api() を残しているのは、 ユーザ操作起点の呼び出しではロゴ
+// スピナーを出したいため。
+function apiSilent<T = ApiResp>(path: string, opts?: ApiOpts): Promise<T> {
+  return api<T>(path, { ...(opts || {}), silent: true });
 }
 
 // 元 JS で `funcName = function () {...}` の形で宣言なしに代入 + 後段で再代入
@@ -515,6 +522,8 @@ async function load(opts: Loose = {}) {
   // 50 件ずつのページング。 「もっと表示」 で append=true、 それ以外
   // (カテゴリ切替 / ソート変更 / 検索 / 自動 refresh) は先頭から取り直す。
   const append = opts.append === true;
+  const silent = opts.silent === true;
+  const apiFn = silent ? apiSilent : api;
   const offset = append ? state.bookmarks.length : 0;
   const qs = new URLSearchParams();
   if (state.category) qs.set('category', state.category);
@@ -523,8 +532,8 @@ async function load(opts: Loose = {}) {
   qs.set('limit', String(BOOKMARKS_PAGE_SIZE));
   qs.set('offset', String(offset));
   const [bookmarksRes, categoriesRes] = await Promise.all([
-    api(`/api/bookmarks?${qs.toString()}`),
-    api('/api/categories'),
+    apiFn(`/api/bookmarks?${qs.toString()}`),
+    apiFn('/api/categories'),
   ]);
   state.bookmarks = append
     ? [...state.bookmarks, ...(bookmarksRes.items || [])]
@@ -810,7 +819,7 @@ async function generateDetailCloud() {
 function pollDetailCloud(cloudId) {
   if (state.detailCloudPolling) clearInterval(state.detailCloudPolling);
   state.detailCloudPolling = setInterval(async () => {
-    const c = await api(`/api/wordcloud/${cloudId}`).catch(() => null);
+    const c = await apiSilent(`/api/wordcloud/${cloudId}`).catch(() => null);
     if (!c || c.status === 'pending') return;
     clearInterval(state.detailCloudPolling);
     state.detailCloudPolling = null;
@@ -960,7 +969,7 @@ load().catch(err => {
 
 async function refreshVisitsBadge() {
   try {
-    const r = await api('/api/visits/unsaved/count');
+    const r = await apiSilent('/api/visits/unsaved/count');
     const badge = $('tabVisitsCount');
     if (!badge) return;
     if ((r.count ?? 0) > 0) {
@@ -974,7 +983,7 @@ async function refreshVisitsBadge() {
 
 async function refreshQueue() {
   try {
-    const snap = await api('/api/queue/items');
+    const snap = await apiSilent('/api/queue/items');
     state.queue = snap;
     // Sum depth across all groups for the top-bar badge.
     const groups = ['summary','dig','wordcloud','diary','weekly','domain','page'];
@@ -1609,7 +1618,7 @@ function pollDigSession(id) {
   loadDigSession(id);
   // Poll faster while waiting for preview, then settle.
   state.digPolling = setInterval(async () => {
-    const s = await api(`/api/dig/${id}`).catch(() => null);
+    const s = await apiSilent(`/api/dig/${id}`).catch(() => null);
     if (!s) return;
     const had = state.digSession;
     state.digSession = s;
@@ -2242,7 +2251,7 @@ function pollCloud(id) {
   if (state.cloudPolling) clearInterval(state.cloudPolling);
   loadCloud(id);
   state.cloudPolling = setInterval(async () => {
-    const c = await api(`/api/wordcloud/${id}`).catch(() => null);
+    const c = await apiSilent(`/api/wordcloud/${id}`).catch(() => null);
     if (!c) return;
     if (c.status !== 'pending') {
       clearInterval(state.cloudPolling);
@@ -3039,7 +3048,7 @@ function pollWeekly(ws) {
     if (state.weeklyDetailWeek !== ws) {
       clearInterval(state.weeklyPolling); state.weeklyPolling = null; return;
     }
-    const w = await api(`/api/weekly/${ws}`).catch(() => null);
+    const w = await apiSilent(`/api/weekly/${ws}`).catch(() => null);
     if (!w) return;
     if (w.status !== 'pending') {
       clearInterval(state.weeklyPolling); state.weeklyPolling = null;
@@ -3199,7 +3208,7 @@ function pollDiary(date) {
     if (state.diaryDetailDate !== date) {
       clearInterval(state.diaryPolling); state.diaryPolling = null; return;
     }
-    const d = await api(`/api/diary/${date}`).catch(() => null);
+    const d = await apiSilent(`/api/diary/${date}`).catch(() => null);
     if (!d) return;
     if (d.status !== 'pending') {
       clearInterval(state.diaryPolling); state.diaryPolling = null;
@@ -3905,9 +3914,9 @@ const REC_AGENT_LABELS = {
 
 let recPollTimer = null;
 
-async function loadRecommendations() {
+async function loadRecommendations(opts: { silent?: boolean } = {}) {
   try {
-    const data = await api('/api/recommendations');
+    const data = await (opts.silent ? apiSilent : api)('/api/recommendations');
     state.recommendations = {
       available: !!data.available,
       running: !!data.running,
@@ -3926,7 +3935,7 @@ async function loadRecommendations() {
 function startRecPolling() {
   if (recPollTimer) return;
   recPollTimer = setInterval(() => {
-    loadRecommendations().catch(() => { /* ignore — next tick retries */ });
+    loadRecommendations({ silent: true }).catch(() => { /* ignore — next tick retries */ });
   }, 5000);
 }
 
@@ -4683,7 +4692,7 @@ async function refreshExtensionBadge() {
     return;
   }
   try {
-    const s = await api('/api/extension/status');
+    const s = await apiSilent('/api/extension/status');
     badge.hidden = false;
     if (s.configured) {
       badge.className = 'ext-badge ext-ok';
@@ -4911,7 +4920,9 @@ $('visitsAll').addEventListener('click', (e) => {
 setInterval(async () => {
   const depth = await refreshQueue();
   await refreshVisitsBadge();
-  if (depth > 0 || state.bookmarks.some(b => b.status === 'pending')) load();
+  // 定期 poll の流れで bookmarks を refresh するときも silent。 ユーザが手動で
+  // 並び替え / 検索したときは load() が直接呼ばれてロゴスピナーが出る。
+  if (depth > 0 || state.bookmarks.some(b => b.status === 'pending')) load({ silent: true });
   if (state.tab === 'queue') renderQueue();
 }, 2000);
 refreshQueue();
@@ -4940,7 +4951,7 @@ async function pingStaleness(): Promise<void> {
   if (_stalenessPingInFlight) return;
   _stalenessPingInFlight = true;
   try {
-    const r = await api('/api/staleness') as Record<string, unknown>;
+    const r = await apiSilent('/api/staleness') as Record<string, unknown>;
     for (const k of ['review', 'weather', 'transit_rides']) {
       const v = r[k];
       if (typeof v === 'string') STALE_SIGS[k] = v;
@@ -5026,9 +5037,28 @@ async function openAiSettings() {
       ];
       return opts.join('');
     }
+    // 機能名は内部キー (summarize 等) のままだとユーザに意味が伝わらないので日本語で表示。
+    // 未マップなら原文を fallback。
+    const TASK_LABELS_JA: Record<string, string> = {
+      summarize: '📚 ブックマーク要約',
+      dig: '🔎 ディグ (検索結果分析)',
+      dig_preview: '🔎 ディグ (タイトル/概要プレビュー)',
+      cloud_extract: '🌐 ワードクラウド (語句抽出)',
+      cloud_validate: '🌐 ワードクラウド (語句検証)',
+      domain_classify: '🏷 ドメイン辞書 (サイト分類)',
+      page_summary: '🔖 訪問URL要約 (kind / 短文要約)',
+      diary_work: '📓 日記 (作業内容)',
+      diary_highlights: '📓 日記 (ハイライト)',
+      diary_weekly: '📓 日記 (週報)',
+      meal_vision: '🍽 食事写真 解析',
+      meal_calorie: '🍽 食事カロリー 推定',
+      app_classify: '💻 アプリ 分類 (PC使用統計)',
+      recommendation_agent: '✨ おすすめ (候補抽出)',
+      recommendation_synthesize: '✨ おすすめ (統合)',
+    };
     $('aiTaskRows').innerHTML = tasks.map(t => `
       <div class="ai-task-row">
-        <label>${escapeHtml(t)}</label>
+        <label title="${escapeHtml(t)}">${escapeHtml(TASK_LABELS_JA[t] || t)}</label>
         <select data-task="${t}" class="ai-task-provider">${optionsHtml}</select>
         <select data-task="${t}" class="ai-task-model"></select>
       </div>
@@ -5069,11 +5099,14 @@ async function openAiSettings() {
     }
     if (r.runtime) {
       const rt = r.runtime;
-      $('aiRuntimeInfo').innerHTML = `
-        <div><b>port</b>: ${escapeHtml(String(rt.port))}</div>
-        <div><b>data_dir</b>: <code>${escapeHtml(rt.data_dir)}</code></div>
-        <div><b>platform</b>: ${escapeHtml(rt.platform)}</div>
-      `;
+      const rtEl = document.getElementById('aiRuntimeInfo');
+      if (rtEl) {
+        rtEl.innerHTML = `
+          <div><b>port</b>: ${escapeHtml(String(rt.port))}</div>
+          <div><b>data_dir</b>: <code>${escapeHtml(rt.data_dir)}</code></div>
+          <div><b>platform</b>: ${escapeHtml(rt.platform)}</div>
+        `;
+      }
     }
     // privacy / feature flags (Legatus 連携 ON/OFF, tracks/meals 可視化 etc.) を
     // ここで一括ロードしておく。 API タブには Legatus 連携トグルが、 privacy タブには
@@ -5445,6 +5478,38 @@ async function saveAiSettings() {
   }
 }
 
+// 「全部」 タブで section 上に挿入する見出しラベル (stab → 表示名)。
+const SETTINGS_STAB_LABELS: Record<string, string> = {
+  ai: '🤖 AI / モデル',
+  api: '🔌 連携 / API key',
+  profile: '🧍 プロフィール',
+  data: '📦 データ / Hub',
+  privacy: '🔒 プライバシー / 表示',
+};
+// 「全部」 タブで非表示にする 手順系 (= 一度しか見ない / 別 UI)。
+const SETTINGS_STAB_EXCLUDE_FROM_ALL = new Set(['setup', 'agent-projects']);
+
+function applyAllModeHeadings(panel: HTMLElement, isAll: boolean) {
+  // 既存の見出しを除去
+  panel.querySelectorAll('.settings-all-mode-heading').forEach((el) => el.remove());
+  if (!isAll) return;
+  panel.querySelectorAll('.settings-tab-body').forEach((sec) => {
+    const stab = (sec as HTMLElement).dataset.stab || '';
+    if (SETTINGS_STAB_EXCLUDE_FROM_ALL.has(stab)) return;
+    const label = SETTINGS_STAB_LABELS[stab];
+    if (!label) return;
+    // 同じ stab の複数 section に重複させない: 最初の 1 個目だけに付ける
+    const prev = sec.previousElementSibling;
+    if (prev && (prev as HTMLElement).classList.contains('settings-all-mode-heading')
+        && (prev as HTMLElement).dataset.forStab === stab) return;
+    const h = document.createElement('h3');
+    h.className = 'settings-all-mode-heading';
+    h.dataset.forStab = stab;
+    h.textContent = label;
+    sec.parentNode?.insertBefore(h, sec);
+  });
+}
+
 // ── settings 内部タブ切替 ─────────────────────────────
 document.addEventListener('click', (ev) => {
   const target = ev.target;
@@ -5455,9 +5520,20 @@ document.addEventListener('click', (ev) => {
   if (!panel || panel.classList.contains('hidden')) return;
   const stab = btn.dataset.stab;
   panel.querySelectorAll('.settings-tab').forEach(b => b.classList.toggle('active', b === btn));
-  panel.querySelectorAll('.settings-tab-body').forEach(sec => {
-    sec.classList.toggle('hidden', sec.dataset.stab !== stab);
-  });
+  if (stab === 'all') {
+    panel.querySelectorAll('.settings-tab-body').forEach(sec => {
+      const sstab = (sec as HTMLElement).dataset.stab || '';
+      sec.classList.toggle('hidden', SETTINGS_STAB_EXCLUDE_FROM_ALL.has(sstab));
+    });
+    applyAllModeHeadings(panel, true);
+    // 全部表示時は privacy 側 (Legatus 等) もロードしておく
+    loadPrivacySettings().catch(console.warn);
+  } else {
+    applyAllModeHeadings(panel, false);
+    panel.querySelectorAll('.settings-tab-body').forEach(sec => {
+      sec.classList.toggle('hidden', sec.dataset.stab !== stab);
+    });
+  }
   // タブを切り替えたら panel を上にリセット (各タブの先頭から見たい)
   if (stab === 'privacy') loadPrivacySettings().catch(console.warn);
   if (stab === 'setup') loadSetupDocs().catch(console.warn);
@@ -5732,9 +5808,10 @@ let ensureMemoriaFeatureViews = function () {
   const footer = document.querySelector('.settings-footer');
   if (settingsTabs && !document.querySelector('.settings-tab[data-stab="privacy"]')) {
     for (const spec of [
-      ['privacy', 'プライバシー / 表示'],
-      ['setup', 'セットアップ手順'],
-      ['agent-projects', 'AI 実装プロジェクト'],
+      ['privacy', '🔒 プライバシー / 表示'],
+      ['setup', '📚 セットアップ手順'],
+      ['agent-projects', '🤖 AI 実装プロジェクト'],
+      ['all', '🌐 全部'],
     ]) {
       const b = document.createElement('button');
       b.type = 'button';
@@ -6969,7 +7046,7 @@ async function refreshAgentRunHistory(taskId) {
 
 async function refreshAgentRunLog(runId) {
   try {
-    const r = await api(`/api/agent-runs/${runId}/log?tail=131072`);
+    const r = await apiSilent(`/api/agent-runs/${runId}/log?tail=131072`);
     $('agentRunLog').textContent = r.log || '(ログなし)';
     $('agentRunLog').dataset.runId = String(runId);
     const status = r.run?.status || 'unknown';
@@ -6995,22 +7072,18 @@ async function startAgentRunFromModal() {
   const agent = $('agentRunAgent')?.value || 'claude_code';
   const model = $('agentRunModel')?.value || '';
   if (!projectId) return alert('プロジェクトが未登録です。設定 → AI 実装プロジェクトから登録してください');
-  $('agentRunStartBtn').disabled = true;
-  $('agentRunStartBtn').textContent = '起動中…';
-  try {
-    const r = await api(`/api/tasks/${_agentRunCurrentTask.id}/agent-run`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ project_id: projectId, agent, model }),
-    });
-    await refreshAgentRunHistory(_agentRunCurrentTask.id);
-    if (r.run?.id) refreshAgentRunLog(r.run.id);
-  } catch (e) {
-    alert(`起動失敗: ${e.message}`);
-  } finally {
-    $('agentRunStartBtn').disabled = false;
-    $('agentRunStartBtn').textContent = '▶ 実装を開始';
-  }
+  const task = _agentRunCurrentTask;
+  // 「キューに乗せる」 UX: ボタン押下と同時にダイアログを閉じてトーストでフィードバック、
+  // API 呼び出しは fire-and-forget。 結果はトーストで通知し、 履歴はモーダル次回起動時に表示。
+  closeAgentRunModal();
+  flashToast(`🤖 「${task.title}」 を AI 実装キューへ送信しました`);
+  api(`/api/tasks/${task.id}/agent-run`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ project_id: projectId, agent, model }),
+  })
+    .then(() => { flashToast(`✅ 「${task.title}」 の AI 実装を開始しました`); })
+    .catch((e) => { flashToast(`⚠ AI 実装の起動に失敗: ${e.message}`); });
 }
 
 // ── GPS / Place API helpers ────────────────────────────────────────────────
@@ -7073,6 +7146,7 @@ async function _silentCheckin() {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ latitude: coords.latitude, longitude: coords.longitude }),
+      silent: true,
     });
     _workplaceLastSilentMs = Date.now();
     const banner = $('workplaceCurrentBanner');
@@ -11395,7 +11469,7 @@ $('transitRideManualSaveBtn')?.addEventListener('click', async () => {
   }
 });
 
-async function loadMeals() {
+async function loadMeals(opts: { silent?: boolean } = {}) {
   const list = document.getElementById('mealsList');
   if (!list) return;
   // 単一日付フィルタ — 値があれば「その日 0:00 〜 23:59」 で絞り込み
@@ -11407,7 +11481,7 @@ async function loadMeals() {
     params.set('to', v + 'T23:59:59');
   }
   try {
-    const r = await api(`/api/meals?${params.toString()}`);
+    const r = await (opts.silent ? apiSilent : api)(`/api/meals?${params.toString()}`);
     mealsState.items = r.meals || [];
     renderMeals();
     schedulePendingPoll();
@@ -11633,7 +11707,7 @@ function schedulePendingPoll() {
   if (!hasPending) return;
   mealsState.pollTimer = setTimeout(() => {
     if (state.tab !== 'meals') return;
-    loadMeals();
+    loadMeals({ silent: true });
   }, 4000);
 }
 
@@ -11974,7 +12048,10 @@ async function submitMealModal() {
     return;
   }
 
+  // ボタン押下フィードバック: ダイアログを即座に閉じてキューを進め、 ネットワーク処理はバックグラウンドで進める。
   if (status) status.textContent = item.kind === 'edit' ? `📝 保存中…` : `📤 登録中…`;
+  flashToast(item.kind === 'edit' ? '📝 保存をキューに入れました' : '📤 登録をキューに入れました');
+  advanceMealQueue();
 
   try {
     if (item.kind === 'edit') {
@@ -12052,10 +12129,10 @@ async function submitMealModal() {
     if (status) status.textContent = item.kind === 'edit'
       ? `⚠ 保存エラー: ${e.message}`
       : `⚠ 登録エラー: ${e.message}`;
+    flashToast(item.kind === 'edit' ? `⚠ 保存エラー: ${e.message}` : `⚠ 登録エラー: ${e.message}`);
     console.warn('[meals] submit error:', e);
   }
   await loadMeals();
-  advanceMealQueue();
 }
 
 function skipMealModalItem() {

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -10868,9 +10868,32 @@ interface RepoWatchItem {
   fetch_error: string | null;
   items?: RepoListItem[];
 }
+interface RepoCommit {
+  sha: string;
+  message: string;
+  html_url: string;
+  author: string | null;
+  when: string | null;
+}
 // expandedRepos: 「more」 で 50 件展開済みの repo id 集合。 一覧 refresh しても保持。
-const repoWatchState: { items: RepoWatchItem[]; tokenSet: boolean; expandedRepos: Set<number> } =
-  { items: [], tokenSet: false, expandedRepos: new Set() };
+// openedRepos: カード「開閉」 状態。 開いた repo は header クリックで閉じる。
+// commitsByRepo: 直近コミット の lazy fetch キャッシュ (open する度に再 fetch しない)。
+// commitsLoading: いま fetch 中の repo id (= スピナー表示用)。
+const repoWatchState: {
+  items: RepoWatchItem[];
+  tokenSet: boolean;
+  expandedRepos: Set<number>;
+  openedRepos: Set<number>;
+  commitsByRepo: Map<number, { items: RepoCommit[]; error: string | null }>;
+  commitsLoading: Set<number>;
+} = {
+  items: [],
+  tokenSet: false,
+  expandedRepos: new Set(),
+  openedRepos: new Set(),
+  commitsByRepo: new Map(),
+  commitsLoading: new Set(),
+};
 
 /** ざっくり相対時刻 ("3時間前" 等)。 不正値や未来は fmtDate にフォールバック。 */
 function repoFmtAgo(s: string | null): string {
@@ -10974,6 +10997,9 @@ function renderRepoWatch() {
       : '';
     const ciBadge = repoCiBadge(it);
 
+    // 開閉ステート: 開いていれば PR/Issue + 直近の作業 サマリを表示、 閉じていれば
+    // ヘッダ + stats + 最終コミット の 1 行だけにまとめる。 既定は閉。
+    const isOpened = repoWatchState.openedRepos.has(it.id);
     // PR / Issue items: 既定 5 件、 expanded なら最大 50 件 (loadRepoItemsMore で差し替え済)。
     const isExpanded = repoWatchState.expandedRepos.has(it.id);
     const totalCount = (it.open_pr_count ?? 0) + (it.open_issue_count ?? 0);
@@ -10994,9 +11020,55 @@ function renderRepoWatch() {
       itemsBlock = `<p class="muted repo-watch-empty-items">open な PR / Issue はありません</p>`;
     }
 
+    // 「直近の作業」 サマリ (= 開いた時だけ表示)。 lazy fetch のキャッシュを使う。
+    let commitsBlock = '';
+    if (isOpened) {
+      if (repoWatchState.commitsLoading.has(it.id)) {
+        commitsBlock = `<div class="repo-watch-commits">
+          <div class="repo-watch-commits-head">📝 直近の作業</div>
+          <p class="muted" style="font-size:12px">読み込み中…</p>
+        </div>`;
+      } else {
+        const cached = repoWatchState.commitsByRepo.get(it.id);
+        if (cached) {
+          if (cached.items.length === 0) {
+            const errMsg = cached.error
+              ? `<p class="muted" style="font-size:11px;color:#c0392b">⚠ ${escapeHtml(cached.error.slice(0, 200))}</p>`
+              : `<p class="muted" style="font-size:12px">直近のコミットはありません</p>`;
+            commitsBlock = `<div class="repo-watch-commits">
+              <div class="repo-watch-commits-head">📝 直近の作業</div>
+              ${errMsg}
+            </div>`;
+          } else {
+            const rows = cached.items.map((cm) => {
+              const short = (cm.sha || '').slice(0, 7);
+              const who = cm.author ? `<span class="muted">${escapeHtml(cm.author)}</span>` : '';
+              const when = cm.when
+                ? `<span class="muted" title="${escapeHtml(fmtDate(cm.when))}">${escapeHtml(repoFmtAgo(cm.when))}</span>`
+                : '';
+              return `<li class="repo-watch-commit">
+                <a class="repo-watch-commit-link" href="${escapeHtml(cm.html_url)}" target="_blank" rel="noopener" title="${escapeHtml(cm.message)}">
+                  <code class="repo-watch-commit-sha">${escapeHtml(short)}</code>
+                  <span class="repo-watch-commit-text">${escapeHtml(cm.message)}</span>
+                </a>
+                ${who}${when}
+              </li>`;
+            }).join('');
+            commitsBlock = `<div class="repo-watch-commits">
+              <div class="repo-watch-commits-head">📝 直近の作業 (${cached.items.length})</div>
+              <ul class="repo-watch-commits-list">${rows}</ul>
+            </div>`;
+          }
+        }
+      }
+    }
+
+    const toggleIcon = isOpened ? '▾' : '▸';
+    const toggleTitle = isOpened ? '閉じる' : '開いて直近の作業 + PR/Issue を表示';
     return `
-      <article class="card repo-watch-card" data-repo-id="${it.id}">
+      <article class="card repo-watch-card ${isOpened ? 'is-opened' : 'is-closed'}" data-repo-id="${it.id}">
         <header class="repo-watch-head">
+          <button class="ghost repo-toggle-btn" type="button" data-repo-id="${it.id}" title="${escapeHtml(toggleTitle)}" aria-expanded="${isOpened}">${toggleIcon}</button>
           <a class="repo-watch-slug" href="${escapeHtml(it.html_url)}" target="_blank" rel="noopener">
             <strong>${escapeHtml(slug)}</strong>
           </a>
@@ -11015,7 +11087,8 @@ function renderRepoWatch() {
             <span class="repo-watch-stat-label">Open Issue</span>
           </a>
         </div>
-        ${itemsBlock}
+        ${isOpened ? itemsBlock : ''}
+        ${commitsBlock}
         <div class="repo-watch-branch">
           <a href="${escapeHtml(branchLink)}" target="_blank" rel="noopener" title="デフォルトブランチのコミット一覧"><code>${escapeHtml(branch)}</code></a>
           <span class="repo-watch-commit-msg">${commitMsg}</span>
@@ -11025,6 +11098,40 @@ function renderRepoWatch() {
         ${err}
       </article>`;
   }).join('');
+}
+
+/** 「開く」 アクション: opened フラグを立て、 commits を lazy fetch (初回のみ)。 */
+async function openRepoWatchCard(id: number) {
+  if (repoWatchState.openedRepos.has(id)) return;
+  repoWatchState.openedRepos.add(id);
+  // すでにキャッシュ済みなら即 render、 なければ loading 状態で render → fetch。
+  const cached = repoWatchState.commitsByRepo.get(id);
+  if (cached) {
+    renderRepoWatch();
+    return;
+  }
+  repoWatchState.commitsLoading.add(id);
+  renderRepoWatch();
+  try {
+    const r = await api(`/api/repos/${id}/commits?limit=10`) as { items?: RepoCommit[]; error?: string | null };
+    repoWatchState.commitsByRepo.set(id, { items: r.items || [], error: r.error || null });
+  } catch (e) {
+    repoWatchState.commitsByRepo.set(id, { items: [], error: (e as Error).message });
+  } finally {
+    repoWatchState.commitsLoading.delete(id);
+    renderRepoWatch();
+  }
+}
+
+function closeRepoWatchCard(id: number) {
+  if (!repoWatchState.openedRepos.has(id)) return;
+  repoWatchState.openedRepos.delete(id);
+  renderRepoWatch();
+}
+
+function toggleRepoWatchCard(id: number) {
+  if (repoWatchState.openedRepos.has(id)) closeRepoWatchCard(id);
+  else void openRepoWatchCard(id);
 }
 
 async function loadRepoItemsMore(id: number) {
@@ -11085,7 +11192,24 @@ async function refreshRepoWatch(id: number) {
     const { item } = await res.json() as { item: RepoWatchItem };
     const idx = repoWatchState.items.findIndex((r) => r.id === id);
     if (idx >= 0) repoWatchState.items[idx] = item;
-    renderRepoWatch();
+    // 直近コミット キャッシュも破棄 (= refresh 後に開いた時は再取得)。
+    // 開いたままなら即座に再 fetch して画面を更新する。
+    repoWatchState.commitsByRepo.delete(id);
+    if (repoWatchState.openedRepos.has(id)) {
+      repoWatchState.commitsLoading.add(id);
+      renderRepoWatch();
+      try {
+        const r2 = await api(`/api/repos/${id}/commits?limit=10`) as { items?: RepoCommit[]; error?: string | null };
+        repoWatchState.commitsByRepo.set(id, { items: r2.items || [], error: r2.error || null });
+      } catch (e) {
+        repoWatchState.commitsByRepo.set(id, { items: [], error: (e as Error).message });
+      } finally {
+        repoWatchState.commitsLoading.delete(id);
+        renderRepoWatch();
+      }
+    } else {
+      renderRepoWatch();
+    }
   } catch (e) {
     flashToast(`更新失敗: ${(e as Error).message}`);
   }
@@ -11142,6 +11266,11 @@ document.getElementById('repoList')?.addEventListener('click', (ev) => {
   const deleteBtn = target.closest('.repo-delete-btn') as HTMLElement | null;
   if (deleteBtn) {
     void deleteRepoWatch(Number(deleteBtn.dataset.repoId));
+    return;
+  }
+  const toggleBtn = target.closest('.repo-toggle-btn') as HTMLElement | null;
+  if (toggleBtn) {
+    toggleRepoWatchCard(Number(toggleBtn.dataset.repoId));
     return;
   }
   const moreBtn = target.closest('.repo-watch-more-btn') as HTMLElement | null;

--- a/server/public/src/page-help.ts
+++ b/server/public/src/page-help.ts
@@ -30,6 +30,14 @@ export const PAGE_HELP: Record<string, PageHelpEntry> = {
         <li>左の「☰ カテゴリ」 で AI 分類で絞り込み</li>
         <li>各エントリの「再要約」 ボタンで手動再生成</li>
       </ul>
+      <h4>📌 スマホでブックマークしたい</h4>
+      <p>スマホは Chrome 拡張が使えないので、 Memoria を <b>PWA</b> としてインストールしてから OS の共有メニューで送ります。</p>
+      <ol>
+        <li>Memoria の URL を開いた状態でブラウザのメニュー → <b>「ホーム画面に追加」</b> または <b>「アプリをインストール」</b></li>
+        <li>シェアしたいページで <b>共有</b> ボタンを押す</li>
+        <li>共有先のリストから <b>Memoria</b> を選ぶと自動で保存キューに入ります</li>
+      </ol>
+      <p>iOS Safari は Web Share Target に対応しないので、 <a href="https://github.com/LUDIARS/Memoria/blob/main/docs/mobile-share.md" target="_blank" rel="noreferrer">iOS Shortcut テンプレート</a> を使ってください。</p>
     `,
   },
   notes: {

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -6810,3 +6810,66 @@ dialog.loc-edit-modal[open] {
 .repo-watch-more-row { margin-top: 4px; }
 .repo-watch-more-btn { font-size: 11px; padding: 2px 8px; }
 .repo-watch-empty-items { font-size: 11px; margin: 6px 0 0; }
+
+/* ── 「開く」 トグル + 直近の作業 サマリ ────────────────────────── */
+.repo-toggle-btn {
+  padding: 0 6px;
+  min-width: 22px;
+  font-size: 12px;
+  line-height: 1.2;
+  border-radius: 4px;
+  color: var(--muted);
+}
+.repo-toggle-btn[aria-expanded="true"] { color: var(--accent); }
+.repo-watch-commits {
+  margin-top: 6px;
+  padding: 8px 10px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+.repo-watch-commits-head {
+  font-size: 11px;
+  color: var(--muted);
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+.repo-watch-commits-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.repo-watch-commit {
+  display: flex;
+  gap: 4px;
+  align-items: baseline;
+  font-size: 12px;
+  line-height: 1.45;
+  overflow: hidden;
+}
+.repo-watch-commit-link {
+  flex: 1;
+  min-width: 0;
+  display: inline-flex;
+  gap: 6px;
+  align-items: baseline;
+  text-decoration: none;
+  color: inherit;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.repo-watch-commit-link:hover { color: var(--accent); }
+.repo-watch-commit-sha {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0 4px;
+  font-size: 10px;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+.repo-watch-commit-text { overflow: hidden; text-overflow: ellipsis; }

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -1610,28 +1610,22 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   transform: translateX(-50%) translateY(0);
 }
 
-/* グローバル読み込み pill — 画面上部中央。 pointer-events:none で
-   他の操作を一切ブロックしない。 250ms 以上の api() 読み込み中だけ表示。 */
-.mem-loading {
-  position: fixed;
-  top: 12px;
-  left: 50%;
-  transform: translateX(-50%) translateY(-12px);
-  background: rgba(31, 86, 192, 0.95);
-  color: #fff;
-  padding: 6px 16px;
-  border-radius: 999px;
-  font-size: 12px;
-  box-shadow: 0 4px 16px rgba(0,0,0,0.18);
+/* 旧グローバル読み込み pill (`#memLoading`) は廃止。 代わりにロゴ (`.brand`)
+   の横に小さなスピナーを描く。 定期 poll は api(opts.silent=true) でこちらも
+   出さない (= 自動読み込み中の点滅ノイズを完全に消す)。 */
+.brand { position: relative; display: inline-flex; align-items: center; gap: 6px; }
+.brand-spinner {
+  display: none;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent);
+  animation: brand-spin 0.9s linear infinite;
   pointer-events: none;
-  opacity: 0;
-  transition: opacity .2s ease, transform .2s ease;
-  z-index: 9998;
 }
-.mem-loading.show {
-  opacity: 1;
-  transform: translateX(-50%) translateY(0);
-}
+.brand-spinner.show { display: inline-block; }
+@keyframes brand-spin { to { transform: rotate(360deg); } }
 .visits-actions {
   display: flex;
   gap: 10px;
@@ -1818,6 +1812,10 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   margin-bottom: 12px;
 }
 .cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 12px; }
+@media (min-width: 761px) {
+  /* PC 版はリポジトリ ウォッチ カードを横幅 2 倍に (280px → 560px) */
+  #repoList.cards { grid-template-columns: repeat(auto-fill, minmax(560px, 1fr)); }
+}
 .card {
   background: var(--panel);
   border: 1px solid var(--border);
@@ -2125,12 +2123,24 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
   border-radius: 12px;
   padding: 18px 22px;
   box-shadow: 0 12px 48px rgba(0,0,0,0.2);
-  width: 560px;
-  max-height: 80vh;
+  /* PC は横 2.5x (= 1400px) + 最大の高さで固定。 viewport より大きい時は cap */
+  width: min(1400px, calc(100vw - 24px));
+  max-height: 92vh;
   overflow-y: auto;
   resize: none;
   z-index: 100;
 }
+/* 「全部」 タブで section の上に表示する見出し */
+.settings-all-mode-heading {
+  font-size: 14px;
+  margin: 22px 0 8px;
+  padding: 6px 10px;
+  background: var(--accent-bg);
+  border-left: 3px solid var(--accent);
+  border-radius: 4px;
+  color: var(--text);
+}
+.settings-all-mode-heading:first-of-type { margin-top: 10px; }
 .ai-settings-head {
   display: flex;
   justify-content: space-between;

--- a/server/routes/repo.ts
+++ b/server/routes/repo.ts
@@ -19,7 +19,7 @@ import {
   updateRepoWatchStats, replaceRepoWatchItems, listRepoWatchItems,
   getDiarySettings, type RepoWatchRow, type RepoWatchItemRow,
 } from '../db.js';
-import { parseRepoInput, fetchRepoStats, REPO_PROVIDERS } from '../lib/repo-watch.js';
+import { parseRepoInput, fetchRepoStats, fetchRepoRecentCommits, REPO_PROVIDERS } from '../lib/repo-watch.js';
 
 type Db = BetterSqlite3.Database;
 
@@ -81,6 +81,18 @@ export function makeRepoRouter(deps: RepoRouterDeps): Hono {
     const limit = Math.min(50, Math.max(1, Number(c.req.query('limit')) || 50));
     const items: RepoWatchItemRow[] = listRepoWatchItems(db, id, limit);
     return c.json({ items });
+  });
+
+  // ── 1 リポの直近コミット (= カードを 「開いた」 時に出す「直近の作業」 サマリ) ─
+  // キャッシュ列を増やさず lazy fetch のみ。 失敗時は items=[] + error を返す。
+  r.get('/api/repos/:id/commits', async (c: Context) => {
+    const id = Number(c.req.param('id'));
+    if (!Number.isFinite(id)) return c.json({ error: 'invalid id' }, 400);
+    const row = getRepoWatch(db, id);
+    if (!row) return c.json({ error: 'not_found' }, 404);
+    const limit = Math.min(30, Math.max(1, Number(c.req.query('limit')) || 10));
+    const r2 = await fetchRepoRecentCommits(row, githubToken(db), limit);
+    return c.json(r2);
   });
 
   // ── 追加 ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

UI 改修まとめ (1 PR バッチ)。

### 📦 リポジトリ カード
- PC 版で 280→560px の最小幅 (2 倍) に拡張 (`#repoList.cards` のみ対象)

### 🤖 タスク AI 実装 / 🍽 食事登録
- 「▶ 実装を開始」 押下で **即ダイアログを閉じてキュー化**、 `flashToast` で押下フィードバック (API は fire-and-forget)
- 食事「登録」 ボタンも同様に即閉じ + トースト

### ⚙ 設定ダイアログ 再編
- タブ削除: 🔔 通知/端末、 🛠 ランタイム
- 移設:
  - 🎮 Steam Web API → 🔌 連携 / API key
  - 📝 日記の常設メモ → 🧍 プロフィール
  - 🎓 はじめての Memoria → 📚 セットアップ手順
  - 📱 通知 (WebPush) + 🖥 デスクトップアプリ → 🔒 プライバシー / 表示
- 削除:
  - 📌 スマホでブックマーク方法 ボタン (database タブのヘルプ drawer でカバー)
  - 📦 データ / Hub のドメイン取得 (recatalogAll) セクション
- 動的タブ (privacy / setup / agent-projects) に **アイコン付与**
- 新規: 🌐 **全部** タブ — 手順系 (setup / agent-projects) 以外の全 section を見出し付きで一覧
- AI タスク行のラベルを内部キー (`summarize` 等) から日本語機能名 (`📚 ブックマーク要約` 等) へ
- ダイアログ幅 560px → **min(1400px, calc(100vw - 24px))** で 2.5 倍化、 max-height 80vh → 92vh

### 🔄 自動読み込み 静音化
- 旧 青い 「読み込み中…」 pill (`#memLoading`) を廃止し、 ロゴ右の **小スピナー** に置換
- `api(opts.silent)` 追加 + 定期 poll を一括 silent 化:
  queue/visits 2 s ・ staleness 60 s ・ extension 30 s ・ dig/cloud/diary/weekly status ・ recommendations 5 s ・ agent-run log 3 s ・ meals 4 s ・ workplace checkin 5 min

## Test plan
- [ ] PC で 設定 ⚙ 開き、 タブ列が AI/連携/プロフィール/データ + (動的) プライバシー/セットアップ/AI実装プロジェクト/全部 の順
- [ ] 全部 タブで section ごとに見出し (🤖 AI / モデル ・ 🔌 連携 / API key …) が見える
- [ ] AI タスク行のラベルが日本語 (📚 ブックマーク要約 等)
- [ ] 設定ダイアログが画面ほぼ最大に表示される
- [ ] タスク「🤖 AI実装」 → 「▶ 実装を開始」 押下で即閉じ + 「🤖 …キューへ送信しました」 トースト
- [ ] 食事「登録」 押下で即閉じ + 「📤 登録をキューに入れました」 トースト
- [ ] スマホブックマーク方法が 💡 ヘルプ → 🗄 データベース 内に出る
- [ ] 定期 poll 中に青い pill が出ない (ロゴ右の小さなクルクルのみ)
- [ ] PC でリポジトリ カードが 2 列レイアウト (横幅 2 倍)

🤖 Generated with [Claude Code](https://claude.com/claude-code)