### PR TITLE
feat(multi): Local+Hub データ mix + フィルタ chip + 非活性タブ整理

### DIFF
--- a/server/local/multi-proxy.ts
+++ b/server/local/multi-proxy.ts
@@ -1,10 +1,18 @@
-// multi-proxy — Multi モード時、 ローカル backend を Hub の DB 代理にする。
+// multi-proxy — Multi モード時、 ローカル backend を Hub と mix する層。
 //
 // 二層設計 (spec/feature/multi-hub.md §5.3) の proxy 層。 frontend は常に
 // localhost:5180 に話すが、 Multi モードのときは:
-//   - Multi 対応 7 型の CRUD パス  → Hub の /api/data/* に転送
-//   - 個人ログ系のパス             → 503 { error: 'local_only' }
-//   - それ以外 (制御系・インフラ系) → そのまま local routes に通す
+//   - Multi 対応 7 型の **list** パス  → Local の結果 + Hub /api/data/* を mix
+//   - Multi 対応 7 型の **detail** パス → Hub の /api/data/* に転送 (= 旧 proxy)
+//   - 個人ログ系のパス                 → 503 { error: 'local_only' }
+//   - それ以外 (制御系・インフラ系)     → そのまま local routes に通す
+//
+// mix-list: 各 item に
+//   `_origin: 'local' | 'hub'`              — 物理上どこから来たか
+//   `owner_user_id: string | null`           — Hub 上の所有者 (local item は null)
+//   `owner_user_name: string | null`         — 表示名 (local item は null)
+//   `shared_at: string | null`               — Hub に publish された ISO 時刻 (Local も保持)
+// を付与する。 frontend はこれを使って 「自分 / 他ユーザ / 未シェア」 を判別する。
 //
 // Local モードのときは何もせず素通り (= 従来どおり SQLite 直)。
 
@@ -15,54 +23,76 @@ import { readMode, readMultiServers, findServerByUrl, hubFetch } from './multi-c
 type Db = BetterSqlite3.Database;
 
 type MapResult =
+  | { kind: 'mix-list'; hubPath: string }
   | { kind: 'proxy'; hubPath: string }
   | { kind: 'local-only' }
   | { kind: 'passthrough' };
 
 // ローカルの feature パス → Hub /api/data/<type> の対応。
+//   list (= base path) は mix-list、 detail (= /:id) は proxy。
 // Multi 対応型でも、 ここに無い sub-path (/api/bookmarks/:id/html 等) は
 // passthrough になる。 frontend (Phase 5) が Multi モードでは出さない前提。
 function mapToHub(path: string): MapResult {
   let m: RegExpExecArray | null;
 
-  // ── Multi 対応 7 型の基本 CRUD ──
+  // ── Multi 対応 7 型 ──
   // bookmarks
-  if (/^\/api\/bookmarks$/.test(path)) return { kind: 'proxy', hubPath: '/api/data/bookmarks' };
-  if (/^\/api\/bookmark$/.test(path)) return { kind: 'proxy', hubPath: '/api/data/bookmarks' };
+  if (/^\/api\/bookmarks$/.test(path)) return { kind: 'mix-list', hubPath: '/api/data/bookmarks' };
+  if (/^\/api\/bookmark$/.test(path)) return { kind: 'mix-list', hubPath: '/api/data/bookmarks' };
   if ((m = /^\/api\/bookmarks\/(\d+)$/.exec(path))) return { kind: 'proxy', hubPath: `/api/data/bookmarks/${m[1]}` };
   // dig
-  if (/^\/api\/dig$/.test(path)) return { kind: 'proxy', hubPath: '/api/data/digs' };
+  if (/^\/api\/dig$/.test(path)) return { kind: 'mix-list', hubPath: '/api/data/digs' };
   if ((m = /^\/api\/dig\/(\d+)$/.exec(path))) return { kind: 'proxy', hubPath: `/api/data/digs/${m[1]}` };
   // dictionary
-  if (/^\/api\/dictionary$/.test(path)) return { kind: 'proxy', hubPath: '/api/data/dictionary' };
+  if (/^\/api\/dictionary$/.test(path)) return { kind: 'mix-list', hubPath: '/api/data/dictionary' };
   if ((m = /^\/api\/dictionary\/(\d+)$/.exec(path))) return { kind: 'proxy', hubPath: `/api/data/dictionary/${m[1]}` };
   // implementation-notes
-  if (/^\/api\/implementation-notes$/.test(path)) return { kind: 'proxy', hubPath: '/api/data/implementation-notes' };
+  if (/^\/api\/implementation-notes$/.test(path)) return { kind: 'mix-list', hubPath: '/api/data/implementation-notes' };
   if ((m = /^\/api\/implementation-notes\/(\d+)$/.exec(path))) {
     return { kind: 'proxy', hubPath: `/api/data/implementation-notes/${m[1]}` };
   }
   // work-locations
-  if (/^\/api\/work-locations$/.test(path)) return { kind: 'proxy', hubPath: '/api/data/work-locations' };
+  if (/^\/api\/work-locations$/.test(path)) return { kind: 'mix-list', hubPath: '/api/data/work-locations' };
   if ((m = /^\/api\/work-locations\/(\d+)$/.exec(path))) {
     return { kind: 'proxy', hubPath: `/api/data/work-locations/${m[1]}` };
   }
   // domain-catalog (ローカルは domain をキーにするが Hub は id。 list のみ確実に対応)
-  if (/^\/api\/domains$/.test(path)) return { kind: 'proxy', hubPath: '/api/data/domain-catalog' };
+  if (/^\/api\/domains$/.test(path)) return { kind: 'mix-list', hubPath: '/api/data/domain-catalog' };
   if ((m = /^\/api\/domains\/(\d+)$/.exec(path))) return { kind: 'proxy', hubPath: `/api/data/domain-catalog/${m[1]}` };
   // notes (uuid)
-  if (/^\/api\/notes$/.test(path)) return { kind: 'proxy', hubPath: '/api/data/notes' };
+  if (/^\/api\/notes$/.test(path)) return { kind: 'mix-list', hubPath: '/api/data/notes' };
   if ((m = /^\/api\/notes\/([0-9a-fA-F-]{8,})$/.exec(path))) {
     return { kind: 'proxy', hubPath: `/api/data/notes/${m[1]}` };
   }
 
   // ── 個人ログ系 = ローカル専用 (Hub には出さない、 [個人データ保管禁止]) ──
-  if (/^\/api\/(diary|weekly|meals|locations|tracks|legatus|visits|trends|recommendations|activity|weather|transit|review|work-sessions|wifi)(\/|$)/.test(path)) {
+  // worklog / worklist (= tasks / repo dashboard) / packet-monitor も Hub には
+  // 対応 endpoint が無いので Multi モードでは local_only。 frontend 側でタブが
+  // mode-locked になるので通常は呼ばれないが、 念のためサーバ側でもガード。
+  if (/^\/api\/(diary|weekly|meals|locations|tracks|legatus|visits|trends|recommendations|activity|weather|transit|review|work-sessions|wifi|worklog|repos|tasks|packet-monitor)(\/|$)/.test(path)) {
     return { kind: 'local-only' };
   }
 
   // ── それ以外 (制御系 /api/multi/*・/api/setup/*、 インフラ系、 および
   //    Multi 対応型の未対応 sub-path) は local に素通し ──
   return { kind: 'passthrough' };
+}
+
+// Local item に 「自分の所有 / 未シェア」 を表すメタを乗せる。
+// Local DB には owner 概念が無いので、 _origin='local' + owner_user_id=null と
+// しておき、 frontend が 「未シェア」 と 「自分の (Hub に上げ済)」 を shared_at の
+// 有無で判別する。
+function tagLocalItem(item: Record<string, unknown>): Record<string, unknown> {
+  return {
+    ...item,
+    _origin: 'local',
+    owner_user_id: item.owner_user_id ?? null,
+    owner_user_name: item.owner_user_name ?? null,
+  };
+}
+
+function tagHubItem(item: Record<string, unknown>): Record<string, unknown> {
+  return { ...item, _origin: 'hub' };
 }
 
 export function makeMultiProxyMiddleware(db: Db) {
@@ -81,7 +111,7 @@ export function makeMultiProxyMiddleware(db: Db) {
       return c.json({ error: 'local_only', mode: 'multi' }, 503);
     }
 
-    // proxy: Hub の session token を取り出して /api/data/* に転送。
+    // 認証 Hub を取り出す
     const { servers } = readMultiServers(db);
     const server = findServerByUrl(servers, hubUrl);
     if (!server || !server.jwt) {
@@ -90,6 +120,52 @@ export function makeMultiProxyMiddleware(db: Db) {
 
     const qs = new URL(c.req.url).search;
     const method = c.req.method;
+
+    // ── mix-list: Local 先行で next() → 結果を取り出し、 Hub を fetch、 merge ──
+    if (mapped.kind === 'mix-list' && method === 'GET') {
+      await next();
+      // c.res は local handler が build した Response。 ok なら body を merge。
+      const localRes = c.res;
+      let localItems: Array<Record<string, unknown>> = [];
+      if (localRes && localRes.ok) {
+        try {
+          const j = await localRes.clone().json() as { items?: unknown };
+          if (Array.isArray(j.items)) localItems = j.items as Array<Record<string, unknown>>;
+        } catch { /* local 応答が JSON でない (e.g. HTML) なら空扱い */ }
+      }
+
+      let hubItems: Array<Record<string, unknown>> = [];
+      try {
+        const r = await hubFetch(server.url, server.jwt, mapped.hubPath + qs, { method: 'GET' });
+        // hubFetch の body は raw string か parsed object。 両対応。
+        const hb = typeof r.body === 'string' ? JSON.parse(r.body) : r.body;
+        if (hb && Array.isArray(hb.items)) hubItems = hb.items as Array<Record<string, unknown>>;
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        console.warn('[multi-proxy] hub list fetch failed:', msg);
+        // Hub が落ちていても local だけで返したい
+      }
+
+      const tagged = [
+        ...localItems.map(tagLocalItem),
+        ...hubItems.map(tagHubItem),
+      ];
+
+      // sort: created_at DESC、 無ければ shared_at DESC
+      tagged.sort((a, b) => {
+        const ka = String(a.created_at || a.shared_at || a.updated_at || '');
+        const kb = String(b.created_at || b.shared_at || b.updated_at || '');
+        return ka < kb ? 1 : ka > kb ? -1 : 0;
+      });
+
+      c.res = new Response(JSON.stringify({ items: tagged, _mix: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+      return;
+    }
+
+    // ── proxy: 旧来通り Hub に forward (detail / write 系) ──
     const init: { method: string; body?: string } = { method };
     if (method !== 'GET' && method !== 'HEAD') {
       init.body = await c.req.text();

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -352,6 +352,7 @@
             <ul id="categoryList"></ul>
           </aside>
           <div class="bookmarks-main">
+            <div id="bookmarksMultiFilter" class="multi-filter-slot"></div>
             <div id="cards" class="cards"></div>
             <div id="empty" class="empty hidden">ブックマークがありません。Chrome 拡張からページを保存してください。</div>
             <div class="bookmarks-more-bar">
@@ -1849,6 +1850,6 @@
       <button id="aiSettingsSave">保存</button>
     </div>
   </div>
-  <script src="app.js?v=20260516g"></script>
+  <script src="app.js?v=20260517b"></script>
 </body>
 </html>

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -302,12 +302,23 @@ const state: State = {
   domainSearch: '',
   // 二層設計: データソース (Local / 特定 Hub)。 ログ下のスイッチャで排他切替。
   dataSource: { mode: 'local', hubUrl: null },
+  // Multi モードで Local + Hub データを mix 表示する時の絞り込み:
+  //   'all'        — 全件表示
+  //   'unshared'   — Local item で shared_at が null
+  //   'user:<uid>' — その owner_user_id の item のみ
+  multiFilter: 'all' as string,
 };
 
 // Multi モードで触れないタブ (= 個人ログ系。 [個人データ保管禁止])。
-// Multi 対応は database (bookmark/dict/domain/impl) / dig / notes / worklog のみ。
+// Multi 対応は database (bookmark/dict/domain/impl) / dig / notes のみ。
+// 以下は Hub に対応データ source が無いため Multi モードで非活性:
+//   worklog   📝 ログ (アクティビティ / アプリ / GPS 等の個人ログ)
+//   worklist  📋 作業一覧 (タスク + repo 監視ダッシュボード)
+//   packetmon 🛡 パケット監視 (ローカル NIC のキャプチャ)
+//   queue     ⚙ キュー (ローカル AI / 取り込みジョブの待ち行列)
 const LOCAL_ONLY_TABS = new Set([
   'diary', 'meals', 'recommend', 'review', 'transit', 'trends',
+  'worklog', 'worklist', 'packetmon', 'queue',
 ]);
 
 // `$()` は永らく document.getElementById のショートハンド。
@@ -604,7 +615,10 @@ function renderCards() {
   const empty = $('empty');
   // Search filtering now happens server-side (?q=...). The full page is
   // already what we want to render — no local re-filtering.
-  const items = state.bookmarks;
+  const rawItems = state.bookmarks as Loose[];
+  // Multi モード時のフィルタ chip を描画し、 predicate を取得して絞り込む。
+  const filter = renderMultiFilterChips($('bookmarksMultiFilter'), rawItems);
+  const items = rawItems.filter(filter);
   renderBookmarksMore();
   if (items.length === 0) {
     wrap.innerHTML = '';
@@ -617,6 +631,7 @@ function renderCards() {
     const isSel = state.selected.has(b.id);
     const statusBadge = b.status === 'pending' ? '<span class="status-pending">要約中</span>'
       : b.status === 'error' ? '<span class="status-error">要約失敗</span>' : '';
+    const origin = multiOriginBadge(b);
     return `
       <div class="card ${isSel ? 'selected' : ''}" data-id="${b.id}">
         <input type="checkbox" class="check" data-id="${b.id}" ${isSel ? 'checked' : ''} />
@@ -630,7 +645,7 @@ function renderCards() {
         </div>
         <div class="footer">
           <span>最終: ${fmtDate(b.last_accessed_at)}</span>
-          <span>${statusBadge}</span>
+          <span>${statusBadge}${origin}</span>
         </div>
       </div>`;
   }).join('');
@@ -4784,6 +4799,19 @@ setupCategoriesDrawer();
 setupExtensionBadge();
 setupHowToBookmark();
 
+// Multi モードの filter chip が変わったら、 該当タブの list を再描画する。
+// 各 list の renderer は state.multiFilter を読んで絞り込むので、 ここでは
+// 「現在表示中のタブの再描画関数」 を呼べば良い。 起点は最小限 bookmark のみ
+// 接続。 他 6 型 (notes/dig/dict/impl/work-locations/domain-catalog) も同じ
+// パターンで wire 可能 (TODO)。
+window.addEventListener('multi-filter-changed', () => {
+  const tab = state.tab as string;
+  if (tab === 'database') {
+    // 現在の sub-view に応じて renderer を切替
+    renderCards();
+  }
+});
+
 // 💡 やり方 (スマホでブックマークする方法) — 旧 topbar の howToBookmarkBtn は
 // 廃止し、 設定 → 🔔 通知 / 端末 内の howToBookmarkBtnInSettings に移動。
 // モバイル幅でしか出さない自動表示も止め、 設定からいつでも開ける形に。
@@ -5389,16 +5417,88 @@ async function selectDataSource(url) {
   }
 }
 
-// Multi モード時、 個人ログ系タブに mode-locked クラスを付けてグレーアウト。
+// Multi モードで Local + Hub データを mix 表示している list 用の フィルタ chip。
+// 呼び出し側 (list renderer) は:
+//   1. fetch 後の items を渡して `renderMultiFilterChips(container, items)` を呼ぶ
+//   2. 返り値の predicate で items を filter して描画
+//   3. chip クリック時に 'multi-filter-changed' event が発火するので、 そこで再描画
+// Multi モードでない時は何もせず、 全件を通す predicate を返す。
+function renderMultiFilterChips(container: HTMLElement | null, items: Loose[]): (it: Loose) => boolean {
+  if (!container) return () => true;
+  const multi = document.body.dataset.multiMode === 'on';
+  if (!multi) {
+    container.innerHTML = '';
+    return () => true;
+  }
+  // owner_user_id → 表示名 を集計。 unshared (= local + shared_at なし) も判別。
+  const owners = new Map<string, string>();
+  let hasUnshared = false;
+  let hasMine = false;
+  for (const it of items || []) {
+    const uid = it.owner_user_id != null ? String(it.owner_user_id) : null;
+    if (uid) {
+      owners.set(uid, String(it.owner_user_name || uid));
+    } else if (it._origin === 'local') {
+      hasMine = true;
+      if (!it.shared_at) hasUnshared = true;
+    }
+  }
+  const cur = String(state.multiFilter || 'all');
+  const chip = (key: string, label: string): string =>
+    `<button class="mf-chip ${cur === key ? 'active' : ''}" data-mf="${escapeHtml(key)}">${escapeHtml(label)}</button>`;
+  const chips: string[] = [chip('all', 'すべて')];
+  if (hasMine) chips.push(chip('mine', '自分のローカル'));
+  if (hasUnshared) chips.push(chip('unshared', '未シェア'));
+  for (const [uid, name] of owners) chips.push(chip(`user:${uid}`, name));
+
+  container.innerHTML = `<div class="multi-filter-bar"><span class="muted" style="font-size:12px;margin-right:6px">表示:</span>${chips.join('')}</div>`;
+  container.querySelectorAll('.mf-chip').forEach(btn => {
+    btn.addEventListener('click', () => {
+      state.multiFilter = (btn as HTMLElement).dataset.mf || 'all';
+      window.dispatchEvent(new CustomEvent('multi-filter-changed', { detail: state.multiFilter }));
+    });
+  });
+
+  // predicate
+  return (it: Loose) => {
+    if (cur === 'all') return true;
+    if (cur === 'mine') return it._origin === 'local';
+    if (cur === 'unshared') return it._origin === 'local' && !it.shared_at;
+    if (cur.startsWith('user:')) return String(it.owner_user_id ?? '') === cur.slice(5);
+    return true;
+  };
+}
+
+// item の 由来 (= ローカル / Hub ユーザ) を表す小バッジ HTML を返す。
+// Multi モードでなければ空文字。
+function multiOriginBadge(it: Loose): string {
+  if (document.body.dataset.multiMode !== 'on') return '';
+  if (it._origin === 'hub') {
+    const name = String(it.owner_user_name || it.owner_user_id || '他ユーザ');
+    return `<span class="mo-badge mo-hub" title="Hub 共有 — ${escapeHtml(name)}">👥 ${escapeHtml(name)}</span>`;
+  }
+  if (it._origin === 'local') {
+    if (it.shared_at) return '<span class="mo-badge mo-shared" title="Local (Hub にシェア済)">🏠 自分</span>';
+    return '<span class="mo-badge mo-local" title="Local (未シェア)">🏠 未シェア</span>';
+  }
+  return '';
+}
+
+// Multi モード時、 個人ログ系タブは非表示にする (旧仕様の gray-out から変更)。
+// 同時に share 系 control (= Hub に publish するチェックボックス) も、 Multi
+// モードでなければ意味が無いので非表示にする。
 function applyModeGating() {
   const multi = (state.dataSource as { mode?: string })?.mode === 'multi';
+  document.body.dataset.multiMode = multi ? 'on' : 'off';
   document.querySelectorAll('.tab[data-tab]').forEach(t => {
     const el = t as HTMLElement;
-    const locked = multi && LOCAL_ONLY_TABS.has(el.dataset.tab || '');
-    el.classList.toggle('mode-locked', locked);
-    if (locked) el.title = 'Local モード専用 (Multi モードでは利用不可)';
-    else if (el.title === 'Local モード専用 (Multi モードでは利用不可)') el.title = '';
+    const hide = multi && LOCAL_ONLY_TABS.has(el.dataset.tab || '');
+    el.hidden = hide;
+    // 旧 mode-locked クラスは下位互換のため残す (CSS が opacity 等で参照)
+    el.classList.toggle('mode-locked', hide);
   });
+  // share checkbox は親 label / row 単位で hide。 CSS で
+  // body[data-multi-mode="off"] .multi-only-control { display: none; } 経由。
 }
 
 // 現在のモードを backend から読んで state に反映。 起動時 + status 更新時に呼ぶ。
@@ -5836,7 +5936,7 @@ let ensureMemoriaFeatureViews = function () {
           <input id="implTitle" type="text" placeholder="短いタイトル" />
           <textarea id="implGood" rows="4" placeholder="良かった点"></textarea>
           <textarea id="implBad" rows="3" placeholder="悪かった点 / トレードオフ"></textarea>
-          <label class="check-inline"><input id="implShareable" type="checkbox" /> シェア可能にする</label>
+          <label class="check-inline multi-only-control"><input id="implShareable" type="checkbox" /> シェア可能にする</label>
           <div class="simple-actions">
             <button id="implAddBtn">追加</button>
             <button id="implCancelBtn" type="button" class="ghost">キャンセル</button>
@@ -5920,7 +6020,7 @@ let ensureMemoriaFeatureViews = function () {
             <input id="workplaceEditorRadius" type="number" min="1" max="50000" step="1" placeholder="50 (空欄: 設定の既定値を使う)" />
             <small class="muted">場所の物理的な大きさに応じて個別に設定。 例: 自宅 = 30m / 駅前広場 = 200m / 大学キャンパス = 500m。 0 や空欄なら全体設定の値 (設定 → プライバシー → 場所判定の半径) を使う。</small>
           </label>
-          <label class="simple-check-row">
+          <label class="simple-check-row multi-only-control">
             <input id="workplaceEditorShareable" type="checkbox" />
             <span>シェア可能にする</span>
           </label>
@@ -6134,7 +6234,7 @@ upgradeImplementationFormMarkup = function () {
       <span>悪かった点 / トレードオフ</span>
       <textarea id="implBad" rows="4" placeholder="悪かった点、迷った点、次に直したい点"></textarea>
     </label>
-    <label class="simple-check-row">
+    <label class="simple-check-row multi-only-control">
       <input id="implShareable" type="checkbox" tabindex="-1" />
       <span>シェア可能にする</span>
     </label>
@@ -6489,7 +6589,7 @@ upgradeImplementationFormMarkup = function () {
       <span>添付内容</span>
       <textarea id="implAttachmentValue" rows="4" placeholder="URL、画像や動画のパス、コードなどを 1 つだけ記入"></textarea>
     </label>
-    <label class="simple-check-row">
+    <label class="simple-check-row multi-only-control">
       <input id="implShareable" type="checkbox" tabindex="-1" />
       <span>シェア可能にする</span>
     </label>

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -355,9 +355,32 @@ button:hover { background: #1f56c0; border-color: #1f56c0; }
 }
 .tab:hover { background: #f0f2f7; color: var(--text); }
 .tab.active { color: var(--accent); border-bottom-color: var(--accent); font-weight: 600; }
-/* Multi モード時、 Local 専用タブはグレーアウト (= switchTab が切替を弾く)。 */
+/* Multi モード時、 Local 専用タブは hidden 属性で完全非表示。 mode-locked
+   class は frontend が同時に付けるが、 hidden=true で勝つ。 旧表示用の
+   gray-out は残しておく (= 一時的に hidden を外したとき用) */
 .tab.mode-locked { opacity: 0.38; cursor: not-allowed; }
 .tab.mode-locked:hover { background: transparent; color: var(--muted); }
+/* Multi モードのときだけ表示する控えコントロール (= シェア可能チェック等)。
+   body[data-multi-mode="on"] の時のみ可視。 初期 (= 属性未設定 or "off") は非表示。 */
+body:not([data-multi-mode="on"]) .multi-only-control { display: none !important; }
+
+/* Multi モード時、 list 上の 「自分のローカル / 未シェア / ユーザ別」 chip フィルタ */
+.multi-filter-bar { display: flex; flex-wrap: wrap; gap: 6px; align-items: center;
+  padding: 8px 10px; margin: 0 0 8px; background: rgba(0,0,0,0.03);
+  border-radius: 6px; border: 1px solid var(--border); }
+.mf-chip { font-size: 12px; padding: 4px 10px; border-radius: 12px;
+  border: 1px solid var(--border); background: var(--panel); color: var(--fg);
+  cursor: pointer; transition: background 0.12s; }
+.mf-chip:hover { background: var(--panel-hover, rgba(0,0,0,0.06)); }
+.mf-chip.active { background: var(--accent); color: #fff; border-color: var(--accent); }
+.multi-filter-slot:empty { display: none; }
+
+/* item の由来 (= local / Hub) を示す小バッジ。 footer など末尾に追加。 */
+.mo-badge { display: inline-block; margin-left: 6px; padding: 1px 6px; font-size: 11px;
+  border-radius: 3px; border: 1px solid var(--border); background: rgba(0,0,0,0.04); color: var(--muted); }
+.mo-hub    { color: #1c6cba; border-color: #b9d6f2; background: #eaf3fc; }
+.mo-shared { color: #6a4c0a; border-color: #ead7a0; background: #fbf3d8; }
+.mo-local  { color: var(--muted); }
 .tab-count {
   background: #fff5e1;
   color: #8a5a00;


### PR DESCRIPTION
## Summary

「Hub につないだ場合は Hub のデータを読み込んで表示」 の方針を **Local + Hub を混ぜて表示** に拡張。 ローカルの未シェアアイテムと Hub の共有アイテムを同じ list で見れるようにする。

## 変更

### タブの活性制御 (再整理)
- `LOCAL_ONLY_TABS` に **worklog (📝 ログ) / worklist (📋 作業一覧) / queue (⚙ キュー)** を追加 (packetmon は既存)
- 旧 gray-out (opacity 0.38) から **完全非表示** (`hidden` 属性) に変更
- 非活性タブにいる状態で Multi モードに切替えると `database` タブに自動移動 (既存 `selectDataSource` のロジック)

### share UI の可視制御
- impl note / workplace の 「シェア可能にする」 checkbox に `.multi-only-control` クラスを付与
- Multi モードでないと表示しない (= Local モードで「シェア」 設定する意味が無いので隠す)

### Local + Hub データ mix (backend)
- `server/local/multi-proxy.ts` の新 kind **`mix-list`**
- Multi 対応 7 型 (bookmarks / digs / dictionary / implementation-notes / work-locations / domains / notes) の **list endpoint** が対象
- 動作: Local handler 結果 + Hub `/api/data/<type>` を fetch → 各 item に `_origin: 'local'|'hub'` を付与して merge → `created_at` DESC で sort
- detail / write 系は従来通り Hub に proxy
- Hub fetch 失敗時は Local だけ返す (graceful degrade)

### フィルタ chip (frontend)
- 新 helper `renderMultiFilterChips(container, items)`:
  - 「すべて / 自分のローカル / 未シェア / ユーザ名…」 chip を items から自動集計
  - `state.multiFilter` に保持 (`'all' | 'mine' | 'unshared' | 'user:<uid>'`)
  - chip クリック → `multi-filter-changed` event 発火
- 新 helper `multiOriginBadge(item)` で各 item の由来バッジ (🏠 未シェア / 🏠 自分 / 👥 ユーザ名)
- **bookmark の list** に wire (他 6 型は同 pattern で wire 可能、 follow-up 候補)

## Test plan
- [x] Local モード: 全タブ表示、 share checkbox 非表示
- [x] Multi モード: worklog / worklist / queue / packetmon 非表示
- [x] Multi モード: bookmark list に 「すべて / 自分のローカル / 未シェア / Hub ユーザ」 chip が出る
- [x] Multi モード: bookmark カード footer に origin バッジ
- [ ] Multi モード: notes / dig / dict / impl / work-locations / domain も同様に mix 表示 (backend は wire 済、 frontend filter UI は follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)