### PR TITLE
feat(hooks): Codex CLI のプロンプトを Memoria に記録 (codex_prompt)

### DIFF
--- a/docs/setup/user-setup.md
+++ b/docs/setup/user-setup.md
@@ -9,6 +9,7 @@ Memoria には来ないデータ」 を 1 箇所にまとめる。
 | **GitHub commits** | Personal Access Token (classic 推奨) | 設定 → 📝 日記 → GitHub 連携 | 日記 / 週報の commit 集計 |
 | **git ローカル post-commit** | hook の install ([git-hooks.md](./git-hooks.md)) | global core.hooksPath or per-repo | ローカル commit (= push 前) を活動として記録 |
 | **Claude Code prompt** | UserPromptSubmit hook ([claude-code-prompt.mjs](../../server/hooks/claude-code-prompt.mjs)) | `~/.claude/settings.json` の hooks | Claude Code への指示を「開発活動」 として記録 |
+| **Codex CLI prompt** | UserPromptSubmit hook ([codex-prompt.mjs](../../server/hooks/codex-prompt.mjs)) | `~/.codex/hooks.json` の `UserPromptSubmit` | Codex CLI への指示を「開発活動」(kind=codex_prompt) として記録 |
 | **OwnTracks GPS 軌跡** | iPhone OwnTracks → MQTT key | 軌跡タブ → 🔑 key → OwnTracks の設定 | 移動軌跡 / 作業場所自動判定 |
 | **Steam ゲームプレイ** | Steam ID (+ optional Web API key) | 設定 → 🔌 連携 → Steam | ゲームタイトル + playtime 自動取得 |
 | **Google Geolocation API** | API key | 環境変数 `MEMORIA_GOOGLE_GEOLOCATION_API_KEY` | PC の WiFi スキャン → 概略位置 |
@@ -32,6 +33,8 @@ Memoria には来ないデータ」 を 1 箇所にまとめる。
 4. 設定 → 🔌 連携 → GitHub PAT / Steam ID を入れる
 5. `node server/hooks/setup.mjs` で git post-commit hook 導入 ([git-hooks.md](./git-hooks.md))
 6. `~/.claude/settings.json` に Claude Code hook を追加
+   - (任意) Codex CLI を使うなら `~/.codex/hooks.json` の `UserPromptSubmit` に
+     `node .../server/hooks/codex-prompt.mjs` も追加し、 codex 側で `/hooks` を trust
 7. (任意) Cernere ログイン → マルチサーバ接続
 8. (任意) iOS で「ホーム画面に追加」 → 通知許可
 9. (任意) OwnTracks 設定 → GPS 軌跡

--- a/server/hooks/codex-prompt.mjs
+++ b/server/hooks/codex-prompt.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// Codex CLI UserPromptSubmit hook → Memoria activity event.
+//
+// Claude Code 用の claude-code-prompt.mjs と対になる Codex 版。 Codex CLI には
+// Claude Code のような UserPromptSubmit hook 由来の Memoria 記録経路が無く、
+// codex への指示が Memoria に残らなかった (kind=codex_prompt は DB/API 的には
+// 既にサポート済だが、 投げ込む hook が存在しなかった)。 本スクリプトがその
+// 隙間を埋める。
+//
+// stdin から Codex の hook payload (prompt / session_id / cwd ... の JSON) を読み、
+// `codex_prompt` イベントとして Memoria の /api/activity/event に POST する。
+//
+// 設計方針 (claude-code-prompt.mjs と同一):
+//   - **絶対にプロンプト処理を妨げない**。 ネットワーク失敗 / parse 失敗 / JSON
+//     不正は全部握りつぶして exit 0。 stdout も汚さない。
+//   - 1 秒タイムアウト。 Memoria が落ちてれば即諦める。
+//   - prompt 先頭 240 文字だけ送る (個人情報の漏洩面を最小化)。
+//
+// ~/.codex/hooks.json 設定例 (UserPromptSubmit に concordia-hook と並べる):
+//   "UserPromptSubmit": [{
+//     "hooks": [
+//       { "type": "command", "command": "node .../Concordia/tools/concordia-hook.mjs prompt" },
+//       { "type": "command", "command": "node .../Memoria/server/hooks/codex-prompt.mjs" }
+//     ]
+//   }]
+//
+// 環境変数:
+//   MEMORIA_URL — base URL (default http://localhost:5180)
+
+const MEMORIA_URL = process.env.MEMORIA_URL || 'http://localhost:5180';
+const TIMEOUT_MS = 1000;
+const CONTENT_MAX = 240;
+
+let buf = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (c) => { buf += c; });
+process.stdin.on('end', async () => {
+  try {
+    const payload = JSON.parse(buf || '{}');
+    // Codex の hook payload は user prompt を `prompt` に入れる。 将来差異に備え
+    // `user_prompt` もフォールバックで見る。
+    const prompt =
+      typeof payload.prompt === 'string' ? payload.prompt
+      : typeof payload.user_prompt === 'string' ? payload.user_prompt
+      : '';
+    const sessionId = payload.session_id || payload.sid || null;
+    const body = {
+      kind: 'codex_prompt',
+      ref_id: sessionId ? `${sessionId}:${Date.now()}` : null,
+      source: payload.cwd || null,
+      content: prompt.slice(0, CONTENT_MAX),
+      occurred_at: new Date().toISOString(),
+      metadata: {
+        cwd: payload.cwd || null,
+        session_id: sessionId,
+        prompt_length: prompt.length,
+      },
+    };
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), TIMEOUT_MS);
+    try {
+      await fetch(`${MEMORIA_URL}/api/activity/event`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+        signal: ac.signal,
+      });
+    } catch {
+      // ignore — server down / timeout
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch {
+    // ignore — stdin not JSON / unreadable
+  }
+  // 必ず exit 0 (プロンプト処理を妨げない)
+  process.exit(0);
+});
+process.stdin.on('error', () => process.exit(0));


### PR DESCRIPTION
## 概要
Codex CLI には Claude Code の UserPromptSubmit hook 由来の Memoria 記録経路が無く、codex への指示が Memoria に残らなかった (`kind=codex_prompt` は DB/API では既にサポート済だが、投げ込む hook が欠けていた)。

## 変更
- `claude-code-prompt.mjs` と対になる `server/hooks/codex-prompt.mjs` を追加。stdin の Codex hook payload (`prompt` / `session_id` / `cwd`) を読み、`kind=codex_prompt` として `/api/activity/event` に POST。
- 1s timeout・全例外握り潰し・stdout 非汚染でプロンプト処理を妨げない方針は claude 版と同一。
- `docs/setup/user-setup.md` に `~/.codex/hooks.json` への登録手順を追記。

## ユーザ側手順
`~/.codex/hooks.json` の `UserPromptSubmit` に concordia-hook と並べて codex-prompt.mjs を追加し、codex 側で `/hooks` を trust する (本リポ管理外の user config なので別途設定済)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)