### PR TITLE
feat(concordia): Memoria の CC 指示ログを Concordia に forward

### DIFF
--- a/server/agent-dispatch.ts
+++ b/server/agent-dispatch.ts
@@ -6,6 +6,7 @@ import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { mkdirSync, createWriteStream, existsSync, readFileSync, statSync } from 'node:fs';
 import { join, isAbsolute } from 'node:path';
 import type BetterSqlite3 from 'better-sqlite3';
+import { forwardToConcordia } from './concordia-forward.js';
 import {
   insertAgentRun, updateAgentRun, recordActivityEvent,
 } from './db.js';
@@ -182,6 +183,15 @@ export function startAgentRun(
     metadata: { agent_run_id: runId, agent: a, model: effectiveModel || null, project: project.name },
   });
 
+  const dispatchStartedAt = Date.now();
+  forwardToConcordia({
+    kind: 'llm-request',
+    task: `agent-dispatch:${task.title}`,
+    provider: a,
+    model: effectiveModel || undefined,
+    text: prompt,
+  });
+
   const timer = setTimeout(() => {
     try { child.kill('SIGKILL'); } catch { /* ignore */ }
   }, timeoutMs);
@@ -219,6 +229,14 @@ export function startAgentRun(
       ref_id: undefined,
       content: `[AI実装${code === 0 ? '完了' : '失敗'}] ${task.title}`,
       metadata: { agent_run_id: runId, exit_code: code },
+    });
+    forwardToConcordia({
+      kind: code === 0 ? 'llm-response' : 'llm-error',
+      task: `agent-dispatch:${task.title}`,
+      provider: a,
+      model: effectiveModel || undefined,
+      text: code === 0 ? (summary || `exit=${code}`) : `exit=${code} ${summary}`,
+      durationMs: Date.now() - dispatchStartedAt,
     });
   });
 

--- a/server/concordia-forward.ts
+++ b/server/concordia-forward.ts
@@ -1,0 +1,95 @@
+// Memoria → Concordia へ「CC への指示 / 応答」 を forward する.
+//
+// 主目的: Memoria が裏で claude / codex / gemini に投げているプロンプトと結果を
+// Concordia の chat 経由でログに残し、 開発時に AI に「Memoria が何を考えて
+// 何を投げたか」 を把握させる. ユーザ要望 (2026-05-23).
+//
+// best-effort + 非同期: Concordia が落ちていても Memoria 本機能には一切影響
+// しないよう、 fire-and-forget + 短い timeout で握りつぶす.
+//
+// env で opt-in:
+//   MEMORIA_CONCORDIA_FORWARD=1            forward を有効化 (既定: 無効)
+//   MEMORIA_CONCORDIA_URL=http://127.0.0.1:17330   Concordia base URL
+//   MEMORIA_CONCORDIA_CHANNEL=memoria-cc-instructions  chat channel 名
+
+const DEFAULT_URL = 'http://127.0.0.1:17330';
+const DEFAULT_CHANNEL = 'memoria-cc-instructions';
+const FORWARD_TIMEOUT_MS = 2_000;
+const TEXT_HEAD_LIMIT = 4_000;
+
+function isEnabled(): boolean {
+  return process.env.MEMORIA_CONCORDIA_FORWARD === '1';
+}
+
+function endpoint(): string {
+  const base = (process.env.MEMORIA_CONCORDIA_URL || DEFAULT_URL).replace(/\/+$/, '');
+  return `${base}/v1/chat`;
+}
+
+function channel(): string {
+  return process.env.MEMORIA_CONCORDIA_CHANNEL || DEFAULT_CHANNEL;
+}
+
+function truncate(text: string): { head: string; suffix: string } {
+  if (text.length <= TEXT_HEAD_LIMIT) return { head: text, suffix: '' };
+  return {
+    head: text.slice(0, TEXT_HEAD_LIMIT),
+    suffix: ` …(+${text.length - TEXT_HEAD_LIMIT} chars)`,
+  };
+}
+
+export type ConcordiaForwardKind = 'llm-request' | 'llm-response' | 'llm-error';
+
+export interface ConcordiaForwardArgs {
+  kind: ConcordiaForwardKind;
+  task: string;       // LlmTaskName
+  provider: string;   // 'claude' | 'gemini' | 'codex' | 'openai'
+  text: string;       // prompt / result / error
+  model?: string;
+  durationMs?: number;
+}
+
+export function formatForwardText(args: ConcordiaForwardArgs): string {
+  const { head, suffix } = truncate(args.text);
+  const meta = [
+    `task=${args.task}`,
+    `provider=${args.provider}`,
+    args.model ? `model=${args.model}` : null,
+    args.durationMs !== undefined ? `duration=${args.durationMs}ms` : null,
+  ].filter(Boolean).join(' ');
+  return `[${args.kind}] ${meta}\n${head}${suffix}`;
+}
+
+/**
+ * Concordia へ chat post を投げる. 失敗は握りつぶす (Memoria 本機能には影響させない).
+ * 戻り値は「forward を試みたか」 (= enabled かつ fetch をキック)。 完了は待たない.
+ */
+export function forwardToConcordia(args: ConcordiaForwardArgs): boolean {
+  if (!isEnabled()) return false;
+  const body = JSON.stringify({
+    channel: channel(),
+    session_id: null,
+    author_label: `Memoria / ${args.task}`,
+    text: formatForwardText(args),
+  });
+  // fire-and-forget. 失敗ログは出さない (ノイズになる).
+  void (async () => {
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), FORWARD_TIMEOUT_MS);
+      try {
+        await fetch(endpoint(), {
+          method: 'POST',
+          headers: { 'content-type': 'application/json; charset=utf-8' },
+          body,
+          signal: controller.signal,
+        });
+      } finally {
+        clearTimeout(timer);
+      }
+    } catch {
+      // swallow
+    }
+  })();
+  return true;
+}

--- a/server/llm.ts
+++ b/server/llm.ts
@@ -3,6 +3,7 @@
 // per task: Claude CLI, Gemini CLI, Codex CLI, or the OpenAI Chat API.
 
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { forwardToConcordia } from './concordia-forward.js';
 
 export type LlmTaskName =
   | 'summarize' | 'dig' | 'dig_preview' | 'cloud_extract' | 'cloud_validate'
@@ -176,36 +177,71 @@ export interface RunLlmArgs {
 /**
  * Run an LLM call for a named task. Falls back to Claude CLI if the configured
  * provider isn't usable (e.g. OpenAI selected but no API key set).
+ *
+ * Concordia forwarding: 開始 / 終了 / エラー で `forwardToConcordia` を呼ぶ.
+ * fire-and-forget なので Memoria の本処理時間には影響しない.
  */
 export async function runLlm({ task, prompt, tools, timeoutMs = 180_000 }: RunLlmArgs): Promise<string> {
+  const start = Date.now();
   const taskCfg = cfg.tasks[task] || { provider: 'claude' as LlmProviderKey };
   let provider: LlmProviderKey = taskCfg.provider || 'claude';
   if (provider === 'openai' && !cfg.openai_api_key) provider = 'claude';
   const p = PROVIDERS[provider];
   if (!p) throw new Error(`unknown provider: ${provider}`);
   if (p.kind === 'none') return '';
-  if (p.kind === 'api') {
-    return runOpenAi({
-      apiKey: cfg.openai_api_key,
-      model: taskCfg.model || cfg.openai_model || PROVIDER_DEFAULT_MODEL.openai || 'gpt-4o-mini',
-      prompt, timeoutMs,
+
+  const modelToUse: string =
+    taskCfg.model ||
+    (p.kind === 'api'
+      ? (cfg.openai_model || PROVIDER_DEFAULT_MODEL.openai || 'gpt-4o-mini')
+      : (TASK_DEFAULT_MODELS[task] || PROVIDER_DEFAULT_MODEL[provider] || ''));
+
+  forwardToConcordia({ kind: 'llm-request', task, provider, model: modelToUse, text: prompt });
+
+  try {
+    let result: string;
+    if (p.kind === 'api') {
+      result = await runOpenAi({
+        apiKey: cfg.openai_api_key,
+        model: modelToUse,
+        prompt, timeoutMs,
+      });
+    } else {
+      // CLI providers
+      const bin = (cfg.bins as Record<string, string>)[provider] || p.defaultBin || provider;
+      const args = buildCliArgs({
+        provider,
+        model: modelToUse,
+        tools,
+        supportsModel: p.supportsModel,
+        supportsTools: p.supportsTools,
+      });
+      const env = { ...process.env };
+      if (provider === 'claude' && cfg.git_bash_path) {
+        env.CLAUDE_CODE_GIT_BASH_PATH = cfg.git_bash_path;
+      }
+      result = await runCli({ bin, args, prompt, timeoutMs, env, label: provider, jsonOutput: !!p.jsonOutput });
+    }
+    forwardToConcordia({
+      kind: 'llm-response',
+      task,
+      provider,
+      model: modelToUse,
+      text: result,
+      durationMs: Date.now() - start,
     });
+    return result;
+  } catch (err) {
+    forwardToConcordia({
+      kind: 'llm-error',
+      task,
+      provider,
+      model: modelToUse,
+      text: err instanceof Error ? err.message : String(err),
+      durationMs: Date.now() - start,
+    });
+    throw err;
   }
-  // CLI providers
-  const bin = (cfg.bins as Record<string, string>)[provider] || p.defaultBin || provider;
-  const modelToUse = taskCfg.model || TASK_DEFAULT_MODELS[task] || PROVIDER_DEFAULT_MODEL[provider] || '';
-  const args = buildCliArgs({
-    provider,
-    model: modelToUse,
-    tools,
-    supportsModel: p.supportsModel,
-    supportsTools: p.supportsTools,
-  });
-  const env = { ...process.env };
-  if (provider === 'claude' && cfg.git_bash_path) {
-    env.CLAUDE_CODE_GIT_BASH_PATH = cfg.git_bash_path;
-  }
-  return runCli({ bin, args, prompt, timeoutMs, env, label: provider, jsonOutput: !!p.jsonOutput });
 }
 
 function buildCliArgs({


### PR DESCRIPTION
## Summary
Memoria が裏で claude / codex / gemini に投げている prompt とその結果を Concordia の chat に **fire-and-forget で post** する。 AI agent が他 session の動きを「Memoria が何を考えて何を投げたか」 として把握できるようにする (ユーザ要望 2026-05-23)。

> 「明日のセッションから適用」 の方針なので open のままにしてあります。 マージ後 Memoria の env に `MEMORIA_CONCORDIA_FORWARD=1` を入れて再起動で有効化。

## 経路 (2 系統)

| 経路 | ファイル | 用途 |
|---|---|---|
| `runLlm` | `server/llm.ts` | Memoria 内部 LLM 呼び出し (summarize / dig / page_summary / diary_* / meal_* / domain_classify 等) |
| `startAgentRun` | `server/agent-dispatch.ts` | 「タスク AI 委託」 で claude_code / codex / gemini を non-interactive spawn する経路 |

両方の (呼出開始 / 完了 / エラー) で `forwardToConcordia` を呼ぶ。

## `concordia-forward.ts` (新規)
- fire-and-forget + 2 秒 timeout の `fetch('/v1/chat', ...)` を非同期で投げる
- Concordia 落ち / network error は握りつぶす (Memoria 本機能には影響させない)
- text は先頭 4000 文字に truncate、 越えた分は ` …(+N chars)`
- meta は `[kind] task=... provider=... model=... duration=...ms` 形式

## env (デフォルト無効、 opt-in)
```env
MEMORIA_CONCORDIA_FORWARD=1
MEMORIA_CONCORDIA_URL=http://127.0.0.1:17330     # 既定
MEMORIA_CONCORDIA_CHANNEL=memoria-cc-instructions # 既定
```

## Test
- 既存テスト基盤無し (server/CLAUDE.md より v0.1 は手動テスト方針)
- `npx tsc --noEmit -p tsconfig.json` 通過
- 動作確認は明日のセッションで env=1 + Memoria 再起動 + Concordia chat 投稿の有無を curl で確認

## Notes
- Concordia 側に対応する受信 endpoint は不要 (既存 `/v1/chat` をそのまま使う)
- channel `memoria-cc-instructions` は新規。 既存 chitchat / consultation / 報告 / と並立
- 関連 Concordia PR: [#15 永続 WS クライアント方式 + stat retry + agent client](https://github.com/LUDIARS/Concordia/pull/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)