### PR TITLE
spec(hub-shell): Memoria Hub に LUDIARS アプリ集約 frontend shell を載せる Phase 0 準備

### DIFF
--- a/server/multi/shell/README.md
+++ b/server/multi/shell/README.md
@@ -1,0 +1,22 @@
+# Memoria Hub — Shell (placeholder)
+
+This directory is a **Phase 0 placeholder** for the Hub Shell (frontend
+aggregator for multiple LUDIARS apps). See
+[`spec/feature/hub-shell.md`](../../../spec/feature/hub-shell.md) for the
+design.
+
+Phase 0 ships only:
+
+- this README
+- `apps.example.json` — example app registry (multiple apps in one bootstrap file)
+- `well-known.example.json` — example of what a single app exposes at
+  `/.well-known/ludiars-app.json` for Hub self-registration (§9.1)
+- `registry.schema.sql` — proposed Postgres DDL for the `hub_apps` table
+  used by the self-setup UI (§9.3) — NOT a real migration yet
+
+No mount loader, no shell SPA, no integration with `server/multi/index.js`
+yet. Phase 1 starts once the bundle method (§3 of the spec) is decided.
+
+The shell is kept self-contained under this directory so it can later be
+extracted into a separate `LUDIARS Shell` service without entangling with
+Memoria-specific code.

--- a/server/multi/shell/apps.example.json
+++ b/server/multi/shell/apps.example.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "../../../spec/schema/ludiars-app-manifest.schema.json",
+  "_comment": "Example Hub Shell app registry. Phase 0 placeholder — not consumed by any code yet. The real format is a JSON array of LUDIARS App Manifests; each app may also self-publish at /.well-known/ludiars-app.json (Phase 1 decision). 'description' shows in the tab nav under the app name (see hub-shell.md §4.2). 'dataChannels' declares cross-app data interop (see §8).",
+  "apps": [
+    {
+      "id": "memoria",
+      "displayName": "Memoria",
+      "description": "ナレッジ管理",
+      "shortCode": "Mm",
+      "icon": "📓",
+      "version": "0.0.0-placeholder",
+      "entry": {
+        "type": "web-component",
+        "tag": "memoria-app",
+        "url": "https://memoria.example/dist/element.js"
+      },
+      "capabilities": ["cernere-session", "design-tokens"],
+      "dataChannels": [
+        { "name": "task", "role": "consumer" }
+      ],
+      "routes": [
+        { "path": "/apps/memoria", "default": true }
+      ]
+    },
+    {
+      "id": "actio",
+      "displayName": "Actio",
+      "description": "予定・タスク管理",
+      "shortCode": "A",
+      "icon": "📅",
+      "version": "0.0.0-placeholder",
+      "entry": {
+        "type": "web-component",
+        "tag": "actio-app",
+        "url": "https://actio.example/dist/element.js"
+      },
+      "capabilities": ["cernere-session", "design-tokens"],
+      "dataChannels": [
+        { "name": "task", "role": "provider" }
+      ],
+      "routes": [
+        { "path": "/apps/actio", "default": true }
+      ]
+    },
+    {
+      "id": "bibliotheca",
+      "displayName": "Bibliotheca",
+      "description": "蔵書・機材の貸出台帳",
+      "shortCode": "Bb",
+      "icon": "📚",
+      "version": "0.0.0-placeholder",
+      "entry": {
+        "type": "web-component",
+        "tag": "bibliotheca-app",
+        "url": "https://bibliotheca.example/dist/element.js"
+      },
+      "capabilities": ["cernere-session", "design-tokens"],
+      "routes": [
+        { "path": "/apps/bibliotheca", "default": true }
+      ]
+    },
+    {
+      "id": "calicula",
+      "displayName": "Calicula",
+      "description": "カリキュラム計画",
+      "shortCode": "Ca",
+      "icon": "📐",
+      "version": "0.0.0-placeholder",
+      "entry": {
+        "type": "web-component",
+        "tag": "calicula-app",
+        "url": "https://calicula.example/dist/element.js"
+      },
+      "capabilities": ["cernere-session", "design-tokens"],
+      "routes": [
+        { "path": "/apps/calicula", "default": true }
+      ]
+    }
+  ]
+}

--- a/server/multi/shell/registry.schema.sql
+++ b/server/multi/shell/registry.schema.sql
@@ -1,0 +1,32 @@
+-- Hub Shell apps registry — Phase 0 PLACEHOLDER.
+-- See spec/feature/hub-shell.md §9.3.
+--
+-- This file is NOT a real migration yet. Phase 1 will:
+--   1. Move this DDL into server/multi/migrations/NNN_hub_apps.sql with a
+--      proper sequence number.
+--   2. Wire it into server/multi/migrate.js so memoria-multi-server applies
+--      it on startup.
+--
+-- Until then this file documents the intended shape so reviewers can spot
+-- problems early.
+
+CREATE TABLE IF NOT EXISTS hub_apps (
+  id                  TEXT        PRIMARY KEY,                              -- manifest.id (e.g. 'bibliotheca')
+  manifest_url        TEXT        NOT NULL,                                 -- fetch source URL
+  manifest_json       JSONB       NOT NULL,                                 -- last validated manifest
+  display_order       INTEGER     NOT NULL DEFAULT 0,                       -- tab order
+  enabled             BOOLEAN     NOT NULL DEFAULT TRUE,
+  installed_by        TEXT        NOT NULL,                                 -- Cernere user id (admin role)
+  installed_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_refetched_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_etag           TEXT,                                                  -- If-None-Match cache key
+  last_error          TEXT                                                   -- non-null = last refetch failed
+);
+
+-- Active tabs query (the only hot path): list enabled apps ordered by display_order.
+CREATE INDEX IF NOT EXISTS hub_apps_display_order_idx
+  ON hub_apps (display_order, id)
+  WHERE enabled;
+
+-- manifest_url is informational; the same id from a different url is treated as
+-- a re-install (UPDATE), not a duplicate. UNIQUE on id (the PK) is sufficient.

--- a/server/multi/shell/well-known.example.json
+++ b/server/multi/shell/well-known.example.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../../../spec/schema/ludiars-app-manifest.schema.json",
+  "_comment": "Example response of GET /.well-known/ludiars-app.json an app exposes for Hub Shell self-registration. See spec/feature/hub-shell.md §9.1. The response is a SINGLE manifest (this app), not an array — apps.example.json shows multiple, but each well-known is one. Strip the '_comment' line in real responses; it isn't part of the schema.",
+  "id": "memoria",
+  "displayName": "Memoria",
+  "description": "ナレッジ管理",
+  "shortCode": "Mm",
+  "icon": "📓",
+  "version": "0.0.0-placeholder",
+  "entry": {
+    "type": "web-component",
+    "tag": "memoria-app",
+    "url": "https://memoria.example/dist/element.js"
+  },
+  "capabilities": ["cernere-session", "design-tokens"],
+  "dataChannels": [
+    { "name": "task", "role": "consumer" }
+  ],
+  "routes": [
+    { "path": "/apps/memoria", "default": true }
+  ]
+}

--- a/spec/feature/hub-shell.md
+++ b/spec/feature/hub-shell.md
@@ -1,0 +1,471 @@
+# hub-shell — Memoria Hub に LUDIARS アプリ群を集約する frontend shell
+
+> このドキュメントは Memoria Hub に **複数 LUDIARS アプリを一つのフロントエンド
+> として集約する shell 機能** を載せる方向性の **準備段階の設計書**。
+> 実装はまだ開始しない (= 「準備だけする」 段階)。
+> 関連: [`multi-hub.md`](./multi-hub.md) (データハブ側の既存設計)
+
+## 1. 背景と狙い
+
+### 現状
+
+Memoria Hub (`server/multi/`) は Postgres を持ち、 共有 7 型 (bookmarks / digs /
+dictionary / implementation-notes / work-locations / domain-catalog / notes) の
+JSON CRUD を出す **データハブ**。 UI は setup/login の 2 ページのみで、
+本来の Memoria UI はローカル frontend (`server/index.ts` の Hono static + Electron) が
+持つ。
+
+他の LUDIARS アプリ (Actio / Calicula / Bibliotheca / Quaestor / Praeforma /
+Hora / Susurrus / Ludellus 等) はそれぞれ独自に Web フロントエンドを持っており、
+ユーザは複数の URL / Tauri アプリを跨いで使う必要がある。
+
+### 狙い
+
+- 複数 LUDIARS アプリを **Memoria Hub 上で集約レンダリング** する shell を持つ
+- レンダリングは shell が **一貫した design system (Foundation UI) で** 行う
+  ことでアプリ間の見た目・操作感を統一する
+- 集約自体は Memoria 固有機能ではないので、 将来的に **別サービス
+  (仮称: LUDIARS Shell)** として切り出す。 が、 実装パターンは変わらないので
+  当面は Memoria Hub の中で育てる
+- このドキュメントは **Phase 0 = 準備** のスコープのみ確定する
+
+### 非スコープ (このドキュメントでは決めない)
+
+- 各アプリの認証統合 (= Cernere SSO で既に対応済 / アプリごとに別途検討)
+- 各アプリの API gateway / reverse proxy 化
+- 既存 Memoria UI そのものの再実装
+- 「データハブ」 側機能 ([`multi-hub.md`](./multi-hub.md)) との関係整理 (= Phase 1 で扱う)
+
+### Phase 0 (準備) 段階で **明示的に取り込む** 要件
+
+ユーザ指示で確定した、 準備の段階で仕様に盛り込んでおく要件:
+
+1. **集約ナビは「役割が読める」タブ形式**。 アプリ名だけでなく、 そのツールが
+   何をするものかを短い説明で添える。 詳細は §4.2。
+2. **タスクは Actio と統合可能にしておく**。 Memoria task 機能と Actio task
+   機能を Hub Shell 上で同じデータとして扱える設計の土台を作る。 詳細は §8。
+3. **タブはユーザが自分で増やせる**。 Hub の Web UI から URL を貼るだけで
+   新規アプリを登録でき、 LUDIARS のコアが提供していないアプリでも
+   manifest を出していれば追加できる。 詳細は §9。
+
+## 2. 用語
+
+- **Hub Shell** (本ドキュメントの主役): Memoria Hub に載る、 複数アプリを
+  集約する frontend shell
+- **集約対象アプリ** / **Mounted App**: Hub Shell の中に組み込まれる
+  LUDIARS アプリ (Actio / Bibliotheca 等)
+- **App Manifest**: 各アプリが Hub Shell に提示する metadata
+  (表示名 / icon / route / 必要 capability 等)。 静的 JSON または config 経由
+- **App Registry**: Hub Shell が知っている Mounted App の集合。 起動時に
+  manifest を集めて nav に並べる
+
+## 3. 集約方式の選択肢
+
+「Hub がレンダリングを行う」 をどこまで厳密にとるかで 3 案。 決定指標は
+ユーザ環境の標準軸: **(1) AI 学習量 / (2) 作業コスト / (3) 解決度 /
+(4) 主目的との一致度** (主目的 = 「一貫した frontend で集約」)。
+
+### A. iframe 方式
+
+各アプリの既存 frontend を `<iframe>` で読み込み、 Hub Shell は chrome
+(nav / 認証 / theme) だけ提供。
+
+| 指標 | 値 |
+|---|---|
+| AI 学習量 | ★☆☆☆☆ (既存 iframe 周りのコモディティ知識) |
+| 作業コスト | 低 — 各アプリの frontend に手を入れずに済む |
+| 解決度 | ★★☆☆☆ — chrome は統一されるが、 中身は各アプリの素の UI そのまま |
+| 主目的との一致度 | ★★☆☆☆ — 「一貫レンダリング」 ではなく 「一貫ナビ」 にしかならない |
+
+### B. micro-frontend 方式 (Web Components / Module Federation)
+
+各アプリが Hub Shell に **mount 可能なバンドル** (Web Component, ESM module,
+Module Federation の remote 等) を公開し、 Hub Shell が動的 import して
+shell 内に直接マウントする。 design system (Foundation UI) は shell が提供し、
+各アプリは shell から CSS variable / Tailwind preset を受け取って描く。
+
+| 指標 | 値 |
+|---|---|
+| AI 学習量 | ★★★★☆ (Module Federation / WC / build pipeline で得るものは多い) |
+| 作業コスト | 中 — 各アプリの frontend を 「shell に渡せる単位」 にリパッケージ。 build 設定の追加 |
+| 解決度 | ★★★★☆ — shell が CSS / theme / nav を握り、 中身も DOM 上は単一木 |
+| 主目的との一致度 | ★★★★★ — 「Hub がレンダリング」 を文字通り満たす |
+
+### C. shell が再実装方式
+
+各アプリの API のみを使い、 UI は Hub Shell が自前 React/Vanilla SPA で
+全部書く。 各アプリの既存 frontend は (Hub Shell 経由では) 使わない。
+
+| 指標 | 値 |
+|---|---|
+| AI 学習量 | ★★★☆☆ (個別アプリの再実装は反復作業に近い) |
+| 作業コスト | 大 — 集約対象が増えるごとに UI 全部書き直し。 各アプリの仕様変更に追随必要 |
+| 解決度 | ★★★★★ — 完全に統一 |
+| 主目的との一致度 | ★★★★☆ — 一貫だが、 各アプリの実装と二重管理 |
+
+### 推奨: **B (micro-frontend)**
+
+- 「Hub がレンダリングを行う」 主目的を最も正確に満たす
+- C と比べて二重実装にならない (各アプリの frontend を mount 可能形に
+  リパッケージするだけで済む)
+- A よりも「一貫レンダリング」 が deep に効く (CSS / theme / DOM が共通)
+- 将来 Hub Shell が別サービスに分離しても、 同じ mount API でそのまま使える
+
+ただし B は build pipeline の選択 (Web Components vs Module Federation
+vs UMD) が一段未確定。 これは **Phase 0 の Decision-1 として確定する** (§5)。
+
+## 4. App Manifest (準備)
+
+### 4.1 manifest フィールド
+
+集約対象アプリは Hub Shell に対し以下の manifest を提示する。 形式は
+JSON、 配信は (a) 各アプリの `/.well-known/ludiars-app.json` または
+(b) Hub の `apps.json` 静的設定の 2 経路を想定する (Phase 0 では仕様だけ確定)。
+
+```jsonc
+{
+  "id": "bibliotheca",            // 短い不変 ID (URL でも使う)
+  "displayName": "Bibliotheca",   // タブのアプリ名
+  "description": "蔵書・機材の貸出台帳",  // タブの役割行 (必須、 §4.2)
+  "shortCode": "Bb",              // LUDIARS の 2 文字略称
+  "icon": "📚",                   // emoji or relative URL to SVG
+  "version": "0.1.0",
+  "entry": {                       // mount するバンドルの所在
+    "type": "web-component",       // 暫定: web-component / esm / module-federation
+    "tag": "bibliotheca-app",      // type=web-component の場合
+    "url": "https://bibliotheca.example/dist/element.js"
+  },
+  "capabilities": [                // Hub に要求する権限 (将来用)
+    "cernere-session",             // shell から Cernere session を受け取る
+    "design-tokens"                // shell の CSS variable を継承
+  ],
+  "dataChannels": [                // 他アプリと統合するデータ種別 (§8)
+    { "name": "task", "role": "consumer" }
+  ],
+  "routes": [                      // shell の URL 空間でのアプリの場所
+    { "path": "/apps/bibliotheca", "default": true }
+  ]
+}
+```
+
+Phase 0 ではこの schema 定義だけ確定 + JSON schema ファイル化する。
+動的 fetch / 検証ロジックは Phase 1 以降。
+
+### 4.2 タブ UX (役割の見せ方)
+
+集約ナビは **タブ形式**。 タブ 1 個に以下 3 要素を必ず出す:
+
+| 要素 | 出どころ (manifest) | 用途 |
+|---|---|---|
+| アイコン | `icon` | 視覚的識別 (emoji 1 字 or SVG) |
+| アプリ名 | `displayName` | 「Memoria」「Actio」 等 |
+| **役割 (description)** | `description` | 「ナレッジ管理」「予定・タスク管理」 等の 1 行説明 |
+
+`description` は **必須**。 タブ表示で常に見える状態にすることでユーザが
+「どのタブが何のためのものか」 を覚えていなくても辿り着ける。
+
+レイアウトイメージ (1 タブ):
+
+```
+┌──────────────────────────────┐
+│  📓  Memoria                 │
+│      ナレッジ管理             │
+└──────────────────────────────┘
+```
+
+- 横幅に余裕がある画面 (デスクトップ等): 上記の **アイコン + 名前 + 役割** を
+  並べた縦 2 行のタブ
+- 狭い画面 (モバイル等): アイコン + 名前のみ、 役割は active タブ下に
+  サブタイトルとして 1 行表示
+
+`description` の文字数指標: 全角 6〜14 文字。 schema で `maxLength: 40` を
+強制し、 タブの幅が破綻しないようにする。
+
+## 5. Phase 0 (準備) の成果物
+
+このドキュメント自身を含め、 以下を準備フェーズの成果物とする。
+**実装コード (mount loader / shell SPA) は Phase 1 から**。
+
+| # | 成果物 | パス | 状態 |
+|---|---|---|---|
+| 0-1 | hub-shell 設計書 (本ドキュメント) | `spec/feature/hub-shell.md` | ✅ 本 PR |
+| 0-2 | App Manifest の JSON schema (description / dataChannels 含む) | `spec/schema/ludiars-app-manifest.schema.json` | 本 PR で stub 作成 |
+| 0-3 | Decision-1: バンドル方式 (WC / ESM / MF) の確定 | この doc の §3 を更新 | 別 PR (検証込み) |
+| 0-4 | Hub Shell の置き場所 scaffold | `server/multi/shell/` (空 dir + README) | 本 PR で placeholder |
+| 0-5 | shell が想定する apps の暫定リスト (description + task channel 入り) | `server/multi/shell/apps.example.json` | 本 PR で placeholder |
+| 0-6 | 既存 `multi-hub.md` (データハブ) との関係追記 | `spec/feature/multi-hub.md` の §1 末尾 | 本 PR で 1 段落追記 |
+| 0-7 | task channel の interop 契約 (§8) | この doc の §8 | ✅ 本 PR |
+| 0-8 | self-registration 仕様 (§9) — well-known + Hub setup UI + 保存スキーマ | この doc の §9 | ✅ 本 PR |
+| 0-9 | LUDIARS App Manifest well-known エンドポイント例 | `server/multi/shell/well-known.example.json` | 本 PR で placeholder |
+| 0-10 | Hub apps レジストリ DB スキーマ案 | `server/multi/shell/registry.schema.sql` | 本 PR で placeholder (実 migration 化は Phase 1) |
+
+## 6. 将来の分離 (LUDIARS Shell 化)
+
+集約 shell は Memoria 固有機能ではないので、 安定したら別リポ
+**LUDIARS Shell** (短縮コード未定) として切り出す予定。 そのために
+Phase 0 から以下を守る:
+
+- shell の実装は `server/multi/shell/` 配下に閉じる
+  (Memoria の他コードと依存を作らない)
+- App Manifest / Mount API は Memoria に依存しない汎用 schema にする
+- Hub 認証 (Cernere SSO) も Memoria 固有ではないので分離容易
+
+切り出し時に Memoria は「Mounted App の一つ」 になる。
+
+## 7. 未決事項 (Phase 0 内で詰めるもの)
+
+- (a) バンドル方式 (§3 Decision-1)
+- (b) 認証 propagation — Cernere session token を shell → mounted app に渡す
+  経路 (postMessage / shared cookie / shadowRoot context)
+- (c) routing — shell 側の history と mounted app の history の合成
+  (例: `/apps/bibliotheca/books/42` がアプリ内 deep link に解決される設計)
+- (d) design system 配布 — Foundation UI の CSS variable / Tailwind preset を
+  shell 経由で配る (npm package? CDN? inline?)
+- (e) task channel の authority 決定 (Memoria / Actio どちらが正 / sync 方向、 §8)
+- (f) manifest 改竄/破損時の挙動 (タブを隠す / エラータブ表示 / 自動 disable、 §9.6)
+- (g) cross-origin manifest fetch の許可ポリシー (Hub と同一 origin? 任意 origin?、 §9.4)
+
+これらは Phase 0 の終わりに別 issue として open する。
+
+## 8. データ統合 — task channel (Memoria ↔ Actio)
+
+### 8.1 現状
+
+- **Memoria** は SQLite に `tasks` を持ち、 AI 委託 / 日記連動 / カテゴリ /
+  リマインダー機能を持つ ([`spec/feature/task.md`](./task.md))。 既に
+  `POST /api/tasks/:id/share/actio` で **片方向 push** する経路がある
+  (Actio の `share_url` に直 POST、 Hub 経由しない)。
+- **Actio** は `tasks` テーブル + プラグインアーキテクチャを持つ
+  ([`Actio/CLAUDE.md`](../../../Actio/CLAUDE.md))。 status は
+  `open / in_progress / blocked / done / cancelled`、 plugin (PM 等) を
+  寄せる前提。
+- 現状の片方向 share は **Hub Shell とは無関係** の独立経路。 Memoria 側で
+  edit しても Actio 側に伝わらず、 Actio で done にしても Memoria 側で
+  open のまま、 という不整合がある。
+
+### 8.2 Hub Shell における「task channel」 の位置づけ
+
+Hub Shell は、 アプリ間で扱う共通データ種別を **dataChannel** として manifest で
+宣言させる (§4.1)。 task はその最初の channel。
+
+| channel 名 | 内容 | provider 候補 | consumer 候補 |
+|---|---|---|---|
+| `task` | 「やるべきこと」 単位の項目 (タイトル / 詳細 / status / due) | Actio (core task)、 Memoria (個人 task) | Memoria の AI 委託 UI、 他アプリのタスクウィジェット |
+
+各アプリは manifest で `role` を宣言:
+
+- `"provider"` — この channel の権威ストアを提供する (= 読み書きの正)
+- `"consumer"` — 他 provider のデータを読む / 書く (= 自身では権威を持たない)
+- `"both"` — 双方向同期する自前ストアも持ちつつ他 provider にも書く
+
+### 8.3 task channel の interop 契約 (Phase 0 で確定する最小スキーマ)
+
+shell mediation を経由して取り回される task のレコード形は以下:
+
+```jsonc
+{
+  "id": "string",              // channel 内で一意 (provider が発番)
+  "source": "actio" | "memoria",  // 発生元
+  "externalId": "string?",     // 連動済の場合、 相手側 ID
+  "title": "string",
+  "details": "string?",
+  "status": "open" | "in_progress" | "done" | "cancelled" | "blocked",
+  "dueAt": "ISO-8601?",
+  "createdAt": "ISO-8601",
+  "updatedAt": "ISO-8601",
+  "ownerUserId": "string"      // Cernere user id
+}
+```
+
+Memoria の `todo/doing/done` は `open/in_progress/done` にマップ。
+Actio の `blocked/cancelled` はそのまま。 Memoria 側に逆輸入する際は
+`open` 扱い (Memoria 側のステータス空間が小さい)。
+
+### 8.4 同期方向 (準備段階での提案、 Decision-2)
+
+3 案を decision-metrics で比較 (主目的 = 「タスクが Actio と統合可能」):
+
+| 案 | 概要 | AI 学習量 | 作業コスト | 解決度 | 主目的一致度 |
+|---|---|---|---|---|---|
+| **i. Actio 一元化** | Memoria は task を持たず、 全部 Actio API を叩く | ★★☆☆☆ | 中 (Memoria 既存 task 機能を Actio バックで再実装) | ★★★★★ | ★★★★★ |
+| **ii. 双方向同期** | 双方が自前 store + shell mediation で同期。 externalId で対応付け | ★★★★☆ | 大 (conflict resolution / loop 防止) | ★★★★☆ | ★★★★☆ |
+| **iii. 既存 share の改修** | 現 `/api/tasks/:id/share/actio` を pull も含めた API に拡張、 shell は介入しない | ★★☆☆☆ | 小 | ★★★☆☆ | ★★★☆☆ |
+
+**推奨 (準備段階の方針): i. Actio 一元化**
+
+- Actio は既に「予定 + タスク」 のコアプラットフォーム ([`Actio/CLAUDE.md`](../../../Actio/CLAUDE.md))。
+  task の権威を Actio に集約する方が責務分担として自然
+- Memoria 側の task UI (AI 委託 / 日記連動 / カテゴリ) は shell で
+  Actio task channel を consume する形で温存可能
+- 個人データ保管禁止ルール (§AIFormat) の観点でも、 task data の単一情報源化は望ましい
+- ただし「AI agent_run」 / 「日記の notes 追記」 のような Memoria 固有
+  サイドエフェクトは Memoria 側に残るため、 「Actio task に紐付く Memoria
+  メタデータ」 という形でローカル拡張テーブルを許す
+
+この方針は **Decision-2** として §7 (e) に上げる。 Phase 1 着手前に確定する。
+
+### 8.5 Phase 0 で準備するもの (task 統合に絞った範囲)
+
+- App Manifest に `dataChannels` フィールドを追加 (4.1 / schema 反映済)
+- `apps.example.json` で Actio = `task` provider、 Memoria = `task` consumer
+  として宣言 (本 PR)
+- 実装 (mount loader / channel mediation / sync) は **Phase 1 以降**
+
+## 9. Self-registration & セットアップ
+
+ユーザが Hub の Web UI から **アプリを自分で追加できる** ことを Phase 0 で
+仕様確定する。 §4 で定義した manifest と組み合わせて、 「URL を貼る → タブが増える」
+を最小フローにする。
+
+### 9.1 アプリ側 publication 規約
+
+集約対象になりたいアプリは、 自身の origin で manifest を以下 2 経路のいずれかで
+公開する:
+
+| 経路 | エンドポイント | 用途 |
+|---|---|---|
+| **well-known** (推奨) | `GET <origin>/.well-known/ludiars-app.json` | Hub が origin を貼られたら自動 fetch する canonical 経路 |
+| **explicit URL** | 任意の URL (例: `https://app.example/manifest.json`) | well-known を立てられない場合の fallback |
+
+レスポンスは §4.1 の manifest schema に準拠した JSON 1 個。
+配信時は以下を満たす:
+
+- `Content-Type: application/json; charset=utf-8`
+- `Cache-Control: max-age=300` (5 分) 程度を推奨。 Hub は ETag 尊重
+- CORS: `Access-Control-Allow-Origin: <hub-origin>` を必ず返す
+  (Hub が browser から直接 fetch する設計のため、 §9.4 参照)
+- HTTPS 必須 (localhost / .local TLD のみ HTTP を許容)
+
+### 9.2 Hub 側セットアップ UI
+
+Hub の管理ページ (`/admin/apps` 仮) に、 以下 UI を持つ:
+
+#### 一覧画面
+
+- 登録済アプリのリスト (タブ順)
+  - アイコン / displayName / description / status (enabled/disabled/error)
+  - 並び替え (drag & drop または ↑↓ ボタン)
+  - 行アクション: `Edit` / `Refetch` / `Disable` / `Remove`
+- 「+ アプリを追加」 ボタン
+
+#### 追加ダイアログ
+
+```
+┌─ アプリを追加 ──────────────────────────────────┐
+│                                                  │
+│  アプリの URL (origin または manifest URL)        │
+│  [_________________________________________]     │
+│                                                  │
+│  例:                                              │
+│   - https://bibliotheca.example.com             │
+│     → /.well-known/ludiars-app.json を自動取得    │
+│   - https://app.example.com/manifest.json       │
+│     → そのまま fetch                              │
+│                                                  │
+│  [取得してプレビュー]                              │
+│                                                  │
+│  ─ プレビュー (取得後) ─                          │
+│   📚  Bibliotheca                               │
+│        蔵書・機材の貸出台帳                       │
+│   タグ: cernere-session, design-tokens          │
+│   データ連携: task (consumer)                    │
+│                                                  │
+│         [追加してタブ表示]   [キャンセル]          │
+└──────────────────────────────────────────────────┘
+```
+
+フロー:
+
+1. ユーザが URL を入力 → `[取得してプレビュー]`
+2. Hub は **サーバ側で** fetch (browser の CORS 制約を回避し、 任意 origin を
+   許容するため)。 取得した JSON を §4 schema で検証
+3. 検証 OK → プレビュー (タブの外観 + capabilities + dataChannels) を表示。
+   不一致や fetch 失敗ならエラー (URL / schema / network / TLS)
+4. `[追加してタブ表示]` → DB に保存 (§9.3) → ライブ反映 (全 Hub クライアントに
+   broadcast)
+
+#### 編集 / 削除
+
+- `Edit` — manifest URL の差し替え + enabled flag 切替
+- `Refetch` — 同 URL から再取得し、 schema 検証
+- `Disable` — タブを隠すだけ。 DB には残る
+- `Remove` — DB から削除。 確認ダイアログ必須
+
+### 9.3 保存スキーマ (Postgres)
+
+Hub の既存 Postgres にテーブル `hub_apps` を追加する (実 migration は Phase 1):
+
+```sql
+CREATE TABLE hub_apps (
+  id              TEXT PRIMARY KEY,           -- manifest.id
+  manifest_url    TEXT NOT NULL,              -- fetch 元 URL
+  manifest_json   JSONB NOT NULL,             -- 最後に取得した manifest 全体
+  display_order   INTEGER NOT NULL DEFAULT 0, -- タブの並び順
+  enabled         BOOLEAN NOT NULL DEFAULT TRUE,
+  installed_by    TEXT NOT NULL,              -- Cernere user id (admin role 必須)
+  installed_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_refetched_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_etag       TEXT,                       -- 次回 fetch の If-None-Match に使う
+  last_error      TEXT                        -- refetch 失敗時の最新エラー (NULL = OK)
+);
+
+CREATE INDEX hub_apps_display_order_idx ON hub_apps (display_order, id) WHERE enabled;
+```
+
+設計メモ:
+
+- `id` は manifest が決めるので、 同じ id を別 URL から二重登録は弾く
+  (UNIQUE 制約で自然に阻止)
+- `manifest_json` を JSONB で持つことで、 次回 fetch 失敗時もタブが消えない
+- `installed_by` は Cernere user id。 admin role のみ登録を許す (§9.5)
+- 個人データ非該当 (manifest は公開情報のみ)、 個人データ保管禁止ルールに抵触しない
+
+### 9.4 fetch サーバプロキシ (cross-origin 配慮)
+
+Hub の SPA が直接 `https://random-app.example/.well-known/...` を fetch すると、
+そのアプリが Hub origin を CORS 許可していない限り browser ブロックされる。
+対策として、 manifest fetch は **Hub backend が代理で行う**:
+
+```
+POST /api/admin/apps/preview { url } → manifest JSON (validated)
+POST /api/admin/apps          { url } → 登録
+GET  /api/admin/apps                  → 一覧
+PATCH /api/admin/apps/:id    { enabled?, display_order? }
+POST /api/admin/apps/:id/refetch      → 再取得 + 検証
+DELETE /api/admin/apps/:id
+```
+
+- preview / refetch / 登録の `url` はサーバ側 fetch
+- timeout 5 秒、 redirect 最大 3、 response 上限 256KB (manifest が肥大化しない前提)
+- SSRF 対策: private IP (10/8, 172.16/12, 192.168/16, ::1, 127/8) への fetch は拒否
+  - ただし `MEMORIA_DEV=1` 時は localhost 許可 (開発用)
+- Decision: 「Hub と同一 origin に限定」 まで絞るか、 「任意 HTTPS 公開 origin」 まで広げるかは
+  §7 (g) で決定
+
+### 9.5 認証 & 認可
+
+- セットアップ UI 全体は **Cernere 認証 + admin role 必須**
+  ([`Actio/CLAUDE.md`](../../../Actio/CLAUDE.md) のロールモデルに準拠)
+- 一般ユーザは「現在登録されているタブを使う」 ことだけできる
+- admin が複数いる場合の競合は last-write-wins (Phase 0 範囲)。 audit log は
+  Phase 1 で追加
+
+### 9.6 manifest 破損 / 改竄時の挙動
+
+- **schema 検証失敗**: 登録は阻止。 既存登録の refetch で失敗した場合は、
+  最後に成功した `manifest_json` を引き続き使い、 `last_error` をログに残す
+  + 管理 UI に警告バッジ表示
+- **fetch 不能 (404/5xx/timeout)**: 同上、 既存 manifest をそのまま使う。
+  連続 N 回失敗で自動 disable するかは §7 (f) で決定 (現時点では未自動化)
+- **entry の url が dead**: タブを開いた瞬間に shell が検知し、 ユーザに
+  「読み込みに失敗しました」 表示。 タブ自体は隠さない (誤検知防止)
+
+### 9.7 Phase 0 で準備するもの
+
+- 本セクション (仕様確定)
+- `well-known.example.json` — well-known エンドポイントが返す JSON の例
+  (Memoria 自身が出す想定の形)
+- `registry.schema.sql` — `hub_apps` テーブル DDL の case (実 migration は Phase 1)
+
+実装 (`/api/admin/apps/*` + setup UI 画面 + browser 側のタブ動的反映) は
+**Phase 1 以降**。

--- a/spec/feature/ludiars-app-manifest.md
+++ b/spec/feature/ludiars-app-manifest.md
@@ -1,0 +1,133 @@
+# LUDIARS App Manifest フォーマット
+
+Memoria Hub Shell に集約されるアプリが Hub に対して公開する manifest の
+形式。 schema 正本は [`../schema/ludiars-app-manifest.schema.json`](../schema/ludiars-app-manifest.schema.json)、
+shell 全体の設計は [`hub-shell.md`](./hub-shell.md) を参照。
+
+- **公開経路**: `GET https://<app>/.well-known/ludiars-app.json`
+  (CORS で Hub origin 許可、 HTTPS 必須。 詳細は [`hub-shell.md`](./hub-shell.md) §9.1)
+- **配信形式**: `Content-Type: application/json; charset=utf-8`
+- **キャッシュ**: `Cache-Control: max-age=300` 程度推奨 (Hub は ETag 尊重)
+
+## フィールド一覧
+
+| field | 必須 | 型 / 制約 | 用途 |
+|---|---|---|---|
+| `id` | ✅ | `^[a-z][a-z0-9-]{1,31}$` | URL / 内部キー (manifest 間で一意) |
+| `displayName` | ✅ | string 1–64 | タブのアプリ名 |
+| `description` | ✅ | string 1–40 | **タブの役割行** (例 「ナレッジ管理」) |
+| `shortCode` | — | `^[A-Z][a-zA-Z]?$` | LUDIARS 2 文字略称 (Mm / A / Bb 等) |
+| `icon` | — | string | emoji 1 字 or SVG/PNG URL |
+| `version` | — | string | manifest 自体のバージョン (semver 推奨) |
+| `entry` | ✅ | object (3 種から 1 つ) | mount 方式 (§entry) |
+| `capabilities` | — | enum array | shell に要求する権限 |
+| `dataChannels` | — | object array | アプリ間データ連携 (§dataChannels) |
+| `routes` | — | object array | shell URL 空間でのパス (`/apps/<id>...`) |
+
+## `entry` — 3 種の mount 方式 (oneOf)
+
+```jsonc
+// (a) Web Components
+"entry": {
+  "type": "web-component",
+  "tag": "bibliotheca-app",                 // 必ずハイフンを含む
+  "url": "https://app.example/element.js"
+}
+
+// (b) ESM module
+"entry": {
+  "type": "esm",
+  "url": "https://app.example/mount.js"     // default export: { mount(el, ctx), unmount(el) }
+}
+
+// (c) Module Federation
+"entry": {
+  "type": "module-federation",
+  "remoteEntry": "https://app.example/remoteEntry.js",
+  "exposedModule": "./AppRoot"
+}
+```
+
+最終的にどの方式を採用するかは [`hub-shell.md`](./hub-shell.md) §3 Decision-1
+で確定する (Phase 0 では 3 方式とも schema に乗せておく)。
+
+## `capabilities` — shell が提供する権限 (enum)
+
+| 値 | 内容 |
+|---|---|
+| `cernere-session` | shell から Cernere session を受け取る |
+| `design-tokens` | shell の CSS variable / Foundation UI トークンを継承 |
+| `shell-router` | shell の history API にフックする |
+| `push-notification` | shell 経由で WebPush を送る |
+
+Phase 1 で各 capability の contract (mount context の型) を定義する。
+
+## `dataChannels` — アプリ間連携 (Phase 0 は `task` のみ)
+
+```jsonc
+"dataChannels": [
+  { "name": "task", "role": "provider" }    // 権威ストア (例: Actio)
+  // role: provider | consumer | both
+]
+```
+
+- `provider`: この channel の権威ストアを提供する
+- `consumer`: 他 provider のデータを読む / 書く (自身では権威を持たない)
+- `both`: 双方向同期する自前ストアを持ちつつ他 provider にも書く
+
+詳細と task channel の interop 契約は [`hub-shell.md`](./hub-shell.md) §8。
+
+## `routes` — shell URL マッピング
+
+```jsonc
+"routes": [
+  { "path": "/apps/bibliotheca", "default": true }  // path は ^/apps/<id> 必須
+]
+```
+
+複数 route を持てる (= deep link の suffix を寄せる)。 `default: true` の route が
+`/apps/<id>` 単独でアクセスされた時の解決先。
+
+## 最小例
+
+```json
+{
+  "id": "memoria",
+  "displayName": "Memoria",
+  "description": "ナレッジ管理",
+  "icon": "📓",
+  "entry": {
+    "type": "web-component",
+    "tag": "memoria-app",
+    "url": "https://memoria.example/dist/element.js"
+  },
+  "dataChannels": [{ "name": "task", "role": "consumer" }],
+  "routes": [{ "path": "/apps/memoria", "default": true }]
+}
+```
+
+同形のファイル: [`../../server/multi/shell/well-known.example.json`](../../server/multi/shell/well-known.example.json)
+
+## Hub 側の使い方 (セットアップ UI フロー)
+
+1. admin が `/admin/apps` で URL を貼付 (origin または manifest URL)
+2. Hub backend が `<origin>/.well-known/ludiars-app.json` を fetch
+   (SSRF 対策込、 詳細は [`hub-shell.md`](./hub-shell.md) §9.4)
+3. JSON Schema で検証 → プレビュー (タブ外観 + capabilities + dataChannels) を表示
+4. 確定 → `hub_apps` テーブルに保存
+   ([`../../server/multi/shell/registry.schema.sql`](../../server/multi/shell/registry.schema.sql))
+5. ライブ反映 — タブが増える
+
+## バージョン管理 / 後方互換
+
+- `version` フィールド (semver) はアプリ側 manifest の改訂版数 (Hub の解釈は
+  「変わったら refetch しても古い state を上書きしてよい」 の目印)
+- schema 自体の互換性は `$id` の URL バージョンで管理する。 破壊的変更時は
+  `$id` の path を `v2/` に切る (Phase 1 以降に成立予定)
+
+## 検証ツール (将来)
+
+Hub の `/api/admin/apps/preview` は登録前にこの schema で検証する。 アプリ開発者は
+ローカルで `ajv validate -s ludiars-app-manifest.schema.json -d my-manifest.json` の
+ような ajv-cli ベース手順を踏める。 Phase 1 で `scripts/validate-manifest.mjs` を
+同梱予定。

--- a/spec/feature/multi-hub.md
+++ b/spec/feature/multi-hub.md
@@ -20,6 +20,12 @@ share/download する」 モデルだった。 これだと:
   データアクセス先が Hub の JSON API になる。
 - 拠点ごとに Hub を立てられる (= 各 Hub が独立した Cernere + データストア)。
 
+> **関連**: 本書は Hub の **データハブ役** (Memoria 共有 7 型の JSON CRUD) の
+> 設計。 Hub にはこれと別に **frontend shell 役** (複数 LUDIARS アプリの集約
+> レンダリング) を将来載せる方向で準備中。 そちらは
+> [`hub-shell.md`](./hub-shell.md) を参照。 2 役は Hub 内で同居するが
+> 互いに依存しない。
+
 ## 2. アーキテクチャ
 
 ```

--- a/spec/schema/ludiars-app-manifest.schema.json
+++ b/spec/schema/ludiars-app-manifest.schema.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ludiars.github.io/Memoria/spec/schema/ludiars-app-manifest.schema.json",
+  "title": "LUDIARS App Manifest",
+  "description": "Manifest a LUDIARS app exposes to a Hub Shell (see spec/feature/hub-shell.md). Phase 0 stub — fields may change before Phase 1 starts.",
+  "type": "object",
+  "required": ["id", "displayName", "description", "entry"],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]{1,31}$",
+      "description": "Short immutable identifier. Used in URLs and Hub Shell internals."
+    },
+    "displayName": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "description": "Human-readable name shown in the Hub Shell nav."
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 40,
+      "description": "One-line role description displayed under the app name in the tab nav (e.g. 'ナレッジ管理'). Required; kept short to fit the tab layout. See hub-shell.md §4.2."
+    },
+    "shortCode": {
+      "type": "string",
+      "pattern": "^[A-Z][a-zA-Z]?$",
+      "description": "LUDIARS 2-letter project code (see reference_project_codes)."
+    },
+    "icon": {
+      "type": "string",
+      "description": "Emoji or URL to SVG/PNG. URL is resolved relative to the manifest if a base is known."
+    },
+    "version": {
+      "type": "string",
+      "description": "Manifest version (semver recommended)."
+    },
+    "entry": {
+      "description": "How the Hub Shell should mount this app's UI.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["type", "tag", "url"],
+          "additionalProperties": false,
+          "properties": {
+            "type": { "const": "web-component" },
+            "tag": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9-]*-[a-z0-9-]+$",
+              "description": "Custom element tag (must contain a hyphen per HTML spec)."
+            },
+            "url": {
+              "type": "string",
+              "format": "uri",
+              "description": "URL to the JS module that registers the custom element."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["type", "url"],
+          "additionalProperties": false,
+          "properties": {
+            "type": { "const": "esm" },
+            "url": {
+              "type": "string",
+              "format": "uri",
+              "description": "URL to an ESM module whose default export is { mount(el, ctx), unmount(el) }."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["type", "remoteEntry", "exposedModule"],
+          "additionalProperties": false,
+          "properties": {
+            "type": { "const": "module-federation" },
+            "remoteEntry": { "type": "string", "format": "uri" },
+            "exposedModule": { "type": "string" }
+          }
+        }
+      ]
+    },
+    "capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["cernere-session", "design-tokens", "shell-router", "push-notification"]
+      },
+      "uniqueItems": true,
+      "description": "Capabilities the app requests from the Hub Shell. Phase 1 will define each."
+    },
+    "dataChannels": {
+      "type": "array",
+      "description": "Cross-app data channels this app participates in (see hub-shell.md §8). Phase 0 only declares 'task'; more channels added later.",
+      "items": {
+        "type": "object",
+        "required": ["name", "role"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": ["task"],
+            "description": "Channel identifier. Phase 0 ships 'task' only."
+          },
+          "role": {
+            "type": "string",
+            "enum": ["provider", "consumer", "both"],
+            "description": "provider = authoritative store; consumer = reads/writes via shell mediation; both = bidirectional sync."
+          }
+        }
+      },
+      "uniqueItems": true
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["path"],
+        "additionalProperties": false,
+        "properties": {
+          "path": {
+            "type": "string",
+            "pattern": "^/apps/[a-z][a-z0-9-]*(/.*)?$",
+            "description": "URL prefix in the Hub Shell's URL space."
+          },
+          "default": {
+            "type": "boolean",
+            "description": "If true, navigating to /apps/<id> resolves to this route."
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Memoria Hub に複数 LUDIARS アプリを 1 つのフロントエンドとして集約する **Hub Shell** を載せる方向で、 Phase 0 (準備フェーズ) の仕様 / scaffold を確定。 実装コードはなし、 すべて spec + placeholder。

将来 `LUDIARS Shell` として別サービス切り出しを想定するため、 実装は `server/multi/shell/` 配下に閉じる方針。

## 主要な追加

- **`spec/feature/hub-shell.md`** — 全体設計
  - §3 集約方式 3 案 (iframe / micro-frontend / shell が再実装) を decision-metrics で比較、 **推奨 B (micro-frontend)**
  - §4.2 タブ UX — アイコン + アプリ名 + 役割 (description) の縦 2 行
  - §8 task channel (Memoria ↔ Actio 統合)、 同期方向 3 案 → **推奨: Actio 一元化**
  - §9 self-registration & セットアップ — ユーザが Hub UI から URL 貼付でタブ追加
- **`spec/feature/ludiars-app-manifest.md`** — manifest フォーマット単体ドキュメント
- **`spec/schema/ludiars-app-manifest.schema.json`** — JSON Schema
  - `id` / `displayName` / `description` (必須、 maxLength 40) / `entry` (web-component / esm / module-federation 3 種 oneOf) / `capabilities` / `dataChannels` (Phase 0 は `task` のみ) / `routes`
- **`server/multi/shell/`** scaffold
  - `apps.example.json` — Memoria/Actio/Bibliotheca/Calicula 4 アプリのレジストリ例
  - `well-known.example.json` — `/.well-known/ludiars-app.json` レスポンス例
  - `registry.schema.sql` — `hub_apps` テーブル DDL (実 migration は Phase 1)
- **`spec/feature/multi-hub.md`** — Hub の二役 (データハブ + frontend shell) の関係を §1 末尾に 1 段落追記

## 未決事項 (Phase 0 で詰める)

- (a) バンドル方式 (WC / ESM / Module Federation) の最終確定 — Decision-1
- (b) 認証 propagation 経路 (postMessage / shared cookie / shadowRoot context)
- (c) routing 合成 (shell history と mounted app history)
- (d) design system 配布方式
- (e) task channel authority (Memoria / Actio) — Decision-2
- (f) manifest refetch 連続失敗時の自動 disable しきい値
- (g) manifest fetch を Hub 同 origin に絞るか任意 HTTPS origin を許すか

## Test plan

- [ ] spec 変更のみ、 実行コード変更なし (CI 影響なし)
- [ ] schema 構文確認 (JSON Schema draft 2020-12 として valid であること)
- [ ] レビュー観点: §3 / §8.4 / §9 の方針が将来分離 (LUDIARS Shell 化) と矛盾しないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)