### PR TITLE
fix(hub): Cernere 認証フロー — auth login の gate 緩和 + PASETO ISO 時刻対応 + docker-compose env

### DIFF
--- a/server/multi/paseto-verifier.js
+++ b/server/multi/paseto-verifier.js
@@ -87,6 +87,11 @@ export async function verifyPaseto(token) {
       if (!HUB_PUBLIC_URL) {
         console.warn('[paseto] MEMORIA_HUB_PUBLIC_URL not set — aud check skipped');
       }
+      // paseto v3 規約で iat/exp は ISO 8601 文字列。 Hub 内部表現は Unix epoch
+      // (秒) に揃えるため変換する。 未パースは null。
+      const expUnix = typeof payload.exp === 'string'
+        ? Math.floor(new Date(payload.exp).getTime() / 1000)
+        : typeof payload.exp === 'number' ? payload.exp : null;
       return {
         userId: typeof payload.sub === 'string' ? payload.sub : null,
         role: typeof payload.role === 'string' ? payload.role : 'general',
@@ -94,7 +99,7 @@ export async function verifyPaseto(token) {
         projectKey: typeof payload.projectKey === 'string' ? payload.projectKey : null,
         kid,
         jti: typeof payload.jti === 'string' ? payload.jti : null,
-        exp: typeof payload.exp === 'number' ? payload.exp : null,
+        exp: Number.isFinite(expUnix) ? expUnix : null,
       };
     } catch (e) {
       // kid 違い or invalid → 次の key を試す


### PR DESCRIPTION
## Summary
- 二層設計 (#157) の Cernere 代理ログインフローを実機で回したときに 3 点詰まったため修正
- (1) Hub の `POST /api/auth/login` が `hasInfisicalCreds()` ガードで 503 を返す → host env で `CERNERE_BASE_URL` を直接渡すケース (dev / Excubitor inject / docker-compose) が排除される
- (2) `paseto-verifier.js` が `exp` を Unix epoch number で読んでいた → paseto v3.1.4 規約で iat/exp は ISO 8601 文字列 (Cernere 側 fix と対)
- (3) `docker-compose.yml` が Phase 1+ 二層設計で必須の env (`CERNERE_BASE_URL`, `MEMORIA_HUB_PUBLIC_URL`, `INFISICAL_*`) を渡していない

## 修正内容
1. `server/multi/index.js` POST /api/auth/login: ガード条件を `!CERNERE_BASE_URL && !hasInfisicalCreds()` に差し替え
2. `server/multi/paseto-verifier.js`: 受け取った ISO 文字列の exp を Unix epoch (秒) に変換 (内部表現を統一)、 number 型 fallback も維持
3. `server/multi/docker-compose.yml`:
   - `CERNERE_BASE_URL` (default `http://host.docker.internal:8080`)
   - `MEMORIA_HUB_PUBLIC_URL` (default `http://localhost:5280`)
   - `INFISICAL_*` (任意、 host env から bootstrap.js が拾う)
   - 旧 OAuth 案内コメントを二層設計の login flow 案内に差し替え

## 検証
- Hub container を新コードで再ビルドして起動 → `/healthz` + `/` (login form) が応答
- Cernere に register + Hub `/api/auth/login` 経由で sessionToken が返ることを確認 (HS256 fallback まで動作。 PASETO 経路は LUDIARS/Cernere の対 PR が必要)
- paseto roundtrip (sign + verify) はローカル test で確認

## 関連
- 対 fix: LUDIARS/Cernere#95 (Ed25519 KeyObject + ISO 時刻)
- 二層設計の元 PR: #157

## Test plan
- [ ] `docker compose up -d --build` で Hub 起動
- [ ] Cernere に register したユーザで Hub `/api/auth/login` 経由でログインして sessionToken が返る
- [ ] (Cernere 側 PR マージ後) sessionToken が `v4.public.` で始まる PASETO 形式になり、Hub の authMiddleware が verify を通す
- [ ] `/api/data/bookmarks` 等を Bearer 付きで叩いて 200 が返る

🤖 Generated with [Claude Code](https://claude.com/claude-code)