### PR TITLE
feat(tasks): 「目標」 種別 + カテゴリにリポジトリサジェスト

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -652,8 +652,8 @@ export function openDb(dbPath: string): Db {
       ON tasks(status, created_at DESC);
     CREATE INDEX IF NOT EXISTS idx_tasks_due
       ON tasks(due_at);
-    CREATE INDEX IF NOT EXISTS idx_tasks_kind
-      ON tasks(kind);
+    -- idx_tasks_kind は ALTER で kind カラムを足した後にしか作れないので、
+    -- migration block の末尾で作成する (下記 ALTER 群の直後を参照)。
 
     CREATE TABLE IF NOT EXISTS agent_projects (
       id             INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -912,9 +912,9 @@ export function openDb(dbPath: string): Db {
       db.exec(`ALTER TABLE tasks ADD COLUMN ${col} ${ddl}`);
     }
   }
-  if (taskCols.length > 0 && !taskCols.includes('kind')) {
-    db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_kind ON tasks(kind)`);
-  }
+  // kind カラムは ALTER で足したばかり (or 元から存在) — どちらにせよ
+  // index を作る。 IF NOT EXISTS で冪等。
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_kind ON tasks(kind)`);
   // agent_runs.model — add if missing on existing DBs.
   const arCols = (db.prepare(`PRAGMA table_info(agent_runs)`).all() as { name: string }[]).map(c => c.name);
   if (arCols.length > 0 && !arCols.includes('model')) {

--- a/server/db.ts
+++ b/server/db.ts
@@ -638,6 +638,7 @@ export function openDb(dbPath: string): Db {
       title         TEXT NOT NULL,
       details       TEXT,
       status        TEXT NOT NULL DEFAULT 'todo',
+      kind          TEXT NOT NULL DEFAULT 'task',
       creator_type  TEXT NOT NULL DEFAULT 'human',
       due_at        TEXT,
       share_actio   INTEGER NOT NULL DEFAULT 0,
@@ -651,6 +652,8 @@ export function openDb(dbPath: string): Db {
       ON tasks(status, created_at DESC);
     CREATE INDEX IF NOT EXISTS idx_tasks_due
       ON tasks(due_at);
+    CREATE INDEX IF NOT EXISTS idx_tasks_kind
+      ON tasks(kind);
 
     CREATE TABLE IF NOT EXISTS agent_projects (
       id             INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -902,11 +905,15 @@ export function openDb(dbPath: string): Db {
     ['shared_at', 'TEXT'],
     ['shared_origin', 'TEXT'],
     ['category', 'TEXT'],
+    ['kind', `TEXT NOT NULL DEFAULT 'task'`],
   ];
   for (const [col, ddl] of taskAlters) {
     if (taskCols.length > 0 && !taskCols.includes(col)) {
       db.exec(`ALTER TABLE tasks ADD COLUMN ${col} ${ddl}`);
     }
+  }
+  if (taskCols.length > 0 && !taskCols.includes('kind')) {
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_kind ON tasks(kind)`);
   }
   // agent_runs.model — add if missing on existing DBs.
   const arCols = (db.prepare(`PRAGMA table_info(agent_runs)`).all() as { name: string }[]).map(c => c.name);
@@ -2458,6 +2465,9 @@ const ACTIVITY_KINDS = new Set<ActivityKind>([
   'task_created',
   'task_done',
   'task_updated',
+  'goal_created',
+  'goal_done',
+  'goal_updated',
 ]);
 
 export interface RecordActivityEventInput {
@@ -4710,16 +4720,28 @@ export function setWorkLocationOwner(db: Db, id: number, { ownerUserId, ownerUse
 
 export interface ListTasksOptions {
   status?: TaskRow['status'] | null;
+  /**
+   * - 'task' | 'goal' : その kind だけ返す
+   * - 'all'           : 両方
+   * - null (既定)      : 'task' (= 通常タスク一覧、 目標は別 query で取る前提)
+   */
+  kind?: TaskRow['kind'] | 'all' | null;
   limit?: number;
   offset?: number;
 }
 
-export function listTasks(db: Db, { status = null, limit = 100, offset = 0 }: ListTasksOptions = {}): TaskRow[] {
+export function listTasks(db: Db, { status = null, kind = null, limit = 100, offset = 0 }: ListTasksOptions = {}): TaskRow[] {
   const where: string[] = [];
   const args: unknown[] = [];
   if (status) {
     where.push('status = ?');
     args.push(status);
+  }
+  if (kind === null) {
+    where.push(`kind = 'task'`);
+  } else if (kind !== 'all') {
+    where.push('kind = ?');
+    args.push(kind);
   }
   args.push(limit, offset);
   return db.prepare(`
@@ -4741,6 +4763,7 @@ export interface InsertTaskInput {
   title: string;
   details?: string | null;
   status?: TaskRow['status'];
+  kind?: TaskRow['kind'];
   creator_type?: TaskRow['creator_type'];
   due_at?: string | null;
   share_actio?: boolean | 0 | 1;
@@ -4749,12 +4772,13 @@ export interface InsertTaskInput {
 
 export function insertTask(db: Db, task: InsertTaskInput): number {
   const info = db.prepare(`
-    INSERT INTO tasks (title, details, status, creator_type, due_at, share_actio, category)
-    VALUES (?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO tasks (title, details, status, kind, creator_type, due_at, share_actio, category)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     task.title,
     task.details ?? null,
     task.status || 'todo',
+    task.kind === 'goal' ? 'goal' : 'task',
     task.creator_type === 'ai' ? 'ai' : 'human',
     task.due_at ?? null,
     task.share_actio ? 1 : 0,
@@ -4831,7 +4855,7 @@ export function unregisterTaskCategory(db: Db, name: string): void {
 }
 
 export function updateTask(db: Db, id: number, patch: Record<string, unknown>): void {
-  const allowed = new Set(['title', 'details', 'status', 'creator_type', 'due_at', 'share_actio', 'shared_at', 'shared_origin', 'category']);
+  const allowed = new Set(['title', 'details', 'status', 'kind', 'creator_type', 'due_at', 'share_actio', 'shared_at', 'shared_origin', 'category']);
   const cols: string[] = [];
   const args: unknown[] = [];
   for (const [k, v] of Object.entries(patch)) {

--- a/server/db/types/activity.ts
+++ b/server/db/types/activity.ts
@@ -8,7 +8,10 @@ export type ActivityKind =
   | 'codex_prompt'
   | 'task_created'
   | 'task_done'
-  | 'task_updated';
+  | 'task_updated'
+  | 'goal_created'
+  | 'goal_done'
+  | 'goal_updated';
 
 export interface ActivityEventRow {
   id: number;

--- a/server/db/types/task.ts
+++ b/server/db/types/task.ts
@@ -3,12 +3,18 @@
 
 export type TaskStatus = 'todo' | 'doing' | 'done';
 export type TaskCreatorType = 'human' | 'ai';
+export type TaskKind = 'task' | 'goal';
 
 export interface TaskRow {
   id: number;
   title: string;
   details: string | null;
   status: TaskStatus;
+  /**
+   * 'task' (既定) は通常のタスク、 'goal' は「目標」 として扱う。
+   * 目標は status (todo/doing/done) と組み合わせて、 達成したかどうかを表す。
+   */
+  kind: TaskKind;
   creator_type: TaskCreatorType;
   due_at: string | null;       // UTC ISO or 'YYYY-MM-DDTHH:MM' (local)
   share_actio: 0 | 1;

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -6911,16 +6911,18 @@ function parseTaskCategories(s) {
 
 function taskCardHtml(t) {
   const aiBadge = t.creator_type === 'ai' ? '<span class="task-origin ai">AI</span>' : '<span class="task-origin human">人間</span>';
+  const isGoal = t.kind === 'goal';
+  const kindBadge = isGoal ? '<span class="task-kind goal">🎯 目標</span>' : '';
   const cats = parseTaskCategories(t.category);
   const catBadges = cats.map(c => `<span class="task-category">${escapeHtml(c)}</span>`).join('');
   const doneBtn = t.status === 'done'
     ? '<button class="ghost" disabled>Done</button>'
     : `<button class="ghost" data-task-done="${t.id}">Done</button>`;
   return `
-    <article class="task-card" data-task-open="${t.id}" data-task-drag="${t.id}" draggable="${t.status === 'done' ? 'false' : 'true'}">
+    <article class="task-card${isGoal ? ' task-card--goal' : ''}" data-task-open="${t.id}" data-task-drag="${t.id}" draggable="${t.status === 'done' ? 'false' : 'true'}">
       <div class="task-card-head">
         <strong>${escapeHtml(t.title)}</strong>
-        ${aiBadge}${catBadges}
+        ${kindBadge}${aiBadge}${catBadges}
       </div>
       <div class="muted">期日: ${escapeHtml(formatTaskDue(t.due_at))}</div>
       <p>${escapeHtml(t.details || '')}</p>
@@ -7566,7 +7568,10 @@ async function saveWorkLocationFromForm() {
 function openTaskEditor(task = null) {
   const isEdit = !!task;
   if (!$('taskEditorModal')) return;
-  $('taskEditorHeading').textContent = isEdit ? 'タスクを変更' : 'タスクを追加';
+  const kind = task?.kind === 'goal' ? 'goal' : 'task';
+  const noun = kind === 'goal' ? '目標' : 'タスク';
+  $('taskEditorHeading').textContent = isEdit ? `${noun}を変更` : `${noun}を追加`;
+  if ($('taskEditorKind')) $('taskEditorKind').value = kind;
   $('taskEditorTitle').value = task?.title || '';
   $('taskEditorDue').value = task?.due_at ? String(task.due_at).slice(0, 16) : '';
   $('taskEditorStatus').value = task?.status || 'todo';
@@ -7574,11 +7579,32 @@ function openTaskEditor(task = null) {
   $('taskEditorShareActio').checked = !!task?.share_actio;
   $('taskEditorCategory').value = task?.category || '';
   $('taskEditorTaskId').value = task?.id ? String(task.id) : '';
-  // populate category autocomplete
+  // populate category autocomplete (登録済カテゴリ + 登録済リポジトリのサジェスト)
   api('/api/tasks/categories').then(r => {
     const dl = $('taskCategoryOptions');
-    if (dl) dl.innerHTML = (r.items || []).map(c => `<option value="${escapeHtml(c)}"></option>`).join('');
+    if (!dl) return;
+    const items = (r.items || []).map(c => ({ value: c }));
+    const repos = ((r.suggestions && r.suggestions.repos) || []).map(c => ({ value: c, hint: 'リポジトリ' }));
+    // dedup
+    const seen = new Set();
+    const merged = [];
+    for (const o of [...items, ...repos]) {
+      if (!o.value || seen.has(o.value)) continue;
+      seen.add(o.value);
+      merged.push(o);
+    }
+    dl.innerHTML = merged
+      .map(o => `<option value="${escapeHtml(o.value)}"${o.hint ? ` label="${escapeHtml(o.hint)}"` : ''}></option>`)
+      .join('');
   }).catch(() => {});
+  // kind 切替で見出しも追従させる
+  const kindEl = $('taskEditorKind');
+  if (kindEl) {
+    kindEl.onchange = () => {
+      const k = kindEl.value === 'goal' ? '目標' : 'タスク';
+      $('taskEditorHeading').textContent = isEdit ? `${k}を変更` : `${k}を追加`;
+    };
+  }
   showModal('taskEditorModal');
   $('taskEditorTitle').focus();
 }
@@ -7801,14 +7827,31 @@ function renderTaskBoard() {
     btn.classList.toggle('active', btn.dataset.taskMenu === state.taskMenu);
   });
   renderTaskCategoryMenu();
+  const filterByCat = (arr) => state.taskCategoryFilter == null
+    ? arr
+    : (state.taskCategoryFilter === '__none__'
+        ? arr.filter((t) => parseTaskCategories(t.category).length === 0)
+        : arr.filter((t) => parseTaskCategories(t.category).includes(state.taskCategoryFilter)));
+  const goals = state.goalItems || [];
+  const goalStatusFiltered = state.taskMenu === 'done'
+    ? goals.filter((g) => g.status === 'done')
+    : goals.filter((g) => g.status !== 'done');
+  const goalView = filterByCat(goalStatusFiltered);
+  const goalsPane = $('tasksGoalsPane');
+  const goalsList = $('tasksGoalsList');
+  if (goalsPane && goalsList) {
+    if (goalView.length === 0) {
+      goalsPane.classList.add('hidden');
+      goalsList.innerHTML = '';
+    } else {
+      goalsPane.classList.remove('hidden');
+      goalsList.innerHTML = goalView.map(taskCardHtml).join('');
+    }
+  }
   const statusFiltered = state.taskMenu === 'done'
     ? state.taskItems.filter((t) => t.status === 'done')
     : state.taskItems.filter((t) => t.status !== 'done');
-  const base = state.taskCategoryFilter == null
-    ? statusFiltered
-    : (state.taskCategoryFilter === '__none__'
-        ? statusFiltered.filter((t) => parseTaskCategories(t.category).length === 0)
-        : statusFiltered.filter((t) => parseTaskCategories(t.category).includes(state.taskCategoryFilter)));
+  const base = filterByCat(statusFiltered);
   const middleItems = base.filter((t) => taskDatePartition(t) === 'middle');
   const rightItems = base.filter((t) => taskDatePartition(t) === 'right');
   middle.innerHTML = middleItems.length ? middleItems.map(taskCardHtml).join('') : '<div class="queue-empty">対象タスクなし</div>';
@@ -7936,6 +7979,10 @@ ensureMemoriaFeatureViews = function () {
           <button id="taskNewBtn" type="button">+ 追加</button>
         </div>
         <div id="taskForm" class="simple-form hidden"></div>
+        <section id="tasksGoalsPane" class="tasks-goals-pane hidden">
+          <h3>🎯 目標</h3>
+          <div id="tasksGoalsList" class="simple-list"></div>
+        </section>
         <div class="tasks-three-pane">
           <aside id="tasksMenu" class="tasks-menu">
             <div class="tasks-menu-section">
@@ -7967,6 +8014,13 @@ ensureMemoriaFeatureViews = function () {
           <button type="button" class="modal-close" id="taskEditorClose" aria-label="close">×</button>
           <h3 id="taskEditorHeading">タスクを追加</h3>
           <input type="hidden" id="taskEditorTaskId" />
+          <label class="simple-field">
+            <span>種別</span>
+            <select id="taskEditorKind">
+              <option value="task">📝 タスク (短期の作業)</option>
+              <option value="goal">🎯 目標 (中長期で達成したいこと)</option>
+            </select>
+          </label>
           <label class="simple-field">
             <span>タスク内容</span>
             <input id="taskEditorTitle" type="text" />
@@ -8110,12 +8164,16 @@ ensureMemoriaFeatureViews = function () {
 loadTasks = async function () {
   ensureMemoriaFeatureViews();
   const [r] = await Promise.all([
-    api('/api/tasks'),
+    api('/api/tasks?kind=all'),
     reloadTaskCategoriesCache(),
   ]);
-  state.taskItems = r.items || [];
+  const items = r.items || [];
+  // 既存コードは state.taskItems 一本 (tasks のみ) を仮定するので、 互換のため
+  // kind='task' のみを taskItems、 'goal' は別配列で保持。
+  state.taskItems = items.filter((t) => t.kind !== 'goal');
+  state.goalItems = items.filter((t) => t.kind === 'goal');
   if (state.taskDetail?.id) {
-    state.taskDetail = state.taskItems.find((t) => t.id === state.taskDetail.id) || null;
+    state.taskDetail = items.find((t) => t.id === state.taskDetail.id) || null;
   }
   renderTaskBoard();
   renderTaskDetail();
@@ -8126,6 +8184,7 @@ addTaskFromForm = async function () {
   if (!title) return;
   const editId = Number($('taskEditorTaskId')?.value || 0);
   const category = $('taskEditorCategory')?.value.trim() || null;
+  const kind = $('taskEditorKind')?.value === 'goal' ? 'goal' : 'task';
   if (editId) {
     await api(`/api/tasks/${editId}`, {
       method: 'PATCH',
@@ -8135,6 +8194,7 @@ addTaskFromForm = async function () {
         details: $('taskEditorDetails')?.value.trim() || '',
         due_at: $('taskEditorDue')?.value || null,
         status: $('taskEditorStatus')?.value || 'todo',
+        kind,
         share_actio: !!$('taskEditorShareActio')?.checked,
         category,
       }),
@@ -8148,6 +8208,7 @@ addTaskFromForm = async function () {
         details: $('taskEditorDetails')?.value.trim() || '',
         due_at: $('taskEditorDue')?.value || null,
         status: $('taskEditorStatus')?.value || 'todo',
+        kind,
         share_actio: !!$('taskEditorShareActio')?.checked,
         category,
         creator_type: 'human',

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -4490,6 +4490,39 @@ dialog.meal-modal[open] {
   border: 1px solid var(--border);
   color: var(--muted);
 }
+/* 「目標」 = 中長期で達成したいこと。 タスクと並べた時に視覚的に区別する。 */
+.tasks-goals-pane {
+  margin: 0 0 12px;
+  padding: 10px 12px 12px;
+  border: 1px solid #d8c98a;
+  border-radius: 10px;
+  background: linear-gradient(180deg, #fffcec 0%, #fff9d8 100%);
+}
+.tasks-goals-pane.hidden { display: none; }
+.tasks-goals-pane h3 {
+  margin: 0 0 8px;
+  font-size: 13px;
+  color: #8a6d00;
+  letter-spacing: 0.04em;
+}
+.task-card--goal {
+  border-left: 4px solid #d8a900;
+}
+.task-kind {
+  display: inline-flex;
+  align-items: center;
+  height: 20px;
+  padding: 0 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  border: 1px solid var(--border);
+  color: var(--muted);
+}
+.task-kind.goal {
+  border-color: #d8a900;
+  color: #6b5300;
+  background: #fff3c4;
+}
 .task-origin.ai {
   border-color: #c37a00;
   color: #9a6000;

--- a/server/routes/task.ts
+++ b/server/routes/task.ts
@@ -8,6 +8,7 @@ import {
   getTask, insertTask, updateTask, deleteTask,
   insertExternalChatMessage, listExternalChatMessages,
   getDiary, upsertDiary, recordActivityEvent,
+  listRepoWatch,
 } from '../db.js';
 import { formatLocalDate } from '../diary.js';
 import { privacySettings } from '../lib/privacy.js';
@@ -61,11 +62,21 @@ export function makeTaskRouter(deps: TaskRouterDeps): Hono {
     const status = statusQ && (validStatuses as readonly string[]).includes(statusQ)
       ? statusQ as typeof validStatuses[number]
       : null;
-    return c.json({ items: listTasks(db, { status, limit, offset }) });
+    // kind: 'task' (default) | 'goal' | 'all'。 互換性のため未指定なら通常タスクのみ。
+    const kindQ = c.req.query('kind');
+    const validKinds = ['task', 'goal', 'all'] as const;
+    const kind = kindQ && (validKinds as readonly string[]).includes(kindQ)
+      ? kindQ as typeof validKinds[number]
+      : null;
+    return c.json({ items: listTasks(db, { status, kind, limit, offset }) });
   });
 
   r.get('/api/tasks/categories', (c: Context) => {
-    return c.json({ items: listTaskCategories(db) });
+    const items = listTaskCategories(db);
+    // サジェスト用に登録済リポを `owner/name` 形式で返す。 登録済カテゴリと
+    // 被ったものは items 側にも残り、 datalist 側で union 表示すれば良い。
+    const repos = listRepoWatch(db).map((r) => `${r.owner}/${r.name}`);
+    return c.json({ items, suggestions: { repos } });
   });
 
   r.post('/api/tasks/categories', async (c: Context) => {
@@ -84,17 +95,19 @@ export function makeTaskRouter(deps: TaskRouterDeps): Hono {
 
   r.post('/api/tasks', async (c: Context) => {
     const body = await c.req.json().catch(() => ({})) as
-      { title?: unknown; details?: unknown; status?: unknown; creator_type?: unknown;
+      { title?: unknown; details?: unknown; status?: unknown; kind?: unknown; creator_type?: unknown;
         due_at?: unknown; share_actio?: unknown; category?: unknown };
     const title = String(body.title ?? '').trim();
     if (!title) return c.json({ error: 'title required' }, 400);
     const status: 'todo' | 'doing' | 'done' = (['todo', 'doing', 'done'] as const).includes(body.status as 'todo' | 'doing' | 'done')
       ? body.status as 'todo' | 'doing' | 'done'
       : 'todo';
+    const kind: 'task' | 'goal' = body.kind === 'goal' ? 'goal' : 'task';
     const id = insertTask(db, {
       title,
       details: String(body.details ?? '').trim(),
       status,
+      kind,
       creator_type: body.creator_type === 'ai' ? 'ai' : 'human',
       due_at: typeof body.due_at === 'string' ? body.due_at : null,
       share_actio: !!body.share_actio,
@@ -102,9 +115,10 @@ export function makeTaskRouter(deps: TaskRouterDeps): Hono {
     });
     const created = getTask(db, id);
     if (!created) return c.json({ error: 'failed to read inserted task' }, 500);
-    appendTaskDiaryLog(`タスク発行: ${created.title}${created.due_at ? ` (期日: ${created.due_at})` : ''}`);
+    const label = kind === 'goal' ? '目標発行' : 'タスク発行';
+    appendTaskDiaryLog(`${label}: ${created.title}${created.due_at ? ` (期日: ${created.due_at})` : ''}`);
     recordActivityEvent(db, {
-      kind: 'task_created',
+      kind: kind === 'goal' ? 'goal_created' : 'task_created',
       content: created.title,
       metadata: created.due_at ? { due_at: created.due_at } : undefined,
     });
@@ -116,12 +130,13 @@ export function makeTaskRouter(deps: TaskRouterDeps): Hono {
     const before = getTask(db, id);
     if (!before) return c.json({ error: 'not found' }, 404);
     const body = await c.req.json().catch(() => ({})) as
-      { title?: unknown; details?: unknown; status?: unknown; due_at?: unknown;
+      { title?: unknown; details?: unknown; status?: unknown; kind?: unknown; due_at?: unknown;
         share_actio?: unknown; category?: unknown };
     const patch: Record<string, unknown> = {};
     if (typeof body.title === 'string') patch.title = body.title.trim();
     if (typeof body.details === 'string') patch.details = body.details.trim();
     if ((['todo', 'doing', 'done'] as const).includes(body.status as 'todo' | 'doing' | 'done')) patch.status = body.status;
+    if (body.kind === 'task' || body.kind === 'goal') patch.kind = body.kind;
     if (body.due_at === null || typeof body.due_at === 'string') patch.due_at = body.due_at || null;
     if (typeof body.share_actio === 'boolean') patch.share_actio = body.share_actio;
     if (typeof body.category === 'string' || body.category === null) patch.category = body.category;
@@ -131,17 +146,19 @@ export function makeTaskRouter(deps: TaskRouterDeps): Hono {
     updateTask(db, id, patch);
     const after = getTask(db, id);
     if (!after) return c.json({ error: 'task disappeared' }, 500);
+    const isGoal = after.kind === 'goal';
+    const noun = isGoal ? '目標' : 'タスク';
     const completedNow = before.status !== 'done' && after.status === 'done';
     if (completedNow) {
-      appendTaskDiaryLog(`タスク完了: ${after.title}`);
-      recordActivityEvent(db, { kind: 'task_done', content: after.title });
+      appendTaskDiaryLog(`${noun}完了: ${after.title}`);
+      recordActivityEvent(db, { kind: isGoal ? 'goal_done' : 'task_done', content: after.title });
     } else {
-      const changed = ['title', 'details', 'status', 'due_at', 'share_actio'].some((k) => Object.hasOwn(patch, k));
+      const changed = ['title', 'details', 'status', 'due_at', 'share_actio', 'kind'].some((k) => Object.hasOwn(patch, k));
       const isHumanChange = before.creator_type === 'human' || (before.creator_type === 'ai' && after.creator_type === 'human');
       if (changed && isHumanChange) {
-        appendTaskDiaryLog(`タスク更新: ${after.title}${after.due_at ? ` (期日: ${after.due_at})` : ''}`);
+        appendTaskDiaryLog(`${noun}更新: ${after.title}${after.due_at ? ` (期日: ${after.due_at})` : ''}`);
         recordActivityEvent(db, {
-          kind: 'task_updated',
+          kind: isGoal ? 'goal_updated' : 'task_updated',
           content: after.title,
           metadata: patch.status ? { status: after.status } : undefined,
         });

--- a/spec/api/task.md
+++ b/spec/api/task.md
@@ -6,7 +6,7 @@
 | POST | `/api/tasks` | `TaskCreateRequest` | `{ task: TaskRow }` (201) |
 | PATCH | `/api/tasks/:id` | `TaskUpdateRequest` | `{ task: TaskRow }` |
 | DELETE | `/api/tasks/:id` | — | `{ ok: true }` |
-| GET | `/api/tasks/categories` | — | `{ items: string[] }` |
+| GET | `/api/tasks/categories` | — | `{ items: string[], suggestions: { repos: string[] } }` |
 | POST | `/api/tasks/categories` | `{ name: string }` | `{ items: string[] }` (201) |
 | DELETE | `/api/tasks/categories/:name` | — | `{ items: string[] }` |
 | POST | `/api/tasks/:id/agent-run` | `AgentRunStartRequest` | `{ run: AgentRunRow }` (201) |
@@ -16,3 +16,8 @@
 - `category` は **カンマ区切りの複数値** ("開発, 学習") として送受信。
 - `creator_type` は `'human' | 'ai'`、 デフォルト `'human'`。
 - `due_at` は UTC ISO もしくは `'YYYY-MM-DDTHH:MM'` (datetime-local)。
+- `kind` は `'task' | 'goal'`、 デフォルト `'task'`。 `goal` は中長期で達成したい
+  目標を表す。 `GET /api/tasks?kind=task|goal|all` で filter 可能 (未指定は `task` のみ)。
+- `GET /api/tasks/categories` の `suggestions.repos` は `repo_watch` に登録済の
+  リポジトリ名 (`owner/name`) を返す。 フロントエンドはこれを datalist の補助
+  候補として使う想定。


### PR DESCRIPTION
## Summary

タスクリストに「目標」 を扱える種別を追加し、 カテゴリ入力に登録済リポジトリ名をサジェスト候補として出すようにした。

### 「目標」 種別
- `tasks.kind` カラム (`'task'` | `'goal'`、 default `'task'`)、 既存 DB 向けに ALTER で安全 add column
- `GET /api/tasks?kind=task|goal|all` で filter (未指定は `task` 後方互換)
- POST / PATCH の body で kind 受付
- activity_events.kind に `goal_created` / `goal_done` / `goal_updated` 追加
- フロント: タスクタブの最上部に 🎯 目標 セクション (0 件なら非表示)、 エディタの種別 select + 見出し切替、 目標カードは金色アクセント

### カテゴリのリポサジェスト
- `GET /api/tasks/categories` が `suggestions.repos: string[]` (= repo_watch の `owner/name`) を併せて返す
- エディタの category datalist が登録済カテゴリ + リポを union 表示

### spec
- `spec/api/task.md` の categories エンドポイントレスポンスと kind 仕様を追記

## Test plan

- [x] server typecheck pass
- [x] frontend bundle build pass
- [x] eslint clean (ローカル)
- [ ] CI green (lint + smoke)
- [ ] 手動: 既存 DB の Memoria を起動 → ALTER が走り tasks に kind カラムが生え、 既存タスクは default `'task'` のまま
- [ ] 手動: 目標を 1 件追加 → 上部セクションに表示、 完了で 「目標完了」 が diary に記録
- [ ] 手動: タスク追加 UI のカテゴリ入力でリポ名 (e.g. `LUDIARS/Memoria`) がサジェスト候補に出る

🤖 Generated with [Claude Code](https://claude.com/claude-code)