### PR TITLE
docs(desktop): 自動アップデート稼働状況を README に反映

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -176,5 +176,7 @@ zip を貼り付けます (`v0.0.0-dev` がデフォルト)。
 - アイコンは現状プレースホルダ。 本番ブランディング時に差し替え
 - macOS の codesign / notarize はまだ実装していません — DMG は
   「未確認の開発元」ダイアログ越しでしか起動できない状態です
-- 自動アップデート (`electron-updater`) も未実装。 アップデートは
-  毎回インストーラ再ダウンロードしてください
+- 自動アップデート (`electron-updater`) は v1.0.1 から稼働中。
+  起動 5 秒後と 6 時間毎に GitHub Releases (LUDIARS/Memoria) の
+  `latest.yml` を見に行き、 更新があれば background download →
+  終了時 install。 Tray menu から手動チェック + 「適用して再起動」 も可能


### PR DESCRIPTION
## Summary
- v1.0.1 (#171) で electron-updater が稼働しているのに desktop/README.md の制約事項に「自動アップデート未実装」 と残っていたので、 実態に合わせて書き直し
- アップデート方式 (5 秒後 + 6 時間毎、 background download → 終了時 install、 Tray から手動チェック) を README に明示

## Test plan
- [ ] README 表示確認だけ (実装変更なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)