### PR TITLE
Publish Corpus hub service manifest (D6)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -259,6 +259,35 @@ app.route('/', makeWeatherRouter({ db }));
 app.route('/', makeTransitRouter({ db }));
 app.route('/', makeStalenessRouter({ db }));
 
+// ---- Corpus hub マニフェスト (VantanHub-DESIGN.md D6) ----------------------
+// Memoria は横断 hub サービス Corpus から参照される leaf。 knowledge (ブクマ /
+// 辞書 / ディグ / ドメイン) は scope:multi で共有可、 lifelog (日記 / 週次 /
+// 食事 / 軌跡 / 活動) は scope:local で端末内に留める。 scope が「シェア可能 /
+// 不可」 の境界そのもの。 panels[] は declarative rendering 確定後に追加する。
+// 認証不要 (local Memoria は loopback 信頼で local Corpus が読む)。
+app.get('/.well-known/corpus-service.json', (c) =>
+  c.json({
+    service: 'memoria',
+    displayName: 'Memoria',
+    version: '0.1.0',
+    corpusApi: 1,
+    health: '/api/server/info',
+    data: [
+      { id: 'bookmarks', title: 'ブックマーク', path: '/api/bookmarks', scope: 'multi' },
+      { id: 'dictionary', title: '辞書', path: '/api/dictionary', scope: 'multi' },
+      { id: 'dig', title: 'ディグ', path: '/api/dig', scope: 'multi' },
+      { id: 'domains', title: 'ドメイン辞書', path: '/api/domains', scope: 'multi' },
+      { id: 'diary', title: '日記', path: '/api/diary', scope: 'local' },
+      { id: 'weekly', title: '週次レポート', path: '/api/weekly', scope: 'local' },
+      { id: 'meals', title: '食事記録', path: '/api/meals', scope: 'local' },
+      { id: 'locations', title: 'GPS 軌跡', path: '/api/locations', scope: 'local' },
+      { id: 'activity', title: '開発活動', path: '/api/activity/work-time', scope: 'local' },
+    ],
+    panels: [],
+    auth: 'none',
+  }),
+);
+
 // ---- static UI ------------------------------------------------------------
 
 // SPA assets: ブラウザの aggressive cache を無効化 (古い app.js が掴まれて


### PR DESCRIPTION
## 概要

Memoria を横断 hub サービス [Corpus](https://github.com/LUDIARS/Corpus) から
参照される **leaf サービス**にする第一歩。`GET /.well-known/corpus-service.json`
（D6 サービスマニフェスト）を公開する。

「Memoria の lifelog 部分とブックマーク（シェア可能）部分を分けるか」 の検討
結果、**サービスは分けず**、`scope` フィールドで境界を引く **X 案**で確定済み。

## 変更

`server/index.ts` に追加ルート 1 本:

- **knowledge**（ブクマ / 辞書 / ディグ / ドメイン）→ `scope:multi` — Corpus 経由で
  共有・集約できる
- **lifelog**（日記 / 週次 / 食事 / GPS 軌跡 / 開発活動）→ `scope:local` — 端末内に
  留め、 サーバ / multi ハブには出さない。`scope` が「シェア可能 / 不可」 の
  境界そのもの
- `auth: none` — local Memoria は loopback 信頼で local Corpus が読む
- `panels[]` は空。 lifelog/knowledge ビューのパネルは declarative rendering の
  形式確定後（別作業）に追加

## 補足

- 追加ルートのみで Memoria の standalone 動作・既存機能には影響しない。
- 横断集約ハブは Corpus（独立サービス）で確定。`spec/feature/hub-aggregation.md`
  （branch `docs/hub-aggregation-design`）の「Memoria 内ゲートウェイ」 前提は
  Corpus 前提に読み替え（同ブランチ側で別途整理）。

## 検証

- `npm run typecheck` パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
