### PR TITLE
feat(discord): Discord Bot 統合 (行動ログ取得 + 自動処理 + 通知 + 設定UI)

### DIFF
--- a/review/2026-05-30/CODE_CONVENTIONS_REVIEW.md
+++ b/review/2026-05-30/CODE_CONVENTIONS_REVIEW.md
@@ -1,0 +1,97 @@
+# Memoria コード規約レビュー (2026-05-30)
+
+規約: `AIFormat/RULE_CODE.md` (共通) + `Memoria/CLAUDE.md` 「コード規約 (Memoria 固有)」 — God Class 警戒 / 機能ごとのファイル分割 (`server/<domain>/`) / domain cross-import 禁止 / ナレッジ系切り出し前提 / レイヤ単方向 / 入力 UI `.foundation-form` / 個人データはローカル SQLite に閉じる。
+
+## サマリ
+- 違反件数: Critical 2 / High 4 / Medium 5 / Low 3
+- 注目点: `server/db.ts` (5742 行 / 239 export) が全 domain の DB アクセスを 1 file に集約 → ナレッジ系切り出しの最大阻害要因。 routes 側は概ね domain 分割済だが note / packet-monitor に複合責務あり。
+
+## God Class 一覧 (既存 / 新規追加禁止)
+
+| ファイル | 主要責務 (推定) | 行数 | 推奨分割案 |
+|---------|--------------|------|------------|
+| `server/db.ts` | スキーマ + CRUD (bookmarks / notes / dig / diary / tasks / meals 全 domain) + migration + query helper | 5742 | `server/<domain>/db.ts` に分解 (= bookmarks/db.ts / notes/db.ts / dig/db.ts ...) + `server/shared/db-helpers.ts` |
+| `server/routes/packet-monitor.ts` | TSV parse + DNS 逆引き + well-known service mapping + プロセス属性化 | 1026 | `routes/packet-monitor/analyzer.ts` + `lib/packet-analyzer.ts` + `lib/packet-process-attribution.ts` (既存) |
+| `server/routes/note.ts` | Note CRUD + blocks + comment sets + extension rules (Chat / Shopping / Notion) + 外部 HTML parse | 870 | `routes/note/blocks.ts` + `routes/note/comments.ts` + `routes/note/extensions/*.ts` |
+
+## Critical
+
+- `server/db.ts:1267-5743` — God Class: 239 個の export function が単一 file に集約 (= 全 domain DB アクセスのハブ)
+  - 違反: 共通 §1 (SRP) + §2 (ファイル分割) + Memoria 固有「God Class 新規禁止 + 機能ごと分割 + ナレッジ系切り出し前提」
+  - 影響: bookmarks / notes / dig を独立サービス化しようとした瞬間に「db.ts を分けるところから」 になる。 切り出し前提を最も阻害している。
+  - 修正提案: domain 単位で分割 → `server/bookmarks/db.ts` / `server/notes/db.ts` / `server/dig/db.ts` / `server/diary/db.ts` / `server/meals/db.ts` + 共通 helper (`safeParse` / `extractDomain` / 等) を `server/shared/db-helpers.ts` へ。 routes 側の import 1 行差し替えで段階移行可能。
+
+- `server/llm.ts` (モデル定義) + `server/agent-dispatch.ts` (spawn 実装) — LLM dispatch が 2 file に責務 split (= 同種の関心が分散)
+  - 違反: 共通 §1 (SRP の境界が曖昧) + §4 (命名: `LlmTaskName` vs `AgentKind` 混在)
+  - 修正提案: `llm.ts` は「モデル構成 (provider / model id / params)」 のみに限定、 `agent-dispatch.ts` は「実行 (spawn / handle / log)」 のみに限定。 共通の型 (TaskName 等) は `server/shared/llm-config.ts` に集約。
+
+## High
+
+- `server/routes/packet-monitor.ts:1-1026` — TSV parse + DNS lookup + well-known service classify + process attribution が同居
+  - 違反: 共通 §1 (責務過多)
+  - 修正提案: `routes/packet-monitor/analyzer.ts` (flow grouping のみ) + `lib/packet-analyzer.ts` (well-known service 判定) + `lib/packet-process-attribution.ts` (既存。 責務境界を明示)。
+
+- `server/routes/note.ts:1-870` — Note CRUD + Block 管理 + CommentSet + Extension (Chat / Shopping / Notion) が混在
+  - 違反: 共通 §1 (複数責務) + §2 (extension ごとに分割可能)
+  - 修正提案: `routes/note/blocks.ts` / `routes/note/comments.ts` / `routes/note/extensions/{chat,shopping,notion}.ts`。 extension は `server/shared/extension-*.ts` 候補。
+
+- `server/db.ts:35-50` — helper (`safeParse` / `extractDomain` / `firstPathSegment`) が db.ts 内に同居 + 他 file でも重複実装
+  - 違反: 共通 §2 (DRY / 配置先誤り)
+  - 修正提案: `server/shared/url-helpers.ts` に集約、 db.ts / diary.ts / dig.ts から import。
+
+- `server/agent-dispatch.ts:179, 357, 393` — `catch (e)` で型注釈 / message log なし (= silent failure 化リスク)
+  - 違反: 共通 §「例外の空 catch 禁止 (理由コメント必須)」 + §「TS strict / any 濫用しない」
+  - 修正提案: `catch (e: unknown) { console.error('agent spawn failed:', e); ... }` に統一。 swallow する場合は best-effort 理由を 1 行コメント。
+
+## Medium
+
+- `server/concordia-spawn-client.ts:110, 248` — `catch (e)` で console log なし、 throw のみ (= 上流で握りつぶされた場合に痕跡が残らない)
+  - 修正提案: `} catch (e) { console.error('spawn client error:', e); throw ...; }` を default に。
+
+- `server/lib/activity-sampler.ts:87, 138, 196` / `server/lib/app-activity-sampler.ts:34` — `catch (e)` で型注釈なし + 理由コメントなし
+  - 修正提案: `catch (e: unknown)` 統一、 debug log 追加。
+
+- `server/routes/bookmark.ts:40-50` — 型キャスト (`as | null`) の連鎖でリクエスト body を扱う
+  - 違反: 共通 §5 (型安全性 / any 濫用)
+  - 修正提案: zod / valibot で body 検証、 `routes/types/bookmark-request.ts` に schema 集約。
+
+- `server/db.ts:1485, 1493` — `setDigPreview` / `setDigRawResults` の引数が `unknown` (= JSON stringify で処理)
+  - 違反: 共通 §5 (公開境界での型省略)
+  - 修正提案: `DigestPreview` / `DigestRawResults` 型を定義 + 渡し側で型固定。
+
+- `server/routes/dig.ts:29-32` — request body キャストが雑 (`as | null`)
+  - 修正提案: `routes/types/dig-request.ts` で `DigCreateRequest` を定義、 zod で validate。
+
+## Low
+
+- `server/url-preview.ts:89` — `reader.cancel().catch(() => {})` の意図が不明
+  - 修正提案: `.catch(() => { /* stream cleanup; ignore errors */ })` でコメント付与。
+
+- `server/concordia-spawn-client.ts:223` — `json.catch(() => ({}))` で空 object を返す (= parse 失敗を黙殺)
+  - 修正提案: `catch (e) { console.error(...); throw new Error('spawn-client parse failed'); }` に。
+
+- `server/app-catalog.ts:72-73` — JSON parse 失敗時に raw 全文を log 出力
+  - 違反: Memoria 固有「個人データ」 (= 外部 API response がアカウント情報を含む可能性)
+  - 修正提案: 先頭 100 char のみ log、 詳細は `NODE_ENV !== 'production'` 時のみ。
+
+## ナレッジ系切り出し可否 (Memoria 固有の最重要観点)
+
+| domain | 切り出し可否 | 阻害要因 / 対処 |
+|--------|--------------|----------------|
+| **bookmarks** | ◯ ほぼ可 | `server/db.ts` 内の bookmark 関数群が独立。 db.ts 分割が前提条件、 完了すれば `server/bookmarks/{db,routes}.ts` だけで切り出せる |
+| **notes** | △ 軽微な阻害 | block + comment は内部完結。 extension (Chat / Shopping / Notion) を `server/shared/extension-*.ts` 経由化で独立性向上。 `getBookmark(db, ...)` 直接呼び出しは interface で隔離する |
+| **dig** | △ 要 refactor | `db/types/dig.ts` は独立。 `routes/dig.ts` で `bulkSaveDeps` (= bookmarks integration) を呼ぶため、 DI で明示化 → bookmarks service への HTTP 呼び出しに差し替え可能にする |
+| diary / meals | △ 影響小 | db.ts 分割と同じスコープで一緒に切れる |
+
+## 全体評価
+
+- **routes/ 分割**: 概ね domain 単位で分かれており健全 (= packet-monitor / note を除く)。
+- **筆頭リスク**: `server/db.ts` の God Class 化。 ここを domain 別に割れば「ナレッジ系切り出し前提」 規約が一気に守られる。
+- **次点**: error handling の型注釈 / log 出力の不統一。 「サイレント失敗」 が混じる risk を消す。
+
+## 推奨優先度
+
+1. **Critical**: `server/db.ts` を domain 別に分割 (= 単独で大きい PR、 機能変更は伴わない pure refactor)
+2. **High**: 大型 routes (note / packet-monitor) の責務分割 + LLM dispatch の境界整理
+3. **Medium**: error handling 統一 (`catch (e: unknown)` + console.error + 理由コメント)
+4. **Low**: 型強化 (zod / valibot) + 個人データ log の絞り込み

--- a/server/db.ts
+++ b/server/db.ts
@@ -2477,6 +2477,10 @@ const ACTIVITY_KINDS = new Set<ActivityKind>([
   'goal_created',
   'goal_done',
   'goal_updated',
+  'discord_message',
+  'discord_presence',
+  'discord_voice',
+  'discord_reaction',
 ]);
 
 export interface RecordActivityEventInput {

--- a/server/db/types/activity.ts
+++ b/server/db/types/activity.ts
@@ -11,7 +11,11 @@ export type ActivityKind =
   | 'task_updated'
   | 'goal_created'
   | 'goal_done'
-  | 'goal_updated';
+  | 'goal_updated'
+  | 'discord_message'
+  | 'discord_presence'
+  | 'discord_voice'
+  | 'discord_reaction';
 
 export interface ActivityEventRow {
   id: number;

--- a/server/discord/actions/bookmark.ts
+++ b/server/discord/actions/bookmark.ts
@@ -1,0 +1,18 @@
+// ブックマーク登録。 URL を既存 POST /api/bookmarks/from-url に委譲する
+// (fetch + 保存 + 要約キュー投入まで既存パイプラインが行う)。
+
+import { apiPostJson } from '../http.js';
+
+/** メッセージ本文から最初の URL を抜き出す。 無ければ null。 */
+export function extractFirstUrl(text: string): string | null {
+  const m = text.match(/https?:\/\/[^\s<>"')]+/);
+  return m ? m[0] : null;
+}
+
+export async function createBookmark(url: string): Promise<string> {
+  const res = await apiPostJson('/api/bookmarks/from-url', { url });
+  if (!res.ok) return `ブックマーク失敗 (${res.status})`;
+  const json = await res.json().catch(() => ({})) as { duplicate?: boolean; title?: string };
+  if (json.duplicate) return `既に登録済: ${url}`;
+  return `ブックマーク登録: ${json.title ?? url}`;
+}

--- a/server/discord/actions/meal.ts
+++ b/server/discord/actions/meal.ts
@@ -1,0 +1,23 @@
+// 食事登録。 Discord 添付画像を取得して既存 POST /api/meals (multipart) に委譲する
+// (insertMeal + vision 解析まで既存パイプラインが行う)。
+
+import { apiPostForm } from '../http.js';
+
+export interface MealImage {
+  url: string;
+  name: string;
+  contentType: string | null;
+}
+
+/** 添付画像をダウンロードして食事として登録する。 */
+export async function createMeal(image: MealImage, note: string): Promise<string> {
+  const dl = await fetch(image.url);
+  if (!dl.ok) return `画像取得失敗 (${dl.status})`;
+  const buf = Buffer.from(await dl.arrayBuffer());
+  const form = new FormData();
+  form.append('photo', new Blob([buf], { type: image.contentType ?? 'image/jpeg' }), image.name || 'meal.jpg');
+  if (note) form.append('user_note', note);
+  const res = await apiPostForm('/api/meals', form);
+  if (!res.ok) return `食事登録失敗 (${res.status})`;
+  return '食事を登録しました (解析中)';
+}

--- a/server/discord/actions/recommend.ts
+++ b/server/discord/actions/recommend.ts
@@ -1,0 +1,17 @@
+// おすすめ生成。 既存 runAiRecommendations を直接呼ぶ (top-level モジュールなので
+// domain cross-import には該当しない)。 結果サマリ文字列を返す。
+
+import type BetterSqlite3 from 'better-sqlite3';
+import { runAiRecommendations, isAiRecommendationsAvailable } from '../../recommendations-ai.js';
+
+type Db = BetterSqlite3.Database;
+
+export async function runRecommend(db: Db): Promise<string> {
+  const avail = isAiRecommendationsAvailable();
+  if (!avail.available) return `おすすめ生成不可: ${avail.reason}`;
+  const result = await runAiRecommendations(db, { force: true });
+  const items = result.items ?? [];
+  if (items.length === 0) return 'おすすめは見つかりませんでした';
+  const lines = items.slice(0, 5).map((it, i) => `${i + 1}. ${it.title ?? ''}`);
+  return ['🎯 おすすめ', ...lines].join('\n');
+}

--- a/server/discord/actions/task.ts
+++ b/server/discord/actions/task.ts
@@ -1,0 +1,38 @@
+// タスク / メモ作成。 既存 POST /api/tasks に委譲する。
+// タスク = due_at 付き (= リマインダー対象)、 メモ = due_at 無し + category 'memo'。
+
+import { apiPostJson } from '../http.js';
+
+export interface TaskInput {
+  title: string;
+  details?: string;
+  /** ISO 文字列。 指定時はリマインダー対象になる。 */
+  dueAt?: string | null;
+}
+
+/** タスク作成 (リマインダー付き)。 結果サマリ文字列を返す。 */
+export async function createTask(input: TaskInput): Promise<string> {
+  const res = await apiPostJson('/api/tasks', {
+    title: input.title,
+    details: input.details ?? '',
+    kind: 'task',
+    creator_type: 'ai',
+    due_at: input.dueAt ?? null,
+  });
+  if (!res.ok) return `タスク作成失敗 (${res.status})`;
+  return input.dueAt ? `タスク登録: ${input.title} (期日 ${input.dueAt})` : `タスク登録: ${input.title}`;
+}
+
+/** メモ作成 (リマインダー無し)。 */
+export async function createMemo(title: string, details = ''): Promise<string> {
+  const res = await apiPostJson('/api/tasks', {
+    title,
+    details,
+    kind: 'task',
+    creator_type: 'ai',
+    due_at: null,
+    category: 'memo',
+  });
+  if (!res.ok) return `メモ作成失敗 (${res.status})`;
+  return `メモ登録: ${title}`;
+}

--- a/server/discord/activity-capture.ts
+++ b/server/discord/activity-capture.ts
@@ -1,0 +1,83 @@
+// 行動ログ取得。 self のメッセージ / プレゼンス / ボイス / リアクションを
+// activity_events に記録する。 各 capture はオプトアウトで個別 OFF 可。
+// 設定変更を即反映するため、 イベントごとに discordSettings(db) を読み直す。
+//
+// 個人データ: 本文等は Memoria local にのみ保存 (RULE §5)。 識別情報は持たない。
+
+import type { Client, Message, PartialMessage } from 'discord.js';
+import type BetterSqlite3 from 'better-sqlite3';
+import { recordActivityEvent } from '../db.js';
+import { discordSettings } from './settings.js';
+import { isSelf } from './user-map.js';
+
+type Db = BetterSqlite3.Database;
+
+const CONTENT_MAX = 1000;
+
+function record(db: Db, kind: Parameters<typeof recordActivityEvent>[1]['kind'], refId: string, content: string, metadata: Record<string, unknown>): void {
+  try {
+    recordActivityEvent(db, {
+      kind,
+      ref_id: refId,
+      source: 'discord',
+      content: content.slice(0, CONTENT_MAX),
+      metadata,
+    });
+  } catch {
+    // best-effort — 取得失敗は本筋 (Memoria server) を止めない
+  }
+}
+
+/** Client にキャプチャ用リスナーを登録する。 enabled な capture のみ記録。 */
+export function registerCapture(client: Client, db: Db): void {
+  client.on('messageCreate', (msg: Message) => {
+    const cfg = discordSettings(db);
+    if (!cfg.captureMessage || msg.author?.bot || !isSelf(cfg, msg.author?.id)) return;
+    record(db, 'discord_message', msg.id, msg.content ?? '', {
+      channel_id: msg.channelId,
+      channel_name: 'name' in msg.channel ? msg.channel.name : null,
+      attachments: msg.attachments.size,
+      has_url: /https?:\/\//.test(msg.content ?? ''),
+    });
+  });
+
+  client.on('presenceUpdate', (_old, next) => {
+    const cfg = discordSettings(db);
+    if (!cfg.capturePresence || !isSelf(cfg, next.userId)) return;
+    const activities = next.activities.map((a) => ({ name: a.name, type: a.type, state: a.state ?? null, details: a.details ?? null }));
+    record(db, 'discord_presence', `${next.userId}:${Date.now()}`, next.status, {
+      status: next.status,
+      client_status: next.clientStatus ?? null,
+      activities,
+    });
+  });
+
+  client.on('voiceStateUpdate', (oldState, newState) => {
+    const cfg = discordSettings(db);
+    const userId = newState.member?.id ?? oldState.member?.id;
+    if (!cfg.captureVoice || !isSelf(cfg, userId)) return;
+    const action = !oldState.channelId && newState.channelId ? 'join'
+      : oldState.channelId && !newState.channelId ? 'leave'
+        : 'update';
+    record(db, 'discord_voice', `${userId}:${Date.now()}`, action, {
+      action,
+      from_channel: oldState.channelId,
+      to_channel: newState.channelId,
+      self_mute: newState.selfMute,
+      self_deaf: newState.selfDeaf,
+      streaming: newState.streaming,
+      self_video: newState.selfVideo,
+    });
+  });
+
+  client.on('messageReactionAdd', (reaction, user) => {
+    const cfg = discordSettings(db);
+    if (!cfg.captureReaction || !isSelf(cfg, user.id)) return;
+    const msg: Message | PartialMessage = reaction.message;
+    record(db, 'discord_reaction', `${user.id}:${msg.id}:${reaction.emoji.name ?? ''}`, reaction.emoji.name ?? '', {
+      message_id: msg.id,
+      channel_id: msg.channelId,
+      emoji: reaction.emoji.name ?? reaction.emoji.id,
+    });
+  });
+}

--- a/server/discord/client.ts
+++ b/server/discord/client.ts
@@ -40,7 +40,7 @@ export async function createDiscordClient(db: Db): Promise<Client | null> {
   registerInteractions(client, db);
 
   try {
-    await client.login(discordBotToken());
+    await client.login(discordBotToken(db));
     return client;
   } catch (e: unknown) {
     console.error(`[discord] login 失敗: ${e instanceof Error ? e.message : String(e)}`);

--- a/server/discord/client.ts
+++ b/server/discord/client.ts
@@ -1,0 +1,44 @@
+// discord.js client の生成とライフサイクル。 ready 時にレイアウトを冪等生成し、
+// capture を登録する。 Discord 障害は Memoria 本体を止めないよう全て best-effort。
+
+import { Client, Events } from 'discord.js';
+import type BetterSqlite3 from 'better-sqlite3';
+import { DISCORD_INTENTS, DISCORD_PARTIALS } from './intents.js';
+import { discordBotToken, discordSettings } from './settings.js';
+import { registerCapture } from './activity-capture.js';
+import { ensureDiscordLayout } from './layout.js';
+
+type Db = BetterSqlite3.Database;
+
+/** login 済みの client を生成して返す。 失敗時は null (本体は継続)。 */
+export async function createDiscordClient(db: Db): Promise<Client | null> {
+  const client = new Client({ intents: DISCORD_INTENTS, partials: DISCORD_PARTIALS });
+
+  client.once(Events.ClientReady, (c) => {
+    console.log(`[discord] logged in as ${c.user.tag}`);
+    const guildId = discordSettings(db).guildId;
+    const guild = c.guilds.cache.get(guildId);
+    if (!guild) {
+      console.warn(`[discord] guild ${guildId} not found (Bot が招待されていない可能性)`);
+      return;
+    }
+    ensureDiscordLayout(guild, db).catch((e: unknown) => {
+      console.warn(`[discord] layout 生成失敗: ${e instanceof Error ? e.message : String(e)}`);
+    });
+  });
+
+  client.on(Events.Error, (e) => {
+    console.warn(`[discord] client error: ${e.message}`);
+  });
+
+  registerCapture(client, db);
+
+  try {
+    await client.login(discordBotToken());
+    return client;
+  } catch (e: unknown) {
+    console.error(`[discord] login 失敗: ${e instanceof Error ? e.message : String(e)}`);
+    try { client.destroy(); } catch { /* swallow */ }
+    return null;
+  }
+}

--- a/server/discord/client.ts
+++ b/server/discord/client.ts
@@ -6,6 +6,8 @@ import type BetterSqlite3 from 'better-sqlite3';
 import { DISCORD_INTENTS, DISCORD_PARTIALS } from './intents.js';
 import { discordBotToken, discordSettings } from './settings.js';
 import { registerCapture } from './activity-capture.js';
+import { registerRouter } from './message-router.js';
+import { registerInteractions, registerSlashCommands } from './slash-commands.js';
 import { ensureDiscordLayout } from './layout.js';
 
 type Db = BetterSqlite3.Database;
@@ -22,9 +24,11 @@ export async function createDiscordClient(db: Db): Promise<Client | null> {
       console.warn(`[discord] guild ${guildId} not found (Bot が招待されていない可能性)`);
       return;
     }
-    ensureDiscordLayout(guild, db).catch((e: unknown) => {
-      console.warn(`[discord] layout 生成失敗: ${e instanceof Error ? e.message : String(e)}`);
-    });
+    ensureDiscordLayout(guild, db)
+      .then(() => registerSlashCommands(guild))
+      .catch((e: unknown) => {
+        console.warn(`[discord] layout / slash 登録失敗: ${e instanceof Error ? e.message : String(e)}`);
+      });
   });
 
   client.on(Events.Error, (e) => {
@@ -32,6 +36,8 @@ export async function createDiscordClient(db: Db): Promise<Client | null> {
   });
 
   registerCapture(client, db);
+  registerRouter(client, db);
+  registerInteractions(client, db);
 
   try {
     await client.login(discordBotToken());

--- a/server/discord/http.ts
+++ b/server/discord/http.ts
@@ -1,0 +1,18 @@
+// Discord action から Memoria 自身の HTTP API を叩くための薄いクライアント。
+// 既存パイプライン (task / bookmark / meal) をそのまま再利用し、 discord/ を
+// 「mv するだけで切り出せる」 境界に保つ (domain への直 import を避ける)。
+
+const PORT = Number(process.env.MEMORIA_PORT ?? 5180);
+const BASE = `http://127.0.0.1:${PORT}`;
+
+export async function apiPostJson(path: string, body: unknown): Promise<Response> {
+  return fetch(`${BASE}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+export async function apiPostForm(path: string, form: FormData): Promise<Response> {
+  return fetch(`${BASE}${path}`, { method: 'POST', body: form });
+}

--- a/server/discord/index.ts
+++ b/server/discord/index.ts
@@ -5,6 +5,7 @@ import type { Client } from 'discord.js';
 import type BetterSqlite3 from 'better-sqlite3';
 import { discordReady } from './settings.js';
 import { createDiscordClient } from './client.js';
+import { postAnnouncement } from './notifier.js';
 
 type Db = BetterSqlite3.Database;
 
@@ -26,4 +27,14 @@ export function stopDiscordBot(): void {
   if (!current) return;
   try { current.destroy(); } catch { /* swallow */ }
   current = null;
+}
+
+/**
+ * 既存の通知 (日記完了 / リマインダー等) を Discord #announce に投稿する seam。
+ * Bot 未起動 / 未接続なら何もしない (best-effort)。 Memoria の通知トリガからこれを
+ * 呼べば「アナウンスを Discord にも流す」 が実現する。
+ */
+export async function announceToDiscord(db: Db, text: string): Promise<void> {
+  if (!current?.isReady()) return;
+  await postAnnouncement(current, db, text);
 }

--- a/server/discord/index.ts
+++ b/server/discord/index.ts
@@ -1,0 +1,29 @@
+// Discord Bot の起動/停止エントリ。 server/index.ts の listen 後に呼ぶ。
+// enabled かつ token/self/guild が揃っているときだけ起動する。全て best-effort。
+
+import type { Client } from 'discord.js';
+import type BetterSqlite3 from 'better-sqlite3';
+import { discordReady } from './settings.js';
+import { createDiscordClient } from './client.js';
+
+type Db = BetterSqlite3.Database;
+
+let current: Client | null = null;
+
+/** Discord Bot を起動する (条件を満たさなければ skip)。 */
+export async function startDiscordBot(db: Db): Promise<void> {
+  if (current) return; // 二重起動防止
+  const ready = discordReady(db);
+  if (!ready.ok) {
+    console.log(`[discord] 起動 skip: ${ready.reason}`);
+    return;
+  }
+  current = await createDiscordClient(db);
+}
+
+/** Discord Bot を停止する。 */
+export function stopDiscordBot(): void {
+  if (!current) return;
+  try { current.destroy(); } catch { /* swallow */ }
+  current = null;
+}

--- a/server/discord/intents.ts
+++ b/server/discord/intents.ts
@@ -1,0 +1,28 @@
+// Discord Gateway intents / partials.
+//
+// MESSAGE_CONTENT / GUILD_PRESENCES / GUILD_MEMBERS は Discord Developer Portal の
+// "Privileged Gateway Intents" を ON にしていないと接続が拒否される (DisallowedIntents)。
+// spec/feature/discord-bot.md の権限チェックリスト参照。
+
+import { GatewayIntentBits, Partials } from 'discord.js';
+
+/** 行動ログ取得 + 自動処理に必要な intent 一式。 */
+export const DISCORD_INTENTS: GatewayIntentBits[] = [
+  GatewayIntentBits.Guilds,
+  GatewayIntentBits.GuildMessages,
+  GatewayIntentBits.MessageContent, // privileged — 本文取得
+  GatewayIntentBits.GuildMessageReactions,
+  GatewayIntentBits.GuildPresences, // privileged — オンライン状態 / アクティビティ
+  GatewayIntentBits.GuildMembers, // privileged — メンバー / ニックネーム
+  GatewayIntentBits.GuildVoiceStates, // ボイス入退室
+  GatewayIntentBits.DirectMessages,
+];
+
+/** リアクション等で uncached entity を扱うための partials。 */
+export const DISCORD_PARTIALS: Partials[] = [
+  Partials.Message,
+  Partials.Channel,
+  Partials.Reaction,
+  Partials.User,
+  Partials.GuildMember,
+];

--- a/server/discord/layout.ts
+++ b/server/discord/layout.ts
@@ -1,0 +1,63 @@
+// カテゴリ / チャンネルの冪等自動生成。 有効化時に Memoria カテゴリと必要な
+// チャンネルを作り、 id を app_settings に保存する。 Manage Channels 権限が必要。
+// 既存チャンネルは触らず、 Memoria カテゴリ配下のみを管理する (Concordia の
+// ensureDiscordLayout と同方針)。
+
+import { ChannelType, type Guild } from 'discord.js';
+import type BetterSqlite3 from 'better-sqlite3';
+import { getAppSettings, setAppSettings } from '../db.js';
+import { discordSettings } from './settings.js';
+
+type Db = BetterSqlite3.Database;
+
+const CATEGORY_NAME = 'Memoria';
+
+/** オプトアウトに連動して生成するチャンネル一覧。 capture/各機能が OFF なら作らない。 */
+function desiredChannels(cfg: ReturnType<typeof discordSettings>): string[] {
+  const out: string[] = ['activity']; // 集約ログは常設
+  if (cfg.autoTask) out.push('task');
+  if (cfg.autoMemo) out.push('memo');
+  if (cfg.autoBookmark) out.push('bookmark');
+  if (cfg.autoMeal) out.push('meal');
+  if (cfg.autoRecommend) out.push('recommend');
+  if (cfg.announce) out.push('announce');
+  return out;
+}
+
+async function ensureCategory(guild: Guild, db: Db): Promise<string> {
+  const s = getAppSettings(db);
+  const cached = s['discord.category_id'];
+  if (cached && guild.channels.cache.get(cached)?.type === ChannelType.GuildCategory) return cached;
+  const existing = guild.channels.cache.find(
+    (c) => c.type === ChannelType.GuildCategory && c.name === CATEGORY_NAME,
+  );
+  const cat = existing ?? (await guild.channels.create({ name: CATEGORY_NAME, type: ChannelType.GuildCategory }));
+  setAppSettings(db, { 'discord.category_id': cat.id });
+  return cat.id;
+}
+
+async function ensureTextChannel(guild: Guild, db: Db, parentId: string, name: string): Promise<void> {
+  const key = `discord.channel.${name}_id`;
+  const s = getAppSettings(db);
+  const cached = s[key];
+  if (cached && guild.channels.cache.get(cached)?.type === ChannelType.GuildText) return;
+  const existing = guild.channels.cache.find(
+    (c) => c.type === ChannelType.GuildText && c.name === name && c.parentId === parentId,
+  );
+  const ch = existing ?? (await guild.channels.create({ name, type: ChannelType.GuildText, parent: parentId }));
+  setAppSettings(db, { [key]: ch.id });
+}
+
+/** カテゴリ + 必要チャンネルを冪等生成し、 id を永続化する。 best-effort。 */
+export async function ensureDiscordLayout(guild: Guild, db: Db): Promise<void> {
+  const cfg = discordSettings(db);
+  const categoryId = await ensureCategory(guild, db);
+  for (const name of desiredChannels(cfg)) {
+    await ensureTextChannel(guild, db, categoryId, name);
+  }
+}
+
+/** kind 名 (例 'activity') の channel id を返す。 未生成なら null。 */
+export function channelIdFor(db: Db, name: string): string | null {
+  return getAppSettings(db)[`discord.channel.${name}_id`] || null;
+}

--- a/server/discord/message-router.ts
+++ b/server/discord/message-router.ts
@@ -1,0 +1,86 @@
+// メッセージを 6 アクションのいずれかに振り分ける (Imperativus 風だが実行は
+// 制限アクションのみ)。 判定順:
+//   1. チャンネル名 (#task/#memo/#bookmark/#meal) → 決定的ルーティング
+//   2. 添付画像 → meal / 本文に URL → bookmark
+//   3. それ以外 + ai_process ON → AI で意図分類 → task/memo/bookmark/recommend
+// 任意 shell/コード実行はしない。 失敗時は何もせず capture のログだけ残る。
+
+import { type Client, type Message, Events } from 'discord.js';
+import type BetterSqlite3 from 'better-sqlite3';
+import { runLlm } from '../llm.js';
+import { discordSettings, type DiscordSettings } from './settings.js';
+import { isSelf } from './user-map.js';
+import { createTask, createMemo } from './actions/task.js';
+import { createBookmark, extractFirstUrl } from './actions/bookmark.js';
+import { createMeal } from './actions/meal.js';
+import { runRecommend } from './actions/recommend.js';
+
+type Db = BetterSqlite3.Database;
+type Action = 'task' | 'memo' | 'bookmark' | 'meal' | 'recommend' | 'none';
+
+function channelName(msg: Message): string {
+  return 'name' in msg.channel && msg.channel.name ? msg.channel.name : '';
+}
+
+/** AI に意図分類させる。 出力 JSON {action,title,due_at} を期待。 失敗時 none。 */
+async function classify(text: string): Promise<{ action: Action; title?: string; dueAt?: string | null }> {
+  const prompt = `あなたはライフログ Bot のルーターです。次のメッセージを task/memo/bookmark/recommend のいずれかに分類し、JSON のみで答えてください。\n` +
+    `task=締切のある予定/やること, memo=締切のないメモ, recommend=おすすめ要求, bookmark=保存したいURL。\n` +
+    `形式: {"action":"task|memo|bookmark|recommend|none","title":"...","due_at":"ISO8601 or null"}\n\nメッセージ: ${text}`;
+  try {
+    const raw = await runLlm({ task: 'discord_route', prompt, timeoutMs: 30_000 });
+    const m = raw.match(/\{[\s\S]*\}/);
+    if (!m) return { action: 'none' };
+    const j = JSON.parse(m[0]) as { action?: string; title?: string; due_at?: string | null };
+    const allowed: string[] = ['task', 'memo', 'bookmark', 'recommend'];
+    const action: Action = allowed.includes(j.action ?? '') ? (j.action as Action) : 'none';
+    return { action, title: j.title, dueAt: j.due_at ?? null };
+  } catch {
+    return { action: 'none' };
+  }
+}
+
+async function dispatch(db: Db, cfg: DiscordSettings, msg: Message): Promise<string | null> {
+  const text = (msg.content ?? '').trim();
+  const ch = channelName(msg);
+  const image = msg.attachments.find((a) => (a.contentType ?? '').startsWith('image/'));
+  const url = extractFirstUrl(text);
+
+  // 1. チャンネル決定的ルーティング
+  if (ch === 'task' && cfg.autoTask) return createTask({ title: text });
+  if (ch === 'memo' && cfg.autoMemo) return createMemo(text);
+  if (ch === 'bookmark' && cfg.autoBookmark && url) return createBookmark(url);
+  if (ch === 'meal' && cfg.autoMeal && image) return createMeal({ url: image.url, name: image.name, contentType: image.contentType }, text);
+
+  // 2. 構造判定 (どの channel でも)
+  if (image && cfg.autoMeal) return createMeal({ url: image.url, name: image.name, contentType: image.contentType }, text);
+  if (url && cfg.autoBookmark) return createBookmark(url);
+
+  // 3. AI 分類
+  if (!cfg.aiProcess || !text) return null;
+  const r = await classify(text);
+  if (r.action === 'task' && cfg.autoTask) return createTask({ title: r.title || text, dueAt: r.dueAt });
+  if (r.action === 'memo' && cfg.autoMemo) return createMemo(r.title || text);
+  if (r.action === 'bookmark' && cfg.autoBookmark && url) return createBookmark(url);
+  if (r.action === 'recommend' && cfg.autoRecommend) return runRecommend(db);
+  return null;
+}
+
+/** ルーターを Client に登録する。 self の投稿のみ処理。 */
+export function registerRouter(client: Client, db: Db): void {
+  client.on(Events.MessageCreate, (msg) => {
+    const cfg = discordSettings(db);
+    if (msg.author?.bot || !isSelf(cfg, msg.author?.id)) return;
+    void (async () => {
+      try {
+        const summary = await dispatch(db, cfg, msg);
+        if (summary) {
+          await msg.react('✅').catch(() => {});
+          await msg.reply(summary).catch(() => {});
+        }
+      } catch {
+        // best-effort — 失敗しても capture ログは残る
+      }
+    })();
+  });
+}

--- a/server/discord/notifier.ts
+++ b/server/discord/notifier.ts
@@ -1,0 +1,37 @@
+// Discord への送信抽象。 直送 (discord.js client) で実装。 将来 Nuntius 経由に
+// 切り替える場合もこのモジュールだけ差し替えれば済むようにする。
+
+import { ChannelType, type Client } from 'discord.js';
+import type BetterSqlite3 from 'better-sqlite3';
+import { discordSettings } from './settings.js';
+import { channelIdFor } from './layout.js';
+
+type Db = BetterSqlite3.Database;
+
+/** self メンション文字列 (`<@id>`)。 self 未設定なら空。 */
+export function selfMention(db: Db): string {
+  const id = discordSettings(db).selfUserId;
+  return id ? `<@${id}>` : '';
+}
+
+/** 指定 kind (例 'announce') の channel にテキストを送る。 best-effort。 */
+export async function postToChannel(client: Client, db: Db, kind: string, content: string): Promise<void> {
+  const id = channelIdFor(db, kind);
+  if (!id) return;
+  try {
+    const ch = await client.channels.fetch(id);
+    if (ch && ch.type === ChannelType.GuildText) {
+      await ch.send(content.slice(0, 1900));
+    }
+  } catch {
+    // best-effort — 送信失敗は本筋を止めない
+  }
+}
+
+/** アナウンス (= 既存の通知系) を #announce に投稿。 mention_notify ON なら self メンション付き。 */
+export async function postAnnouncement(client: Client, db: Db, text: string): Promise<void> {
+  const cfg = discordSettings(db);
+  if (!cfg.announce) return;
+  const prefix = cfg.mentionNotify ? `${selfMention(db)} ` : '';
+  await postToChannel(client, db, 'announce', `${prefix}📢 ${text}`);
+}

--- a/server/discord/settings.ts
+++ b/server/discord/settings.ts
@@ -31,8 +31,17 @@ export interface DiscordSettings {
   autoRecommend: boolean;
 }
 
-/** Bot token は env のみ。 値は DB / フロント / ログに出さない。 */
-export function discordBotToken(): string {
+/**
+ * Bot token。 Memoria の設定 (app_settings) を優先し、 無ければ env を見る。
+ * Memoria はローカル SQLite に閉じる個人アプリで、 既に OpenAI key 等を設定保存
+ * しているため同パターン。 値は GET API / フロント / ログには決して出さない
+ * (token_set の bool のみ公開)。
+ */
+export function discordBotToken(db?: Db): string {
+  if (db) {
+    const t = getAppSettings(db)['features.discord.bot_token'];
+    if (t) return t;
+  }
   return process.env.MEMORIA_DISCORD_BOT_TOKEN ?? '';
 }
 
@@ -61,7 +70,7 @@ export function discordSettings(db: Db): DiscordSettings {
 export function discordReady(db: Db): { ok: boolean; reason: string } {
   const cfg = discordSettings(db);
   if (!cfg.enabled) return { ok: false, reason: 'disabled' };
-  if (!discordBotToken()) return { ok: false, reason: 'MEMORIA_DISCORD_BOT_TOKEN 未設定' };
+  if (!discordBotToken(db)) return { ok: false, reason: 'Bot token 未設定' };
   if (!cfg.selfUserId) return { ok: false, reason: 'self_user_id 未設定' };
   if (!cfg.guildId) return { ok: false, reason: 'guild_id 未設定' };
   return { ok: true, reason: '' };

--- a/server/discord/settings.ts
+++ b/server/discord/settings.ts
@@ -1,0 +1,68 @@
+// Discord 機能の設定読み出し。 privacy.ts と同じく app_settings から正規化して返す。
+// すべて opt-out 可。 token だけは DB に置かず env (サービスシークレット)。
+
+import type BetterSqlite3 from 'better-sqlite3';
+import { getAppSettings } from '../db.js';
+import { settingBool } from '../lib/privacy.js';
+
+type Db = BetterSqlite3.Database;
+
+export interface DiscordSettings {
+  /** マスタ。 OFF なら Bot 自体を起動しない (明示 opt-in、 既定 false)。 */
+  enabled: boolean;
+  /** ログ対象の自分の Discord user id。 複数人サーバーで取りこぼし/混入を防ぐため必須。 */
+  selfUserId: string;
+  /** 対象サーバー (guild) id。 layout 生成・capture のスコープ。 */
+  guildId: string;
+  // capture 群 (既定 true)
+  captureMessage: boolean;
+  capturePresence: boolean;
+  captureVoice: boolean;
+  captureReaction: boolean;
+  // 処理 / 出力 (既定 true)
+  aiProcess: boolean;
+  mentionNotify: boolean;
+  announce: boolean;
+  // 各自動処理 (既定 true)
+  autoTask: boolean;
+  autoMemo: boolean;
+  autoBookmark: boolean;
+  autoMeal: boolean;
+  autoRecommend: boolean;
+}
+
+/** Bot token は env のみ。 値は DB / フロント / ログに出さない。 */
+export function discordBotToken(): string {
+  return process.env.MEMORIA_DISCORD_BOT_TOKEN ?? '';
+}
+
+export function discordSettings(db: Db): DiscordSettings {
+  const s = getAppSettings(db);
+  return {
+    enabled: settingBool(s, 'features.discord.enabled', false),
+    selfUserId: s['features.discord.self_user_id'] || '',
+    guildId: s['features.discord.guild_id'] || '',
+    captureMessage: settingBool(s, 'features.discord.capture.message', true),
+    capturePresence: settingBool(s, 'features.discord.capture.presence', true),
+    captureVoice: settingBool(s, 'features.discord.capture.voice', true),
+    captureReaction: settingBool(s, 'features.discord.capture.reaction', true),
+    aiProcess: settingBool(s, 'features.discord.ai_process', true),
+    mentionNotify: settingBool(s, 'features.discord.mention_notify', true),
+    announce: settingBool(s, 'features.discord.announce', true),
+    autoTask: settingBool(s, 'features.discord.autoproc.task', true),
+    autoMemo: settingBool(s, 'features.discord.autoproc.memo', true),
+    autoBookmark: settingBool(s, 'features.discord.autoproc.bookmark', true),
+    autoMeal: settingBool(s, 'features.discord.autoproc.meal', true),
+    autoRecommend: settingBool(s, 'features.discord.autoproc.recommend', true),
+  };
+}
+
+/** 起動可能か (マスタ ON + token + self + guild が揃っているか)。 */
+export function discordReady(db: Db): { ok: boolean; reason: string } {
+  const cfg = discordSettings(db);
+  if (!cfg.enabled) return { ok: false, reason: 'disabled' };
+  if (!discordBotToken()) return { ok: false, reason: 'MEMORIA_DISCORD_BOT_TOKEN 未設定' };
+  if (!cfg.selfUserId) return { ok: false, reason: 'self_user_id 未設定' };
+  if (!cfg.guildId) return { ok: false, reason: 'guild_id 未設定' };
+  return { ok: true, reason: '' };
+}

--- a/server/discord/slash-commands.ts
+++ b/server/discord/slash-commands.ts
@@ -1,0 +1,50 @@
+// スラッシュコマンド。 ready 時に guild に登録 (guild コマンドは即時反映)。
+//   /recommend            — おすすめ生成 → 内容を投稿
+//   /task <text> [due]    — タスク登録 (リマインダー付き)
+//   /memo <text>          — メモ登録 (リマインダー無し)
+
+import { type Client, Events, type Guild, SlashCommandBuilder, MessageFlags } from 'discord.js';
+import type BetterSqlite3 from 'better-sqlite3';
+import { discordSettings } from './settings.js';
+import { createTask, createMemo } from './actions/task.js';
+import { runRecommend } from './actions/recommend.js';
+
+type Db = BetterSqlite3.Database;
+
+const COMMANDS = [
+  new SlashCommandBuilder().setName('recommend').setDescription('おすすめを生成して投稿する'),
+  new SlashCommandBuilder().setName('task').setDescription('タスクを登録 (リマインダー付き)')
+    .addStringOption((o) => o.setName('text').setDescription('内容').setRequired(true))
+    .addStringOption((o) => o.setName('due').setDescription('期日 (ISO8601)')),
+  new SlashCommandBuilder().setName('memo').setDescription('メモを登録 (リマインダー無し)')
+    .addStringOption((o) => o.setName('text').setDescription('内容').setRequired(true)),
+].map((c) => c.toJSON());
+
+export async function registerSlashCommands(guild: Guild): Promise<void> {
+  await guild.commands.set(COMMANDS);
+}
+
+export function registerInteractions(client: Client, db: Db): void {
+  client.on(Events.InteractionCreate, (interaction) => {
+    if (!interaction.isChatInputCommand()) return;
+    void (async () => {
+      const cfg = discordSettings(db);
+      try {
+        if (interaction.commandName === 'recommend') {
+          if (!cfg.autoRecommend) { await interaction.reply({ content: 'おすすめは無効化されています', flags: MessageFlags.Ephemeral }); return; }
+          await interaction.deferReply();
+          await interaction.editReply(await runRecommend(db));
+        } else if (interaction.commandName === 'task') {
+          const text = interaction.options.getString('text', true);
+          const due = interaction.options.getString('due');
+          await interaction.reply(await createTask({ title: text, dueAt: due }));
+        } else if (interaction.commandName === 'memo') {
+          const text = interaction.options.getString('text', true);
+          await interaction.reply(await createMemo(text));
+        }
+      } catch {
+        try { await interaction.reply({ content: '処理に失敗しました', flags: MessageFlags.Ephemeral }); } catch { /* swallow */ }
+      }
+    })();
+  });
+}

--- a/server/discord/user-map.ts
+++ b/server/discord/user-map.ts
@@ -1,0 +1,11 @@
+// self 判定。 個人サーバーでも複数人いる場合に、 設定した自分の Discord user id の
+// イベントだけをログ対象にする (混入・取りこぼし防止)。識別情報の正本は Cernere な
+// ので、 ここでは id の一致判定のみ行い氏名等は保持しない (RULE §5)。
+
+import type { DiscordSettings } from './settings.js';
+
+/** userId が設定された self_user_id と一致するか。 self 未設定なら常に false。 */
+export function isSelf(cfg: DiscordSettings, userId: string | null | undefined): boolean {
+  if (!cfg.selfUserId) return false;
+  return userId === cfg.selfUserId;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -34,6 +34,7 @@ import { startSchedulers } from './lib/scheduler.js';
 import { makeMcpServer } from './lib/mcp-server.js';
 import { startLegatusSubscriber } from './lib/legatus-subscriber.js';
 import { startMqttBroker } from './mqtt/broker.js';
+import { startDiscordBot } from './discord/index.js';
 import { startWifiLocation } from './wifi-location.js';
 import { fetchPageHtml } from './lib/fetch-page.js';
 import { privacySettings } from './lib/privacy.js';
@@ -460,6 +461,14 @@ try {
   const msg = e instanceof Error ? e.message : String(e);
   console.error(`[mqtt-broker] failed to start: ${msg}`);
 }
+
+// ---- Discord Bot (行動ログ取得 + 自動処理 + 通知) --------------------------
+//
+// features.discord.enabled かつ token/self/guild が揃っているときだけ起動。
+// spec/feature/discord-bot.md。 起動失敗は best-effort で本体に影響させない。
+startDiscordBot(db).catch((e: unknown) => {
+  console.error(`[discord] failed to start: ${e instanceof Error ? e.message : String(e)}`);
+});
 
 // ---- PC WiFi → 位置情報 (Google Geolocation API) --------------------------
 //

--- a/server/index.ts
+++ b/server/index.ts
@@ -45,6 +45,7 @@ import { makeDomainRouter } from './routes/domain.js';
 import { makeVisitRouter } from './routes/visit.js';
 import { makeDictRouter } from './routes/dict.js';
 import { makeMealRouter } from './routes/meal.js';
+import { makeDiscordRouter } from './routes/discord.js';
 import { makeDiaryRouter } from './routes/diary.js';
 import { makeTaskRouter } from './routes/task.js';
 import { makeAgentRouter } from './routes/agent.js';
@@ -237,6 +238,7 @@ app.route('/', makeDiaryRouter({
 app.route('/', makeTaskRouter({ db }));
 app.route('/', makeAgentRouter({ db, dataDir: DATA_DIR }));
 app.route('/', makeWorkplaceRouter({ db }));
+app.route('/', makeDiscordRouter({ db }));
 app.route('/', makeActivityRouter({ db }));
 app.route('/', makeImplRouter({ db }));
 app.route('/', makePushRouter({ db }));

--- a/server/llm.ts
+++ b/server/llm.ts
@@ -12,7 +12,8 @@ export type LlmTaskName =
   | 'meal_vision' | 'meal_calorie'
   | 'app_classify'
   | 'recommendation_agent' | 'recommendation_synthesize'
-  | 'endpoint_identify';
+  | 'endpoint_identify'
+  | 'discord_route';
 
 export const TASKS: LlmTaskName[] = [
   'summarize', 'dig', 'dig_preview', 'cloud_extract', 'cloud_validate',
@@ -22,6 +23,7 @@ export const TASKS: LlmTaskName[] = [
   'app_classify',
   'recommendation_agent', 'recommendation_synthesize',
   'endpoint_identify',
+  'discord_route',
 ];
 
 const TASK_DEFAULT_MODELS: Partial<Record<LlmTaskName, string>> = {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,6 +11,7 @@
         "@hono/node-server": "^1.13.7",
         "aedes": "^0.51.3",
         "better-sqlite3": "^11.3.0",
+        "discord.js": "^14.26.4",
         "exifr": "^7.1.3",
         "hono": "^4.6.10",
         "mqtt": "^5.15.1",
@@ -31,6 +32,146 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@discordjs/builders": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.14.1.tgz",
+      "integrity": "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.40",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.1.tgz",
+      "integrity": "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.5",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.40",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "6.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@sapphire/snowflake": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.1",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -461,6 +602,39 @@
         "hono": "^4"
       }
     },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v16"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
@@ -496,6 +670,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/abort-controller": {
@@ -810,6 +994,42 @@
         "node": ">=8"
       }
     },
+    "node_modules/discord-api-types": {
+      "version": "0.38.48",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.48.tgz",
+      "integrity": "sha512-WFUE/2o0lBlLeCQonQ+Pu2RqHAqbytBJ2RlXR91gzk05InSS6k9ShzzLYoymrA4c2oRgRKGE7/VqQJNNdGWSxQ==",
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
+    },
+    "node_modules/discord.js": {
+      "version": "14.26.4",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.26.4.tgz",
+      "integrity": "sha512-4oBp8tc6Kf8IDBwAHhbsMaAqx1b5fob9SNasZT7V6yyyUydoO5i5fGuX7TmvRtR+q/WgKRnRViRoAWnG7fNyvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/builders": "^1.14.1",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/rest": "^2.6.1",
+        "@discordjs/util": "^1.2.0",
+        "@discordjs/ws": "^1.2.3",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "^0.38.40",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "6.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
@@ -968,6 +1188,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
     },
     "node_modules/fast-unique-numbers": {
       "version": "9.0.27",
@@ -1193,11 +1419,29 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
+      "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
+      "license": "MIT"
     },
     "node_modules/mimic-response": {
       "version": "3.1.0",
@@ -1787,6 +2031,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -1829,6 +2079,15 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.19.2",

--- a/server/package.json
+++ b/server/package.json
@@ -26,6 +26,7 @@
     "@hono/node-server": "^1.13.7",
     "aedes": "^0.51.3",
     "better-sqlite3": "^11.3.0",
+    "discord.js": "^14.26.4",
     "exifr": "^7.1.3",
     "hono": "^4.6.10",
     "mqtt": "^5.15.1",

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -5966,9 +5966,9 @@ function renderEvents(items) {
 
 // ── Discord 設定 (⚙ 設定 → 🤖 Discord タブ) ───────────────────────────────
 async function loadDiscordSettings() {
-  let r: any;
-  try { r = await api('/api/discord/config'); }
-  catch (e: any) { const s = $('discordStatus'); if (s) s.textContent = `設定取得失敗: ${e.message}`; return; }
+  let r: { config?: Record<string, unknown>; token_set?: boolean; ready?: boolean; reason?: string };
+  try { r = await api('/api/discord/config') as typeof r; }
+  catch (e) { const s = $('discordStatus'); if (s) s.textContent = `設定取得失敗: ${(e as Error).message}`; return; }
   const c = r.config || {};
   const setChk = (id: string, v: unknown) => { const el = $(id) as HTMLInputElement | null; if (el) el.checked = v !== false; };
   const setVal = (id: string, v: unknown) => { const el = $(id) as HTMLInputElement | null; if (el) el.value = (v as string) || ''; };
@@ -6004,7 +6004,7 @@ async function saveDiscordSettings() {
     await api('/api/discord/config', { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
     flashToast('Discord 設定を保存しました');
     await loadDiscordSettings();
-  } catch (e: any) { alert(`保存失敗: ${e.message}`); }
+  } catch (e) { alert(`保存失敗: ${(e as Error).message}`); }
 }
 
 document.getElementById('eventsRefresh')?.addEventListener('click', loadEvents);

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -5800,6 +5800,7 @@ const SETTINGS_STAB_LABELS: Record<string, string> = {
   profile: '🧍 プロフィール',
   data: '📦 データ / Hub',
   privacy: '🔒 プライバシー / 表示',
+  discord: '🤖 Discord',
 };
 // 「全部」 タブで非表示にする 手順系 (= 一度しか見ない / 別 UI)。
 const SETTINGS_STAB_EXCLUDE_FROM_ALL = new Set(['setup']);
@@ -5851,6 +5852,7 @@ document.addEventListener('click', (ev) => {
   }
   // タブを切り替えたら panel を上にリセット (各タブの先頭から見たい)
   if (stab === 'privacy') loadPrivacySettings().catch(console.warn);
+  if (stab === 'discord') loadDiscordSettings().catch(console.warn);
   if (stab === 'setup') loadSetupDocs().catch(console.warn);
   // 'agent-projects' タブは廃止 (AI 実装プロジェクト機能を休止)
   panel.scrollTop = 0;
@@ -5960,6 +5962,45 @@ function renderEvents(items) {
       ${det}
     </li>`;
   }).join('');
+}
+
+// ── Discord 設定 (⚙ 設定 → 🤖 Discord タブ) ───────────────────────────────
+async function loadDiscordSettings() {
+  let r: any;
+  try { r = await api('/api/discord/config'); }
+  catch (e: any) { const s = $('discordStatus'); if (s) s.textContent = `設定取得失敗: ${e.message}`; return; }
+  const c = r.config || {};
+  const setChk = (id: string, v: unknown) => { const el = $(id) as HTMLInputElement | null; if (el) el.checked = v !== false; };
+  const setVal = (id: string, v: unknown) => { const el = $(id) as HTMLInputElement | null; if (el) el.value = (v as string) || ''; };
+  setChk('dcEnabled', c.enabled);
+  setVal('dcSelfUserId', c.selfUserId); setVal('dcGuildId', c.guildId);
+  setChk('dcCaptureMessage', c.captureMessage); setChk('dcCapturePresence', c.capturePresence);
+  setChk('dcCaptureVoice', c.captureVoice); setChk('dcCaptureReaction', c.captureReaction);
+  setChk('dcAiProcess', c.aiProcess); setChk('dcMentionNotify', c.mentionNotify); setChk('dcAnnounce', c.announce);
+  setChk('dcAutoTask', c.autoTask); setChk('dcAutoMemo', c.autoMemo); setChk('dcAutoBookmark', c.autoBookmark);
+  setChk('dcAutoMeal', c.autoMeal); setChk('dcAutoRecommend', c.autoRecommend);
+  const s = $('discordStatus');
+  if (s) s.textContent = `状態: ${r.ready ? '✅ 起動可能' : '⚠ ' + (r.reason || '')} ／ token: ${r.token_set ? '設定済 (env)' : '未設定 (MEMORIA_DISCORD_BOT_TOKEN)'}`;
+  const btn = $('discordSaveBtn') as HTMLButtonElement | null;
+  if (btn) btn.onclick = saveDiscordSettings;
+}
+
+async function saveDiscordSettings() {
+  const chk = (id: string) => !!($(id) as HTMLInputElement | null)?.checked;
+  const val = (id: string) => (($(id) as HTMLInputElement | null)?.value || '').trim();
+  const payload = {
+    enabled: chk('dcEnabled'), selfUserId: val('dcSelfUserId'), guildId: val('dcGuildId'),
+    captureMessage: chk('dcCaptureMessage'), capturePresence: chk('dcCapturePresence'),
+    captureVoice: chk('dcCaptureVoice'), captureReaction: chk('dcCaptureReaction'),
+    aiProcess: chk('dcAiProcess'), mentionNotify: chk('dcMentionNotify'), announce: chk('dcAnnounce'),
+    autoTask: chk('dcAutoTask'), autoMemo: chk('dcAutoMemo'), autoBookmark: chk('dcAutoBookmark'),
+    autoMeal: chk('dcAutoMeal'), autoRecommend: chk('dcAutoRecommend'),
+  };
+  try {
+    await api('/api/discord/config', { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+    flashToast('Discord 設定を保存しました');
+    await loadDiscordSettings();
+  } catch (e: any) { alert(`保存失敗: ${e.message}`); }
 }
 
 document.getElementById('eventsRefresh')?.addEventListener('click', loadEvents);
@@ -6133,6 +6174,7 @@ let ensureMemoriaFeatureViews = function () {
     settingsTabs.insertBefore(allBtn, settingsTabs.firstChild);
     for (const spec of [
       ['privacy', '🔒 プライバシー / 表示'],
+      ['discord', '🤖 Discord'],
       ['setup', '📚 セットアップ手順'],
     ]) {
       const b = document.createElement('button');
@@ -6185,6 +6227,37 @@ let ensureMemoriaFeatureViews = function () {
       </p>
       <p class="diary-settings-help" style="margin-top:6px">「移動速度の閾値」 はプロフィール タブに移動しました。</p>
       <p class="diary-settings-help" style="margin-top:6px">iOS で受け取る場合はホーム画面に追加 + 通知を許可してください。GPS 共有は Hub 接続済みのときのみ動作します。</p>`;
+    footer.parentNode.insertBefore(sec, footer);
+  }
+  if (footer && !$('discordSettingsBody')) {
+    const sec = document.createElement('section');
+    sec.id = 'discordSettingsBody';
+    sec.className = 'settings-tab-body foundation-form hidden';
+    sec.dataset.stab = 'discord';
+    sec.innerHTML = `
+      <h4>🤖 Discord Bot</h4>
+      <p class="diary-settings-help">行動ログ取得 + 自動処理 + 通知。Bot Token は <code>MEMORIA_DISCORD_BOT_TOKEN</code> (env) に設定してください。詳細は spec/feature/discord-bot.md。</p>
+      <div id="discordStatus" class="muted" style="margin:6px 0"></div>
+      <label class="check-inline"><input id="dcEnabled" type="checkbox" /> Discord Bot を有効にする (マスタ)</label>
+      <label>自分の Discord user id: <input id="dcSelfUserId" type="text" placeholder="123456789012345678" /></label>
+      <label>対象サーバー (guild) id: <input id="dcGuildId" type="text" placeholder="123456789012345678" /></label>
+      <h4 style="margin-top:12px">取得 (オプトアウト)</h4>
+      <label class="check-inline"><input id="dcCaptureMessage" type="checkbox" /> メッセージ本文を記録</label>
+      <label class="check-inline"><input id="dcCapturePresence" type="checkbox" /> オンライン状態 / アクティビティを記録</label>
+      <label class="check-inline"><input id="dcCaptureVoice" type="checkbox" /> ボイス入退室を記録</label>
+      <label class="check-inline"><input id="dcCaptureReaction" type="checkbox" /> リアクションを記録</label>
+      <h4 style="margin-top:12px">処理 / 通知 (オプトアウト)</h4>
+      <label class="check-inline"><input id="dcAiProcess" type="checkbox" /> AI で意図分類して自動処理する</label>
+      <label class="check-inline"><input id="dcMentionNotify" type="checkbox" /> 通知時に自分をメンションする</label>
+      <label class="check-inline"><input id="dcAnnounce" type="checkbox" /> 通知を #announce に投稿する</label>
+      <h4 style="margin-top:12px">自動処理 (オプトアウト)</h4>
+      <label class="check-inline"><input id="dcAutoTask" type="checkbox" /> タスク (リマインダー付き)</label>
+      <label class="check-inline"><input id="dcAutoMemo" type="checkbox" /> メモ</label>
+      <label class="check-inline"><input id="dcAutoBookmark" type="checkbox" /> ブックマーク (URL 検知)</label>
+      <label class="check-inline"><input id="dcAutoMeal" type="checkbox" /> 食事 (画像検知)</label>
+      <label class="check-inline"><input id="dcAutoRecommend" type="checkbox" /> おすすめ (/recommend)</label>
+      <div style="margin-top:10px"><button id="discordSaveBtn" type="button" class="primary">保存</button></div>
+      <p class="diary-settings-help" style="margin-top:6px">設定したチャンネル/カテゴリは Bot 有効化 + 起動時に自動生成されます。反映には Memoria の再起動が必要な場合があります。</p>`;
     footer.parentNode.insertBefore(sec, footer);
   }
   if (footer && !$('setupDocsBody')) {

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -5974,6 +5974,8 @@ async function loadDiscordSettings() {
   const setVal = (id: string, v: unknown) => { const el = $(id) as HTMLInputElement | null; if (el) el.value = (v as string) || ''; };
   setChk('dcEnabled', c.enabled);
   setVal('dcSelfUserId', c.selfUserId); setVal('dcGuildId', c.guildId);
+  const tk = $('dcBotToken') as HTMLInputElement | null;
+  if (tk) { tk.value = ''; tk.placeholder = r.token_set ? '●●●●●● (設定済み・再入力で上書き)' : 'Bot Token を入力'; }
   setChk('dcCaptureMessage', c.captureMessage); setChk('dcCapturePresence', c.capturePresence);
   setChk('dcCaptureVoice', c.captureVoice); setChk('dcCaptureReaction', c.captureReaction);
   setChk('dcAiProcess', c.aiProcess); setChk('dcMentionNotify', c.mentionNotify); setChk('dcAnnounce', c.announce);
@@ -5988,8 +5990,10 @@ async function loadDiscordSettings() {
 async function saveDiscordSettings() {
   const chk = (id: string) => !!($(id) as HTMLInputElement | null)?.checked;
   const val = (id: string) => (($(id) as HTMLInputElement | null)?.value || '').trim();
-  const payload = {
+  const token = val('dcBotToken'); // 空欄なら据え置き (送らない)
+  const payload: Record<string, unknown> = {
     enabled: chk('dcEnabled'), selfUserId: val('dcSelfUserId'), guildId: val('dcGuildId'),
+    ...(token ? { botToken: token } : {}),
     captureMessage: chk('dcCaptureMessage'), capturePresence: chk('dcCapturePresence'),
     captureVoice: chk('dcCaptureVoice'), captureReaction: chk('dcCaptureReaction'),
     aiProcess: chk('dcAiProcess'), mentionNotify: chk('dcMentionNotify'), announce: chk('dcAnnounce'),
@@ -6239,6 +6243,7 @@ let ensureMemoriaFeatureViews = function () {
       <p class="diary-settings-help">行動ログ取得 + 自動処理 + 通知。Bot Token は <code>MEMORIA_DISCORD_BOT_TOKEN</code> (env) に設定してください。詳細は spec/feature/discord-bot.md。</p>
       <div id="discordStatus" class="muted" style="margin:6px 0"></div>
       <label class="check-inline"><input id="dcEnabled" type="checkbox" /> Discord Bot を有効にする (マスタ)</label>
+      <label>Bot Token: <input id="dcBotToken" type="password" placeholder="Bot Token を入力" autocomplete="off" /></label>
       <label>自分の Discord user id: <input id="dcSelfUserId" type="text" placeholder="123456789012345678" /></label>
       <label>対象サーバー (guild) id: <input id="dcGuildId" type="text" placeholder="123456789012345678" /></label>
       <h4 style="margin-top:12px">取得 (オプトアウト)</h4>

--- a/server/routes/discord.ts
+++ b/server/routes/discord.ts
@@ -1,0 +1,70 @@
+// Discord 設定 API。 設定画面の「Discord」セクションが読み書きする。
+// token は返さない / 受け取らない (env 管理)。 opt-out は app_settings に保存。
+
+import { Hono, type Context } from 'hono';
+import type BetterSqlite3 from 'better-sqlite3';
+import { setAppSettings } from '../db.js';
+import { discordSettings, discordReady, discordBotToken } from '../discord/settings.js';
+import { announceToDiscord } from '../discord/index.js';
+
+type Db = BetterSqlite3.Database;
+
+export interface DiscordRouterDeps { db: Db; }
+
+// PATCH で受け付ける bool キー (settings key ← camelCase フィールド)。
+const BOOL_KEYS: Record<string, string> = {
+  enabled: 'features.discord.enabled',
+  captureMessage: 'features.discord.capture.message',
+  capturePresence: 'features.discord.capture.presence',
+  captureVoice: 'features.discord.capture.voice',
+  captureReaction: 'features.discord.capture.reaction',
+  aiProcess: 'features.discord.ai_process',
+  mentionNotify: 'features.discord.mention_notify',
+  announce: 'features.discord.announce',
+  autoTask: 'features.discord.autoproc.task',
+  autoMemo: 'features.discord.autoproc.memo',
+  autoBookmark: 'features.discord.autoproc.bookmark',
+  autoMeal: 'features.discord.autoproc.meal',
+  autoRecommend: 'features.discord.autoproc.recommend',
+};
+const STRING_KEYS: Record<string, string> = {
+  selfUserId: 'features.discord.self_user_id',
+  guildId: 'features.discord.guild_id',
+};
+
+export function makeDiscordRouter(deps: DiscordRouterDeps): Hono {
+  const { db } = deps;
+  const r = new Hono();
+
+  // 現在の設定 + 接続可否。 token 値は出さず「設定済みか」だけ返す。
+  r.get('/api/discord/config', (c: Context) => {
+    const cfg = discordSettings(db);
+    const ready = discordReady(db);
+    return c.json({ config: cfg, token_set: !!discordBotToken(), ready: ready.ok, reason: ready.reason });
+  });
+
+  // opt-out / self/guild の更新。 反映は次回 capture / Bot 再起動から。
+  r.patch('/api/discord/config', async (c: Context) => {
+    const body = await c.req.json().catch(() => ({})) as Record<string, unknown>;
+    const patch: Record<string, unknown> = {};
+    for (const [field, key] of Object.entries(BOOL_KEYS)) {
+      if (field in body) patch[key] = body[field] ? '1' : '0';
+    }
+    for (const [field, key] of Object.entries(STRING_KEYS)) {
+      if (field in body && typeof body[field] === 'string') patch[key] = (body[field] as string).trim();
+    }
+    if (Object.keys(patch).length > 0) setAppSettings(db, patch);
+    return c.json({ ok: true, config: discordSettings(db) });
+  });
+
+  // 通知を Discord #announce に流す seam (テスト / 外部トリガ用)。
+  r.post('/api/discord/announce', async (c: Context) => {
+    const body = await c.req.json().catch(() => ({})) as { text?: unknown };
+    const text = String(body.text ?? '').trim();
+    if (!text) return c.json({ error: 'text required' }, 400);
+    await announceToDiscord(db, text);
+    return c.json({ ok: true });
+  });
+
+  return r;
+}

--- a/server/routes/discord.ts
+++ b/server/routes/discord.ts
@@ -40,10 +40,11 @@ export function makeDiscordRouter(deps: DiscordRouterDeps): Hono {
   r.get('/api/discord/config', (c: Context) => {
     const cfg = discordSettings(db);
     const ready = discordReady(db);
-    return c.json({ config: cfg, token_set: !!discordBotToken(), ready: ready.ok, reason: ready.reason });
+    return c.json({ config: cfg, token_set: !!discordBotToken(db), ready: ready.ok, reason: ready.reason });
   });
 
-  // opt-out / self/guild の更新。 反映は次回 capture / Bot 再起動から。
+  // opt-out / self/guild / token の更新。 反映は次回 capture / Bot 再起動から。
+  // token は空文字なら据え置き (パスワード UX)、 非空なら上書き保存。
   r.patch('/api/discord/config', async (c: Context) => {
     const body = await c.req.json().catch(() => ({})) as Record<string, unknown>;
     const patch: Record<string, unknown> = {};
@@ -53,8 +54,11 @@ export function makeDiscordRouter(deps: DiscordRouterDeps): Hono {
     for (const [field, key] of Object.entries(STRING_KEYS)) {
       if (field in body && typeof body[field] === 'string') patch[key] = (body[field] as string).trim();
     }
+    if (typeof body.botToken === 'string' && body.botToken.trim()) {
+      patch['features.discord.bot_token'] = body.botToken.trim();
+    }
     if (Object.keys(patch).length > 0) setAppSettings(db, patch);
-    return c.json({ ok: true, config: discordSettings(db) });
+    return c.json({ ok: true, config: discordSettings(db), token_set: !!discordBotToken(db) });
   });
 
   // 通知を Discord #announce に流す seam (テスト / 外部トリガ用)。

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -557,8 +557,8 @@ export function makeVisitRouter(deps: VisitRouterDeps): Hono {
   r.get('/api/activity/events', (c: Context) => {
     const date = c.req.query('date');
     const kindQ = c.req.query('kind');
-    const allowedKinds = new Set<string>(['git_commit', 'claude_code_prompt', 'gemini_prompt', 'codex_prompt', 'task_created', 'task_done', 'task_updated']);
-    type ActivityKindLocal = 'git_commit' | 'claude_code_prompt' | 'gemini_prompt' | 'codex_prompt' | 'task_created' | 'task_done' | 'task_updated';
+    const allowedKinds = new Set<string>(['git_commit', 'claude_code_prompt', 'gemini_prompt', 'codex_prompt', 'task_created', 'task_done', 'task_updated', 'discord_message', 'discord_presence', 'discord_voice', 'discord_reaction']);
+    type ActivityKindLocal = 'git_commit' | 'claude_code_prompt' | 'gemini_prompt' | 'codex_prompt' | 'task_created' | 'task_done' | 'task_updated' | 'discord_message' | 'discord_presence' | 'discord_voice' | 'discord_reaction';
     const kind: ActivityKindLocal | null = kindQ && allowedKinds.has(kindQ) ? kindQ as ActivityKindLocal : null;
     if (date) {
       if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return c.json({ error: 'invalid date' }, 400);

--- a/spec/feature/discord-bot.md
+++ b/spec/feature/discord-bot.md
@@ -1,0 +1,120 @@
+# Discord Bot (行動ログ入力 + 自動処理 + 通知)
+
+Memoria server に discord.js Gateway Bot を同梱し、Discord を **行動ログの取得源** /
+**自動処理の入力チャネル** / **通知の出力先** として使う。
+
+## 方針 / 前提 (2026-05-30 決定)
+
+- **個人サーバー想定。** サーバーに複数人いる場合は `features.discord.self_user_id`
+  に **自分の Discord user id** を設定し、その人物のイベントのみログ対象にする
+  (未設定なら全員ではなく「Bot 以外の人間全員」ではなく self 必須 = 取りこぼし
+  防止のため、self 未設定時は capture を停止し UI で促す)。
+- **送信は discord.js 直送** (同一 client を再利用)。将来 Nuntius 経由に切替可能な
+  よう `notifier.ts` で薄く抽象化のみしておく。
+- **Bot は「入力アダプタ」に徹する。** 6 つの自動処理は Memoria の既存パイプライン
+  (task+reminder / meal_vision / visit+domain bookmark / recommendations-ai /
+  通知トリガー) に委譲する。Bot 側で業務ロジックを再実装しない。
+- **アクティビティ chnl は 1 本に集約** (`#activity`)。
+- **AI 処理は Imperativus 風** だが、実行可能アクションを 6 種に制限したホワイト
+  リストで縛る (任意コマンド実行はしない)。
+
+## 個人データ境界 (RULE §5)
+
+- 行動ログ (message / presence / voice / reaction) は **Memoria local に保存** (ローカル
+  ログサービスの本分)。
+- 氏名・メール・ロール等の **識別情報は Cernere が正本**。Discord user id を join key
+  にし、識別情報をミラーしない。`self_user_id` と Cernere user の対応のみ持つ。
+- Bot token は **アプリ単位のサービスシークレット** → `.env.secrets` / Infisical。DB・
+  フロント・ログに値を出さない。
+
+## 取得できる個人情報 (intent 別)
+
+| 情報 | intent | 保存 kind |
+|------|--------|-----------|
+| メッセージ本文 / 添付 / 編集 | MESSAGE_CONTENT (privileged) | `discord_message` |
+| リアクション | GUILD_MESSAGE_REACTIONS | `discord_reaction` |
+| オンライン状態 / 端末 / アクティビティ(ゲーム/Spotify/カスタム) | PRESENCE (privileged) | `discord_presence` |
+| ボイス入退室 / mute / 配信 / カメラ | GUILD_VOICE_STATES | `discord_voice` |
+| ニックネーム / ロール / 参加日時 | GUILD_MEMBERS (privileged) | (識別情報は保存せず id のみ) |
+| メール / 電話 / 連携アカウント | — | **Bot では取得不可** (範囲外) |
+
+## Bot 権限 / OAuth
+
+- OAuth2 scope: `bot`, `applications.commands`
+- Privileged Gateway Intents (Dev Portal で ON 必須): MESSAGE CONTENT / SERVER MEMBERS / PRESENCE
+- Permissions: View Channels, Read Message History, Send Messages, Embed Links,
+  Attach Files, Add Reactions, **Manage Channels** (自動生成), Use Application Commands
+- Manage Channels は強権限。自動生成は **Memoria カテゴリ配下のみ**、既存は触らない。
+
+## チャンネル / カテゴリ自動生成
+
+有効化時に冪等生成し、id を `app_settings` (`discord.channel.<kind>_id` /
+`discord.category_id`) に保存。Concordia の `ensureDiscordLayout` と同方針。
+
+- カテゴリ `Memoria`
+  - `#activity` (集約: presence/voice/message ログのミラー & デバッグ)
+  - `#task` `#memo` `#bookmark` `#meal` `#recommend` `#announce`
+- オプトアウトされた機能のチャンネルは作らない。
+
+## 6 つの自動処理 → 既存パイプライン
+
+| 投稿 | トリガー | 委譲先 |
+|------|---------|--------|
+| タスク (リマインダー付) | テキスト or `/task` | `insertTask` + `features.tasks.reminder.*` |
+| メモ (リマインダーなし) | テキスト or `/memo` | task(note) reminder 無し |
+| ブックマーク | URL 検知 | visit + domain-catalog + (opt) bookmark 要約 |
+| 食事 | 画像添付検知 | meal pipeline (`meals_auto_vision`) |
+| おすすめ | `/recommend` slash | `recommendations-ai` → 結果投稿 |
+| アナウンス | 既存通知トリガー | `notifier` → `#announce` 投稿 + 必要なら self メンション |
+
+## AI ルーター (Imperativus 風 / 制限付き)
+
+`#task/#memo/#bookmark/#meal` 以外への投稿、または曖昧な投稿は AI で意図分類し
+6 アクションのいずれかにルーティング。実行は上記委譲先のみ。任意 shell/コード実行
+はしない。AI 失敗時は `#activity` にログだけ残す。
+
+## 設定 (`features.discord.*`、独立セクション)
+
+すべて opt-out 可。`enabled` がマスタ。OFF の機能は capture もチャンネル生成もしない。
+
+| key | 既定 | 意味 |
+|-----|------|------|
+| `features.discord.enabled` | false | マスタ (明示 opt-in) |
+| `features.discord.self_user_id` | "" | ログ対象の自分の Discord user id |
+| `features.discord.guild_id` | "" | 対象サーバー id |
+| `features.discord.capture.message` | true | メッセージ取得 |
+| `features.discord.capture.presence` | true | プレゼンス取得 |
+| `features.discord.capture.voice` | true | ボイス取得 |
+| `features.discord.capture.reaction` | true | リアクション取得 |
+| `features.discord.ai_process` | true | AI ルーティング |
+| `features.discord.mention_notify` | true | self メンション通知 |
+| `features.discord.announce` | true | 通知の #announce 転送 |
+| `features.discord.autoproc.task` / `.memo` / `.bookmark` / `.meal` / `.recommend` | true | 各自動処理 |
+
+token は設定に置かず env: `MEMORIA_DISCORD_BOT_TOKEN`。
+
+## モジュール構成 (`server/discord/`、責務別)
+
+- `client.ts` — discord.js client 生成 / login / ライフサイクル
+- `intents.ts` — intent / partials 定義
+- `settings.ts` — `discordSettings(db)` (privacy.ts 風) + token 取得
+- `layout.ts` — カテゴリ/チャンネル冪等生成 + id 永続化
+- `user-map.ts` — self_user_id 判定 / Discord↔Memoria
+- `activity-capture.ts` — presence/voice/message/reaction → activity_events
+- `message-router.ts` — 構造判定 (URL/画像/コマンド) + AI 分類 → action 振り分け
+- `actions/{task,memo,bookmark,meal,recommend,announce}.ts` — 既存パイプライン委譲
+- `slash-commands.ts` — `/task /memo /recommend` 等の登録 / ハンドラ
+- `notifier.ts` — 送信抽象 (直送、将来 Nuntius 差替点)
+- `index.ts` — bootstrap から呼ぶ起動/停止 (enabled 時のみ)
+
+## activity_events 拡張
+
+`ActivityKind` に `discord_message` `discord_presence` `discord_voice`
+`discord_reaction` を追加 (db/types/activity.ts)。`/api/activity/event` の
+ALLOWED_KINDS / `/api/activity/events` の allowedKinds にも追加。
+
+## フェーズ
+
+P1 基盤(client/intents/settings/privacy keys/bootstrap) → P2 layout/user-map →
+P3 capture(activity_events) → P4 message-router + actions(task/memo/bookmark/meal) →
+P5 slash(recommend) + mention/announce(notifier) → P6 設定UI「Discord」+ opt-out。

--- a/spec/feature/discord-bot.md
+++ b/spec/feature/discord-bot.md
@@ -24,8 +24,11 @@ Memoria server に discord.js Gateway Bot を同梱し、Discord を **行動ロ
   ログサービスの本分)。
 - 氏名・メール・ロール等の **識別情報は Cernere が正本**。Discord user id を join key
   にし、識別情報をミラーしない。`self_user_id` と Cernere user の対応のみ持つ。
-- Bot token は **アプリ単位のサービスシークレット** → `.env.secrets` / Infisical。DB・
-  フロント・ログに値を出さない。
+- Bot token は **Memoria の設定 UI から指定** し `app_settings`
+  (`features.discord.bot_token`) に保存する。Memoria はローカル SQLite に閉じる個人
+  アプリで OpenAI key 等も設定保存しているため同パターン。env
+  `MEMORIA_DISCORD_BOT_TOKEN` をフォールバックで見る。値は GET API / フロント /
+  ログには出さない (`token_set` の bool のみ公開)。
 
 ## 取得できる個人情報 (intent 別)
 
@@ -90,8 +93,7 @@ Memoria server に discord.js Gateway Bot を同梱し、Discord を **行動ロ
 | `features.discord.mention_notify` | true | self メンション通知 |
 | `features.discord.announce` | true | 通知の #announce 転送 |
 | `features.discord.autoproc.task` / `.memo` / `.bookmark` / `.meal` / `.recommend` | true | 各自動処理 |
-
-token は設定に置かず env: `MEMORIA_DISCORD_BOT_TOKEN`。
+| `features.discord.bot_token` | "" | Bot token (設定 UI で指定 / 値は非公開、 env フォールバック可) |
 
 ## モジュール構成 (`server/discord/`、責務別)
 


### PR DESCRIPTION
## 概要
Memoria server に discord.js Gateway Bot を同梱。Discord を **行動ログの取得源 / 自動処理の入力チャネル / 通知の出力先** にする。spec: `spec/feature/discord-bot.md`。

個人サーバー想定・送信は直送・アクティビティは #activity 集約（ユーザー確認済）。

## フェーズ
- **P1 基盤**: `server/discord/` を責務別分割 (intents/settings/client/index/user-map/layout/activity-capture/http/notifier/message-router/slash-commands/actions)。discord.js@14。token は env `MEMORIA_DISCORD_BOT_TOKEN`、設定は `features.discord.*` で opt-out。enabled+token+self+guild が揃った時のみ起動 (best-effort)。
- **P2 レイアウト**: Memoria カテゴリ + #activity/#task/#memo/#bookmark/#meal/#recommend/#announce を冪等自動生成、opt-out 連動、既存は触らない。
- **P3 取得**: self の message/presence/voice/reaction を `activity_events` に記録 (新 kind 4 種)。capture は個別 opt-out。識別情報は持たず id のみ (RULE §5)。
- **P4 AI処理 + 6自動処理**: message-router (チャンネル/構造判定 → AI 意図分類、制限アクションのみ)。task/memo/bookmark/meal は localhost HTTP で既存パイプライン再利用、recommend は直呼び。
- **P5 slash + 通知**: /recommend /task /memo + notifier (直送、self メンション、#announce アナウンス seam `announceToDiscord`)。
- **P6 設定UI**: 設定に独立タブ「🤖 Discord」+ 全機能 opt-out + 状態表示 + 保存。`/api/discord/config` GET/PATCH。

## 権限 / OAuth (ユーザー手作業)
- Dev Portal: Bot 作成 + **Privileged Intents 3つ ON** (MESSAGE CONTENT / SERVER MEMBERS / PRESENCE)
- 招待: scope `bot`+`applications.commands` / 権限 View・Read History・Send・Embed・Attach・Add Reactions・**Manage Channels**・Use Commands
- `.env.secrets` に `MEMORIA_DISCORD_BOT_TOKEN`、設定 UI で enabled/self/guild

## 取得できる個人情報
message本文・添付 / リアクション / オンライン状態・アクティビティ / ボイス / (id のみ: ニックネーム・ロール)。メール・電話・連携は Bot では取得不可。識別情報の正本は Cernere、行動ログは Memoria local。

## 検証
backend + frontend `npm run typecheck` green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)