### PR TITLE
fix(desktop): .deb ビルド向けに homepage/author/maintainer を追加

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -3,6 +3,15 @@
   "version": "1.0.0",
   "private": true,
   "description": "Memoria desktop wrapper — Electron shell that runs the Memoria Node server as a child process and shows its UI in a Chromium window.",
+  "homepage": "https://github.com/LUDIARS/Memoria",
+  "author": {
+    "name": "LUDIARS",
+    "email": "ludiars@users.noreply.github.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LUDIARS/Memoria.git"
+  },
   "main": "out/main.js",
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.scripts.json",
@@ -69,7 +78,8 @@
       "target": ["AppImage", "deb"],
       "icon": "icons/icon.png",
       "category": "Office",
-      "synopsis": "Web bookmarking + research + diary"
+      "synopsis": "Web bookmarking + research + diary",
+      "maintainer": "LUDIARS <ludiars@users.noreply.github.com>"
     }
   }
 }


### PR DESCRIPTION
## Summary

v1.0.0 初回 release の linux-x64 ビルドが .deb 段階で停止していた:

\`\`\`
⨯ Please specify project homepage
   Please specify author 'email' in the application package.json
   It is required to set Linux .deb package maintainer
\`\`\`

\`desktop/package.json\` に以下を追加:

- \`homepage\`: GitHub URL
- \`author\`: { name: \"LUDIARS\", email: \"ludiars@users.noreply.github.com\" }
- \`repository\`: GitHub URL
- \`build.linux.maintainer\`: LUDIARS <noreply>

## Test plan

- [x] CI green (lint + smoke)
- [ ] desktop-release.yml の linux-x64 が成功 → publish job 起動 → Release に 3 ZIP

🤖 Generated with [Claude Code](https://claude.com/claude-code)