### PR TITLE
fix: セキュリティヘッダ middleware を追加 (hono/secure-headers) [要レビュー]

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -11,6 +11,7 @@
 
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
+import { secureHeaders } from 'hono/secure-headers';
 import { serveStatic } from '@hono/node-server/serve-static';
 import { serve } from '@hono/node-server';
 import { WebSocketServer } from 'ws';
@@ -150,6 +151,17 @@ setTimeout(() => {
 
 // ── App ──────────────────────────────────────────────────────────────────
 const app = new Hono();
+// セキュリティヘッダ (HSTS / X-Content-Type-Options / X-Frame-Options / Referrer-Policy 等)。
+// クロスオリジン分離系 (COOP / COEP / CORP) は Cernere SSO ポップアップや Hub 連携を
+// 壊しうるため無効化し、 副作用のない古典的なヘッダのみを付与する。
+app.use(
+  '*',
+  secureHeaders({
+    crossOriginOpenerPolicy: false,
+    crossOriginEmbedderPolicy: false,
+    crossOriginResourcePolicy: false,
+  }),
+);
 app.use('/api/*', cors({ origin: '*', allowMethods: ['GET', 'POST', 'PATCH', 'DELETE', 'OPTIONS'] }));
 
 // 構造化 access ログ


### PR DESCRIPTION
## 概要

デイリーレビュー **2026-05-22** の **High 指摘** への対応 (ludiars-review-daily / 新ポリシー: Critical/High の bounded fix を PR 化)。

- **指摘元**: `review/2026-05-22/REVIEW_VULNERABILITY.md` §2 Web 脆弱性 — 「`server/index.ts` セキュリティヘッダ — CSP/HSTS/X-Content-Type-Options 未設定。Hono middleware でセキュリティヘッダを統一追加」(重大度 High)

## 変更

`server/index.ts` に `hono/secure-headers` の `secureHeaders()` を全ルート適用 (+12 行)。付与されるヘッダ:

- `Strict-Transport-Security` / `X-Content-Type-Options: nosniff` / `X-Frame-Options` / `Referrer-Policy` / `X-Permitted-Cross-Domain-Policies` 他

クロスオリジン分離系 (`Cross-Origin-Opener-Policy` / `-Embedder-Policy` / `-Resource-Policy`) は **明示的に無効化**。Cernere SSO ポップアップや Hub 連携 (Multi mode) を壊しうるため、副作用のない古典的ヘッダのみに限定した。

## 対象外 (REVIEW に手作業項目として残す)

- CORS `origin: '*'` (`server/index.ts:153`) の制限 — Hub public API 向けの挙動変更
- CSP 本体 — SPA への影響評価が必要

## 確認

- 同一パターンの変更を Bibliotheca で `tsc --noEmit` 検証済 (exit 0)。`hono/secure-headers` は hono パッケージ同梱で新規依存なし
- ⚠️ 当環境では Memoria の `node_modules` 未インストールのためローカル typecheck 未実施。GitHub CI (`ci.yml`) の typecheck で検証されます

⚠️ **要レビュー** — 自動生成 PR。CI green 確認の上、マージ前に動作確認をお願いします (オートマージなし)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)