### PR TITLE
feat: env-cli + Composite SSO + AI推薦キュー上書き + 傾向タブ改善

### DIFF
--- a/server/bootstrap.ts
+++ b/server/bootstrap.ts
@@ -10,13 +10,14 @@
  * machine identity がどこにも無い場合でも起動は止めない。 index.ts 側の
  * setup gate middleware が全 route より前段で専用セットアップ画面を出す。
  */
-import { existsSync } from 'node:fs';
+import { existsSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import Database from 'better-sqlite3';
 import { ensureEnv, INFISICAL_SETTING_KEYS } from './lib/env-bootstrap.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const ENV_SECRETS_PATH = resolve(__dirname, '.env.secrets');
 
 /**
  * SQLite app_settings から `infisical.*` を読んで process.env に注入。
@@ -35,10 +36,26 @@ function loadCredsFromDb(): void {
       const rows = db.prepare(
         `SELECT key, value FROM app_settings WHERE key LIKE 'infisical.%'`,
       ).all() as Array<{ key: string; value: string | null }>;
+      const dbCreds: Record<string, string> = {};
       for (const { key, value } of rows) {
         const envName = (INFISICAL_SETTING_KEYS as Record<string, string>)[key];
-        if (envName && value && !process.env[envName]) {
-          process.env[envName] = value;
+        if (envName && value) {
+          dbCreds[envName] = value;
+          if (!process.env[envName]) process.env[envName] = value;
+        }
+      }
+      // 既存ユーザの one-shot migration: SQLite に creds があるのに .env.secrets が
+      // 無ければ書き出す。 これで `npm run env:setup` / `env:gen` が UI 入力分を拾える
+      // (双方向同期、 setup フォーム → .env.secrets / env-cli → .env.secrets)。
+      if (!existsSync(ENV_SECRETS_PATH)
+          && dbCreds.INFISICAL_PROJECT_ID
+          && dbCreds.INFISICAL_CLIENT_ID
+          && dbCreds.INFISICAL_CLIENT_SECRET) {
+        try {
+          writeEnvSecretsFromMap(dbCreds);
+          console.log(`[bootstrap] .env.secrets を SQLite app_settings から自動生成 (env-cli 連携)`);
+        } catch (err) {
+          console.warn(`[bootstrap] .env.secrets 自動生成失敗: ${(err as Error).message}`);
         }
       }
     } finally {
@@ -48,6 +65,24 @@ function loadCredsFromDb(): void {
     // テーブル未作成 (初回起動) 等は無視 — setup gate に任せる。
     console.warn(`[bootstrap] app_settings 読込スキップ: ${(err as Error).message}`);
   }
+}
+
+/** env-cli の saveBootstrap と同じ形式で .env.secrets を書く (one-shot migration 用)。 */
+function writeEnvSecretsFromMap(env: Record<string, string>): void {
+  const content = [
+    '# ─── Infisical Bootstrap Credentials ─────────────────────────',
+    '# Memoria local bootstrap が SQLite app_settings から自動生成。',
+    '# 以後は setup UI / env-cli setup どちらの更新でも両方が更新される。',
+    '# ─────────────────────────────────────────────────────────────',
+    '',
+    `INFISICAL_SITE_URL=${env.INFISICAL_SITE_URL || ''}`,
+    `INFISICAL_PROJECT_ID=${env.INFISICAL_PROJECT_ID}`,
+    `INFISICAL_ENVIRONMENT=${env.INFISICAL_ENVIRONMENT || 'dev'}`,
+    `INFISICAL_CLIENT_ID=${env.INFISICAL_CLIENT_ID}`,
+    `INFISICAL_CLIENT_SECRET=${env.INFISICAL_CLIENT_SECRET}`,
+    '',
+  ].join('\n');
+  writeFileSync(ENV_SECRETS_PATH, content, { encoding: 'utf8', mode: 0o600 });
 }
 
 async function bootstrap(): Promise<void> {

--- a/server/bootstrap.ts
+++ b/server/bootstrap.ts
@@ -1,98 +1,13 @@
 /**
- * bootstrap entry — `.env` ファイル無し運用の起動口。 LUDIARS/Cernere#79 と同パターン。
+ * bootstrap entry — Memoria Local は Infisical を使わない (= 全機能ローカル完結)。
+ * 旧 Infisical bootstrap (machine identity 注入 + ensureEnv) は撤去された。
  *
- * `npm start` / `npm run dev` は `tsx bootstrap.ts`。
- *   1. SQLite app_settings から machine identity (infisical.*) を読んで env に載せる
- *      (= 専用セットアップ画面で入力された分。 Excubitor / host env が既にあればそちら優先)
- *   2. ensureEnv() が Infisical からアプリ設定値を fetch して inject
- *   3. index.js を import して本体起動
+ * Hub 連携が必要な場合は Memoria Hub (server/multi/) 側に Infisical 設定を持たせる
+ * (= env-cli は server/multi/.env.secrets だけを扱う)。
  *
- * machine identity がどこにも無い場合でも起動は止めない。 index.ts 側の
- * setup gate middleware が全 route より前段で専用セットアップ画面を出す。
+ * `npm start` / `npm run dev` は `tsx bootstrap.ts`。 ここでは index.ts を import するだけ。
  */
-import { existsSync, writeFileSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import Database from 'better-sqlite3';
-import { ensureEnv, INFISICAL_SETTING_KEYS } from './lib/env-bootstrap.js';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const ENV_SECRETS_PATH = resolve(__dirname, '.env.secrets');
-
-/**
- * SQLite app_settings から `infisical.*` を読んで process.env に注入。
- * 専用セットアップ画面で入力された machine identity を起動時に拾うため。
- * 既に env にある値 (Excubitor inject / host shell) は上書きしない。
- */
-function loadCredsFromDb(): void {
-  // index.ts と同じ解決ルール: MEMORIA_DATA env、 無ければ server/../data。
-  const dataDir = resolve(process.env.MEMORIA_DATA ?? join(__dirname, '..', 'data'));
-  const dbPath = join(dataDir, 'memoria.db');
-  if (!existsSync(dbPath)) return;
-  try {
-    // better-sqlite3 は同期。 bootstrap でだけ readonly で開いて即閉じる。
-    const db = new Database(dbPath, { readonly: true });
-    try {
-      const rows = db.prepare(
-        `SELECT key, value FROM app_settings WHERE key LIKE 'infisical.%'`,
-      ).all() as Array<{ key: string; value: string | null }>;
-      const dbCreds: Record<string, string> = {};
-      for (const { key, value } of rows) {
-        const envName = (INFISICAL_SETTING_KEYS as Record<string, string>)[key];
-        if (envName && value) {
-          dbCreds[envName] = value;
-          if (!process.env[envName]) process.env[envName] = value;
-        }
-      }
-      // 既存ユーザの one-shot migration: SQLite に creds があるのに .env.secrets が
-      // 無ければ書き出す。 これで `npm run env:setup` / `env:gen` が UI 入力分を拾える
-      // (双方向同期、 setup フォーム → .env.secrets / env-cli → .env.secrets)。
-      if (!existsSync(ENV_SECRETS_PATH)
-          && dbCreds.INFISICAL_PROJECT_ID
-          && dbCreds.INFISICAL_CLIENT_ID
-          && dbCreds.INFISICAL_CLIENT_SECRET) {
-        try {
-          writeEnvSecretsFromMap(dbCreds);
-          console.log(`[bootstrap] .env.secrets を SQLite app_settings から自動生成 (env-cli 連携)`);
-        } catch (err) {
-          console.warn(`[bootstrap] .env.secrets 自動生成失敗: ${(err as Error).message}`);
-        }
-      }
-    } finally {
-      db.close();
-    }
-  } catch (err) {
-    // テーブル未作成 (初回起動) 等は無視 — setup gate に任せる。
-    console.warn(`[bootstrap] app_settings 読込スキップ: ${(err as Error).message}`);
-  }
-}
-
-/** env-cli の saveBootstrap と同じ形式で .env.secrets を書く (one-shot migration 用)。 */
-function writeEnvSecretsFromMap(env: Record<string, string>): void {
-  const content = [
-    '# ─── Infisical Bootstrap Credentials ─────────────────────────',
-    '# Memoria local bootstrap が SQLite app_settings から自動生成。',
-    '# 以後は setup UI / env-cli setup どちらの更新でも両方が更新される。',
-    '# ─────────────────────────────────────────────────────────────',
-    '',
-    `INFISICAL_SITE_URL=${env.INFISICAL_SITE_URL || ''}`,
-    `INFISICAL_PROJECT_ID=${env.INFISICAL_PROJECT_ID}`,
-    `INFISICAL_ENVIRONMENT=${env.INFISICAL_ENVIRONMENT || 'dev'}`,
-    `INFISICAL_CLIENT_ID=${env.INFISICAL_CLIENT_ID}`,
-    `INFISICAL_CLIENT_SECRET=${env.INFISICAL_CLIENT_SECRET}`,
-    '',
-  ].join('\n');
-  writeFileSync(ENV_SECRETS_PATH, content, { encoding: 'utf8', mode: 0o600 });
-}
-
 async function bootstrap(): Promise<void> {
-  loadCredsFromDb();
-  try {
-    await ensureEnv();
-  } catch (err) {
-    // ensureEnv は throw しない設計だが、 想定外は log だけ出して継続。
-    console.error(`[bootstrap] ${(err as Error).message}`);
-  }
   await import('./index.js');
 }
 

--- a/server/db.ts
+++ b/server/db.ts
@@ -3499,8 +3499,24 @@ export function trendsWorkHours(db: Db, { sinceDays = 30 }: { sinceDays?: number
 export interface GpsWalkingRow {
   date: string;
   distance_km: number;
+  /** 徒歩速度帯のみで積算した距離 (カロリー計算用) */
+  walking_distance_km: number;
   walking_minutes: number;
   travel_minutes: number;
+  // ── 「自宅以外にいた時間」 の内訳 (面積棒グラフ用) ──────────────
+  // 1 日 = 自宅 + 移動 + 場所滞在 + 不明 (どこにも match しない停止)。
+  // 「自宅以外」 = travel + 場所滞在 + 不明 の合計分数。 場所滞在は
+  // work_locations (is_home=0) の name でキー化。
+  /** 自宅 (work_locations.is_home=1) に居た分数 */
+  home_minutes: number;
+  /** 自宅以外の連続点をベースに集計した「外にいた」 合計分数 */
+  away_minutes: number;
+  /** 自宅以外 のうち、 0.5 m/s 以上で動いていた区間 */
+  away_moving_minutes: number;
+  /** 自宅以外 のうち、 登録 work_locations にいた時間。 場所 name でキー化。 */
+  away_places: { name: string; minutes: number }[];
+  /** 自宅以外 のうち、 場所未登録 + 停止 (= 不明な滞在) */
+  away_unknown_minutes: number;
 }
 
 /**
@@ -3510,6 +3526,9 @@ export interface GpsWalkingRow {
  *   - walking_minutes: 0.5〜3.5 m/s の区間 Δt 合計 (徒歩速度帯)
  *   - travel_minutes: 0.5 m/s 以上で動いていた区間 Δt 合計 (移動全体、
  *     乗り物含む)
+ *   - home_minutes / away_* : 各 GPS 点を work_locations の radius_m で
+ *     home / 場所 / 不明 に分類 (priority: is_home=1 > is_home=0 > 不明)。
+ *     セグメント Δt をその分類に振り分けて積算する。
  *
  * 静止判定は速度ベース。停車中の jitter は accuracy で弾く。
  */
@@ -3519,7 +3538,13 @@ export function trendsGpsWalking(db: Db, { sinceDays = 30, userId = 'me' }: { si
     return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
   }
   function parseUtc(s: string): Date {
-    return new Date(String(s).replace(' ', 'T') + 'Z');
+    // recorded_at は 2 形式が混在する:
+    //   - "2026-05-16T02:36:06.000Z"  (OwnTracks 直接挿入: ISO + Z)
+    //   - "2026-05-16 02:36:06"       (Legatus/diary 経由: SQLite datetime)
+    // 後者は UTC として 'Z' を付ける必要があるが、 既に Z が付いている前者に
+    // 二度 Z を足すと Invalid Date になる (= 全 row 弾かれて全日 0 になる)。
+    const raw = String(s).replace(' ', 'T');
+    return new Date(/[zZ]$/.test(raw) ? raw : raw + 'Z');
   }
   function haversineMeters(a: { lat: number; lon: number }, b: { lat: number; lon: number }): number {
     const R = 6_371_008;
@@ -3531,11 +3556,45 @@ export function trendsGpsWalking(db: Db, { sinceDays = 30, userId = 'me' }: { si
     const h = sa * sa + Math.cos(toRad(a.lat)) * Math.cos(toRad(b.lat)) * so * so;
     return 2 * R * Math.asin(Math.min(1, Math.sqrt(h)));
   }
-  const SEG_DT_MAX_MS = 10 * 60_000;       // > 10 分の隙間は信頼しない
+  // GPS は 「移動した時だけ点を打つ」 ので、 連続する 2 点 (p1, p2) の間は
+  // 「p1 の場所に居続けて、 p2 で観測される直前に移動した」 と仮定する。
+  //   → gap 全体を p1 の class に倒す (同一クラスでも遷移でも同じ扱い)
+  //   → cap は 12 時間 (これより長い gap はデータ欠落とみなして無視)
+  // 移動メトリクス (距離 / walking / travel) は速度ノイズ防止のため 10 分超
+  // で切る (= 別ロジック)。
+  const SEG_DT_MAX_MS_MOVEMENT = 10 * 60_000;            // 10 分 (移動メトリクス用)
+  const SEG_DT_MAX_MS_DWELL    = 12 * 60 * 60_000;       // 12 時間 (滞在仮定の上限)
   const ACC_MAX_M = 200;                   // accuracy 200m 超は jitter とみなす
   const WALK_MIN_MPS = 0.5;                // 1.8 km/h
   const WALK_MAX_MPS = 3.5;                // 12.6 km/h (上限 = ジョギング以下)
   const TRAVEL_MIN_MPS = 0.5;              // 動いている扱いの下限
+  const DEFAULT_RADIUS_M = 100;            // work_locations.radius_m が NULL の時の既定
+
+  // work_locations を読み、 home + その他の場所に分けて in-memory 配列にする。
+  const places = db.prepare(`
+    SELECT id, name, latitude, longitude, radius_m, is_home
+    FROM work_locations
+    WHERE latitude IS NOT NULL AND longitude IS NOT NULL
+  `).all() as Array<{ id: number; name: string; latitude: number; longitude: number; radius_m: number | null; is_home: 0 | 1 }>;
+  const homePlace = places.find(p => p.is_home === 1) || null;
+  const otherPlaces = places.filter(p => p.is_home === 0);
+
+  function classifyPoint(lat: number, lon: number): { kind: 'home' | 'place' | 'unknown'; placeName?: string } {
+    // priority: home > その他 > 不明。 同 priority 内は最も近い場所を選ぶ。
+    if (homePlace) {
+      const r = homePlace.radius_m ?? DEFAULT_RADIUS_M;
+      const d = haversineMeters({ lat, lon }, { lat: homePlace.latitude, lon: homePlace.longitude });
+      if (d <= r) return { kind: 'home' };
+    }
+    let best: { p: typeof otherPlaces[number]; d: number } | null = null;
+    for (const p of otherPlaces) {
+      const r = p.radius_m ?? DEFAULT_RADIUS_M;
+      const d = haversineMeters({ lat, lon }, { lat: p.latitude, lon: p.longitude });
+      if (d <= r && (!best || d < best.d)) best = { p, d };
+    }
+    if (best) return { kind: 'place', placeName: best.p.name };
+    return { kind: 'unknown' };
+  }
 
   const startDate = new Date(Date.now() - (days - 1) * 86400_000);
   const startKey = dateKeyLocal(startDate);
@@ -3546,35 +3605,73 @@ export function trendsGpsWalking(db: Db, { sinceDays = 30, userId = 'me' }: { si
     ORDER BY recorded_at ASC
   `).all(userId, startKey) as { recorded_at: string; lat: number; lon: number; accuracy_m: number | null }[];
 
-  interface DayBucket { distance_m: number; walking_ms: number; travel_ms: number }
+  interface DayBucket {
+    distance_m: number;        // 移動距離 (vehicle 含む)
+    walking_distance_m: number; // 徒歩速度帯のみで積算 (= カロリー計算の根拠)
+    walking_ms: number;
+    travel_ms: number;
+    home_ms: number;
+    away_moving_ms: number;
+    away_places_ms: Map<string, number>;
+    away_unknown_ms: number;
+  }
   const perDay = new Map<string, DayBucket>();
   function bucket(key: string): DayBucket {
     let b = perDay.get(key);
     if (!b) {
-      b = { distance_m: 0, walking_ms: 0, travel_ms: 0 };
+      b = {
+        distance_m: 0, walking_distance_m: 0, walking_ms: 0, travel_ms: 0,
+        home_ms: 0, away_moving_ms: 0, away_places_ms: new Map(), away_unknown_ms: 0,
+      };
       perDay.set(key, b);
     }
     return b;
   }
-  let prev: { ts: number; key: string; lat: number; lon: number; accOk: boolean } | null = null;
+  function attributeDwell(b: DayBucket, dwellMs: number, cls: ReturnType<typeof classifyPoint>): void {
+    if (dwellMs <= 0) return;
+    if (cls.kind === 'home') b.home_ms += dwellMs;
+    else if (cls.kind === 'place' && cls.placeName) {
+      b.away_places_ms.set(cls.placeName, (b.away_places_ms.get(cls.placeName) || 0) + dwellMs);
+    } else b.away_unknown_ms += dwellMs;
+  }
+  type PrevPoint = { ts: number; key: string; lat: number; lon: number; accOk: boolean; cls: ReturnType<typeof classifyPoint> };
+  let prev: PrevPoint | null = null;
   for (const r of rows) {
     const d = parseUtc(r.recorded_at);
     const ts = d.getTime();
     if (!Number.isFinite(ts)) { prev = null; continue; }
     const key = dateKeyLocal(d);
     const accOk = !r.accuracy_m || r.accuracy_m < ACC_MAX_M;
+    const cls = classifyPoint(r.lat, r.lon);
     if (prev && prev.key === key && accOk && prev.accOk) {
       const dt = ts - prev.ts;
-      if (dt > 0 && dt <= SEG_DT_MAX_MS) {
+      if (dt > 0 && dt <= SEG_DT_MAX_MS_DWELL) {
         const dist = haversineMeters(prev, { lat: r.lat, lon: r.lon });
         const speed = dist / (dt / 1000); // m/s
         const b = bucket(key);
-        b.distance_m += dist;
-        if (speed >= TRAVEL_MIN_MPS) b.travel_ms += dt;
-        if (speed >= WALK_MIN_MPS && speed <= WALK_MAX_MPS) b.walking_ms += dt;
+        const moving = (dt <= SEG_DT_MAX_MS_MOVEMENT) && (speed >= TRAVEL_MIN_MPS);
+
+        // 1. 移動メトリクス (10 分以内 + 速度あり、 速度ノイズ除去)
+        if (dt <= SEG_DT_MAX_MS_MOVEMENT) {
+          b.distance_m += dist;
+          if (speed >= TRAVEL_MIN_MPS) b.travel_ms += dt;
+          if (speed >= WALK_MIN_MPS && speed <= WALK_MAX_MPS) {
+            b.walking_ms += dt;
+            b.walking_distance_m += dist;
+          }
+        }
+
+        // 2. 滞在分類 (GPS は移動した時だけ点を打つ前提):
+        //    短時間 (≤ 10 分) で動いている → 移動中として away_moving
+        //    それ以外の gap (静止 or sparse) → p1 の場所に滞在し続けたと仮定
+        if (moving) {
+          b.away_moving_ms += dt;
+        } else {
+          attributeDwell(b, dt, prev.cls);
+        }
       }
     }
-    prev = { ts, key, lat: r.lat, lon: r.lon, accOk };
+    prev = { ts, key, lat: r.lat, lon: r.lon, accOk, cls };
   }
 
   const out: GpsWalkingRow[] = [];
@@ -3584,11 +3681,33 @@ export function trendsGpsWalking(db: Db, { sinceDays = 30, userId = 'me' }: { si
     dt.setDate(today.getDate() - i);
     const k = dateKeyLocal(dt);
     const b = perDay.get(k);
+    if (!b) {
+      out.push({
+        date: k, distance_km: 0, walking_distance_km: 0, walking_minutes: 0, travel_minutes: 0,
+        home_minutes: 0, away_minutes: 0, away_moving_minutes: 0,
+        away_places: [], away_unknown_minutes: 0,
+      });
+      continue;
+    }
+    const home_min = Math.round(b.home_ms / 60_000);
+    const moving_min = Math.round(b.away_moving_ms / 60_000);
+    const unknown_min = Math.round(b.away_unknown_ms / 60_000);
+    const places_arr = [...b.away_places_ms.entries()]
+      .map(([name, ms]) => ({ name, minutes: Math.round(ms / 60_000) }))
+      .filter(p => p.minutes > 0)
+      .sort((a, b2) => b2.minutes - a.minutes);
+    const places_total = places_arr.reduce((s, p) => s + p.minutes, 0);
     out.push({
       date: k,
-      distance_km: b ? Number((b.distance_m / 1000).toFixed(2)) : 0,
-      walking_minutes: b ? Math.round(b.walking_ms / 60_000) : 0,
-      travel_minutes: b ? Math.round(b.travel_ms / 60_000) : 0,
+      distance_km: Number((b.distance_m / 1000).toFixed(2)),
+      walking_distance_km: Number((b.walking_distance_m / 1000).toFixed(2)),
+      walking_minutes: Math.round(b.walking_ms / 60_000),
+      travel_minutes: Math.round(b.travel_ms / 60_000),
+      home_minutes: home_min,
+      away_minutes: moving_min + places_total + unknown_min,
+      away_moving_minutes: moving_min,
+      away_places: places_arr,
+      away_unknown_minutes: unknown_min,
     });
   }
   return out;
@@ -5257,14 +5376,32 @@ export function insertRecommendationRun(db: Db): number {
 }
 
 export function failRecommendationRun(db: Db, id: number, error: string): void {
+  // WHERE status='running' を付けて、 既に cancel/done に遷移済の row を
+  // 上書きしないようにする (= 「キューを上書き」 した abandoned run が後から
+  // 完了しても、 現在の状態を破壊しない)。
   db.prepare(`
     UPDATE recommendation_runs
        SET status = 'error',
            error = ?,
            finished_at = datetime('now'),
            duration_ms = CAST((julianday('now') - julianday(started_at)) * 86400000 AS INTEGER)
-     WHERE id = ?
+     WHERE id = ? AND status = 'running'
   `).run(error.slice(0, 4000), id);
+}
+
+// 'running' のまま放置されている run を 'cancelled' に変更し、 件数を返す。
+// サーバが死んだまま再起動した / inFlight promise が hang した、 等で
+// 詰まったキューを掃除するために使う。
+export function cancelRunningRecommendationRuns(db: Db, reason = 'user_cancelled'): number {
+  const r = db.prepare(`
+    UPDATE recommendation_runs
+       SET status = 'cancelled',
+           error = ?,
+           finished_at = datetime('now'),
+           duration_ms = CAST((julianday('now') - julianday(started_at)) * 86400000 AS INTEGER)
+     WHERE status = 'running'
+  `).run(reason.slice(0, 4000));
+  return r.changes;
 }
 
 export function completeRecommendationRun(
@@ -5277,6 +5414,8 @@ export function completeRecommendationRun(
     modelOpus: string;
   },
 ): void {
+  // WHERE status='running' で、 cancel/done 済の row を上書きしない。
+  // (force 実行で abandon された旧 run が遅れて終わっても無視する)
   db.prepare(`
     UPDATE recommendation_runs
        SET status = 'done',
@@ -5287,7 +5426,7 @@ export function completeRecommendationRun(
            model_opus = ?,
            result_count = ?,
            duration_ms = CAST((julianday('now') - julianday(started_at)) * 86400000 AS INTEGER)
-     WHERE id = ?
+     WHERE id = ? AND status = 'running'
   `).run(
     JSON.stringify(payload.agentLogs),
     JSON.stringify(payload.results),

--- a/server/env-cli.config.ts
+++ b/server/env-cli.config.ts
@@ -1,0 +1,89 @@
+import type { EnvCliConfig } from "../../Cernere/packages/env-cli/src/types.js";
+
+/**
+ * Memoria local server (個人 PC 常駐版) の env-cli 設定。
+ *
+ * 用途:
+ *   npm run env:setup        Infisical 初回設定 (machine identity を .env.secrets に保存)
+ *   npm run env:gen          Infisical から secret を fetch して .env を生成
+ *   npm run env:list         Infisical 登録 secret の一覧
+ *   npm run env:set <K> <V>  Infisical に secret を登録
+ *   npm run env:test         Infisical 接続テスト
+ *
+ * 設計ノート:
+ *   - INFISICAL_* (machine identity) は env-cli setup で .env.secrets に保存。
+ *     `tsx --env-file-if-exists=.env.secrets bootstrap.ts` がそれを読んで起動。
+ *   - アプリ secret (CERNERE_BASE_URL / 各種 API key) は Infisical 側に置く。
+ *     bootstrap.ts の env-bootstrap が起動時に Infisical から fetch + inject する。
+ *   - Hub (server/multi/) とは別の env-cli.config.ts。 同じ Infisical project を
+ *     共有しても OK だが、 使うキーは別 (Hub は MEMORIA_PG_URL 等のサーバ系、
+ *     local は MEMORIA_PLACES_API_KEY 等のクライアント系)。
+ */
+
+const config: EnvCliConfig = {
+  name: "Memoria (local server)",
+
+  /**
+   * ローカル起動時のフォールバック値。 Infisical に同名キーがあればそちらを優先。
+   * 個人 PC 常駐前提なので docker compose は使わず、 ここの値は単に
+   * `env-cli env` 実行時の .env 出力デフォルトになる。
+   */
+  infraKeys: {
+    // ─── Hono ────────────────────────────────────────────────
+    MEMORIA_PORT: "5180",
+
+    // ─── データ保存ディレクトリ (SQLite + HTML + meals + diary 等) ─────────
+    // 既定: server/../data/ (= リポ直下の data/、 gitignore 済)
+    // 別ドライブに退避する場合はここを上書き。
+    MEMORIA_DATA: "",
+
+    // ─── claude CLI 経路 ─────────────────────────────────────
+    MEMORIA_CLAUDE_BIN: "claude",
+
+    // ─── Hub 連携 (二層設計の Cernere 代理ログイン) ─────────
+    // ※ Multi モード時は Hub の /api/auth/login に proxy するので、
+    //   ローカルは Cernere を直接知らなくて OK (Hub が自分の CERNERE_BASE_URL を持つ)。
+    //   ここで CERNERE_BASE_URL を設定する必要は無い (空欄)。
+    // 旧 online 経路の互換 fallback として残置可。
+    CERNERE_BASE_URL: "",
+
+    // ─── Google Maps / Places (server-side key、 referer 制限なし) ───────────
+    MEMORIA_PLACES_API_KEY: "",
+    // SPA に渡す key (Maps JavaScript API、 referer 制限あり)
+    GOOGLE_MAPS_API_KEY: "",
+
+    // ─── GitHub (diary commit fetch + 📋 作業一覧 タブの fallback) ───────────
+    // 通常は ⚙ 連携設定で UI から PAT を入れる方が推奨。 ここはサーバ起動時の fallback。
+    MEMORIA_GH_TOKEN: "",
+    MEMORIA_GH_USER: "",
+
+    // ─── Legatus (外部 OwnTracks → Memoria 転送、 旧経路。 通常は内蔵 MQTT で OK) ──
+    MEMORIA_LEGATUS_WS: "off",
+    MEMORIA_LEGATUS_WS_URL: "",
+    MEMORIA_LEGATUS_USER_ID: "",
+
+    // ─── MQTT (外部 broker を使う場合のみ。 内蔵 aedes を使う既定運用なら不要) ──
+    MEMORIA_MQTT_URL: "",
+
+    // ─── Steam / packet monitor / tshark (任意機能) ─────────
+    MEMORIA_STEAM_DIR: "",
+    MEMORIA_PACKETMON_LOG_ROOT: "",
+    MEMORIA_TSHARK_BIN: "",
+  },
+
+  secretsPath: ".env.secrets",
+  dotenvPath: ".env",
+
+  defaultSiteUrl: "https://infisical.vtn-game.com",
+  defaultEnvironment: "dev",
+
+  /**
+   * production 環境で env-cli env を実行したとき、 Infisical に存在しない
+   * (= 空欄のまま) と .env 生成を中止するキー。 個人 PC 用なので絞っている。
+   */
+  required: {
+    production: [],
+  },
+};
+
+export default config;

--- a/server/index.ts
+++ b/server/index.ts
@@ -14,7 +14,7 @@ import { cors } from 'hono/cors';
 import { serveStatic } from '@hono/node-server/serve-static';
 import { serve } from '@hono/node-server';
 import { WebSocketServer } from 'ws';
-import { mkdirSync } from 'node:fs';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -226,10 +226,38 @@ app.post('/api/setup/infisical', async (c) => {
     'infisical.client_id': creds.clientId,
     'infisical.client_secret': creds.clientSecret,
   });
+  // env-cli (Cernere/Actio 互換) の .env.secrets にも書き出す。 これで
+  // `npm run env:setup` を実行したときに既存値がプロンプトのデフォルトに出る、
+  // `npm run env:gen` で Infisical から secret を fetch できる、 等の env-cli
+  // 経路が UI 入力と双方向に同期する。 失敗しても致命的ではない (= warn のみ)。
+  try {
+    writeEnvSecrets(creds);
+  } catch (e: unknown) {
+    console.warn(`[infisical] .env.secrets 書き出し失敗 (env-cli 経路は使えない): ${(e as Error).message}`);
+  }
   infisicalConfigured = true;
   console.log(`[infisical] 接続成功 — ${injected} secrets inject`);
   return c.json({ ok: true, injected });
 });
+
+/** env-cli の saveBootstrap と同じ形式で server/.env.secrets を書く。 */
+function writeEnvSecrets(creds: InfisicalCreds): void {
+  const path = resolve(__dirname, '.env.secrets');
+  const content = [
+    '# ─── Infisical Bootstrap Credentials ─────────────────────────',
+    '# Memoria local setup UI または env-cli setup で自動生成。',
+    '# このファイルは .gitignore に含めること。',
+    '# ─────────────────────────────────────────────────────────────',
+    '',
+    `INFISICAL_SITE_URL=${creds.siteUrl}`,
+    `INFISICAL_PROJECT_ID=${creds.projectId}`,
+    `INFISICAL_ENVIRONMENT=${creds.environment}`,
+    `INFISICAL_CLIENT_ID=${creds.clientId}`,
+    `INFISICAL_CLIENT_SECRET=${creds.clientSecret}`,
+    '',
+  ].join('\n');
+  writeFileSync(path, content, { encoding: 'utf8', mode: 0o600 });
+}
 
 // ── Multi モード proxy 層 ─────────────────────────────────────────────────
 //

--- a/server/index.ts
+++ b/server/index.ts
@@ -19,7 +19,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   openDb, ensureUserStopwordsTable,
-  getAppSettings, setAppSettings, setDiaryDataDir, migrateDiariesToSidecar,
+  getAppSettings, setDiaryDataDir, migrateDiariesToSidecar,
   insertGpsLocation, listPendingMeals,
 } from './db.js';
 import { resolveUnresolvedBatch } from './lib/place-resolver.js';

--- a/server/index.ts
+++ b/server/index.ts
@@ -14,7 +14,7 @@ import { cors } from 'hono/cors';
 import { serveStatic } from '@hono/node-server/serve-static';
 import { serve } from '@hono/node-server';
 import { WebSocketServer } from 'ws';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -22,10 +22,6 @@ import {
   getAppSettings, setAppSettings, setDiaryDataDir, migrateDiariesToSidecar,
   insertGpsLocation, listPendingMeals,
 } from './db.js';
-import {
-  hasInfisicalCreds, missingWantedKeys, applyInfisicalCreds,
-  type InfisicalCreds,
-} from './lib/env-bootstrap.js';
 import { resolveUnresolvedBatch } from './lib/place-resolver.js';
 import { loadLlmConfigFromSettings } from './llm.js';
 import { initWebPush } from './push.js';
@@ -173,91 +169,9 @@ app.use('*', async (c, next) => {
   }
 });
 
-// ── Infisical セットアップ (Multi Mode 専用) ─────────────────────────────
-//
-// Local Mode の Memoria は Infisical を使わない (= 全機能ローカル完結)。
-// Multi Mode (Hub 連携) でだけ Cernere 認証が要り、 その CERNERE_BASE_URL 等を
-// Infisical から取る。 なので global gate は張らず、 frontend の Multi view が
-// status を見て「未設定なら setup フォームを出す」 方式にする。
-//
-// machine identity の取得経路 (優先順):
-//   1. Excubitor inject / host shell env
-//   2. app_settings (前回の Multi view 入力)  — bootstrap.ts が起動時に読込済
-//   3. Multi view の setup フォーム            — /api/setup/infisical
-let infisicalConfigured = hasInfisicalCreds();
-if (infisicalConfigured) {
-  const missing = missingWantedKeys();
-  if (missing.length > 0) {
-    console.warn(`[infisical] 接続済だが未取得の設定キー: ${missing.join(', ')} (= Hub 連携の一部が degraded)`);
-  }
-} else {
-  console.log('[infisical] machine identity 未設定 — Local Mode は通常動作、 Multi Mode 利用時に setup を促す');
-}
-
-// Multi view が叩く: Infisical が設定済か (= setup フォームを出すかの判定)。
-app.get('/api/setup/infisical/status', (c) =>
-  c.json({ configured: infisicalConfigured, missing: missingWantedKeys() }));
-
-// Multi view の setup フォームからの machine identity 受け口。
-app.post('/api/setup/infisical', async (c) => {
-  const body = await c.req.json().catch(() => null) as Partial<InfisicalCreds> | null;
-  const creds: InfisicalCreds = {
-    siteUrl: String(body?.siteUrl ?? '').trim().replace(/\/$/, ''),
-    projectId: String(body?.projectId ?? '').trim(),
-    environment: String(body?.environment ?? 'dev').trim() || 'dev',
-    clientId: String(body?.clientId ?? '').trim(),
-    clientSecret: String(body?.clientSecret ?? '').trim(),
-  };
-  if (!creds.siteUrl || !creds.projectId || !creds.clientId || !creds.clientSecret) {
-    return c.json({ error: 'siteUrl / projectId / clientId / clientSecret は必須' }, 400);
-  }
-  let injected = 0;
-  try {
-    ({ injected } = await applyInfisicalCreds(creds));
-  } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e);
-    return c.json({ error: `Infisical 接続失敗: ${msg}` }, 502);
-  }
-  // 成功したら app_settings に永続化 (次回起動は bootstrap.ts が読む)。
-  setAppSettings(db, {
-    'infisical.site_url': creds.siteUrl,
-    'infisical.project_id': creds.projectId,
-    'infisical.environment': creds.environment,
-    'infisical.client_id': creds.clientId,
-    'infisical.client_secret': creds.clientSecret,
-  });
-  // env-cli (Cernere/Actio 互換) の .env.secrets にも書き出す。 これで
-  // `npm run env:setup` を実行したときに既存値がプロンプトのデフォルトに出る、
-  // `npm run env:gen` で Infisical から secret を fetch できる、 等の env-cli
-  // 経路が UI 入力と双方向に同期する。 失敗しても致命的ではない (= warn のみ)。
-  try {
-    writeEnvSecrets(creds);
-  } catch (e: unknown) {
-    console.warn(`[infisical] .env.secrets 書き出し失敗 (env-cli 経路は使えない): ${(e as Error).message}`);
-  }
-  infisicalConfigured = true;
-  console.log(`[infisical] 接続成功 — ${injected} secrets inject`);
-  return c.json({ ok: true, injected });
-});
-
-/** env-cli の saveBootstrap と同じ形式で server/.env.secrets を書く。 */
-function writeEnvSecrets(creds: InfisicalCreds): void {
-  const path = resolve(__dirname, '.env.secrets');
-  const content = [
-    '# ─── Infisical Bootstrap Credentials ─────────────────────────',
-    '# Memoria local setup UI または env-cli setup で自動生成。',
-    '# このファイルは .gitignore に含めること。',
-    '# ─────────────────────────────────────────────────────────────',
-    '',
-    `INFISICAL_SITE_URL=${creds.siteUrl}`,
-    `INFISICAL_PROJECT_ID=${creds.projectId}`,
-    `INFISICAL_ENVIRONMENT=${creds.environment}`,
-    `INFISICAL_CLIENT_ID=${creds.clientId}`,
-    `INFISICAL_CLIENT_SECRET=${creds.clientSecret}`,
-    '',
-  ].join('\n');
-  writeFileSync(path, content, { encoding: 'utf8', mode: 0o600 });
-}
+// Local Memoria は Infisical / Cernere を直接知らない設計に統一済。
+// 旧 /api/setup/infisical* と writeEnvSecrets() は撤去 — Hub 連携は Hub 側 (server/multi/)
+// の Infisical 設定 (= env-cli) で完結する。
 
 // ── Multi モード proxy 層 ─────────────────────────────────────────────────
 //

--- a/server/multi/Dockerfile
+++ b/server/multi/Dockerfile
@@ -15,10 +15,11 @@ RUN apk add --no-cache git
 WORKDIR /tmp
 RUN git clone --depth 1 --filter=blob:none --sparse https://github.com/LUDIARS/Cernere.git
 WORKDIR /tmp/Cernere
-# Both file: deps used by Memoria Hub:
+# file: deps used by Memoria Hub:
 #   @ludiars/cernere-service-adapter  -> packages/service-adapter
 #   @ludiars/cernere-id-cache         -> packages/id-cache
-RUN git sparse-checkout set packages/service-adapter packages/id-cache
+#   @ludiars/cernere-composite        -> packages/composite
+RUN git sparse-checkout set packages/service-adapter packages/id-cache packages/composite
 
 # The sparse clone only ships source; package.json points to dist/index.js,
 # so we compile both adapters here before the deps stage consumes them.
@@ -29,6 +30,12 @@ WORKDIR /tmp/Cernere/packages/service-adapter
 RUN npm install --no-audit --no-fund && npm run build
 WORKDIR /tmp/Cernere/packages/id-cache
 RUN npm install --no-audit --no-fund && npm run build
+WORKDIR /tmp/Cernere/packages/composite
+# composite's package.json references service-adapter via "^0.1.0" (private
+# scope, not on the public registry). Rewrite to a relative file: spec so npm
+# resolves the sibling package we just built.
+RUN node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.dependencies['@ludiars/cernere-service-adapter']='file:../service-adapter'; fs.writeFileSync('package.json', JSON.stringify(p,null,2));"
+RUN npm install --no-audit --no-fund && npm run build
 
 FROM node:20-alpine AS deps
 WORKDIR /app
@@ -36,6 +43,7 @@ WORKDIR /app
 # Resolved from /app, that points to /Cernere/packages/*.
 COPY --from=adapter-build /tmp/Cernere/packages/service-adapter /Cernere/packages/service-adapter
 COPY --from=adapter-build /tmp/Cernere/packages/id-cache /Cernere/packages/id-cache
+COPY --from=adapter-build /tmp/Cernere/packages/composite /Cernere/packages/composite
 COPY package.json ./
 RUN npm install --omit=dev
 
@@ -47,6 +55,7 @@ ENV MEMORIA_HUB_PORT=5280
 # node_modules. The link targets must also exist in the production image.
 COPY --from=adapter-build /tmp/Cernere/packages/service-adapter /Cernere/packages/service-adapter
 COPY --from=adapter-build /tmp/Cernere/packages/id-cache /Cernere/packages/id-cache
+COPY --from=adapter-build /tmp/Cernere/packages/composite /Cernere/packages/composite
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 

--- a/server/multi/creds-store.js
+++ b/server/multi/creds-store.js
@@ -8,8 +8,13 @@
 //   なので machine identity だけはファイルで持つ。 Local backend の
 //   .env.secrets / SQLite app_settings に対応する Hub 版。
 //
-// 保存場所は既定で server/multi/.infisical-creds.json (gitignore 済)。
-// MEMORIA_HUB_CREDS_PATH で上書き可。
+// 保存形式は 2 系統を双方向に同期する:
+//   (A) .infisical-creds.json  — Hub の GET / setup フォーム経由の歴史的形式
+//   (B) .env.secrets           — env-cli (Cernere/Actio 互換) の形式 (KEY=value)
+// 読み込みはどちらか存在する方から、 書き込みは両方を更新する。 これで:
+//   - GET / で入れた値が `npm run env:setup` の既存値として表示される
+//   - `npm run env:setup` で入れた値で Hub bootstrap が起動できる
+// MEMORIA_HUB_CREDS_PATH で .json 側の場所を上書き可、 .env.secrets は同じ dir。
 
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -20,8 +25,29 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 export const CREDS_PATH = process.env.MEMORIA_HUB_CREDS_PATH
   || join(__dirname, '.infisical-creds.json');
 
-/** @returns {{siteUrl,projectId,environment,clientId,clientSecret}|null} */
-export function readCreds() {
+/** env-cli 互換の .env.secrets パス (.infisical-creds.json と同じ dir)。 */
+const ENV_SECRETS_PATH = join(dirname(CREDS_PATH), '.env.secrets');
+
+/** .env 形式の text を key→value に parse (env-cli の parseEnvFile と同じ仕様)。 */
+function parseEnvSecrets(content) {
+  const out = {};
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"'))
+        || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+function readFromJson() {
   if (!existsSync(CREDS_PATH)) return null;
   try {
     const raw = JSON.parse(readFileSync(CREDS_PATH, 'utf8'));
@@ -40,16 +66,66 @@ export function readCreds() {
   return null;
 }
 
+function readFromEnvSecrets() {
+  if (!existsSync(ENV_SECRETS_PATH)) return null;
+  try {
+    const vars = parseEnvSecrets(readFileSync(ENV_SECRETS_PATH, 'utf8'));
+    if (vars.INFISICAL_PROJECT_ID && vars.INFISICAL_CLIENT_ID && vars.INFISICAL_CLIENT_SECRET) {
+      return {
+        siteUrl: vars.INFISICAL_SITE_URL || 'https://app.infisical.com',
+        projectId: vars.INFISICAL_PROJECT_ID,
+        environment: vars.INFISICAL_ENVIRONMENT || 'prod',
+        clientId: vars.INFISICAL_CLIENT_ID,
+        clientSecret: vars.INFISICAL_CLIENT_SECRET,
+      };
+    }
+  } catch (err) {
+    console.warn(`[creds-store] ${ENV_SECRETS_PATH} 読込失敗: ${err.message}`);
+  }
+  return null;
+}
+
+/**
+ * .infisical-creds.json (JSON) と .env.secrets (env-cli 形式) の両方を試す。
+ * .env.secrets を優先する理由:
+ *   - Hub の writeCreds は常に両方を atomic に書く (= 両方存在するときは同期済)
+ *   - 一方 env-cli は .env.secrets だけを書く (= .json は stale 化しうる)
+ *   - よって .env.secrets を信頼すれば「env-cli で更新した値が次回起動で効く」
+ *     経路が壊れない。 .json は env-cli 不使用環境用 fallback として残置。
+ *
+ * @returns {{siteUrl,projectId,environment,clientId,clientSecret}|null}
+ */
+export function readCreds() {
+  return readFromEnvSecrets() ?? readFromJson();
+}
+
+/**
+ * creds を両方の形式で永続化する (= GET / フォームと env-cli setup の
+ * どちらを使っても、 もう一方が次回起動時にそれを拾える)。
+ */
 export function writeCreds(creds) {
-  writeFileSync(
-    CREDS_PATH,
-    JSON.stringify({
-      siteUrl: creds.siteUrl,
-      projectId: creds.projectId,
-      environment: creds.environment || 'prod',
-      clientId: creds.clientId,
-      clientSecret: creds.clientSecret,
-    }, null, 2),
-    { encoding: 'utf8', mode: 0o600 },
-  );
+  const normalized = {
+    siteUrl: creds.siteUrl,
+    projectId: creds.projectId,
+    environment: creds.environment || 'prod',
+    clientId: creds.clientId,
+    clientSecret: creds.clientSecret,
+  };
+  writeFileSync(CREDS_PATH, JSON.stringify(normalized, null, 2),
+    { encoding: 'utf8', mode: 0o600 });
+  const envContent = [
+    '# ─── Infisical Bootstrap Credentials ─────────────────────────',
+    '# Memoria Hub / GET / setup フォーム または env-cli setup で自動生成。',
+    '# このファイルは .gitignore に含めること。',
+    '# ─────────────────────────────────────────────────────────────',
+    '',
+    `INFISICAL_SITE_URL=${normalized.siteUrl}`,
+    `INFISICAL_PROJECT_ID=${normalized.projectId}`,
+    `INFISICAL_ENVIRONMENT=${normalized.environment}`,
+    `INFISICAL_CLIENT_ID=${normalized.clientId}`,
+    `INFISICAL_CLIENT_SECRET=${normalized.clientSecret}`,
+    '',
+  ].join('\n');
+  writeFileSync(ENV_SECRETS_PATH, envContent,
+    { encoding: 'utf8', mode: 0o600 });
 }

--- a/server/multi/docker-compose.yml
+++ b/server/multi/docker-compose.yml
@@ -36,20 +36,20 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    # .env を全部 container に流す (Infisical machine identity + CERNERE_BASE_URL +
+    # MEMORIA_HUB_PUBLIC_URL 等 env-cli の infraKeys を漏れなく渡す)。 個別宣言だと
+    # 新キー追加のたびに docker-compose.yml も触る必要があったが、 env_file で一括。
+    env_file:
+      - .env
     environment:
-      MEMORIA_HUB_PORT: 5280
-      MEMORIA_HUB_BASE: ${MEMORIA_HUB_BASE}
+      # docker compose 経由なら postgres は内部 DNS で参照する (= .env の値を override)
       MEMORIA_PG_URL: postgres://${POSTGRES_USER:-memoria}:${POSTGRES_PASSWORD:-memoria}@postgres:5432/${POSTGRES_DB:-memoria_hub}
       MEMORIA_PG_POOL: 10
-      # service-adapter 接続先。 standalone-dev なら ws://host.docker.internal:8080/ws/service
-      CERNERE_WS_URL: ${CERNERE_WS_URL}
-      CERNERE_SERVICE_CODE: ${CERNERE_SERVICE_CODE:-memoria-hub}
-      CERNERE_SERVICE_SECRET: ${CERNERE_SERVICE_SECRET}
-      SERVICE_JWT_SECRET: ${SERVICE_JWT_SECRET}
-      # Hub の authMiddleware が Bearer JWT を HS256 検証するための共有鍵。
-      # Cernere の JWT_SECRET と必ず同値にする (Infisical 経由で揃えるのが本筋)。
-      CERNERE_JWT_SECRET: ${CERNERE_JWT_SECRET}
-      MEMORIA_HUB_ALLOWED_ORIGINS: ${MEMORIA_HUB_ALLOWED_ORIGINS}
+      # ── 開発時 override: 本番 prod URL (cernere-d.vtn-game.com) は cloudflared
+      # 経由なので、 同じ host で local cernere container が動いていれば直結したい。
+      # 値を override したい時はここをコメント解除。 本番デプロイ時は外す。
+      # CERNERE_BASE_URL: http://host.docker.internal:8080
+      # CERNERE_WS_URL:   ws://host.docker.internal:8080/ws/service
     ports:
       - "${MEMORIA_HUB_HOST_PORT:-5280}:5280"
     # ── creds 配布の推奨フロー ─────────────────────────────────────────

--- a/server/multi/docker-compose.yml
+++ b/server/multi/docker-compose.yml
@@ -52,6 +52,13 @@ services:
       MEMORIA_HUB_ALLOWED_ORIGINS: ${MEMORIA_HUB_ALLOWED_ORIGINS}
     ports:
       - "${MEMORIA_HUB_HOST_PORT:-5280}:5280"
+    # ── creds 配布の推奨フロー ─────────────────────────────────────────
+    # docker 経由で動かす場合、 host 側で先に env-cli setup を実行する:
+    #   npm run env:setup        # .env.secrets を host に書く
+    #   docker compose up -d --build   # build が .env.secrets を image に焼き込む
+    # 起動後に GET / の setup フォームで更新した creds は container 内のみで
+    # 永続化される (image rebuild で吹き飛ぶ)。 永続更新したいなら env-cli で
+    # host 側の .env.secrets を書き換えてから rebuild する。
 
 volumes:
   memoria-hub-pg:

--- a/server/multi/env-cli.config.ts
+++ b/server/multi/env-cli.config.ts
@@ -1,0 +1,94 @@
+import type { EnvCliConfig } from "../../../Cernere/packages/env-cli/src/types.js";
+
+/**
+ * Memoria Hub の env-cli 設定。
+ *
+ * 用途:
+ *   npm run env:setup        Infisical 初回設定 (machine identity を .env.secrets に保存)
+ *   npm run env:gen          Infisical から secret を fetch して .env を生成
+ *   npm run env:list         Infisical 登録 secret の一覧
+ *   npm run env:set <K> <V>  Infisical に secret を登録
+ *   npm run env:test         Infisical 接続テスト
+ *
+ * 設計ノート:
+ *   - INFISICAL_* (machine identity) は Infisical に置けない (chicken-and-egg)。
+ *     env-cli setup で .env.secrets に保存 → bootstrap.js が起動時に読む。
+ *   - infraKeys のデフォルト値は docker-compose の dev fallback。
+ *     Infisical に同名キーがあればそちらが優先される。
+ *   - 個人 secret (CERNERE_SERVICE_SECRET / SERVICE_JWT_SECRET / JWT 系) は
+ *     必ず Infisical に登録すること (デフォルトは dev 用プレースホルダ)。
+ */
+
+const config: EnvCliConfig = {
+  name: "Memoria Hub",
+
+  /**
+   * docker-compose / アプリケーションが .env から読むキーとデフォルト値。
+   * Infisical に同名キーがあればそちらを優先。
+   */
+  infraKeys: {
+    // ─── Hub プロセス自身 ───────────────────────────────────
+    MEMORIA_HUB_PORT: "5280",
+    MEMORIA_HUB_BASE: "http://localhost:5280",
+    // PASETO の aud claim 検証用。 Hub の公開 URL と完全一致させる。
+    MEMORIA_HUB_PUBLIC_URL: "http://localhost:5280",
+    // CORS 許可 origin (CSV)。 ローカル Memoria SPA を許可する想定。
+    MEMORIA_HUB_ALLOWED_ORIGINS: "http://localhost:5180",
+
+    // ─── docker-compose (Postgres) ──────────────────────────
+    POSTGRES_USER: "memoria",
+    POSTGRES_PASSWORD: "memoria",
+    POSTGRES_DB: "memoria_hub",
+    MEMORIA_HUB_HOST_PORT: "5280",
+    MEMORIA_PG_POOL: "10",
+
+    // ─── Hub の Postgres 接続 URL ───────────────────────────
+    // docker compose 経由なら postgres サービスの DNS 名 (postgres:5432) で OK。
+    // 単独起動 (= host から直接) なら 127.0.0.1:<exposed port>。
+    MEMORIA_PG_URL: "postgres://memoria:memoria@postgres:5432/memoria_hub",
+
+    // ─── Cernere 連携 (二層設計 auth flow) ──────────────────
+    // Hub が代理ログイン + PASETO 公開鍵 fetch する先。
+    CERNERE_BASE_URL: "http://host.docker.internal:8080",
+    // managed_projects.key (= cernereProjectToken に渡す project_key)。
+    MEMORIA_CERNERE_PROJECT_KEY: "memoria",
+
+    // ─── Cernere service-adapter (将来 /ws/service 経由の admission push 用) ──
+    CERNERE_WS_URL: "ws://host.docker.internal:8080/ws/service",
+    CERNERE_SERVICE_CODE: "memoria-hub",
+    // 以下は dev placeholder。 本番では必ず Infisical に登録する。
+    CERNERE_SERVICE_SECRET: "dev-secret-placeholder",
+    SERVICE_JWT_SECRET: "memoria-hub-dev-jwt-secret-replace-in-production",
+
+    // ─── 旧 HS256 互換 (PASETO 移行期間中の legacy client 受付用) ──────────
+    // Cernere の JWT_SECRET と同値にする。 PASETO 経路が安定したら撤去予定。
+    CERNERE_JWT_SECRET: "memoria-hub-dev-cernere-jwt-secret",
+  },
+
+  /** Hub は server/multi/.env.secrets に machine identity を持つ。 */
+  secretsPath: ".env.secrets",
+  /** Hub は server/multi/.env に生成する (docker compose が読む先)。 */
+  dotenvPath: ".env",
+
+  defaultSiteUrl: "https://infisical.vtn-game.com",
+  defaultEnvironment: "dev",
+
+  /**
+   * production 環境で env-cli env を実行したとき、 Infisical に存在しない
+   * (= dev 用 placeholder のまま) と .env 生成を中止するキー。
+   * dev fallback が本番に漏れると致命的になる項目を列挙。
+   */
+  required: {
+    production: [
+      "MEMORIA_PG_URL",
+      "MEMORIA_HUB_PUBLIC_URL",
+      "CERNERE_BASE_URL",
+      "CERNERE_SERVICE_SECRET",
+      "SERVICE_JWT_SECRET",
+      "CERNERE_JWT_SECRET",
+      "POSTGRES_PASSWORD",
+    ],
+  },
+};
+
+export default config;

--- a/server/multi/index.js
+++ b/server/multi/index.js
@@ -30,6 +30,8 @@ import { cors } from 'hono/cors';
 import { serve } from '@hono/node-server';
 import { createHmac } from 'node:crypto';
 import { initCernereBridge, getAdapter } from './cernere-bridge.js';
+import { CernereComposite } from '@ludiars/cernere-composite';
+import { WebSocket as NodeWebSocket } from 'ws';
 import {
   applyInfisicalCreds, hasInfisicalCreds, missingWantedKeys,
 } from './env-bootstrap.js';
@@ -234,40 +236,51 @@ function hubPublicUrl(c) {
   return `${proto}://${host}`;
 }
 
-app.post('/api/auth/login', async (c) => {
+// ── Cernere Composite SSO ────────────────────────────────────────────────
+//
+// 旧 cernere-login.js (email/password 代理ログイン) は撤去。 代わりに
+// @ludiars/cernere-composite を使い、 Cernere の native login UI (Passkey /
+// OAuth / Password / FIDO2) を popup で開いて auth_code を交換するフローへ。
+// Memoria 側で password を受け付けない (= ログイン処理の独自実装を排除)。
+const composite = new CernereComposite(
+  {
+    cernereUrl:    process.env.CERNERE_BASE_URL    || 'http://localhost:8080',
+    cernereWsUrl:  process.env.CERNERE_WS_URL      || 'ws://localhost:8080/ws/service',
+    serviceCode:   process.env.CERNERE_SERVICE_CODE   || 'memoria-hub',
+    serviceSecret: process.env.CERNERE_SERVICE_SECRET || '',
+    jwtSecret:     process.env.SERVICE_JWT_SECRET     || '',
+    tokenExpiresIn: 60 * 60 * 24, // 24 時間 (= Memoria セッションの感覚に合わせる)
+  },
+  {}, // ServiceAdapterCallbacks (admission push 等は cernere-bridge.js 側で処理)
+  NodeWebSocket, // Node の ws 実装 (browser global WebSocket は無い)
+);
+
+/** popup に渡す Cernere composite login URL を返す。 origin は postMessage の戻り先 */
+app.get('/api/auth/login-url', (c) => {
+  const origin = c.req.query('origin') || hubPublicUrl(c);
+  return c.json({ url: composite.getLoginUrl(origin) });
+});
+
+/** popup から受け取った auth_code を service_token に交換 */
+app.post('/api/auth/exchange', async (c) => {
   const body = await c.req.json().catch(() => null);
-  const email = body?.email?.trim();
-  const password = body?.password;
-  if (!email || !password) return c.json({ error: 'email + password は必須です' }, 400);
-  if (!hasInfisicalCreds()) {
-    return c.json({ error: 'Hub が未設定です (Infisical)' }, 503);
+  const authCode = body?.authCode || body?.code;
+  if (!authCode || typeof authCode !== 'string') {
+    return c.json({ error: 'authCode は必須です' }, 400);
   }
-
-  let login;
   try {
-    login = await cernereLogin(email, password);
+    const r = await composite.exchange(authCode);
+    return c.json({
+      sessionToken: r.serviceToken,
+      user: {
+        userId: r.user.id,
+        displayName: r.user.displayName,
+        role: r.user.role,
+      },
+    });
   } catch (err) {
-    return c.json({ error: err.message, detail: err.detail }, err.status || 502);
+    return c.json({ error: err.message }, 502);
   }
-
-  const accessToken = login.accessToken;
-  const u = login.user || {};
-  let sessionToken = accessToken;
-  try {
-    const pt = await cernereProjectToken(accessToken, hubPublicUrl(c));
-    if (pt?.accessToken) sessionToken = pt.accessToken;
-  } catch (err) {
-    console.warn(`[auth] project-token 取得失敗、 accessToken を session token に転用: ${err.message}`);
-  }
-
-  return c.json({
-    sessionToken,
-    user: {
-      userId: u.id || u.userId || null,
-      displayName: u.displayName || u.name || u.email || email,
-      role: u.role || 'general',
-    },
-  });
 });
 
 // /api/auth/me, /api/auth/logout は authMiddleware に依存するため、

--- a/server/multi/package-lock.json
+++ b/server/multi/package-lock.json
@@ -9,12 +9,35 @@
       "version": "0.1.0",
       "dependencies": {
         "@hono/node-server": "^1.13.7",
+        "@ludiars/cernere-composite": "file:../../../Cernere/packages/composite",
         "@ludiars/cernere-id-cache": "file:../../../Cernere/packages/id-cache",
         "@ludiars/cernere-service-adapter": "file:../../../Cernere/packages/service-adapter",
         "hono": "^4.6.10",
         "paseto": "^3.1.4",
         "pg": "^8.13.1",
         "ws": "^8.20.0"
+      }
+    },
+    "../../../Cernere/packages/composite": {
+      "name": "@ludiars/cernere-composite",
+      "version": "0.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@ludiars/cernere-service-adapter": "^0.1.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@types/react": "^19.2.0",
+        "react": "^19.2.0",
+        "typescript": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "../../../Cernere/packages/id-cache": {
@@ -56,6 +79,10 @@
       "peerDependencies": {
         "hono": "^4"
       }
+    },
+    "node_modules/@ludiars/cernere-composite": {
+      "resolved": "../../../Cernere/packages/composite",
+      "link": true
     },
     "node_modules/@ludiars/cernere-id-cache": {
       "resolved": "../../../Cernere/packages/id-cache",

--- a/server/multi/package.json
+++ b/server/multi/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.13.7",
+    "@ludiars/cernere-composite": "file:../../../Cernere/packages/composite",
     "@ludiars/cernere-id-cache": "file:../../../Cernere/packages/id-cache",
     "@ludiars/cernere-service-adapter": "file:../../../Cernere/packages/service-adapter",
     "hono": "^4.6.10",

--- a/server/multi/package.json
+++ b/server/multi/package.json
@@ -7,7 +7,14 @@
   "scripts": {
     "start": "node --env-file-if-exists=.env --env-file-if-exists=../../.env bootstrap.js",
     "dev": "node --watch --env-file-if-exists=.env --env-file-if-exists=../../.env bootstrap.js",
-    "migrate": "node migrate.js"
+    "migrate": "node migrate.js",
+    "env:setup": "npx tsx ../../../Cernere/packages/env-cli/src/cli.ts setup",
+    "env:test": "npx tsx ../../../Cernere/packages/env-cli/src/cli.ts test",
+    "env:gen": "npx tsx ../../../Cernere/packages/env-cli/src/cli.ts env",
+    "env:list": "npx tsx ../../../Cernere/packages/env-cli/src/cli.ts list",
+    "env:get": "npx tsx ../../../Cernere/packages/env-cli/src/cli.ts get",
+    "env:set": "npx tsx ../../../Cernere/packages/env-cli/src/cli.ts set",
+    "env:initialize": "npx tsx ../../../Cernere/packages/env-cli/src/cli.ts initialize"
   },
   "dependencies": {
     "@hono/node-server": "^1.13.7",

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,14 @@
     "build:frontend": "esbuild public/src/app.ts --bundle --outfile=public/app.js --target=es2020 --sourcemap --minify",
     "watch:frontend": "esbuild public/src/app.ts --bundle --outfile=public/app.js --target=es2020 --sourcemap --watch",
     "typecheck": "npm install --no-save --no-package-lock --no-audit --no-fund typescript@5.6 @types/node@20 @types/better-sqlite3@7 @types/web-push@3 && npx tsc --noEmit -p tsconfig.json && npx tsc --noEmit -p tsconfig.frontend.json",
-    "lint": "npm install --no-save --no-package-lock --no-audit --no-fund eslint@9 typescript-eslint@8 typescript@5.6 && npx eslint --max-warnings 0 \"**/*.ts\""
+    "lint": "npm install --no-save --no-package-lock --no-audit --no-fund eslint@9 typescript-eslint@8 typescript@5.6 && npx eslint --max-warnings 0 \"**/*.ts\"",
+    "env:setup": "npx tsx ../../Cernere/packages/env-cli/src/cli.ts setup",
+    "env:test": "npx tsx ../../Cernere/packages/env-cli/src/cli.ts test",
+    "env:gen": "npx tsx ../../Cernere/packages/env-cli/src/cli.ts env",
+    "env:list": "npx tsx ../../Cernere/packages/env-cli/src/cli.ts list",
+    "env:get": "npx tsx ../../Cernere/packages/env-cli/src/cli.ts get",
+    "env:set": "npx tsx ../../Cernere/packages/env-cli/src/cli.ts set",
+    "env:initialize": "npx tsx ../../Cernere/packages/env-cli/src/cli.ts initialize"
   },
   "dependencies": {
     "@hono/node-server": "^1.13.7",

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -364,8 +364,8 @@
           <span>保存・閲覧傾向のサマリ。期間を変えると全カードが更新されます。</span>
           <span class="grow"></span>
           <select id="trendsRange">
-            <option value="7">過去 7 日</option>
-            <option value="30" selected>過去 30 日</option>
+            <option value="7" selected>過去 7 日</option>
+            <option value="30">過去 30 日</option>
             <option value="90">過去 90 日</option>
             <option value="365">過去 1 年</option>
           </select>
@@ -384,15 +384,15 @@
           </section>
 
           <section class="trend-card">
-            <h3>1 日の歩いた距離</h3>
-            <p class="trend-help">「軌跡」(OwnTracks GPS) から算出した日別の概算移動距離。accuracy 200m 超は除外。</p>
-            <div id="trendWalkDistance" class="chart"></div>
+            <h3>1 日の消費カロリー (徒歩)</h3>
+            <p class="trend-help">徒歩 3.5 MET × 体重 × 歩行時間 で算出。 歩行時間は速度 1.8〜12.6 km/h の区間 (= vehicle 移動を除く)。 体重は 設定 → ユーザープロファイル で登録した値を使用 (未設定なら 60kg)。</p>
+            <div id="trendWalkCalories" class="chart"></div>
           </section>
 
           <section class="trend-card">
-            <h3>1 日の歩いた時間</h3>
-            <p class="trend-help">徒歩速度帯 (1.8〜12.6 km/h) の区間を合計した分数。乗り物移動は別途ツールチップに「移動時間」として表示。</p>
-            <div id="trendWalkMinutes" class="chart"></div>
+            <h3>1 日の自宅以外にいた時間</h3>
+            <p class="trend-help">GPS から、 自宅 (登録済 work_locations.is_home=1) 以外で過ごした時間を 「移動 / 場所 (登録済) / 不明 (登録外の停止)」 の面積棒グラフで表示。 場所が登録されていない場合は「不明」 にまとまります。</p>
+            <div id="trendAwayStacked" class="chart"></div>
           </section>
 
           <section class="trend-card">
@@ -501,6 +501,7 @@
         </div>
         <div id="recRunning" class="rec-running hidden">
           <p>AI 分析中… (6 並列 Sonnet → Opus 統合、 通常 5–30 分)</p>
+          <p class="muted" style="font-size:12px;margin:4px 0 0">詰まったら 「↻ 再実行 (キュー上書き)」 で前のキューを cancel して新規実行できます。</p>
         </div>
         <div id="recList" class="rec-list"></div>
         <div id="recEmpty" class="queue-empty hidden">まだ AI による分析結果がありません。 「いま生成」 を押して最初の run を開始してください。</div>
@@ -1302,50 +1303,28 @@
       </dialog>
 
       <div id="multiView" class="hidden">
-        <!-- Infisical setup — Multi Mode (Hub 連携) は Cernere 認証が要り、
-             その CERNERE_BASE_URL 等を Infisical から取る。 未設定のときだけ表示。
-             Local Mode では Infisical は一切使わない。 -->
-        <section id="multiInfisicalSetup" class="multi-infisical-setup foundation-form hidden">
-          <h3 style="margin:0 0 4px">🔑 Infisical セットアップ</h3>
-          <p class="muted" style="font-size:12px;margin:0 0 12px;line-height:1.6">
-            Memoria の一部設定値 (Google Maps API キー等) を Infisical から取得します。
-            この PC の machine identity を入力してください。 値は SQLite
-            (<code>app_settings</code>) に保存され、 次回からは自動接続します。
-            Excubitor 経由で起動する場合はこの画面は出ません。
-          </p>
-          <label class="simple-field"><span>Site URL</span>
-            <input id="infiSiteUrl" type="url" value="https://infisical.vtn-game.com" /></label>
-          <label class="simple-field" style="margin-top:8px"><span>Project ID</span>
-            <input id="infiProjectId" type="text" placeholder="xxxxxxxx-xxxx-..." /></label>
-          <label class="simple-field" style="margin-top:8px"><span>Environment</span>
-            <input id="infiEnvironment" type="text" value="dev" /></label>
-          <label class="simple-field" style="margin-top:8px"><span>Machine Identity — Client ID</span>
-            <input id="infiClientId" type="text" placeholder="Universal Auth client id" /></label>
-          <label class="simple-field" style="margin-top:8px"><span>Machine Identity — Client Secret</span>
-            <input id="infiClientSecret" type="password" placeholder="Universal Auth client secret" /></label>
-          <div class="simple-actions" style="margin-top:14px">
-            <button id="infiSetupSubmit" type="button">接続して保存</button>
-          </div>
-          <div id="infiSetupMsg" class="muted" style="font-size:12px;margin-top:8px" hidden></div>
-        </section>
+        <!-- Local Memoria は Infisical を知らない (= 全機能ローカル完結) — 旧
+             multiInfisicalSetup ブロックは撤去された。 Hub の Infisical 設定は
+             Hub 側 (server/multi/) の env-cli で完結する。 -->
 
-        <!-- Hub ログイン — ログの下のスイッチャで未ログイン Hub を選んだとき表示。
-             ローカルは Cernere を直接知らず、 Hub に email/password を渡すだけ。
-             Hub が内部で Cernere に代理ログインして session token を返す。 -->
+        <!-- Hub ログイン — スイッチャで未ログイン Hub を選んだとき表示。
+             Local は email/password を持たない (= Cernere Composite SSO)。
+             Hub から Cernere の login URL を取得 → popup で開く → postMessage で
+             auth_code を受け取り Hub に exchange する。 -->
         <section id="multiCernereLogin" class="multi-infisical-setup foundation-form hidden">
           <h3 style="margin:0 0 4px">🔐 Hub ログイン</h3>
-          <p class="muted" style="font-size:12px;margin:0 0 12px;line-height:1.6">
-            Memoria Hub への接続にはアカウントが必要です。 email / password を
-            Hub に渡すと、 Hub が内部で Cernere に代理ログインして接続します。
+          <p class="muted" style="font-size:12px;margin:0 0 8px;line-height:1.6">
+            Cernere の Composite SSO で接続します。 「ログイン」 を押すと Cernere の
+            ログイン画面が popup で開き、 Face ID / Touch ID / Windows Hello /
+            Password / Google / GitHub のいずれかで認証できます。
+            Memoria 側で password を入力する必要はありません。
           </p>
-          <label class="simple-field"><span>Hub URL</span>
-            <input id="multiLoginUrl" type="url" placeholder="https://memoria-hub.vtn-game.com" /></label>
-          <label class="simple-field" style="margin-top:8px"><span>メールアドレス</span>
-            <input id="multiLoginEmail" type="email" placeholder="you@example.com" /></label>
-          <label class="simple-field" style="margin-top:8px"><span>パスワード</span>
-            <input id="multiLoginPassword" type="password" /></label>
+          <p class="muted" style="font-size:12px;margin:0 0 12px">
+            接続先: <code id="multiLoginUrlDisplay" style="font-size:12px">—</code>
+          </p>
+          <input id="multiLoginUrl" type="hidden" />
           <div class="simple-actions" style="margin-top:14px">
-            <button id="multiLoginSubmit" type="button">ログイン</button>
+            <button id="multiLoginSubmit" type="button">🔐 Cernere でログイン</button>
           </div>
           <div id="multiLoginMsg" class="muted" style="font-size:12px;margin-top:8px" hidden></div>
         </section>
@@ -1792,6 +1771,6 @@
       <button id="aiSettingsSave">保存</button>
     </div>
   </div>
-  <script src="app.js?v=20260513j"></script>
+  <script src="app.js?v=20260516g"></script>
 </body>
 </html>

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -269,7 +269,7 @@ const state: State = {
   visits: [],
   visitsSelected: new Set<unknown>(),
   visitsRange: '7',
-  trendsRange: '30',
+  trendsRange: '7',
   recommendations: { available: true, running: false, items: [], run: null, reason: '' },
   digSession: null,
   digHistory: [],
@@ -3947,8 +3947,15 @@ async function triggerRecommendationRun() {
   const btn = $('recRunNow');
   if (!btn) return;
   btn.disabled = true;
+  // 既に running 中なら force=true で旧キューを cancel して上書き再実行する。
+  // (= キューが詰まって動かなくなった時に「再実行」 で抜け出せるようにする)
+  const force = !!state.recommendations?.running;
   try {
-    await api('/api/recommendations/run', { method: 'POST' });
+    await api('/api/recommendations/run', {
+      method: 'POST',
+      body: JSON.stringify({ force }),
+      headers: { 'Content-Type': 'application/json' },
+    });
     state.recommendations.running = true;
     renderRecommendations();
     startRecPolling();
@@ -3983,7 +3990,12 @@ function renderRecommendations() {
     return;
   }
   disabled.classList.add('hidden');
-  if (runBtn) runBtn.disabled = rec.running;
+  // running 中でも 「再実行」 で旧キューをキャンセル + 上書き開始できるよう
+  // 押下可能にする。 ラベルは状況に応じて切替。
+  if (runBtn) {
+    runBtn.disabled = false;
+    runBtn.textContent = rec.running ? '↻ 再実行 (キュー上書き)' : 'いま生成 (5–30 分)';
+  }
 
   if (runMeta) {
     runMeta.textContent = rec.run
@@ -4158,6 +4170,11 @@ function renderTrendKeywords(items) {
   }).join('');
 }
 
+// 小数第 2 位を切り上げて第 1 位までに丸める。 5.21 → 5.3 / 5.30 → 5.3。
+function ceilTenth(x: number): string {
+  return (Math.ceil((Number(x) || 0) * 10) / 10).toFixed(1);
+}
+
 function renderTrendWorkHours(items) {
   const el = $('trendWorkHours');
   if (!el) return;
@@ -4170,13 +4187,17 @@ function renderTrendWorkHours(items) {
     ...d,
     hours: Number(d.minutes || 0) / 60,
   }));
-  el.innerHTML = svgHorizontalBar(
+  // 週合計 = 直近 7 日 (日記未生成日は present から落ちる)
+  const last7 = presentHours.slice(-7);
+  const weeklyHours = last7.reduce((s, d) => s + (d.hours || 0), 0);
+  const weeklyLabel = `<div class="trend-weekly-summary">週合計 (直近 ${last7.length} 日): <b>${ceilTenth(weeklyHours)}時間</b></div>`;
+  el.innerHTML = weeklyLabel + svgHorizontalBar(
     presentHours,
     (d) => String(d.date || '').slice(5),
     (d) => Number(d.hours || 0),
     '時間',
     {
-      valueLabel: (v) => `${v.toFixed(1)} 時間`,
+      valueLabel: (v) => `${ceilTenth(v)}時間`,
     }
   );
 }
@@ -4196,35 +4217,130 @@ function wireTaskEditorDueShortcuts() {
 }
 
 function renderTrendGpsWalking(items) {
-  // items: [{date, distance_km, walking_minutes, travel_minutes}]
-  const distEl = $('trendWalkDistance');
-  const minsEl = $('trendWalkMinutes');
-  if (!distEl && !minsEl) return;
+  // items: [{date, distance_km, walking_minutes, travel_minutes,
+  //          home_minutes, away_minutes, away_moving_minutes,
+  //          away_places: [{name, minutes}], away_unknown_minutes}]
+  const calEl = $('trendWalkCalories');
+  const awayEl = $('trendAwayStacked');
+  if (!calEl && !awayEl) return;
 
   const list = items || [];
-  const hasAny = list.some(d => d.distance_km > 0 || d.walking_minutes > 0);
+  const hasAny = list.some(d => d.distance_km > 0 || (d.away_minutes || 0) > 0);
   if (!hasAny) {
-    if (distEl) distEl.innerHTML = '<div class="queue-empty">GPS 軌跡が記録されていません</div>';
-    if (minsEl) minsEl.innerHTML = '<div class="queue-empty">GPS 軌跡が記録されていません</div>';
+    if (calEl) calEl.innerHTML = '<div class="queue-empty">GPS 軌跡が記録されていません</div>';
+    if (awayEl) awayEl.innerHTML = '<div class="queue-empty">GPS 軌跡が記録されていません</div>';
     return;
   }
-  if (distEl) {
-    const data = list.map(d => ({ date: d.date, value: d.distance_km, raw: d }));
-    distEl.innerHTML = renderLineChartSvg(data, {
-      yLabel: (v) => `${v.toFixed(1)}km`,
-      pointLabel: (d) => `${d.date} : ${d.value.toFixed(2)} km (歩行 ${d.raw.walking_minutes} 分 / 移動 ${d.raw.travel_minutes} 分)`,
+
+  // 消費カロリー (徒歩): kcal = METs × 体重kg × 時間h で算出。
+  // 徒歩 = 3.5 METs (moderate)、 時間は walking_minutes / 60。
+  // 体重未登録は 60kg。 距離 (distance_km) は vehicle 含むので使わず、
+  // 速度フィルタ済の walking_minutes / walking_distance_km を根拠にする。
+  if (calEl) {
+    const weightKg = Number(state.config?.user_profile?.weight_kg) || 60;
+    const MET_WALK = 3.5;
+    const data = list.map(d => {
+      const hours = (d.walking_minutes || 0) / 60;
+      const kcal = MET_WALK * weightKg * hours;
+      return { date: d.date, value: kcal, raw: { ...d, weightKg } };
     });
-    attachLineChartTooltip(distEl);
+    calEl.innerHTML = renderLineChartSvg(data, {
+      yLabel: (v) => `${Math.round(v)} kcal`,
+      pointLabel: (d) => `${d.date} : ${d.value.toFixed(0)} kcal (徒歩 ${d.raw.walking_minutes} 分 / ${(d.raw.walking_distance_km || 0).toFixed(2)} km × 体重 ${d.raw.weightKg}kg × 3.5 MET)`,
+    });
+    attachLineChartTooltip(calEl);
   }
-  if (minsEl) {
-    const data = list.map(d => ({ date: d.date, value: d.walking_minutes, raw: d }));
-    minsEl.innerHTML = renderLineChartSvg(data, {
-      yLabel: (v) => `${Math.round(v)}分`,
-      pointLabel: (d) => `${d.date} : 歩行 ${d.value} 分 (距離 ${d.raw.distance_km.toFixed(2)} km / 移動 ${d.raw.travel_minutes} 分)`,
-    });
-    attachLineChartTooltip(minsEl);
+
+  if (awayEl) {
+    awayEl.innerHTML = renderAwayStackedBar(list);
   }
 }
+
+// 自宅以外にいた時間 を 面積 (積み上げ) 棒グラフ で描画する。
+// 各日 = [移動, 場所A, 場所B, ..., 不明] の積み上げ。
+// 場所は出現回数が多い上位 6 件 + 「その他」 に折り畳む。
+function renderAwayStackedBar(list: Loose[]): string {
+  if (!list.length) return '<div class="queue-empty">データなし</div>';
+  // 全期間集計で 主要 6 場所 を決める
+  const placeTotals = new Map<string, number>();
+  for (const d of list) {
+    for (const p of (d.away_places || [])) {
+      placeTotals.set(p.name, (placeTotals.get(p.name) || 0) + (p.minutes || 0));
+    }
+  }
+  const topPlaces = [...placeTotals.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 6)
+    .map(([name]) => name);
+
+  // 各日の segment を [移動, 場所1, 場所2, ..., 場所N (= 上位以外+不明)] の順で並べる
+  const segments = ['移動', ...topPlaces, '不明 (場所未登録)'];
+  // 色 palette (面積棒で隣同士を区別できるよう低彩度)
+  const colors = ['#5b9bd5', '#70ad47', '#ed7d31', '#7030a0', '#ffc000', '#264478', '#9e480e', '#a5a5a5'];
+
+  // 各日 stack 値を算出
+  const stacks = list.map(d => {
+    const otherPlaceTotal = (d.away_places || [])
+      .filter(p => !topPlaces.includes(p.name))
+      .reduce((s, p) => s + (p.minutes || 0), 0);
+    const placeBuckets = topPlaces.map(name => {
+      const hit = (d.away_places || []).find(p => p.name === name);
+      return hit ? (hit.minutes || 0) : 0;
+    });
+    const values = [
+      d.away_moving_minutes || 0,
+      ...placeBuckets,
+      (d.away_unknown_minutes || 0) + otherPlaceTotal,
+    ];
+    const total = values.reduce((s, v) => s + v, 0);
+    return { date: d.date, values, total };
+  });
+  const maxTotal = Math.max(1, ...stacks.map(s => s.total));
+
+  // SVG レイアウト
+  const w = 700, padTop = 20, padBottom = 40, padLeft = 80, padRight = 16;
+  const barH = 18, barGap = 4;
+  const innerW = w - padLeft - padRight;
+  const h = padTop + padBottom + stacks.length * (barH + barGap);
+
+  const bars = stacks.map((s, i) => {
+    const y = padTop + i * (barH + barGap);
+    let x = padLeft;
+    const segs = s.values.map((v, j) => {
+      if (v <= 0) return '';
+      const len = (v / maxTotal) * innerW;
+      const seg = `<rect x="${x}" y="${y}" width="${len}" height="${barH}" fill="${colors[j % colors.length]}" data-label="${escapeHtml(`${s.date} ${segments[j]}: ${formatMinutes(v)}`)}"><title>${s.date} ${segments[j]}: ${formatMinutes(v)}</title></rect>`;
+      x += len;
+      return seg;
+    }).join('');
+    const dateLabel = String(s.date || '').slice(5);
+    const totalLabel = s.total > 0 ? formatMinutes(s.total) : '—';
+    return `
+      <g>
+        <text x="${padLeft - 8}" y="${y + barH * 0.72}" text-anchor="end" font-size="11" fill="#666">${escapeHtml(dateLabel)}</text>
+        ${segs}
+        <text x="${x + 4}" y="${y + barH * 0.72}" font-size="11" fill="#666">${escapeHtml(totalLabel)}</text>
+      </g>`;
+  }).join('');
+
+  // 凡例
+  const legend = segments.map((name, j) =>
+    `<span class="away-legend-item"><span class="away-legend-swatch" style="background:${colors[j % colors.length]}"></span>${escapeHtml(name)}</span>`
+  ).join('');
+
+  return `
+    <div class="away-legend">${legend}</div>
+    <svg viewBox="0 0 ${w} ${h}" preserveAspectRatio="xMinYMin meet">${bars}</svg>
+  `;
+}
+
+function formatMinutes(min: number): string {
+  const m = Math.round(Number(min) || 0);
+  if (m < 60) return `${m}分`;
+  const h = Math.floor(m / 60), mm = m % 60;
+  return mm === 0 ? `${h}時間` : `${h}時間${mm}分`;
+}
+
 
 function renderTrendGithub(payload) {
   const card = $('trendGithubCard');
@@ -4259,7 +4375,7 @@ function renderTrendGithub(payload) {
 function svgHorizontalBar(items, labelFn, valueFn, klass = '', opts: Loose = {}) {
   if (!items.length) return '<div class="queue-empty">データなし</div>';
   const max = Math.max(...items.map(valueFn), 1);
-  const rowH = 22, padTop = 4, padLeft = 130, padRight = 40, w = 460;
+  const rowH = 22, padTop = 4, padLeft = 130, padRight = 60, w = 480;
   const h = padTop * 2 + items.length * rowH;
   const rows = items.map((it, i) => {
     const v = valueFn(it);
@@ -4268,12 +4384,15 @@ function svgHorizontalBar(items, labelFn, valueFn, klass = '', opts: Loose = {})
     const label = String(labelFn(it)).slice(0, 18);
     const attr = opts.rowAttr ? opts.rowAttr(it) : '';
     const rowClass = opts.rowClass || '';
+    // opts.valueLabel(v) で表示テキストを差し替えられるようにする
+    // (= 「5.3時間」 のように単位付き / 切り上げ整形)
+    const valText = opts.valueLabel ? opts.valueLabel(v) : String(v);
     return `
       <g class="bar-row ${rowClass}" ${attr}>
         <rect class="bar-hit" x="0" y="${y}" width="${w}" height="${rowH}" fill="transparent" />
         <text class="label" x="${padLeft - 8}" y="${y + 14}" text-anchor="end">${escapeHtml(label)}</text>
         <rect class="bar ${klass}" x="${padLeft}" y="${y + 4}" width="${len}" height="14" rx="2" />
-        <text class="label" x="${padLeft + len + 6}" y="${y + 14}">${v}</text>
+        <text class="label" x="${padLeft + len + 6}" y="${y + 14}">${escapeHtml(valText)}</text>
       </g>
     `;
   }).join('');
@@ -5240,6 +5359,8 @@ async function selectDataSource(url) {
     if (j.needs_login) {
       const urlInput = $('multiLoginUrl') as HTMLInputElement | null;
       if (urlInput && j.url) urlInput.value = j.url;
+      const urlDisplay = $('multiLoginUrlDisplay');
+      if (urlDisplay && j.url) urlDisplay.textContent = j.url;
       switchTab('multi');
       return;
     }
@@ -5332,9 +5453,11 @@ function renderMultiServersList(s) {
 async function multiServerAction(action, url) {
   if (action === 'connect') {
     // Cernere ログインは Multi タブのフォームで行う (= OAuth dance 廃止)。
-    // URL を pre-fill しておいてタブを切り替える。
+    // URL を hidden field と display に流して タブを切り替える。
     const urlInput = $('multiLoginUrl') as HTMLInputElement | null;
     if (urlInput) urlInput.value = url;
+    const urlDisplay = $('multiLoginUrlDisplay');
+    if (urlDisplay) urlDisplay.textContent = url;
     switchTab('multi');
     return;
   }
@@ -8884,7 +9007,9 @@ $('wlGeminiWebContent')?.addEventListener('keydown', (e) => {
 function refreshMultiTabVisibility() {
   const visible = !!state.multi?.connected;
   document.querySelectorAll('.tab-multi-only').forEach(t => { (t as HTMLElement).hidden = !visible; });
-  if (!visible && state.tab === 'multi') switchTab('database');
+  // 未接続でも multi タブに居る場合 (= Hub login をしようとしている) はそのまま居らせる。
+  // 旧仕様では database へ自動リダイレクトしていたが、 二層設計では multi タブは
+  // login フォーム専用ビューなので、 未接続 = 表示すべき状態 になる。
   if (visible) {
     const badge = $('multiUserBadge');
     if (badge) badge.textContent = `🌐 ${state.multi.user.name} (${state.multi.user.role})`;
@@ -8895,30 +9020,27 @@ function refreshMultiTabVisibility() {
 // Hub ログインフォームを出す。 旧 browse 部 (#multiMainContent) は常に隠す。
 async function loadMulti() {
   refreshMultiTabVisibility();
-  let infiConfigured = true;
-  try {
-    const st = await api('/api/setup/infisical/status') as { configured?: boolean };
-    infiConfigured = st.configured !== false;
-  } catch { infiConfigured = true; }
-  const setupEl = $('multiInfisicalSetup');
+  // Local Memoria は Infisical を使わないので、 旧 multiInfisicalSetup の
+  // 出し分けは廃止。 Hub ログインフォームを常に表示する。
   const loginEl = $('multiCernereLogin');
   const mainEl = $('multiMainContent');
   mainEl?.classList.add('hidden');
-  if (!infiConfigured) {
-    setupEl?.classList.remove('hidden');
-    loginEl?.classList.add('hidden');
-    return;
-  }
-  setupEl?.classList.add('hidden');
   loginEl?.classList.remove('hidden');
-  // Hub URL 欄に登録済 server を pre-fill
+  // Hub URL は hidden field に保持。 表示は #multiLoginUrlDisplay に流す。
   const urlInput = $('multiLoginUrl') as HTMLInputElement | null;
+  const urlDisplay = $('multiLoginUrlDisplay');
   const firstUrl = state.multi?.servers?.[0]?.url;
   if (urlInput && firstUrl && !urlInput.value) urlInput.value = firstUrl;
+  if (urlDisplay) urlDisplay.textContent = (urlInput?.value || firstUrl || '— (Hub が未登録)');
 }
 
 // Hub ログインフォーム (#multiView 内) の送信。 成功したら selectDataSource で
 // その Hub を Multi モードのデータソースに切り替える。
+// Cernere Composite SSO popup flow.
+// 1) Local /api/multi/login-url で Cernere popup URL を取得
+// 2) window.open() で popup を開く
+// 3) postMessage({ type: 'cernere:auth', authCode }) を Cernere popup から受け取る
+// 4) Local /api/multi/exchange に authCode を渡して session を確立
 document.getElementById('multiLoginSubmit')?.addEventListener('click', async () => {
   const btn = $('multiLoginSubmit') as HTMLButtonElement | null;
   const msg = $('multiLoginMsg');
@@ -8928,69 +9050,85 @@ document.getElementById('multiLoginSubmit')?.addEventListener('click', async () 
     msg.style.color = ok ? '#1f7a1f' : '#c0392b';
     msg.hidden = false;
   };
-  const url = ($('multiLoginUrl') as HTMLInputElement).value.trim();
-  const email = ($('multiLoginEmail') as HTMLInputElement).value.trim();
-  const password = ($('multiLoginPassword') as HTMLInputElement).value;
-  if (!url || !email || !password) {
-    return setMsg('⚠ Hub URL / メールアドレス / パスワードは必須');
-  }
+  const url = (($('multiLoginUrl') as HTMLInputElement)?.value || state.multi?.servers?.[0]?.url || '').trim().replace(/\/$/, '');
+  if (!url) return setMsg('⚠ Hub が登録されていません。 設定タブから Hub を追加してください');
   if (btn) { btn.disabled = true; btn.textContent = 'ログイン中…'; }
+  let popup: Window | null = null;
+  let onMessage: ((ev: MessageEvent) => void) | null = null;
+  let popupWatch: number | null = null;
+  const cleanup = () => {
+    if (onMessage) window.removeEventListener('message', onMessage);
+    if (popupWatch != null) clearInterval(popupWatch);
+    if (popup && !popup.closed) { try { popup.close(); } catch { /* ignore */ } }
+    if (btn) { btn.disabled = false; btn.textContent = '🔐 Cernere でログイン'; }
+  };
   try {
-    const res = await fetch('/api/multi/login', {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ url, email, password }),
+    // 1. Cernere の popup URL を Local server 経由で取得 (= Hub に問い合わせ)
+    const luQs = `url=${encodeURIComponent(url)}&origin=${encodeURIComponent(window.location.origin)}`;
+    const luRes = await fetch(`/api/multi/login-url?${luQs}`);
+    const luData = await luRes.json() as { url?: string; error?: string };
+    if (!luRes.ok || !luData.url) {
+      setMsg(`⚠ ${luData.error || `login-url 取得失敗: ${luRes.status}`}`);
+      cleanup();
+      return;
+    }
+    // 2. popup を中央寄せで開く (500x700)
+    const w = 500, h = 700;
+    const x = Math.max(0, window.screenX + (window.outerWidth - w) / 2);
+    const y = Math.max(0, window.screenY + (window.outerHeight - h) / 2);
+    popup = window.open(
+      luData.url, 'cernere-login',
+      `width=${w},height=${h},left=${x},top=${y}`,
+    );
+    if (!popup) {
+      setMsg('⚠ popup が開けませんでした (ブラウザのポップアップブロック?)');
+      cleanup();
+      return;
+    }
+    setMsg('Cernere ログインを popup で開きました');
+
+    // 3. postMessage で authCode を受け取る
+    const expectedOrigin = new URL(luData.url).origin;
+    await new Promise<void>((resolve, reject) => {
+      onMessage = (ev: MessageEvent) => {
+        if (ev.origin !== expectedOrigin) return;
+        const m = ev.data as { type?: string; authCode?: string };
+        if (m?.type !== 'cernere:auth' || !m.authCode) return;
+        (async () => {
+          try {
+            const exRes = await fetch('/api/multi/exchange', {
+              method: 'POST', headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ url, authCode: m.authCode }),
+            });
+            const exData = await exRes.json() as { user?: { displayName?: string }; error?: string };
+            if (!exRes.ok) {
+              setMsg(`⚠ ${exData.error || `exchange 失敗: ${exRes.status}`}`);
+              return reject(new Error('exchange failed'));
+            }
+            setMsg(`✓ ${exData.user?.displayName || ''} としてログインしました`, true);
+            await refreshMultiStatus();
+            setTimeout(() => { void selectDataSource(url); }, 400);
+            resolve();
+          } catch (e) { reject(e); }
+        })();
+      };
+      window.addEventListener('message', onMessage);
+      // popup が閉じられたら abort
+      popupWatch = window.setInterval(() => {
+        if (popup && popup.closed) reject(new Error('popup closed by user'));
+      }, 500);
     });
-    const j = await res.json() as { user?: { displayName?: string }; error?: string };
-    if (!res.ok) { setMsg(`⚠ ${j.error || res.status}`); return; }
-    setMsg(`✓ ${j.user?.displayName || ''} としてログインしました`, true);
-    ($('multiLoginPassword') as HTMLInputElement).value = '';
-    await refreshMultiStatus();
-    // ログイン成功 → そのままその Hub をデータソースに切り替える (Multi モードへ)。
-    setTimeout(() => { void selectDataSource(url); }, 400);
   } catch (e: unknown) {
     setMsg(`⚠ ${(e as Error).message}`);
   } finally {
-    if (btn) { btn.disabled = false; btn.textContent = 'ログイン'; }
+    cleanup();
   }
 });
 
 // Infisical setup フォーム (Multi view 内) の送信。 成功したら loadMulti を
 // 呼び直して通常の Hub 内容に切り替える。
-document.getElementById('infiSetupSubmit')?.addEventListener('click', async () => {
-  const btn = $('infiSetupSubmit') as HTMLButtonElement | null;
-  const msg = $('infiSetupMsg');
-  const setMsg = (text: string, ok = false) => {
-    if (!msg) return;
-    msg.textContent = text;
-    msg.style.color = ok ? '#1f7a1f' : '#c0392b';
-    msg.hidden = false;
-  };
-  const body = {
-    siteUrl: ($('infiSiteUrl') as HTMLInputElement).value.trim(),
-    projectId: ($('infiProjectId') as HTMLInputElement).value.trim(),
-    environment: ($('infiEnvironment') as HTMLInputElement).value.trim() || 'dev',
-    clientId: ($('infiClientId') as HTMLInputElement).value.trim(),
-    clientSecret: ($('infiClientSecret') as HTMLInputElement).value.trim(),
-  };
-  if (!body.siteUrl || !body.projectId || !body.clientId || !body.clientSecret) {
-    return setMsg('⚠ Site URL / Project ID / Client ID / Client Secret は必須');
-  }
-  if (btn) { btn.disabled = true; btn.textContent = '接続中…'; }
-  try {
-    const res = await fetch('/api/setup/infisical', {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    });
-    const j = await res.json() as { injected?: number; error?: string };
-    if (!res.ok) { setMsg(`⚠ ${j.error || res.status}`); return; }
-    setMsg(`✓ ${j.injected ?? 0} 件の secret を取得しました`, true);
-    setTimeout(() => { void loadMulti(); }, 900);
-  } catch (e: unknown) {
-    setMsg(`⚠ ${(e as Error).message}`);
-  } finally {
-    if (btn) { btn.disabled = false; btn.textContent = '接続して保存'; }
-  }
-});
+// Local Memoria は Infisical を直接知らない設計に統一済 — 旧 infiSetupSubmit
+// ハンドラ + /api/setup/infisical 経路は撤去された。
 
 // First paint: surface the multi tab if we're already connected.
 refreshMultiTabVisibility();

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -3074,6 +3074,13 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
  * ────────────────────────────────────────────────────────────────────── */
 .trend-help { font-size: 16px; color: var(--muted); margin: 0 0 16px; line-height: 1.55; }
 
+.trend-weekly-summary { font-size: 14px; color: var(--fg); margin: 0 0 12px; padding: 8px 12px; background: var(--bg-alt, rgba(0,0,0,0.04)); border-radius: 6px; }
+.trend-weekly-summary b { font-size: 16px; }
+
+.away-legend { display: flex; flex-wrap: wrap; gap: 12px 18px; margin: 0 0 10px; font-size: 12px; color: var(--muted); }
+.away-legend-item { display: inline-flex; align-items: center; gap: 6px; }
+.away-legend-swatch { display: inline-block; width: 12px; height: 12px; border-radius: 2px; }
+
 .trend-categories-chart .bar-row.clickable:hover .bar { fill: var(--accent); }
 .trend-categories-chart .bar-row.clickable:hover .label { fill: var(--accent); font-weight: 600; }
 .bar-row.clickable { cursor: pointer; }

--- a/server/recommendations-ai.ts
+++ b/server/recommendations-ai.ts
@@ -14,7 +14,7 @@ import {
   recRecentBookmarks, recBrowserHistory, recGitCommits, recClaudePrompts,
   recGamesLastWeek, recAppsLastWeek, recRecentNotes, recRecentDigs,
   insertRecommendationRun, completeRecommendationRun, failRecommendationRun,
-  findRunningRecommendationRun,
+  findRunningRecommendationRun, cancelRunningRecommendationRuns,
   type RecSourceBookmark, type RecBrowserDomain, type RecGitCommit,
   type RecClaudePrompt, type RecGameSummary, type RecAppSummary,
   type RecNoteSummary, type RecDigSummary,
@@ -313,21 +313,51 @@ function parseSynthesisItems(raw: string): RecResultItem[] {
 
 // ── pipeline ──────────────────────────────────────────────────────────────
 
-let inFlight: Promise<RecRunResult> | null = null;
+// inFlight は「現在キューにある run」 の promise + runId を保持する。
+// cancel 時に runId を確定的に DB へ cancelled として書き込みたいので、
+// promise だけでなく id も対で持つ。 force = true で新規 run を開始する際
+// は abandon (= ポインタを差し替え) する: 旧 promise の処理は走り続けるが、
+// completeRecommendationRun の WHERE status='running' で db 上書きされない。
+let inFlight: { runId: number; promise: Promise<RecRunResult> } | null = null;
 
 export function isRecommendationsRunning(db: Db): boolean {
   return inFlight !== null || !!findRunningRecommendationRun(db);
 }
 
-export async function runAiRecommendations(db: Db): Promise<RecRunResult> {
-  if (inFlight) return inFlight;
+/**
+ * 現在 running の run を強制的に cancelled へ遷移させる。
+ * - in-memory inFlight ハンドルをクリア (= 後続の run はブロックされなくなる)
+ * - DB の running 行を全て 'cancelled' に更新 (= isRecommendationsRunning 解除)
+ *
+ * 実際の LLM 呼び出しを中断する手段は持っていないので、 abandon された
+ * 旧 run はバックグラウンドで完了するが、 completeRecommendationRun の
+ * WHERE status='running' により DB 上書きは行われない。
+ */
+export function cancelAiRecommendations(db: Db, reason = 'user_cancelled'): { dbCancelled: number; hadInFlight: boolean } {
+  const hadInFlight = inFlight !== null;
+  inFlight = null;
+  const dbCancelled = cancelRunningRecommendationRuns(db, reason);
+  return { dbCancelled, hadInFlight };
+}
+
+export async function runAiRecommendations(db: Db, options: { force?: boolean } = {}): Promise<RecRunResult> {
+  if (inFlight && !options.force) return inFlight.promise;
+  if (inFlight && options.force) {
+    // 旧 run を abandon。 DB 側も cancelled に倒す。
+    cancelAiRecommendations(db, 'superseded_by_force_run');
+  } else if (options.force) {
+    // inFlight は空でも、 server 再起動で DB に取り残された 'running' がある
+    // 可能性がある。 force なら必ず掃除してから始める。
+    cancelRunningRecommendationRuns(db, 'superseded_by_force_run');
+  }
   const avail = isAiRecommendationsAvailable();
   if (!avail.available) throw new Error(avail.reason);
-  inFlight = (async () => {
-    const cfg = getLlmConfig();
-    const modelSonnet = cfg.tasks.recommendation_agent?.model || 'sonnet';
-    const modelOpus = cfg.tasks.recommendation_synthesize?.model || 'claude-opus-4-7[1m]';
-    const runId = insertRecommendationRun(db);
+  const cfg = getLlmConfig();
+  const modelSonnet = cfg.tasks.recommendation_agent?.model || 'sonnet';
+  const modelOpus = cfg.tasks.recommendation_synthesize?.model || 'claude-opus-4-7[1m]';
+  const runId = insertRecommendationRun(db);
+  const handle = { runId, promise: undefined as unknown as Promise<RecRunResult> };
+  const promise = (async () => {
     try {
       const jobs = buildAgentJobs(db);
       const agentLogs: RecAgentLog[] = await Promise.all(jobs.map(async (j): Promise<RecAgentLog> => {
@@ -362,6 +392,12 @@ export async function runAiRecommendations(db: Db): Promise<RecRunResult> {
       failRecommendationRun(db, runId, msg);
       throw e;
     }
-  })().finally(() => { inFlight = null; });
-  return inFlight;
+  })().finally(() => {
+    // 自分が現役の handle のときだけ clear。 superseded されている場合は
+    // 既に inFlight = null か別の run に置き換わっているので触らない。
+    if (inFlight && inFlight.runId === runId) inFlight = null;
+  });
+  handle.promise = promise;
+  inFlight = handle;
+  return promise;
 }

--- a/server/routes/multi.ts
+++ b/server/routes/multi.ts
@@ -13,7 +13,7 @@ import {
   readMultiState, isConnected,
   readMultiServers, persistServers, upsertServer, removeServer, findServerByUrl,
   saveServerSession, clearServerSession, setActive,
-  readMode, setMode, hubFetch, hubLogin,
+  readMode, setMode, hubFetch,
 } from '../local/multi-client.js';
 import { resolveUnresolvedBatch, getResolverDebug } from '../lib/place-resolver.js';
 import { featureEnabled } from '../lib/privacy.js';
@@ -87,20 +87,43 @@ export function makeMultiRouter(deps: MultiRouterDeps): Hono {
 
   // ── 二層設計: Hub に対するログイン ────────────────────────────────────
   //
-  // 旧: ローカルが Cernere に直ログイン (CERNERE_BASE_URL を 1 つしか持てず、
-  //     複数拠点 Hub に対応できなかった)。
-  // 新: ローカルは Cernere を一切知らない。 Hub の /api/auth/login に
-  //     email/password を渡すだけ。 Hub が自分の Infisical 由来の
-  //     CERNERE_BASE_URL で Cernere に代理ログインし、 session token を返す。
-  //     ローカルはその session token を per-hub に保存する。
-  r.post('/api/multi/login', async (c: Context) => {
+  // Cernere Composite SSO flow:
+  //   1) フロントが GET /api/multi/login-url?url=<hub> で Cernere popup URL を取得
+  //   2) フロントが popup を開く → ユーザが Cernere の native UI (Passkey / Password /
+  //      OAuth / MFA) でログイン → popup が postMessage({ authCode }) を投げる
+  //   3) フロントが POST /api/multi/exchange { url, authCode } → Local server 経由で
+  //      Hub /api/auth/exchange に code を渡す → service_token を取得して per-hub に保存
+  //
+  // Local は Cernere も email/password も触らない (= 「ログイン処理の独自実装ゼロ」)。
+
+  r.get('/api/multi/login-url', async (c: Context) => {
+    const hubUrl = (c.req.query('url') || '').trim().replace(/\/$/, '');
+    if (!hubUrl) return c.json({ error: 'url required' }, 400);
+    // popup の postMessage 戻り先は Local Memoria の origin (= ブラウザの window.location.origin)。
+    // Local server 側からは知れないので、 フロントが追加 query で渡してもらう。
+    const origin = (c.req.query('origin') || '').trim();
+    try {
+      const qs = origin ? `?origin=${encodeURIComponent(origin)}` : '';
+      const res = await fetch(`${hubUrl}/api/auth/login-url${qs}`);
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        return c.json({ error: `Hub login-url 取得失敗: ${res.status}`, detail: body.slice(0, 200) }, 502);
+      }
+      const data = await res.json() as { url?: string };
+      if (!data.url) return c.json({ error: 'Hub が login url を返しませんでした' }, 502);
+      return c.json({ url: data.url });
+    } catch (e: unknown) {
+      return c.json({ error: `Hub に到達できません: ${(e as Error).message}` }, 502);
+    }
+  });
+
+  r.post('/api/multi/exchange', async (c: Context) => {
     const body = await c.req.json().catch(() => null) as
-      { url?: unknown; email?: unknown; password?: unknown; label?: unknown } | null;
+      { url?: unknown; authCode?: unknown; label?: unknown } | null;
     const url = typeof body?.url === 'string' ? body.url.trim().replace(/\/$/, '') : '';
-    const email = typeof body?.email === 'string' ? body.email.trim() : '';
-    const password = typeof body?.password === 'string' ? body.password : '';
+    const authCode = typeof body?.authCode === 'string' ? body.authCode.trim() : '';
     if (!url) return c.json({ error: 'url required' }, 400);
-    if (!email || !password) return c.json({ error: 'email / password required' }, 400);
+    if (!authCode) return c.json({ error: 'authCode required' }, 400);
 
     // 1. server を登録 (未登録なら)
     const { servers, active } = readMultiServers(db);
@@ -108,14 +131,32 @@ export function makeMultiRouter(deps: MultiRouterDeps): Hono {
       ? body.label : (findServerByUrl(servers, url)?.label || url);
     persistServers(db, upsertServer(servers, { url, label }), active);
 
-    // 2. Hub の /api/auth/login に代理ログインを依頼
+    // 2. Hub に authCode を渡して service_token を取得
     let result;
     try {
-      result = await hubLogin(url, email, password);
+      const res = await fetch(`${url}/api/auth/exchange`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ authCode }),
+      });
+      const data = await res.json().catch(() => ({})) as {
+        sessionToken?: string;
+        user?: { userId?: string | null; displayName?: string; role?: string };
+        error?: string;
+      };
+      if (!res.ok || !data.sessionToken) {
+        return c.json({ error: data.error || `Hub exchange 失敗: HTTP ${res.status}` }, res.status as 401);
+      }
+      result = {
+        sessionToken: data.sessionToken,
+        user: {
+          userId: data.user?.userId ?? null,
+          displayName: data.user?.displayName || '(unknown)',
+          role: data.user?.role || 'general',
+        },
+      };
     } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : String(e);
-      const status = (e as { status?: number })?.status ?? 502;
-      return c.json({ error: `Hub ログイン失敗: ${msg}` }, status as 401);
+      return c.json({ error: `Hub に到達できません: ${(e as Error).message}` }, 502);
     }
 
     // 3. session token を per-hub に保存

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -25,6 +25,7 @@ import { shouldSkipDomain } from '../domain-catalog.js';
 import { featureEnabled } from '../lib/privacy.js';
 import {
   runAiRecommendations, isAiRecommendationsAvailable, isRecommendationsRunning,
+  cancelAiRecommendations,
   type RecResultItem, type RecAgentLogBundle,
 } from '../recommendations-ai.js';
 import { fetchGithubRange } from '../diary.js';
@@ -202,15 +203,30 @@ export function makeVisitRouter(deps: VisitRouterDeps): Hono {
     });
   });
 
-  r.post('/api/recommendations/run', (c: Context) => {
+  r.post('/api/recommendations/run', async (c: Context) => {
     const avail = isAiRecommendationsAvailable();
     if (!avail.available) return c.json({ error: avail.reason }, 400);
-    if (isRecommendationsRunning(db)) return c.json({ error: 'already_running' }, 409);
+    // body.force=true で既存のキューを cancel して新規実行を開始する。
+    // (= キューが詰まって動かなくなった時に再実行で上書きするための逃げ道)
+    let force = false;
+    try {
+      const body = await c.req.json().catch(() => null);
+      force = !!(body && (body.force === true || body.force === 'true' || body.force === 1));
+    } catch { /* 空 body は OK */ }
+    if (!force && isRecommendationsRunning(db)) return c.json({ error: 'already_running' }, 409);
     // Fire-and-forget。 ユーザは status を polling する。
-    void runAiRecommendations(db).catch(err => {
+    void runAiRecommendations(db, { force }).catch(err => {
       console.error('[recommendations] run failed:', err instanceof Error ? err.message : err);
     });
-    return c.json({ ok: true, started: true });
+    return c.json({ ok: true, started: true, forced: force });
+  });
+
+  // 詰まったキューを掃除する明示的なエンドポイント。
+  // - in-memory inFlight ハンドルをクリア
+  // - DB の 'running' 行を 'cancelled' に更新
+  r.post('/api/recommendations/cancel', (c: Context) => {
+    const r2 = cancelAiRecommendations(db, 'user_cancelled');
+    return c.json({ ok: true, ...r2 });
   });
 
   r.get('/api/recommendations/runs', (c: Context) => {

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -23,6 +23,8 @@
     "node_modules",
     "multi/node_modules",
     "public/**/*",
-    "data/**/*"
+    "data/**/*",
+    "env-cli.config.ts",
+    "multi/env-cli.config.ts"
   ]
 }


### PR DESCRIPTION
## Summary

このブランチは元々 `env-cli` の双方向同期 (Memoria local + Hub) を入れる予定だったが、 そのまま Cernere Composite SSO 化 / Hub ログインフロー全面刷新 / AI 推薦キューの zombie 対策 / 傾向タブの再設計まで一気通貫で進めたので 1 PR に集約する。

### 1. env-cli 双方向同期 (初回コミット 16bd792 + dd927e1)
- Memoria local / Hub に `env-cli` config + npm scripts を追加
- 設定フォーム入力 ↔ env-cli の双方向同期

### 2. Cernere Composite SSO (Hub ログイン)
- 旧 email/password 代理ログイン (`cernere-login.js`) を撤去し、 `@ludiars/cernere-composite` 経由の popup + postMessage + authCode 交換フローに統一。
- Memoria Local の Infisical bootstrap を完全削除 (Hub 側で env-cli 管理)。
- Hub URL は hidden field + muted 表示 (登録済 URL を自動使用、 入力欄なし)。
- `multi/Dockerfile`: `packages/composite` を sparse-checkout + build に追加、 registry に無い `service-adapter` dep を file: spec に書き換え。
- `docker-compose.yml`: hub サービスに `env_file: .env` を追加。

### 3. AI 推薦キューの強制上書き
- `POST /api/recommendations/run` に `{ force: true }` を追加。 旧キュー (in-flight + DB 'running') を cancel した上で新規実行を開始。 zombie で詰まったキューを 「再実行」 で抜け出せるようにする。
- `POST /api/recommendations/cancel` を新設 (強制 clear のみ)。
- `completeRecommendationRun` / `failRecommendationRun` に `WHERE status='running'` を付与し、 abandoned 旧 run が遅れて完了しても DB 上書きを起こさない。
- UI: running 中でも 「↻ 再実行 (キュー上書き)」 ボタンを押下可能に。

### 4. 傾向タブ改善
- 期間デフォルトを 7 日に変更。
- **1 日の作業時間**: 小数第 2 位を切り上げ (5.21 → 5.3時間)。 svgHorizontalBar の `opts.valueLabel` を実装に反映 (バグ修正)。 週合計時間を card 内ヘッダに併記。
- **1 日の歩いた距離 → 1 日の消費カロリー (徒歩)**: 3.5 MET × 体重 × walking_hours で算出。 体重は `user.weight_kg` 未登録は 60kg。 vehicle 距離は除外。
- **1 日の歩いた時間 → 1 日の自宅以外にいた時間** (積み上げ棒): 移動 / 場所 (work_locations ベース) / 不明 の 3 種で色分け、 上位 6 場所 + その他 を凡例表示。
- `trendsGpsWalking` (db.ts):
  - 連続 2 点間は 「p1 の場所に滞在し続けた」 と仮定 (GPS は移動時のみ点を打つ前提)。
  - dt ≤ 10分 かつ 速度 ≥ 0.5 m/s のみ `away_moving`、 それ以外の gap は p1 の class に倒す。
  - dt > 12時間 はデータ欠落として無視。
  - **`parseUtc` が \"Z\" を二重付与して全 row 弾く既存バグを修正** (recorded_at が ISO + Z 形式の場合に Invalid Date になっていた)。
  - 出力に `home_minutes / away_minutes / away_moving_minutes / away_places / away_unknown_minutes / walking_distance_km` を追加。

### 関連
- Cernere 側の Vite HMR tunnel fix は LUDIARS/Cernere#99 で別 PR

## Test plan
- [x] Memoria Local → Hub ログイン: 「🔐 Cernere でログイン」 → Cernere popup → Passkey / Password / OAuth → service_token 発行 → セッション確立
- [x] AI 推薦 zombie キューが残っている状態で 「↻ 再実行 (キュー上書き)」 → 新規 run 開始 + 旧 run が cancelled に
- [x] 傾向タブ 7 日デフォルト + 作業時間 「5.3時間」 形式 + 週合計表示
- [x] 消費カロリー card が user_profile.weight_kg を使って算出 (vehicle 除外)
- [x] 自宅以外にいた時間 stacked bar が SSS / 国立国会図書館 (work_locations) のセグメントを表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)