### PR TITLE
feat(agent-dispatch): Concordia /v1/spawn 経由の AI 委託モード (選択式)

### DIFF
--- a/server/agent-dispatch.ts
+++ b/server/agent-dispatch.ts
@@ -1,6 +1,10 @@
 // agent-dispatch.ts — Memoria task → AI agent (Claude Code / Codex / Gemini) を
 // プロジェクトディレクトリで non-interactive に走らせ、stdout/stderr を log
 // ファイルにストリーム保存しながら DB の `agent_runs` 行を更新する。
+//
+// 設定 `llm.task_runner` で動作モードを切り替える (spec/feature/concordia-runner.md):
+//   - 'local'    (default): child_process.spawn で CLI を non-interactive 起動
+//   - 'concordia':         Concordia /v1/spawn 経由で wt タブ起動 + inject
 
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { mkdirSync, createWriteStream, existsSync, readFileSync, statSync } from 'node:fs';
@@ -12,6 +16,7 @@ import {
 import type { AgentKind, AgentRunRow } from './db/types/agent.js';
 import type { TaskRow } from './db/types/task.js';
 import type { AgentProjectRow } from './db/types/agent.js';
+import { ConcordiaSpawnClient, type ConcordiaProvider } from './concordia-spawn-client.js';
 
 type Db = BetterSqlite3.Database;
 
@@ -108,6 +113,10 @@ export interface StartAgentRunArgs {
 /**
  * Start an agent run. Returns the new run id immediately. The child process
  * runs in the background and updates the DB row when it exits.
+ *
+ * Dispatches by `settings['llm.task_runner']` (spec/feature/concordia-runner.md):
+ *   - 'local' or unset → local spawn (this function continues below)
+ *   - 'concordia'      → delegate to startConcordiaRun (wt tab + Lictor inject)
  */
 export function startAgentRun(
   db: Db,
@@ -123,6 +132,14 @@ export function startAgentRun(
   if (!existsSync(project.path)) {
     throw new Error(`project.path does not exist: ${project.path}`);
   }
+  const settingsObj = settings || {};
+  const runner = (settingsObj['llm.task_runner'] || 'local').trim().toLowerCase();
+  if (runner === 'concordia') {
+    return startConcordiaRun(db, { dataDir, settings: settingsObj, task, project, agent: a, model });
+  }
+  if (runner !== 'local' && runner !== '') {
+    throw new Error(`unknown llm.task_runner: ${runner} (expected 'local' or 'concordia')`);
+  }
   const logDir = ensureLogDir(dataDir);
   const logFile = `run_${Date.now()}_${Math.random().toString(36).slice(2, 8)}.log`;
   const logPath = join(logDir, logFile);
@@ -137,11 +154,11 @@ export function startAgentRun(
     prompt,
     status: 'pending',
     log_path: logFile,
+    mode: 'local',
   });
 
   // Spawn after row exists so we always have a record even if spawn fails.
   let child: ChildProcessWithoutNullStreams;
-  const settingsObj = settings || {};
   const bin = binaryFor(a, settingsObj);
   const args = buildArgs(a, effectiveModel);
   const env: NodeJS.ProcessEnv = { ...process.env };
@@ -226,9 +243,180 @@ export function startAgentRun(
   return runId;
 }
 
+/**
+ * Concordia /v1/spawn 経路で AI 委託する。 spec/feature/concordia-runner.md。
+ *
+ * 流れ (失敗時は agent_runs.status=failed + summary に原因、 local fallback はしない):
+ *   1. agent_runs を mode='concordia' / status='pending' で insert
+ *   2. Concordia /v1/spawn/info → token → /v1/spawn でwtタブ起動
+ *   3. /v1/sessions?status=active を poll して session_id を発見
+ *   4. /v1/sessions/:id/inject で prompt を流し込む
+ *   5. status='running' + concordia_session_id をセット
+ *
+ * non-blocking: spawn → poll → inject は async で進めつつ run id は即返す。
+ */
+export function startConcordiaRun(
+  db: Db,
+  { dataDir, settings, task, project, agent, model }: {
+    dataDir: string;
+    settings: Record<string, string | null | undefined>;
+    task: TaskRow;
+    project: AgentProjectRow;
+    agent: AgentKind;
+    model?: string | null;
+  },
+): number {
+  const logDir = ensureLogDir(dataDir);
+  const logFile = `run_${Date.now()}_${Math.random().toString(36).slice(2, 8)}.log`;
+  const logPath = join(logDir, logFile);
+  const prompt = buildPrompt({ task, project });
+  const effectiveModel = (model && String(model).trim()) || AGENT_DEFAULT_MODEL[agent] || '';
+  const concordiaUrl = (settings['llm.concordia.url'] || 'http://127.0.0.1:17330').trim();
+
+  const runId = insertAgentRun(db, {
+    task_id: task.id,
+    project_id: project.id,
+    agent,
+    model: effectiveModel || null,
+    prompt,
+    status: 'pending',
+    log_path: logFile,
+    mode: 'concordia',
+  });
+
+  const stream = createWriteStream(logPath, { flags: 'a' });
+  stream.write(
+    `# mode: concordia\n# agent: ${agent}\n# model: ${effectiveModel || '(default)'}\n` +
+    `# concordia: ${concordiaUrl}\n# cwd: ${project.path}\n# started: ${new Date().toISOString()}\n` +
+    `# task: ${task.title}\n\n----- prompt (will be injected) -----\n${prompt}\n----- events -----\n`,
+  );
+
+  recordActivityEvent(db, {
+    kind: 'task_updated',
+    occurred_at: undefined,
+    source: undefined,
+    ref_id: undefined,
+    content: `[AI実装開始/Concordia] ${task.title} (${agent}${effectiveModel ? `:${effectiveModel}` : ''})`,
+    metadata: { agent_run_id: runId, agent, model: effectiveModel || null, project: project.name, mode: 'concordia' },
+  });
+
+  // fire-and-forget. errors land in the log + agent_runs row.
+  void runConcordiaFlow({ runId, agent, project, prompt, concordiaUrl, stream, task })
+    .catch((err: Error) => {
+      stream.write(`\n----- unhandled error -----\n${err.message}\n${err.stack ?? ''}\n`);
+      stream.end();
+      updateAgentRun(db, runId, {
+        status: 'failed',
+        finished_at: new Date().toISOString(),
+        summary: `concordia flow crashed: ${err.message}`.slice(0, 600),
+      });
+    });
+
+  async function runConcordiaFlow(input: {
+    runId: number;
+    agent: AgentKind;
+    project: AgentProjectRow;
+    prompt: string;
+    concordiaUrl: string;
+    stream: ReturnType<typeof createWriteStream>;
+    task: TaskRow;
+  }): Promise<void> {
+    const { runId, agent, project, prompt, concordiaUrl, stream, task } = input;
+    const client = new ConcordiaSpawnClient({ url: concordiaUrl });
+    const concordiaProvider = agentKindToConcordiaProvider(agent);
+    const spawnStartedAtSec = Math.floor(Date.now() / 1000) - 2; // -2s grace for clock skew
+
+    // 2. spawn
+    stream.write(`[${new Date().toISOString()}] spawn → ${client.baseUrl}/v1/spawn\n`);
+    let spawnResult;
+    try {
+      spawnResult = await client.spawn({
+        provider: concordiaProvider,
+        cwd: project.path,
+        mode: 'tab',
+        title: `Memoria/${project.name}/${task.title.slice(0, 40)}`,
+      });
+    } catch (e) {
+      const msg = (e as Error).message;
+      stream.write(`[spawn error] ${msg}\n`);
+      stream.end();
+      updateAgentRun(db, runId, {
+        status: 'failed',
+        finished_at: new Date().toISOString(),
+        summary: `spawn failed: ${msg}`.slice(0, 600),
+      });
+      return;
+    }
+    stream.write(`[spawn ok] id=${spawnResult.id} pid=${spawnResult.pid}\n`);
+    updateAgentRun(db, runId, { pid: spawnResult.pid });
+
+    // 3. session_id discovery
+    const sessionId = await client.waitForSession({
+      provider: concordiaProvider,
+      repoPath: project.path,
+      minStartedAtSec: spawnStartedAtSec,
+    });
+    if (!sessionId) {
+      stream.write(`[session not detected within 30s]\n`);
+      stream.end();
+      updateAgentRun(db, runId, {
+        status: 'failed',
+        finished_at: new Date().toISOString(),
+        summary: 'concordia session not detected within 30s',
+      });
+      return;
+    }
+    stream.write(`[${new Date().toISOString()}] session detected: ${sessionId}\n`);
+    updateAgentRun(db, runId, { concordia_session_id: sessionId });
+
+    // 4. inject
+    try {
+      await client.inject({ sessionId, text: prompt, source: 'memoria-task' });
+    } catch (e) {
+      const msg = (e as Error).message;
+      stream.write(`[inject error] ${msg}\n`);
+      stream.end();
+      updateAgentRun(db, runId, {
+        status: 'failed',
+        finished_at: new Date().toISOString(),
+        summary: `inject failed: ${msg}`.slice(0, 600),
+      });
+      return;
+    }
+    stream.write(`[${new Date().toISOString()}] inject ok — prompt delivered to ${sessionId}\n`);
+    stream.write(`# wt タブで進行を確認してください。 Memoria はここで監視を打ち切り、 status='running' を残します。\n`);
+    stream.end();
+
+    // 5. We don't track exit here — the wt session is long-lived and may
+    // outlive the task. Mark as 'running' and let the user observe in wt.
+    updateAgentRun(db, runId, {
+      status: 'running',
+      summary: `concordia session ${sessionId} は wt タブで進行中`,
+    });
+  }
+
+  return runId;
+}
+
+/**
+ * Memoria の AgentKind → Concordia /v1/spawn の provider 短縮形 (Lictor の
+ * binary 名に対応)。 Concordia 側の `provider` フィルタ値 (`claude-code`/
+ * `codex-cli`/`gemini-cli`) は spawn-client の providerToConcordia で別途
+ * 変換される。
+ */
+function agentKindToConcordiaProvider(a: AgentKind): ConcordiaProvider {
+  if (a === 'codex') return 'codex';
+  if (a === 'gemini') return 'gemini';
+  return 'claude';
+}
+
 export function cancelAgentRun(db: Db, runId: number): { ok: true } | { ok: false; error: string } {
   const child = _running.get(runId);
-  if (!child) return { ok: false, error: 'not_running' };
+  if (!child) {
+    // 'concordia' モードは _running を持たない (wt タブで進行中) ので、 ここで
+    // 区別する。 強制 cancel は wt タブ側で /exit してもらう運用とする。
+    return { ok: false, error: 'not_running (concordia mode は wt タブで /exit してください)' };
+  }
   try {
     child.kill('SIGKILL');
   } catch (e: unknown) {

--- a/server/concordia-spawn-client.ts
+++ b/server/concordia-spawn-client.ts
@@ -1,0 +1,280 @@
+// concordia-spawn-client.ts — Memoria → Concordia /v1/spawn 経路の薄い client。
+//
+// 役割: ローカル直 spawn (agent-dispatch.ts の現行挙動) の代替として、
+// Concordia + Lictor が動いているなら wt タブで対話 session を起動して
+// prompt を inject する 4 段。
+//
+//   1. GET /v1/spawn/info   → token_path を引く (no auth)
+//   2. fs.read(token_path)  → Bearer token を読む
+//   3. POST /v1/spawn       → wt タブで lictor-wrapped Claude/Codex を起動
+//   4. POST /v1/sessions/:id/inject → prompt を pty に流し込む
+//
+// 3 と 4 の間に Lictor が Concordia に register する待ち時間がある。
+// `GET /v1/sessions?status=active&provider=...` を poll して、
+// `repo_path === cwd && started_at_sec > spawnTs - 2` を満たす session を
+// 拾う。 通常 2-5 秒で見える。
+//
+// すべての関数は失敗時に Error を throw する (silent fallback はしない —
+// 「選択式」 spec を守るため。 spec/feature/concordia-runner.md)。
+
+import { readFileSync } from 'node:fs';
+
+export interface ConcordiaSpawnClientOptions {
+  /** Concordia loopback URL. 既定 http://127.0.0.1:17330 */
+  url?: string;
+  /** fetch timeout per call (既定 5s; poll は別 timeout を持つ) */
+  timeoutMs?: number;
+  /** test 注入用 fetch (既定 global fetch) */
+  fetchImpl?: typeof fetch;
+  /** test 注入用 file reader (既定 readFileSync) */
+  readFileSyncImpl?: (path: string, encoding: 'utf8') => string;
+}
+
+export type ConcordiaProvider = 'claude' | 'codex' | 'gemini';
+
+export interface SpawnInfoResult {
+  token_path: string;
+  platform_supported: boolean;
+  default_cwd: string;
+}
+
+export interface SpawnResult {
+  ok: true;
+  id: string;
+  pid: number | null;
+  command: string[];
+}
+
+export interface SessionRow {
+  id: string;
+  provider: string;
+  repo_path: string;
+  status: string;
+  started_at: number;
+  // 残りカラムは使わないので柔軟に
+  [k: string]: unknown;
+}
+
+/** Lictor が Concordia に register 完了するまで poll する既定 timeout。 */
+export const DEFAULT_SESSION_DISCOVERY_TIMEOUT_MS = 30_000;
+/** Poll 1 周期。 1s で十分 (Lictor 起動に数秒かかる)。 */
+export const DEFAULT_SESSION_DISCOVERY_INTERVAL_MS = 1_000;
+
+export class ConcordiaSpawnClient {
+  private readonly url: string;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: typeof fetch;
+  private readonly readFileSyncImpl: (path: string, encoding: 'utf8') => string;
+  private cachedToken: { path: string; value: string } | null = null;
+
+  constructor(opts: ConcordiaSpawnClientOptions = {}) {
+    this.url = (opts.url ?? 'http://127.0.0.1:17330').replace(/\/$/, '');
+    this.timeoutMs = opts.timeoutMs ?? 5_000;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+    this.readFileSyncImpl =
+      opts.readFileSyncImpl ?? ((p, enc) => readFileSync(p, enc) as string);
+  }
+
+  /** Returns the Concordia base URL (no trailing slash) for logging. */
+  get baseUrl(): string {
+    return this.url;
+  }
+
+  /** GET /v1/spawn/info — no auth. Returns token_path + platform info. */
+  async getSpawnInfo(): Promise<SpawnInfoResult> {
+    const res = await this.req('GET', '/v1/spawn/info');
+    const body = (await res.json()) as Partial<SpawnInfoResult>;
+    if (typeof body.token_path !== 'string') {
+      throw new Error('spawn/info: malformed response (no token_path)');
+    }
+    return {
+      token_path: body.token_path,
+      platform_supported: !!body.platform_supported,
+      default_cwd: typeof body.default_cwd === 'string' ? body.default_cwd : '',
+    };
+  }
+
+  /**
+   * Load + cache the spawn Bearer token. Re-reads on every spawn call (= no
+   * cross-spawn caching) by design — Concordia rotates the token on restart
+   * and we want to honor that without a Memoria restart. Override with
+   * `forceFresh: false` only when calling repeatedly in a tight loop.
+   */
+  async loadToken(opts: { forceFresh?: boolean } = {}): Promise<string> {
+    const forceFresh = opts.forceFresh ?? true;
+    if (!forceFresh && this.cachedToken) return this.cachedToken.value;
+    const info = await this.getSpawnInfo();
+    let raw: string;
+    try {
+      raw = this.readFileSyncImpl(info.token_path, 'utf8');
+    } catch (e) {
+      throw new Error(
+        `spawn token unreadable: ${info.token_path}: ${(e as Error).message}`,
+      );
+    }
+    const value = raw.trim();
+    if (!value) {
+      throw new Error(`spawn token file is empty: ${info.token_path}`);
+    }
+    this.cachedToken = { path: info.token_path, value };
+    return value;
+  }
+
+  /**
+   * POST /v1/spawn — launches a wt tab with lictor-wrapped Claude/Codex.
+   * `cwd` should be the absolute project path. `title` shows in the wt tab
+   * header. `args` are appended verbatim after the provider binary.
+   */
+  async spawn(input: {
+    provider: ConcordiaProvider;
+    cwd: string;
+    mode?: 'tab' | 'window';
+    title?: string;
+    args?: string[];
+  }): Promise<SpawnResult> {
+    const token = await this.loadToken();
+    const body = {
+      provider: input.provider,
+      mode: input.mode ?? 'tab',
+      cwd: input.cwd,
+      title: input.title,
+      args: input.args,
+    };
+    const res = await this.req('POST', '/v1/spawn', { body, token });
+    const json = (await res.json()) as { ok?: boolean; id?: string; pid?: number; command?: string[]; error?: string };
+    if (!res.ok || json.ok !== true) {
+      throw new Error(
+        `spawn failed (${res.status}): ${json.error ?? JSON.stringify(json)}`,
+      );
+    }
+    if (typeof json.id !== 'string') {
+      throw new Error('spawn response missing id');
+    }
+    return {
+      ok: true,
+      id: json.id,
+      pid: typeof json.pid === 'number' ? json.pid : null,
+      command: Array.isArray(json.command) ? json.command : [],
+    };
+  }
+
+  /**
+   * Poll `GET /v1/sessions?status=active&provider=...` until a session
+   * matching `repoPath` + `started_at > minStartedAtSec` appears, or the
+   * timeout elapses. Returns the discovered session id, or null on timeout.
+   *
+   * `minStartedAtSec` should be the Unix-second timestamp captured *before*
+   * the spawn call, with a small grace window subtracted (e.g. -2s) so
+   * tiny clock skew doesn't lose the freshly registered session.
+   */
+  async waitForSession(input: {
+    provider: ConcordiaProvider;
+    repoPath: string;
+    minStartedAtSec: number;
+    timeoutMs?: number;
+    intervalMs?: number;
+    /** test override — replaces real-time sleep so tests don't wait. */
+    sleep?: (ms: number) => Promise<void>;
+  }): Promise<string | null> {
+    const timeoutMs = input.timeoutMs ?? DEFAULT_SESSION_DISCOVERY_TIMEOUT_MS;
+    const intervalMs = input.intervalMs ?? DEFAULT_SESSION_DISCOVERY_INTERVAL_MS;
+    const sleep = input.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+    const concordiaProvider = providerToConcordia(input.provider);
+    const normalizedRepoPath = normalizeRepoPath(input.repoPath);
+    const deadline = Date.now() + timeoutMs;
+    do {
+      const url = `/v1/sessions?status=active&provider=${encodeURIComponent(concordiaProvider)}`;
+      let res;
+      try {
+        res = await this.req('GET', url);
+      } catch {
+        // transient — try again
+        await sleep(intervalMs);
+        continue;
+      }
+      let body: { sessions?: SessionRow[] };
+      try {
+        body = (await res.json()) as { sessions?: SessionRow[] };
+      } catch {
+        await sleep(intervalMs);
+        continue;
+      }
+      const sessions = Array.isArray(body.sessions) ? body.sessions : [];
+      const match = sessions.find(
+        (s) =>
+          normalizeRepoPath(s.repo_path) === normalizedRepoPath &&
+          typeof s.started_at === 'number' &&
+          s.started_at >= input.minStartedAtSec,
+      );
+      if (match) return match.id;
+      if (Date.now() >= deadline) return null;
+      await sleep(intervalMs);
+    } while (Date.now() < deadline);
+    return null;
+  }
+
+  /** POST /v1/sessions/:id/inject — pushes the prompt into the pty. */
+  async inject(input: { sessionId: string; text: string; source?: string }): Promise<void> {
+    if (!input.text) throw new Error('inject: text required');
+    const body = { text: input.text, source: input.source ?? 'memoria' };
+    const res = await this.req('POST', `/v1/sessions/${encodeURIComponent(input.sessionId)}/inject`, {
+      body,
+    });
+    const json = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+    if (!res.ok || json.ok !== true) {
+      throw new Error(`inject failed (${res.status}): ${json.error ?? JSON.stringify(json)}`);
+    }
+  }
+
+  // ─── private ─────────────────────────────────────────────────────────────
+
+  private async req(
+    method: 'GET' | 'POST',
+    path: string,
+    init: { body?: unknown; token?: string } = {},
+  ): Promise<Response> {
+    const headers: Record<string, string> = {};
+    if (init.body !== undefined) headers['content-type'] = 'application/json';
+    if (init.token) headers['authorization'] = `Bearer ${init.token}`;
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), this.timeoutMs);
+    try {
+      return await this.fetchImpl(`${this.url}${path}`, {
+        method,
+        headers,
+        body: init.body !== undefined ? JSON.stringify(init.body) : undefined,
+        signal: ac.signal,
+      });
+    } catch (e) {
+      throw new Error(`concordia ${method} ${path}: ${(e as Error).message}`);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+/**
+ * Concordia は provider 名として `claude-code` / `codex-cli` / `gemini-cli` を
+ * 期待する (Lictor `provider.concordiaProvider` 由来)。 Memoria の AgentKind
+ * (`claude_code` / `codex` / `gemini`) → Concordia の `provider` フィルタ値に
+ * 変換するために、 同じ /v1/spawn の input は短縮形 (`claude` / `codex` /
+ * `gemini`) を使う点に注意。
+ */
+function providerToConcordia(p: ConcordiaProvider): string {
+  if (p === 'claude') return 'claude-code';
+  if (p === 'codex') return 'codex-cli';
+  return 'gemini-cli';
+}
+
+/**
+ * Windows のパス差異 (`/` vs `\`、 ドライブレターの大小、 末尾 `/`) を吸収する
+ * 比較用正規化。 Memoria が project.path を Concordia に渡し、 Lictor が
+ * 折り返してきたパスと突き合わせるための片寄せ。
+ */
+function normalizeRepoPath(p: string | null | undefined): string {
+  if (!p) return '';
+  return p.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+}
+
+/** test-only re-export. */
+export const __test = { providerToConcordia, normalizeRepoPath };

--- a/server/db.ts
+++ b/server/db.ts
@@ -678,7 +678,9 @@ export function openDb(dbPath: string): Db {
       pid            INTEGER,
       summary        TEXT,
       started_at     TEXT NOT NULL DEFAULT (datetime('now')),
-      finished_at    TEXT
+      finished_at    TEXT,
+      mode           TEXT NOT NULL DEFAULT 'local',
+      concordia_session_id TEXT
     );
     CREATE INDEX IF NOT EXISTS idx_agent_runs_task
       ON agent_runs(task_id, started_at DESC);
@@ -915,10 +917,17 @@ export function openDb(dbPath: string): Db {
   // kind カラムは ALTER で足したばかり (or 元から存在) — どちらにせよ
   // index を作る。 IF NOT EXISTS で冪等。
   db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_kind ON tasks(kind)`);
-  // agent_runs.model — add if missing on existing DBs.
+  // agent_runs.model / .mode / .concordia_session_id — add if missing on existing DBs.
+  // CREATE INDEX は ALTER の後で発行する (memory: sqlite-create-index-after-alter).
   const arCols = (db.prepare(`PRAGMA table_info(agent_runs)`).all() as { name: string }[]).map(c => c.name);
   if (arCols.length > 0 && !arCols.includes('model')) {
     db.exec(`ALTER TABLE agent_runs ADD COLUMN model TEXT`);
+  }
+  if (arCols.length > 0 && !arCols.includes('mode')) {
+    db.exec(`ALTER TABLE agent_runs ADD COLUMN mode TEXT NOT NULL DEFAULT 'local'`);
+  }
+  if (arCols.length > 0 && !arCols.includes('concordia_session_id')) {
+    db.exec(`ALTER TABLE agent_runs ADD COLUMN concordia_session_id TEXT`);
   }
 
   // Forward-compat: ensure newer columns exist on older word_clouds tables.
@@ -4589,12 +4598,13 @@ export interface InsertAgentRunInput {
   prompt?: string | null;
   status?: AgentRunRow['status'];
   log_path?: string | null;
+  mode?: AgentRunRow['mode'];
 }
 
 export function insertAgentRun(db: Db, r: InsertAgentRunInput): number {
   const info = db.prepare(`
-    INSERT INTO agent_runs (task_id, project_id, agent, model, prompt, status, log_path)
-    VALUES (?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO agent_runs (task_id, project_id, agent, model, prompt, status, log_path, mode)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     r.task_id ?? null,
     r.project_id ?? null,
@@ -4603,12 +4613,13 @@ export function insertAgentRun(db: Db, r: InsertAgentRunInput): number {
     r.prompt ?? null,
     r.status || 'pending',
     r.log_path ?? null,
+    r.mode ?? 'local',
   );
   return Number(info.lastInsertRowid);
 }
 
 export function updateAgentRun(db: Db, id: number, patch: Record<string, unknown>): void {
-  const allowed = new Set(['status', 'exit_code', 'log_path', 'pid', 'summary', 'finished_at', 'model']);
+  const allowed = new Set(['status', 'exit_code', 'log_path', 'pid', 'summary', 'finished_at', 'model', 'concordia_session_id']);
   const cols: string[] = [];
   const args: unknown[] = [];
   for (const [k, v] of Object.entries(patch)) {

--- a/server/db/types/agent.ts
+++ b/server/db/types/agent.ts
@@ -15,6 +15,9 @@ export interface AgentProjectRow {
 
 export type AgentRunStatus = 'pending' | 'running' | 'done' | 'failed' | 'cancelled';
 
+/** ローカル直 spawn か Concordia /v1/spawn 経由か. spec/feature/concordia-runner.md */
+export type AgentRunMode = 'local' | 'concordia';
+
 export interface AgentRunRow {
   id: number;
   task_id: number | null;
@@ -29,4 +32,8 @@ export interface AgentRunRow {
   summary: string | null;
   started_at: string;            // UTC ISO
   finished_at: string | null;    // UTC ISO
+  /** 'local' = child_process.spawn, 'concordia' = wt タブ + Lictor inject (spec/feature/concordia-runner.md). 既存行は 'local'. */
+  mode: AgentRunMode;
+  /** concordia モードのみ. Lictor が register した session_id (`lictor-<uuid>`). spawn 直後は null、 poll で発見後に set. */
+  concordia_session_id: string | null;
 }

--- a/spec/feature/README.md
+++ b/spec/feature/README.md
@@ -22,6 +22,7 @@
 | ドメイン辞書 | [domain-catalog.md](domain-catalog.md) | 🏠 | ブラウジング履歴の蒸留 |
 | タスク管理 | [task.md](task.md) | ✓ | Hub ではなく **Actio** に共有 (`/api/tasks/:id/share/actio`) |
 | エージェント実行 | [agent.md](agent.md) | 🏠 | 絶対パス + プロンプト + コードログを含む |
+| エージェント実行 (Concordia) | [concordia-runner.md](concordia-runner.md) | 🏠 | agent.md の代替経路: wt タブ + Lictor inject。 `llm.task_runner=concordia` で有効 |
 | 作業場所 + presence | [workplace.md](workplace.md) | ✓ | カタログ (lat/lng + 名前 + tags) と presence (enter/leave) の 2 系統 |
 | 実装自慢ノート | [implementation-notes.md](implementation-notes.md) | ✓ | `shareable=1` フラグ必須の二段階フロー |
 | 食事写真 + 栄養推定 | [meal.md](meal.md) | 🏠 | 健康情報の機微度を考慮した意図的 local-only |

--- a/spec/feature/concordia-runner.md
+++ b/spec/feature/concordia-runner.md
@@ -1,0 +1,76 @@
+# concordia-runner — AI 委託の Concordia spawn 経由実行
+
+## 概要
+
+[agent.md](agent.md) の AI 委託は既定で **ローカル直 spawn** (`claude -p ...` / `codex exec ...` / `gemini -p ...` を `child_process.spawn` で non-interactive 起動 → stdout を `agent_logs/` に tee) するが、 Concordia + Lictor が動いている環境では **Concordia の `/v1/spawn` で Lictor-wrapped セッションを Windows Terminal タブに起動** → 起動した session に prompt を inject して進める経路を選択できる。
+
+設定 `llm.task_runner = concordia` を入れた時だけ有効化され、 既定値の `local` ではこれまでの挙動を維持する (= Concordia が無い環境を壊さない選択式)。
+
+## なぜ Concordia 経由を選ぶか
+
+- **可視化**: wt タブで Claude/Codex の TUI がそのまま見えるので、 進行中の AI 出力をユーザが直接観察 / 介入できる
+- **一元監視**: Concordia の dashboard / chat / persona がそのまま乗る (Lictor wrap 経由なので skill 注入 / permission proxy / transcript-tail も自動)
+- **長期 session の再利用**: 既存 session への inject 拡張 (Phase 2) で「いつもの Claude に作業を渡す」 動線が作れる
+
+## ユースケース
+
+- 重い実装タスク (UI ありで進捗を見ながら判断したい場合) を Memoria の AI 委託ボタンから wt タブで起動
+- non-interactive で完結する軽量タスク (lint / typo 直し) は従来通り `local`
+
+## 画面 / 入口
+
+- v0.1: `llm.task_runner` を `/api/config` 経由で `concordia` に切り替え → 既存の `AI 委託` ボタンの挙動が分岐
+- v0.2 (後続 PR): UI に runner toggle、 task 単位で local/concordia override 可
+
+## データ
+
+- 既存 `agent_runs` に 2 カラム追加:
+  - `mode TEXT NOT NULL DEFAULT 'local'` — `'local'` | `'concordia'`
+  - `concordia_session_id TEXT` — Concordia が割り当てた session id (`lictor-<uuid>`)、 spawn 直後は NULL、 poll で session 検出後に set
+- ログ: `concordia` モードでは `agent_logs/` に **spawn と inject のメタイベントのみ** を 1 ファイルに記録する (stdout/stderr 本体は wt タブ側にある)
+- 既存の `prompt` カラムには inject した本文をそのまま保存する (後追い検証用)
+
+## API
+
+- 既存 `POST /api/tasks/:id/agent-run` / `POST /api/agent-runs` の payload はそのまま、 内部で settings を見て分岐する
+- `cancelAgentRun` は **concordia モードでは no-op + 警告**: wt タブを Memoria から殺すと Lictor のクリーンアップに副作用がある可能性があるため、 ユーザに wt 側で `/exit` するよう促す
+
+## Concordia 側に依存するエンドポイント (既存)
+
+- `GET /v1/spawn/info` (no auth) — token_path を返す
+- `POST /v1/spawn` (Bearer token) — `{ provider: 'claude'|'codex'|'gemini', mode: 'tab', cwd, args, title? }` で wt タブ起動
+- `GET /v1/sessions?status=active&provider=...` — Memoria 側で `repo_path` + `started_at > spawnTs` を client-side filter で session を特定
+- `POST /v1/sessions/:id/inject` — Lictor の WS reactor 経由で pty に prompt を流し込む
+
+Concordia 側 (主に `/v1/sessions` の filter) には今回は変更入れない。 必要なら別 PR で `repo_path` filter を追加する。
+
+## 失敗時の振舞い (= 選択式の徹底)
+
+| 失敗ポイント | 振舞い | 理由 |
+|---|---|---|
+| `GET /v1/spawn/info` 接続失敗 | `agent_runs.status = 'failed'`、 summary に `concordia unreachable: ...` を記録。 **local fallback はしない** | 「選択式」 = ユーザが明示的に concordia を選んだ意図を尊重。 silent fallback だと「Concordia 死んでるのに気付かない」 リスク |
+| token 読み込み失敗 | 同上、 summary に `spawn token unreadable: <path>` を記録 | Concordia 起動 user と Memoria 起動 user が違うとパーミッションで詰まる |
+| `POST /v1/spawn` が 4xx/5xx | 同上、 response body を summary に記録 | Concordia の log を見るための breadcrumb |
+| 30s 経っても session 検出できず | `status = 'failed'`、 summary に `session not detected within 30s` | wt 起動には数秒かかるが 30s で出ないなら何かおかしい |
+| `POST /v1/sessions/:id/inject` が 4xx/5xx | session_id は記録、 status = 'failed'、 summary に response | wt タブは残るので、 ユーザが手で prompt 貼れば運用継続可能 |
+
+local fallback したい場合は `llm.task_runner` を `local` に戻すか、 後続 PR で `llm.task_runner = auto` (= concordia 優先、 unreachable なら local fallback) を導入する余地は残す。
+
+## シェア可能か
+
+**local-only** ([agent.md](agent.md) と同じ理由)。 `concordia_session_id` は外部に出ない。
+
+## プライバシー観点
+
+- **Memoria → Concordia 間**: prompt 本体が `POST /v1/sessions/:id/inject` で loopback HTTP を通る。 Concordia は SQLite に inject イベントとして payload を記録する ([Concordia: events table](../../../Concordia/spec/db.md))。
+- **wt タブで起動した CLI**: ユーザの API key で claude/codex/gemini API に prompt を送る。 LLM 提供者には agent.md と同じ範囲の情報が出る。
+- **個人データ保管禁止ルール ([project_personal_data_rule])**: 該当なし (実装ログ + spawn メタのみ)。
+
+## 設定キー
+
+| key | 既定値 | 説明 |
+|---|---|---|
+| `llm.task_runner` | `local` | `local` (現行)、 `concordia` (本機能) |
+| `llm.concordia.url` | `http://127.0.0.1:17330` | Concordia loopback URL |
+
+`llm.concordia.token_path` は持たない (毎回 `/v1/spawn/info` から取得する。 token rotation に追従するため)。


### PR DESCRIPTION
## Summary

Memoria の AI 委託 (\`agent-dispatch.ts\`) に、 Concordia の \`/v1/spawn\` 経由で **Windows Terminal タブに lictor-wrapped Claude/Codex/Gemini を起動 → session 検出 → prompt を inject** する経路を追加。 既定は従来通り local 直 spawn なので Concordia が無い環境を壊さない (= 選択式)。

設定 \`llm.task_runner = concordia\` で有効化、 \`local\` (既定) で従来挙動。

## 主な変更

| ファイル | 内容 |
|---|---|
| \`server/concordia-spawn-client.ts\` 新規 | /v1/spawn/info → token → POST /v1/spawn → poll /v1/sessions → POST /v1/sessions/:id/inject の 4 段。 失敗は throw (silent fallback 無し) |
| \`server/agent-dispatch.ts\` | settings['llm.task_runner'] で分岐。 'concordia' は \`startConcordiaRun()\` (fire-and-forget async flow) に委譲 |
| \`server/db.ts\` | agent_runs に \`mode\` / \`concordia_session_id\` 追加 (CREATE + ALTER の両方、 [[feedback_sqlite_create_index_after_alter]] 準拠) |
| \`server/db/types/agent.ts\` | \`AgentRunMode\` 型 + 2 フィールド |
| \`spec/feature/concordia-runner.md\` 新規 | 設計 / 失敗時の振舞い / 設定キー |
| \`spec/feature/README.md\` | index 行追加 |

## 設定キー

| key | 既定値 | 説明 |
|---|---|---|
| \`llm.task_runner\` | \`local\` | \`local\` (現行)、 \`concordia\` (本機能) |
| \`llm.concordia.url\` | \`http://127.0.0.1:17330\` | Concordia loopback URL |

token は毎回 \`/v1/spawn/info\` から取得 (rotation 追従)。

## 失敗時の振舞い

すべての段で local fallback はしない:
- Concordia 不到達 → \`agent_runs.status='failed'\` + summary に \`spawn failed: ...\`
- session 30s で検出できず → \`status='failed'\` + summary \`session not detected within 30s\`
- inject 4xx/5xx → \`status='failed'\` + summary、 wt タブは残るので手動で続行可

ユーザが明示的に \`concordia\` を選んだ意図を尊重し、 silent fallback で「Concordia 死んでるのに気付かない」 を避ける ([[feedback_no_auto_merge]] と同種の方針)。

## 動作確認

- \`npx tsc --noEmit -p tsconfig.json\` (server) green
- 本実装は実機で wt タブ起動 → session 検出 → inject まで通すには Concordia + Lictor + wt が必要。 ローカル単体テストは設計上ネットワーク mock を要するため別 PR (= ユーザがテストを必要と判断したら) で。

## 残作業 (後続 PR 候補)

- UI 切替 toggle (config 画面に \`llm.task_runner\` を出す)
- MCP server 経由のクライアント (今回スコープ外)
- \`auto\` runner (= concordia 優先 → 失敗時 local fallback) を希望されれば追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)