### PR TITLE
chore(release): v1.0.0

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memoria-desktop",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memoria-desktop",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "electron": "^33.0.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memoria-desktop",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "description": "Memoria desktop wrapper — Electron shell that runs the Memoria Node server as a child process and shows its UI in a Chromium window.",
   "main": "out/main.js",

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memoria-mcp-server",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memoria-mcp-server",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "zod": "^3.23.8"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memoria-mcp-server",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "description": "MCP server bridging Memoria's local HTTP API to MCP-aware clients.",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memoria-server",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memoria-server",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@hono/node-server": "^1.13.7",
         "aedes": "^0.51.3",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memoria-server",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- `server` / `desktop` / `mcp-server` の `package.json` (と lockfile) を **0.1.0 → 1.0.0** に bump
- 初回 GitHub Release (v1.0.0) のための version 揃え
- 機能変更なし

## Release flow

このマージ後に \`main\` で \`v1.0.0\` tag を打って push すると \`.github/workflows/desktop-release.yml\` が発火し、 Windows / macOS / Linux 3 platform のインストーラ ZIP が GitHub Release に upload される。

## Test plan

- [x] CI green (lint + smoke)
- [ ] tag push 後、 desktop-release workflow が 3 platform すべて成功
- [ ] Release に 3 ZIP が並ぶ

🤖 Generated with [Claude Code](https://claude.com/claude-code)