### PR TITLE
feat(discord): タスク通知エンジン (AIカード成形 + 時刻/GPS/ランダム トリガー)

### DIFF
--- a/server/discord/actions/task.ts
+++ b/server/discord/actions/task.ts
@@ -2,15 +2,18 @@
 // タスク = due_at 付き (= リマインダー対象)、 メモ = due_at 無し + category 'memo'。
 
 import { apiPostJson } from '../http.js';
+import { formatSingleTaskCard } from '../notify/card.js';
 
 export interface TaskInput {
   title: string;
-  details?: string;
+  details?: string | null;
   /** ISO 文字列。 指定時はリマインダー対象になる。 */
   dueAt?: string | null;
+  /** カンマ区切りカテゴリ ("買い物, 開発")。 */
+  category?: string | null;
 }
 
-/** タスク作成 (リマインダー付き)。 結果サマリ文字列を返す。 */
+/** タスク作成 (リマインダー付き)。 AI 解釈した内容を確認カードで返す。 */
 export async function createTask(input: TaskInput): Promise<string> {
   const res = await apiPostJson('/api/tasks', {
     title: input.title,
@@ -18,9 +21,15 @@ export async function createTask(input: TaskInput): Promise<string> {
     kind: 'task',
     creator_type: 'ai',
     due_at: input.dueAt ?? null,
+    category: input.category ?? null,
   });
   if (!res.ok) return `タスク作成失敗 (${res.status})`;
-  return input.dueAt ? `タスク登録: ${input.title} (期日 ${input.dueAt})` : `タスク登録: ${input.title}`;
+  return formatSingleTaskCard({
+    title: input.title,
+    category: input.category,
+    dueAt: input.dueAt,
+    details: input.details,
+  });
 }
 
 /** メモ作成 (リマインダー無し)。 */

--- a/server/discord/client.ts
+++ b/server/discord/client.ts
@@ -9,6 +9,7 @@ import { registerCapture } from './activity-capture.js';
 import { registerRouter } from './message-router.js';
 import { registerInteractions, registerSlashCommands } from './slash-commands.js';
 import { ensureDiscordLayout } from './layout.js';
+import { startNotifyScheduler } from './notify/scheduler.js';
 
 type Db = BetterSqlite3.Database;
 
@@ -29,6 +30,8 @@ export async function createDiscordClient(db: Db): Promise<Client | null> {
       .catch((e: unknown) => {
         console.warn(`[discord] layout / slash 登録失敗: ${e instanceof Error ? e.message : String(e)}`);
       });
+    // タスク通知エンジン (時刻 / GPS / ランダム トリガー) を起動。
+    startNotifyScheduler(c, db);
   });
 
   client.on(Events.Error, (e) => {

--- a/server/discord/index.ts
+++ b/server/discord/index.ts
@@ -6,6 +6,8 @@ import type BetterSqlite3 from 'better-sqlite3';
 import { discordReady } from './settings.js';
 import { createDiscordClient } from './client.js';
 import { postAnnouncement } from './notifier.js';
+import { findTrigger } from './notify/config.js';
+import { fireTrigger } from './notify/engine.js';
 
 type Db = BetterSqlite3.Database;
 
@@ -37,4 +39,19 @@ export function stopDiscordBot(): void {
 export async function announceToDiscord(db: Db, text: string): Promise<void> {
   if (!current?.isReady()) return;
   await postAnnouncement(current, db, text);
+}
+
+/**
+ * 指定 id の通知トリガーを即時発火する (設定 UI の「テスト送信」 用)。
+ * Bot 未起動なら not_ready。 該当 0 件でもテストとして送る (postWhenEmpty)。
+ */
+export async function fireNotifyTriggerById(
+  db: Db,
+  id: string,
+): Promise<{ ok: boolean; reason?: string; count?: number }> {
+  if (!current?.isReady()) return { ok: false, reason: 'not_ready' };
+  const trigger = findTrigger(db, id);
+  if (!trigger) return { ok: false, reason: 'not_found' };
+  const r = await fireTrigger(current, db, trigger, { postWhenEmpty: true });
+  return { ok: true, count: r.count };
 }

--- a/server/discord/message-router.ts
+++ b/server/discord/message-router.ts
@@ -22,22 +22,42 @@ function channelName(msg: Message): string {
   return 'name' in msg.channel && msg.channel.name ? msg.channel.name : '';
 }
 
-/** AI に意図分類させる。 出力 JSON {action,title,due_at} を期待。 失敗時 none。 */
-async function classify(text: string): Promise<{ action: Action; title?: string; dueAt?: string | null }> {
+interface Interpreted {
+  action: Action;
+  title?: string;
+  dueAt?: string | null;
+  /** カンマ区切りカテゴリ ("買い物, 開発")。 */
+  category?: string | null;
+  details?: string | null;
+}
+
+/**
+ * AI に意図分類 + タスク内容の解釈をさせる。 task のときは title/category/due/details を
+ * 構造化して「カード」 として成形する。 失敗時 none。
+ */
+async function classify(text: string): Promise<Interpreted> {
   const prompt = `あなたはライフログ Bot のルーターです。次のメッセージを task/memo/bookmark/recommend のいずれかに分類し、JSON のみで答えてください。\n` +
     `task=締切のある予定/やること, memo=締切のないメモ, recommend=おすすめ要求, bookmark=保存したいURL。\n` +
-    `形式: {"action":"task|memo|bookmark|recommend|none","title":"...","due_at":"ISO8601 or null"}\n\nメッセージ: ${text}`;
+    `task の場合は内容を解釈して title(簡潔な見出し) / category(買い物・開発 等のカンマ区切り、無ければ空) / due_at(ISO8601 か null) / details(補足、無ければ空) を埋めること。\n` +
+    `形式: {"action":"task|memo|bookmark|recommend|none","title":"...","due_at":"ISO8601 or null","category":"...","details":"..."}\n\nメッセージ: ${text}`;
   try {
     const raw = await runLlm({ task: 'discord_route', prompt, timeoutMs: 30_000 });
     const m = raw.match(/\{[\s\S]*\}/);
     if (!m) return { action: 'none' };
-    const j = JSON.parse(m[0]) as { action?: string; title?: string; due_at?: string | null };
+    const j = JSON.parse(m[0]) as {
+      action?: string; title?: string; due_at?: string | null; category?: string | null; details?: string | null;
+    };
     const allowed: string[] = ['task', 'memo', 'bookmark', 'recommend'];
     const action: Action = allowed.includes(j.action ?? '') ? (j.action as Action) : 'none';
-    return { action, title: j.title, dueAt: j.due_at ?? null };
+    return { action, title: j.title, dueAt: j.due_at ?? null, category: j.category ?? null, details: j.details ?? null };
   } catch {
     return { action: 'none' };
   }
+}
+
+/** classify 結果を createTask 入力に。 title が空なら原文で補う。 */
+function toTaskInput(text: string, r: Interpreted) {
+  return { title: r.title || text, dueAt: r.dueAt, category: r.category, details: r.details };
 }
 
 async function dispatch(db: Db, cfg: DiscordSettings, msg: Message): Promise<string | null> {
@@ -47,7 +67,11 @@ async function dispatch(db: Db, cfg: DiscordSettings, msg: Message): Promise<str
   const url = extractFirstUrl(text);
 
   // 1. チャンネル決定的ルーティング
-  if (ch === 'task' && cfg.autoTask) return createTask({ title: text });
+  // #task は AI でカード成形してから登録 (ai_process OFF なら原文をそのまま title)。
+  if (ch === 'task' && cfg.autoTask) {
+    if (!cfg.aiProcess || !text) return createTask({ title: text });
+    return createTask(toTaskInput(text, await classify(text)));
+  }
   if (ch === 'memo' && cfg.autoMemo) return createMemo(text);
   if (ch === 'bookmark' && cfg.autoBookmark && url) return createBookmark(url);
   if (ch === 'meal' && cfg.autoMeal && image) return createMeal({ url: image.url, name: image.name, contentType: image.contentType }, text);
@@ -59,7 +83,7 @@ async function dispatch(db: Db, cfg: DiscordSettings, msg: Message): Promise<str
   // 3. AI 分類
   if (!cfg.aiProcess || !text) return null;
   const r = await classify(text);
-  if (r.action === 'task' && cfg.autoTask) return createTask({ title: r.title || text, dueAt: r.dueAt });
+  if (r.action === 'task' && cfg.autoTask) return createTask(toTaskInput(text, r));
   if (r.action === 'memo' && cfg.autoMemo) return createMemo(r.title || text);
   if (r.action === 'bookmark' && cfg.autoBookmark && url) return createBookmark(url);
   if (r.action === 'recommend' && cfg.autoRecommend) return runRecommend(db);

--- a/server/discord/notify/card.ts
+++ b/server/discord/notify/card.ts
@@ -1,0 +1,65 @@
+// タスク (群) → Discord メッセージ整形。 純粋ロジック (テスト対象)。
+
+import type { TaskRow } from '../../db/types/task.js';
+import { parseCategories } from './select.js';
+
+function pad2(n: number): string { return String(n).padStart(2, '0'); }
+
+/** due_at を "MM/DD HH:MM" + 期限マーク (🔴 超過 / 🟡 今日) で表す。 */
+export function formatDue(dueAt: string | null, now: Date = new Date()): string {
+  if (!dueAt) return '';
+  const d = new Date(dueAt);
+  if (!Number.isFinite(d.getTime())) return '';
+  const label = `${pad2(d.getMonth() + 1)}/${pad2(d.getDate())} ${pad2(d.getHours())}:${pad2(d.getMinutes())}`;
+  const endToday = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999).getTime();
+  const startToday = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0).getTime();
+  const t = d.getTime();
+  if (t < startToday) return `🔴 期限超過 ${label}`;
+  if (t <= endToday) return `🟡 本日 ${label}`;
+  return `期日 ${label}`;
+}
+
+/** 1 タスクを 1 行 ("・[カテゴリ] タイトル — 期限") に。 */
+export function formatTaskLine(task: TaskRow, now: Date = new Date()): string {
+  const cats = parseCategories(task.category).filter((c) => c !== 'memo');
+  const catTag = cats.length ? `[${cats.join('/')}] ` : '';
+  const due = formatDue(task.due_at, now);
+  const dueTag = due ? ` — ${due}` : '';
+  return `・${catTag}${task.title.slice(0, 80)}${dueTag}`;
+}
+
+const DISCORD_LIMIT = 1900;
+
+/** タスク群を通知カード (見出し + 箇条書き) に。 上限長で切り詰める。 */
+export function formatTaskListCard(heading: string, tasks: TaskRow[], now: Date = new Date()): string {
+  const header = `🔔 **${heading}** (${tasks.length} 件)`;
+  if (!tasks.length) return `${header}\n該当タスクはありません。`;
+  const lines: string[] = [];
+  let len = header.length;
+  let shown = 0;
+  for (const t of tasks) {
+    const line = formatTaskLine(t, now);
+    if (len + line.length + 1 > DISCORD_LIMIT - 40) break;
+    lines.push(line);
+    len += line.length + 1;
+    shown += 1;
+  }
+  const more = tasks.length > shown ? `\n…他 ${tasks.length - shown} 件` : '';
+  return `${header}\n${lines.join('\n')}${more}`;
+}
+
+/** AI 解釈で登録したタスクの確認カード (1 件)。 */
+export function formatSingleTaskCard(input: {
+  title: string;
+  category?: string | null;
+  dueAt?: string | null;
+  details?: string | null;
+}, now: Date = new Date()): string {
+  const cats = parseCategories(input.category ?? null).filter((c) => c !== 'memo');
+  const lines = [`🗂️ **タスク登録**: ${input.title.slice(0, 120)}`];
+  if (cats.length) lines.push(`カテゴリ: ${cats.join(', ')}`);
+  const due = formatDue(input.dueAt ?? null, now);
+  if (due) lines.push(due);
+  if (input.details && input.details.trim()) lines.push(`📝 ${input.details.trim().slice(0, 200)}`);
+  return lines.join('\n');
+}

--- a/server/discord/notify/config.ts
+++ b/server/discord/notify/config.ts
@@ -1,0 +1,107 @@
+// 通知トリガーの永続化 (app_settings `features.discord.notify.triggers` = JSON 配列)。
+// UI から来た任意入力は normalizeTriggers で型を矯正してから保存する。
+
+import { randomUUID } from 'node:crypto';
+import type BetterSqlite3 from 'better-sqlite3';
+import { getAppSettings, setAppSettings } from '../../db.js';
+import {
+  NOTIFY_CHANNEL_KINDS,
+  type DeadlineFilter,
+  type NotifyFilter,
+  type NotifyTrigger,
+  type TriggerSpec,
+} from './types.js';
+
+type Db = BetterSqlite3.Database;
+
+const KEY = 'features.discord.notify.triggers';
+
+export function loadTriggers(db: Db): NotifyTrigger[] {
+  const raw = getAppSettings(db)[KEY];
+  if (!raw) return [];
+  try {
+    const arr = JSON.parse(raw);
+    return Array.isArray(arr) ? normalizeTriggers(arr) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveTriggers(db: Db, triggers: NotifyTrigger[]): void {
+  setAppSettings(db, { [KEY]: JSON.stringify(triggers) });
+}
+
+export function findTrigger(db: Db, id: string): NotifyTrigger | null {
+  return loadTriggers(db).find((t) => t.id === id) ?? null;
+}
+
+// ─── 正規化 (任意の unknown[] → NotifyTrigger[]) ───────────────────────────
+
+function str(v: unknown, fallback = ''): string {
+  return typeof v === 'string' ? v : fallback;
+}
+function num(v: unknown, fallback: number): number {
+  const n = typeof v === 'number' ? v : Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+/** "HH:MM" に矯正 (不正なら fallback)。 */
+function hhmm(v: unknown, fallback: string): string {
+  const s = str(v).trim();
+  const m = /^(\d{1,2}):(\d{2})$/.exec(s);
+  if (!m) return fallback;
+  const h = Math.min(23, Math.max(0, Number(m[1])));
+  const mi = Math.min(59, Math.max(0, Number(m[2])));
+  return `${String(h).padStart(2, '0')}:${String(mi).padStart(2, '0')}`;
+}
+
+function normSpec(v: unknown): TriggerSpec {
+  const o = (v && typeof v === 'object' ? v : {}) as Record<string, unknown>;
+  if (o.type === 'random') {
+    const w = Array.isArray(o.window) ? o.window : [];
+    return {
+      type: 'random',
+      window: [hhmm(w[0], '09:00'), hhmm(w[1], '21:00')],
+      count: Math.min(10, Math.max(1, Math.round(num(o.count, 1)))),
+    };
+  }
+  if (o.type === 'gps') {
+    return {
+      type: 'gps',
+      event: o.event === 'depart' ? 'depart' : 'arrive',
+      radius_m: Math.min(5000, Math.max(50, Math.round(num(o.radius_m, 200)))),
+    };
+  }
+  // 既定 time
+  return { type: 'time', at: hhmm(o.at, '08:00') };
+}
+
+function normFilter(v: unknown): NotifyFilter {
+  const o = (v && typeof v === 'object' ? v : {}) as Record<string, unknown>;
+  const cats = Array.isArray(o.categories)
+    ? o.categories.filter((c): c is string => typeof c === 'string' && c.trim().length > 0).map((c) => c.trim())
+    : [];
+  const deadline: DeadlineFilter = o.deadline === 'all' ? 'all' : 'due_today_or_overdue';
+  return { categories: cats.length ? cats : ['all'], deadline };
+}
+
+function normChannel(v: unknown): string {
+  const s = str(v, 'announce');
+  return (NOTIFY_CHANNEL_KINDS as readonly string[]).includes(s) ? s : 'announce';
+}
+
+export function normalizeTriggers(input: unknown[]): NotifyTrigger[] {
+  const out: NotifyTrigger[] = [];
+  for (const raw of input) {
+    if (!raw || typeof raw !== 'object') continue;
+    const o = raw as Record<string, unknown>;
+    out.push({
+      id: str(o.id).trim() || randomUUID(),
+      name: str(o.name).trim().slice(0, 80) || '通知',
+      enabled: o.enabled !== false,
+      trigger: normSpec(o.trigger),
+      filter: normFilter(o.filter),
+      channel: normChannel(o.channel),
+    });
+  }
+  return out;
+}

--- a/server/discord/notify/engine.ts
+++ b/server/discord/notify/engine.ts
@@ -1,0 +1,33 @@
+// トリガー発火: filter でタスク選択 → カード整形 → 指定 channel へ投稿。
+
+import type { Client } from 'discord.js';
+import type BetterSqlite3 from 'better-sqlite3';
+import { postToChannel } from '../notifier.js';
+import { selectTasks } from './select.js';
+import { formatTaskListCard } from './card.js';
+import type { NotifyTrigger } from './types.js';
+
+type Db = BetterSqlite3.Database;
+
+export interface FireResult {
+  posted: boolean;
+  count: number;
+}
+
+/**
+ * トリガーを発火する。 該当タスクが 0 件のとき:
+ *   - postWhenEmpty=false (定期実行): 何も送らない (通知過多を避ける)
+ *   - postWhenEmpty=true  (手動テスト): 「該当なし」 を送って動作確認できる
+ */
+export async function fireTrigger(
+  client: Client,
+  db: Db,
+  trigger: NotifyTrigger,
+  opts: { postWhenEmpty?: boolean } = {},
+): Promise<FireResult> {
+  const tasks = selectTasks(db, trigger.filter);
+  if (!tasks.length && !opts.postWhenEmpty) return { posted: false, count: 0 };
+  const card = formatTaskListCard(trigger.name, tasks);
+  await postToChannel(client, db, trigger.channel, card);
+  return { posted: true, count: tasks.length };
+}

--- a/server/discord/notify/geofence.ts
+++ b/server/discord/notify/geofence.ts
@@ -1,0 +1,79 @@
+// 自宅 geofence の inside 判定と 帰宅/出発 遷移検出。
+// 自宅座標は weather.fixed_lat/lon (既存) を流用、 最新 GPS は readLatestGpsLatLon。
+// 遷移状態は app_settings に持つ (process 再起動を跨いで誤発火しないため)。
+
+import type BetterSqlite3 from 'better-sqlite3';
+import { getAppSettings, setAppSettings } from '../../db.js';
+import { readLatestGpsLatLon } from '../../lib/weather.js';
+import type { GpsEvent } from './types.js';
+
+type Db = BetterSqlite3.Database;
+
+const STATE_INSIDE = 'features.discord.notify.gps.inside';        // '1' | '0'
+const STATE_LAST_TRANSITION = 'features.discord.notify.gps.last_transition_at'; // epoch ms
+const COOLDOWN_MS = 10 * 60 * 1000; // 境界での GPS ジッタ抑制
+
+export function haversineMeters(
+  a: { lat: number; lon: number },
+  b: { lat: number; lon: number },
+): number {
+  const R = 6371000;
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(b.lat - a.lat);
+  const dLon = toRad(b.lon - a.lon);
+  const lat1 = toRad(a.lat);
+  const lat2 = toRad(b.lat);
+  const h = Math.sin(dLat / 2) ** 2 + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2;
+  return 2 * R * Math.asin(Math.min(1, Math.sqrt(h)));
+}
+
+/** 自宅座標 (weather.fixed_lat/lon)。 未設定 (0,0 含む) なら null。 */
+export function homeLatLon(db: Db): { lat: number; lon: number } | null {
+  const s = getAppSettings(db);
+  const lat = Number(s['weather.fixed_lat']);
+  const lon = Number(s['weather.fixed_lon']);
+  if (!Number.isFinite(lat) || !Number.isFinite(lon) || (lat === 0 && lon === 0)) return null;
+  return { lat, lon };
+}
+
+/** いま自宅 geofence 内か。 自宅未設定 / GPS 無しなら null。 */
+export function isInsideHome(db: Db, radiusM: number): boolean | null {
+  const home = homeLatLon(db);
+  if (!home) return null;
+  const cur = readLatestGpsLatLon(db);
+  if (!cur) return null;
+  return haversineMeters(home, cur) <= radiusM;
+}
+
+/**
+ * 前回状態と比較して帰宅 (arrive=外→内) / 出発 (depart=内→外) を検出。
+ * - 初回 (状態未保存) は基準を保存して null (発火しない)。
+ * - データ無し (自宅未設定 / GPS 無し) は null。
+ * - cooldown 内の再遷移は無視 (境界ジッタ対策)。
+ * 検出時は状態を更新する (副作用あり)。
+ */
+export function detectHomeTransition(db: Db, radiusM: number, now: number = Date.now()): GpsEvent | null {
+  const inside = isInsideHome(db, radiusM);
+  if (inside === null) return null;
+
+  const s = getAppSettings(db);
+  const prevRaw = s[STATE_INSIDE];
+  const cur = inside ? '1' : '0';
+
+  if (prevRaw !== '0' && prevRaw !== '1') {
+    // 初回: 基準だけ保存
+    setAppSettings(db, { [STATE_INSIDE]: cur });
+    return null;
+  }
+  if (prevRaw === cur) return null; // 遷移なし
+
+  const lastAt = Number(s[STATE_LAST_TRANSITION]);
+  if (Number.isFinite(lastAt) && now - lastAt < COOLDOWN_MS) {
+    // cooldown 内: 状態は更新するが発火しない (ジッタとみなす)
+    setAppSettings(db, { [STATE_INSIDE]: cur });
+    return null;
+  }
+
+  setAppSettings(db, { [STATE_INSIDE]: cur, [STATE_LAST_TRANSITION]: String(now) });
+  return inside ? 'arrive' : 'depart';
+}

--- a/server/discord/notify/scheduler.ts
+++ b/server/discord/notify/scheduler.ts
@@ -1,0 +1,133 @@
+// 通知トリガーの評価ループ。 Bot ready 時に起動し、 process が生きている間動く。
+//   - minuteTick (60s): time / random トリガー
+//   - gpsTick (5min):   gps (帰宅/出発) トリガー
+// dedup は app_settings に持つ。 全て best-effort (失敗は log だけ)。
+
+import type { Client } from 'discord.js';
+import type BetterSqlite3 from 'better-sqlite3';
+import { getAppSettings, setAppSettings } from '../../db.js';
+import { formatLocalDate } from '../../diary.js';
+import { discordSettings } from '../settings.js';
+import { loadTriggers } from './config.js';
+import { detectHomeTransition } from './geofence.js';
+import { fireTrigger } from './engine.js';
+import type { NotifyTrigger, RandomSpec } from './types.js';
+
+type Db = BetterSqlite3.Database;
+
+function hhmmNow(now: Date): string {
+  return `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
+}
+
+// ─── time トリガー dedup ────────────────────────────────────────────────
+const firedKey = (id: string) => `features.discord.notify.fired.${id}`;
+
+// ─── random トリガー: 当日プラン (date / times / fired) ───────────────────
+interface RandomPlan { date: string; times: string[]; fired: string[] }
+const randomKey = (id: string) => `features.discord.notify.random.${id}`;
+
+/** "HH:MM" → 当日内の分。 */
+function toMinutes(hhmm: string): number {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(hhmm);
+  if (!m) return 0;
+  return Number(m[1]) * 60 + Number(m[2]);
+}
+function fromMinutes(min: number): string {
+  const h = Math.floor(min / 60) % 24;
+  const mi = min % 60;
+  return `${String(h).padStart(2, '0')}:${String(mi).padStart(2, '0')}`;
+}
+
+/** window 内で count 個のランダム時刻 (重複なし・昇順) を生成。 */
+export function pickRandomTimes(spec: RandomSpec): string[] {
+  const start = toMinutes(spec.window[0]);
+  const end = toMinutes(spec.window[1]);
+  const lo = Math.min(start, end);
+  const hi = Math.max(start, end);
+  const span = Math.max(0, hi - lo);
+  const n = Math.min(spec.count, span + 1);
+  const set = new Set<number>();
+  let guard = 0;
+  while (set.size < n && guard < 1000) {
+    set.add(lo + Math.floor(Math.random() * (span + 1)));
+    guard += 1;
+  }
+  return [...set].sort((a, b) => a - b).map(fromMinutes);
+}
+
+function loadRandomPlan(db: Db, id: string): RandomPlan | null {
+  const raw = getAppSettings(db)[randomKey(id)];
+  if (!raw) return null;
+  try {
+    const p = JSON.parse(raw) as RandomPlan;
+    if (typeof p?.date === 'string' && Array.isArray(p.times) && Array.isArray(p.fired)) return p;
+  } catch { /* ignore */ }
+  return null;
+}
+
+function ensureRandomPlan(db: Db, id: string, spec: RandomSpec, today: string): RandomPlan {
+  const cur = loadRandomPlan(db, id);
+  if (cur && cur.date === today) return cur;
+  const plan: RandomPlan = { date: today, times: pickRandomTimes(spec), fired: [] };
+  setAppSettings(db, { [randomKey(id)]: JSON.stringify(plan) });
+  return plan;
+}
+
+async function minuteTick(client: Client, db: Db): Promise<void> {
+  if (!discordSettings(db).enabled) return;
+  const now = new Date();
+  const hhmm = hhmmNow(now);
+  const today = formatLocalDate(now);
+  const triggers = loadTriggers(db).filter((t) => t.enabled);
+
+  for (const t of triggers) {
+    try {
+      if (t.trigger.type === 'time') {
+        if (t.trigger.at !== hhmm) continue;
+        if (getAppSettings(db)[firedKey(t.id)] === today) continue;
+        await fireTrigger(client, db, t);
+        setAppSettings(db, { [firedKey(t.id)]: today });
+      } else if (t.trigger.type === 'random') {
+        const plan = ensureRandomPlan(db, t.id, t.trigger, today);
+        const nowMin = toMinutes(hhmm);
+        const due = plan.times.filter((tm) => toMinutes(tm) <= nowMin && !plan.fired.includes(tm));
+        if (!due.length) continue;
+        await fireTrigger(client, db, t);
+        plan.fired.push(...due);
+        setAppSettings(db, { [randomKey(t.id)]: JSON.stringify(plan) });
+      }
+    } catch (e: unknown) {
+      console.warn(`[notify] trigger ${t.id} failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+}
+
+async function gpsTick(client: Client, db: Db): Promise<void> {
+  if (!discordSettings(db).enabled) return;
+  const gps = loadTriggers(db).filter((t) => t.enabled && t.trigger.type === 'gps');
+  if (!gps.length) return;
+  // 複数 gps トリガーは単一の自宅 geofence を共有する (最小 radius を採用)。
+  const radius = Math.min(...gps.map((t) => (t.trigger.type === 'gps' ? t.trigger.radius_m : 200)));
+  const ev = detectHomeTransition(db, radius);
+  if (!ev) return;
+  for (const t of gps) {
+    if (t.trigger.type === 'gps' && t.trigger.event === ev) {
+      try {
+        await fireTrigger(client, db, t);
+      } catch (e: unknown) {
+        console.warn(`[notify] gps trigger ${t.id} failed: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }
+  }
+}
+
+/** Bot ready 時に呼ぶ。 interval を登録 (process 終了まで)。 */
+export function startNotifyScheduler(client: Client, db: Db): void {
+  setInterval(() => { void minuteTick(client, db); }, 60_000).unref?.();
+  setTimeout(() => { void gpsTick(client, db); }, 25_000).unref?.();
+  setInterval(() => { void gpsTick(client, db); }, 5 * 60_000).unref?.();
+  console.log('[notify] task-notify scheduler started');
+}
+
+// 型を re-export (engine 経由で使うものを scheduler からも見えるように)
+export type { NotifyTrigger };

--- a/server/discord/notify/select.ts
+++ b/server/discord/notify/select.ts
@@ -1,0 +1,58 @@
+// 通知フィルタ → アクティブタスク選択。 純粋ロジック (テスト対象)。
+
+import type BetterSqlite3 from 'better-sqlite3';
+import { listTasks } from '../../db.js';
+import type { TaskRow } from '../../db/types/task.js';
+import type { NotifyFilter } from './types.js';
+
+type Db = BetterSqlite3.Database;
+
+/** tasks.category (カンマ区切り) を配列に。 */
+export function parseCategories(raw: string | null): string[] {
+  if (!raw) return [];
+  return raw.split(',').map((s) => s.trim()).filter((s) => s.length > 0);
+}
+
+/** カテゴリフィルタ: ["all"] / 空 は常に一致、 それ以外は交差ありで一致。 */
+export function matchCategory(task: TaskRow, categories: string[]): boolean {
+  if (!categories.length || categories.includes('all')) return true;
+  const taskCats = parseCategories(task.category);
+  return taskCats.some((c) => categories.includes(c));
+}
+
+/** その日のローカル末尾 (23:59:59.999) の epoch ms。 */
+function endOfTodayLocalMs(now: Date): number {
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999).getTime();
+}
+
+/**
+ * 期限フィルタ。 "all" は不問。 "due_today_or_overdue" は due_at が
+ * 「ローカル今日の終わり以前」 (= 今日締切 or 期限超過) のものだけ。
+ * due_at は UTC ISO ('...Z') か local 'YYYY-MM-DDTHH:MM' のどちらも来うるが、
+ * どちらも new Date() で正しく解釈できる (前者=UTC, 後者=ローカル)。
+ */
+export function matchDeadline(task: TaskRow, deadline: NotifyFilter['deadline'], now: Date): boolean {
+  if (deadline === 'all') return true;
+  if (!task.due_at) return false;
+  const due = new Date(task.due_at).getTime();
+  if (!Number.isFinite(due)) return false;
+  return due <= endOfTodayLocalMs(now);
+}
+
+/** filter に合致するアクティブ (todo/doing) タスクを返す。 */
+export function selectTasks(db: Db, filter: NotifyFilter, now: Date = new Date()): TaskRow[] {
+  const active = [
+    ...listTasks(db, { status: 'todo', kind: 'task', limit: 500 }),
+    ...listTasks(db, { status: 'doing', kind: 'task', limit: 500 }),
+  ];
+  return active
+    .filter((t) => matchCategory(t, filter.categories) && matchDeadline(t, filter.deadline, now))
+    .sort((a, b) => dueRank(a) - dueRank(b));
+}
+
+/** 期限が近い順。 due_at 無しは末尾。 */
+function dueRank(t: TaskRow): number {
+  if (!t.due_at) return Number.MAX_SAFE_INTEGER;
+  const v = new Date(t.due_at).getTime();
+  return Number.isFinite(v) ? v : Number.MAX_SAFE_INTEGER;
+}

--- a/server/discord/notify/types.ts
+++ b/server/discord/notify/types.ts
@@ -1,0 +1,53 @@
+// Discord タスク通知エンジンの型。 spec/feature/discord-task-notify.md。
+
+export type TriggerKind = 'time' | 'random' | 'gps';
+export type GpsEvent = 'arrive' | 'depart';
+export type DeadlineFilter = 'all' | 'due_today_or_overdue';
+
+/** 毎日決まった時刻に発火。 */
+export interface TimeSpec {
+  type: 'time';
+  /** "HH:MM" (ローカル時刻)。 */
+  at: string;
+}
+
+/** 1 日に count 回、 window 内のランダム時刻に発火。 */
+export interface RandomSpec {
+  type: 'random';
+  /** ["HH:MM", "HH:MM"] (開始, 終了, ローカル時刻)。 */
+  window: [string, string];
+  /** 1 日あたりの発火回数 (>= 1)。 */
+  count: number;
+}
+
+/** 自宅 geofence の帰宅 (arrive=外→内) / 出発 (depart=内→外) で発火。 */
+export interface GpsSpec {
+  type: 'gps';
+  event: GpsEvent;
+  /** geofence 半径 (m)。 */
+  radius_m: number;
+}
+
+export type TriggerSpec = TimeSpec | RandomSpec | GpsSpec;
+
+export interface NotifyFilter {
+  /** ["all"] = 全カテゴリ、 それ以外は登録カテゴリ名の集合 (いずれか含むタスク)。 */
+  categories: string[];
+  /** "due_today_or_overdue" = 今日締切 or 期限超過のみ、 "all" = 期限不問。 */
+  deadline: DeadlineFilter;
+}
+
+export interface NotifyTrigger {
+  id: string;
+  name: string;
+  enabled: boolean;
+  trigger: TriggerSpec;
+  filter: NotifyFilter;
+  /** 送信先 channel kind (announce/task/memo/bookmark/meal/recommend/activity)。 */
+  channel: string;
+}
+
+/** 通知先に選べる channel kind。 layout.ts の生成 channel と揃える。 */
+export const NOTIFY_CHANNEL_KINDS = [
+  'announce', 'task', 'memo', 'bookmark', 'meal', 'recommend', 'activity',
+] as const;

--- a/server/public/src/app.ts
+++ b/server/public/src/app.ts
@@ -5985,6 +5985,11 @@ async function loadDiscordSettings() {
   if (s) s.textContent = `状態: ${r.ready ? '✅ 起動可能' : '⚠ ' + (r.reason || '')} ／ token: ${r.token_set ? '設定済 (env)' : '未設定 (MEMORIA_DISCORD_BOT_TOKEN)'}`;
   const btn = $('discordSaveBtn') as HTMLButtonElement | null;
   if (btn) btn.onclick = saveDiscordSettings;
+  const addBtn = $('dcNotifyAddBtn') as HTMLButtonElement | null;
+  if (addBtn) addBtn.onclick = () => dcAddTrigger();
+  const tSaveBtn = $('dcNotifySaveBtn') as HTMLButtonElement | null;
+  if (tSaveBtn) tSaveBtn.onclick = () => { void saveNotifyTriggers(); };
+  void loadNotifyTriggers();
 }
 
 async function saveDiscordSettings() {
@@ -6005,6 +6010,149 @@ async function saveDiscordSettings() {
     flashToast('Discord 設定を保存しました');
     await loadDiscordSettings();
   } catch (e) { alert(`保存失敗: ${(e as Error).message}`); }
+}
+
+// ── Discord 通知トリガー UI ──────────────────────────────────────────────
+interface NotifyTriggerUI {
+  id: string;
+  name: string;
+  enabled: boolean;
+  trigger:
+    | { type: 'time'; at: string }
+    | { type: 'random'; window: [string, string]; count: number }
+    | { type: 'gps'; event: 'arrive' | 'depart'; radius_m: number };
+  filter: { categories: string[]; deadline: 'all' | 'due_today_or_overdue' };
+  channel: string;
+}
+let dcNotifyTriggers: NotifyTriggerUI[] = [];
+let dcNotifyChannels: string[] = ['announce', 'task'];
+
+async function loadNotifyTriggers(): Promise<void> {
+  try {
+    const r = await api('/api/discord/notify-triggers') as { triggers?: NotifyTriggerUI[]; channels?: string[] };
+    dcNotifyTriggers = Array.isArray(r.triggers) ? r.triggers : [];
+    if (Array.isArray(r.channels) && r.channels.length) dcNotifyChannels = r.channels;
+  } catch { dcNotifyTriggers = []; }
+  renderNotifyTriggers();
+}
+
+function dcAddTrigger(): void {
+  dcNotifyTriggers = collectNotifyTriggers();
+  dcNotifyTriggers.push({
+    id: '', name: '通知', enabled: true,
+    trigger: { type: 'time', at: '08:00' },
+    filter: { categories: ['all'], deadline: 'due_today_or_overdue' },
+    channel: 'announce',
+  });
+  renderNotifyTriggers();
+}
+
+function renderNotifyParams(tt: NotifyTriggerUI['trigger']): string {
+  if (tt.type === 'random') {
+    return `<input class="t-rstart" type="time" value="${escapeHtml(tt.window?.[0] || '09:00')}" /> 〜 ` +
+      `<input class="t-rend" type="time" value="${escapeHtml(tt.window?.[1] || '21:00')}" /> × ` +
+      `<input class="t-rcount" type="number" min="1" max="10" value="${tt.count || 1}" style="width:70px" /> 回/日`;
+  }
+  if (tt.type === 'gps') {
+    return `<select class="t-gevent"><option value="arrive"${tt.event !== 'depart' ? ' selected' : ''}>帰宅 (自宅に到着)</option>` +
+      `<option value="depart"${tt.event === 'depart' ? ' selected' : ''}>出発 (自宅を離れる)</option></select> ` +
+      `半径 <input class="t-radius" type="number" min="50" max="5000" value="${tt.radius_m || 200}" style="width:80px" /> m`;
+  }
+  return `時刻 <input class="t-at" type="time" value="${escapeHtml(tt.at || '08:00')}" />`;
+}
+
+function renderNotifyTriggers(): void {
+  const box = $('dcNotifyTriggers'); if (!box) return;
+  if (!dcNotifyTriggers.length) { box.innerHTML = '<p class="muted">トリガーはまだありません。「＋ トリガーを追加」で作成します。</p>'; return; }
+  const chOpts = (sel: string) => dcNotifyChannels
+    .map((c) => `<option value="${escapeHtml(c)}"${c === sel ? ' selected' : ''}>#${escapeHtml(c)}</option>`).join('');
+  box.innerHTML = dcNotifyTriggers.map((t, i) => `
+    <div class="dc-trig" data-i="${i}" style="border:1px solid #8884;border-radius:10px;padding:10px;margin-bottom:8px">
+      <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+        <label class="check-inline"><input class="t-en" type="checkbox"${t.enabled ? ' checked' : ''} /> 有効</label>
+        <input class="t-name" type="text" value="${escapeHtml(t.name)}" placeholder="名前" style="flex:1;min-width:120px" />
+        <select class="t-type">
+          <option value="time"${t.trigger.type === 'time' ? ' selected' : ''}>時刻</option>
+          <option value="random"${t.trigger.type === 'random' ? ' selected' : ''}>ランダム時刻</option>
+          <option value="gps"${t.trigger.type === 'gps' ? ' selected' : ''}>GPS 帰宅/出発</option>
+        </select>
+        <button class="t-test" type="button">テスト</button>
+        <button class="t-del" type="button">削除</button>
+      </div>
+      <div class="t-params" style="margin-top:6px">${renderNotifyParams(t.trigger)}</div>
+      <div style="margin-top:6px;display:flex;gap:8px;flex-wrap:wrap;align-items:center">
+        <span>カテゴリ</span><input class="t-cats" type="text" value="${escapeHtml((t.filter.categories || ['all']).join(','))}" placeholder="all または 買い物,開発" style="min-width:160px" />
+        <span>期限</span><select class="t-deadline">
+          <option value="due_today_or_overdue"${t.filter.deadline !== 'all' ? ' selected' : ''}>今日締切/超過のみ</option>
+          <option value="all"${t.filter.deadline === 'all' ? ' selected' : ''}>全て</option>
+        </select>
+        <span>送信先</span><select class="t-channel">${chOpts(t.channel)}</select>
+      </div>
+    </div>`).join('');
+  box.querySelectorAll('.dc-trig').forEach((el) => {
+    const i = Number((el as HTMLElement).dataset.i);
+    (el.querySelector('.t-type') as HTMLSelectElement | null)?.addEventListener('change', () => {
+      dcNotifyTriggers = collectNotifyTriggers();
+      renderNotifyTriggers();
+    });
+    (el.querySelector('.t-del') as HTMLButtonElement | null)?.addEventListener('click', () => {
+      dcNotifyTriggers = collectNotifyTriggers();
+      dcNotifyTriggers.splice(i, 1);
+      renderNotifyTriggers();
+    });
+    (el.querySelector('.t-test') as HTMLButtonElement | null)?.addEventListener('click', () => { void testNotifyTrigger(i); });
+  });
+}
+
+function collectNotifyTriggers(): NotifyTriggerUI[] {
+  const box = $('dcNotifyTriggers'); if (!box) return dcNotifyTriggers;
+  const out: NotifyTriggerUI[] = [];
+  box.querySelectorAll('.dc-trig').forEach((el, idx) => {
+    const val = (s: string): string => (el.querySelector(s) as HTMLInputElement | HTMLSelectElement | null)?.value ?? '';
+    const type = val('.t-type');
+    const prev = dcNotifyTriggers[idx];
+    let trigger: NotifyTriggerUI['trigger'];
+    if (type === 'random') {
+      trigger = { type: 'random', window: [val('.t-rstart') || '09:00', val('.t-rend') || '21:00'], count: Number(val('.t-rcount')) || 1 };
+    } else if (type === 'gps') {
+      trigger = { type: 'gps', event: val('.t-gevent') === 'depart' ? 'depart' : 'arrive', radius_m: Number(val('.t-radius')) || 200 };
+    } else {
+      trigger = { type: 'time', at: val('.t-at') || '08:00' };
+    }
+    const cats = (val('.t-cats') || 'all').split(',').map((s) => s.trim()).filter((s) => s.length > 0);
+    out.push({
+      id: prev?.id || '',
+      name: val('.t-name') || '通知',
+      enabled: (el.querySelector('.t-en') as HTMLInputElement | null)?.checked ?? true,
+      trigger,
+      filter: { categories: cats.length ? cats : ['all'], deadline: val('.t-deadline') === 'all' ? 'all' : 'due_today_or_overdue' },
+      channel: val('.t-channel') || 'announce',
+    });
+  });
+  return out;
+}
+
+async function saveNotifyTriggers(): Promise<void> {
+  const triggers = collectNotifyTriggers();
+  try {
+    const r = await api('/api/discord/notify-triggers', {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ triggers }),
+    }) as { triggers?: NotifyTriggerUI[] };
+    dcNotifyTriggers = Array.isArray(r.triggers) ? r.triggers : triggers;
+    renderNotifyTriggers();
+    flashToast('通知トリガーを保存しました');
+  } catch (e) { alert(`保存失敗: ${(e as Error).message}`); }
+}
+
+async function testNotifyTrigger(i: number): Promise<void> {
+  await saveNotifyTriggers(); // id 確定のため常に保存してからテスト
+  const id = dcNotifyTriggers[i]?.id;
+  if (!id) { alert('保存に失敗しました'); return; }
+  try {
+    const r = await api(`/api/discord/notify-triggers/${encodeURIComponent(id)}/test`, { method: 'POST' }) as { ok?: boolean; count?: number; reason?: string };
+    if (r.ok) flashToast(`テスト送信: ${r.count ?? 0} 件`);
+    else alert(`テスト失敗: ${r.reason === 'not_ready' ? 'Bot が起動していません' : (r.reason || '')}`);
+  } catch (e) { alert(`テスト失敗: ${(e as Error).message}`); }
 }
 
 document.getElementById('eventsRefresh')?.addEventListener('click', loadEvents);
@@ -6262,6 +6410,13 @@ let ensureMemoriaFeatureViews = function () {
       <label class="check-inline"><input id="dcAutoMeal" type="checkbox" /> 食事 (画像検知)</label>
       <label class="check-inline"><input id="dcAutoRecommend" type="checkbox" /> おすすめ (/recommend)</label>
       <div style="margin-top:10px"><button id="discordSaveBtn" type="button" class="primary">保存</button></div>
+      <h4 style="margin-top:16px">通知トリガー</h4>
+      <p class="diary-settings-help">時刻 / GPS(帰宅・出発) / ランダム時刻が発火すると、 条件に合うアクティブタスクを選んだチャンネルへ通知します。GPS は ⚙設定→天気 の固定座標 (自宅) を使います。</p>
+      <div id="dcNotifyTriggers"></div>
+      <div style="margin-top:8px">
+        <button id="dcNotifyAddBtn" type="button">＋ トリガーを追加</button>
+        <button id="dcNotifySaveBtn" type="button" class="primary">トリガーを保存</button>
+      </div>
       <p class="diary-settings-help" style="margin-top:6px">設定したチャンネル/カテゴリは Bot 有効化 + 起動時に自動生成されます。反映には Memoria の再起動が必要な場合があります。</p>`;
     footer.parentNode.insertBefore(sec, footer);
   }

--- a/server/routes/discord.ts
+++ b/server/routes/discord.ts
@@ -84,7 +84,7 @@ export function makeDiscordRouter(deps: DiscordRouterDeps): Hono {
 
   // 1 トリガーを即時発火 (動作確認)。 該当 0 件でも送る。
   r.post('/api/discord/notify-triggers/:id/test', async (c: Context) => {
-    const id = c.req.param('id');
+    const id = c.req.param('id') || '';
     const res = await fireNotifyTriggerById(db, id);
     if (!res.ok) return c.json({ ok: false, reason: res.reason }, res.reason === 'not_found' ? 404 : 409);
     return c.json({ ok: true, count: res.count ?? 0 });

--- a/server/routes/discord.ts
+++ b/server/routes/discord.ts
@@ -3,9 +3,11 @@
 
 import { Hono, type Context } from 'hono';
 import type BetterSqlite3 from 'better-sqlite3';
-import { setAppSettings } from '../db.js';
+import { getAppSettings, setAppSettings } from '../db.js';
 import { discordSettings, discordReady, discordBotToken } from '../discord/settings.js';
-import { announceToDiscord } from '../discord/index.js';
+import { announceToDiscord, fireNotifyTriggerById } from '../discord/index.js';
+import { loadTriggers, saveTriggers, normalizeTriggers } from '../discord/notify/config.js';
+import { NOTIFY_CHANNEL_KINDS } from '../discord/notify/types.js';
 
 type Db = BetterSqlite3.Database;
 
@@ -59,6 +61,33 @@ export function makeDiscordRouter(deps: DiscordRouterDeps): Hono {
     }
     if (Object.keys(patch).length > 0) setAppSettings(db, patch);
     return c.json({ ok: true, config: discordSettings(db), token_set: !!discordBotToken(db) });
+  });
+
+  // 通知トリガー一覧 + UI 用の選択肢 (登録カテゴリ / channel kind)。
+  r.get('/api/discord/notify-triggers', (c: Context) => {
+    let categories: string[] = [];
+    try {
+      const raw = getAppSettings(db)['task.categories.registered'];
+      if (raw) { const a = JSON.parse(raw); if (Array.isArray(a)) categories = a.filter((x): x is string => typeof x === 'string'); }
+    } catch { /* ignore */ }
+    return c.json({ triggers: loadTriggers(db), categories, channels: NOTIFY_CHANNEL_KINDS });
+  });
+
+  // トリガー配列を丸ごと保存 (UI で編集して PUT)。 normalize で型矯正。
+  r.put('/api/discord/notify-triggers', async (c: Context) => {
+    const body = await c.req.json().catch(() => ({})) as { triggers?: unknown };
+    const arr = Array.isArray(body.triggers) ? body.triggers : [];
+    const triggers = normalizeTriggers(arr);
+    saveTriggers(db, triggers);
+    return c.json({ ok: true, triggers });
+  });
+
+  // 1 トリガーを即時発火 (動作確認)。 該当 0 件でも送る。
+  r.post('/api/discord/notify-triggers/:id/test', async (c: Context) => {
+    const id = c.req.param('id');
+    const res = await fireNotifyTriggerById(db, id);
+    if (!res.ok) return c.json({ ok: false, reason: res.reason }, res.reason === 'not_found' ? 404 : 409);
+    return c.json({ ok: true, count: res.count ?? 0 });
   });
 
   // 通知を Discord #announce に流す seam (テスト / 外部トリガ用)。

--- a/spec/feature/discord-task-notify.md
+++ b/spec/feature/discord-task-notify.md
@@ -1,0 +1,92 @@
+# Discord タスク通知エンジン
+
+2026-05-30 起草。 [discord-bot.md](./discord-bot.md) の上に載るタスク通知レイヤー。
+
+## 目的
+
+1. **AI カード成形**: Discord (#task 等) に投げた自然文を AI が解釈し、
+   `{title / category / due_at / details}` の構造化「タスクカード」に成形して登録 + 確認カードを返信。
+2. **トリガー通知エンジン**: 設定したトリガーが発火すると、フィルタに合致する
+   アクティブタスクを選び、選んだ Discord チャンネルへカードで通知する。
+
+すべて opt-in / opt-out。Bot 本体 ([[discord-bot]]) が起動しているときだけ動く。
+
+## トリガー (`features.discord.notify.triggers` = JSON 配列)
+
+各トリガー:
+
+```jsonc
+{
+  "id": "uuid",
+  "name": "朝のタスク",
+  "enabled": true,
+  "trigger": { "type": "time",   "at": "08:00" },                 // 毎日この時刻
+  //          { "type": "random", "window": ["09:00","21:00"], "count": 1 }  // 日に count 回、 窓内のランダム時刻
+  //          { "type": "gps",    "event": "arrive"|"depart", "radius_m": 200 } // 自宅 geofence 帰宅/出発
+  "filter": {
+    "categories": ["all"] | ["買い物","開発"],   // "all" or 登録カテゴリ名の集合
+    "deadline":   "due_today_or_overdue" | "all" // 期限フィルタ
+  },
+  "channel": "announce" | "task" | "<channel kind>"  // 送信先 (discord.channel.<kind>_id)
+}
+```
+
+### フィルタ
+
+- **categories**: `["all"]` で全カテゴリ。それ以外は `tasks.category` (カンマ区切り) に
+  いずれかが含まれるタスクだけ。
+- **deadline = due_today_or_overdue**: status が `todo`/`doing` (= アクティブ) のうち
+  `due_at` がローカル今日の終わり以前 (今日締切 or 期限超過) のものだけ。`all` は期限不問。
+
+### トリガー種別
+
+| type | 発火条件 | dedup |
+|------|----------|-------|
+| `time` | ローカル時刻が `at` (HH:MM) と一致 | `notify.fired.<id>` = 当日日付 (1日1回) |
+| `random` | 当日分の乱数時刻に到達 | 当日プランを `notify.random.<id>.<date>` に保存、 fire 済みフラグ |
+| `gps` | 自宅 geofence の inside/outside 遷移 (arrive=外→内, depart=内→外) | 遷移時のみ発火 (状態 `notify.gps.inside`)、 cooldown 10分 |
+
+- **自宅座標** = `weather.fixed_lat`/`weather.fixed_lon` (既存設定を流用)。未設定なら gps トリガーは no-op。
+- 距離は haversine。`radius_m` 既定 200m。
+- GPS は `gps_locations` の最新行を使う (既存 `readLatestGpsLatLon` と同経路)。
+
+## モジュール (`server/discord/notify/`)
+
+| file | 責務 |
+|------|------|
+| `types.ts` | NotifyTrigger / TriggerSpec / NotifyFilter 型 |
+| `config.ts` | triggers の load/save (app_settings `features.discord.notify.triggers`) |
+| `select.ts` | filter → アクティブタスク選択 (category + deadline) |
+| `card.ts` | タスク (群) → Discord メッセージ整形 (カード) |
+| `geofence.ts` | haversine + 自宅 inside 判定 + 遷移検出 (状態は app_settings) |
+| `engine.ts` | fireTrigger(client, db, trigger): select → card → postToChannel |
+| `scheduler.ts` | startNotifyScheduler(client, db): time/random/gps の interval 評価 |
+
+Bot の ready 時 (`client.ts`) に `startNotifyScheduler(client, db)` を起動する
+(Bot OFF のときは通知も止まる)。
+
+## API (`routes/discord.ts` 追加)
+
+| Verb | Path | 用途 |
+|------|------|------|
+| GET  | `/api/discord/notify-triggers` | triggers 一覧 + 選択肢 (categories / channel kinds) |
+| PUT  | `/api/discord/notify-triggers` | triggers 配列を丸ごと保存 (UI で編集して送る) |
+| POST | `/api/discord/notify-triggers/:id/test` | そのトリガーを即時発火 (動作確認) |
+
+## 設定 UI (⚙ 設定 → 🤖 Discord タブ)
+
+「通知トリガー」 サブセクション: トリガー一覧 (有効トグル / 種別 / フィルタ / 送信先) +
+追加・編集・削除 + 「テスト送信」。入力 UI は `.foundation-form` 準拠
+([[feedback_memoria_foundation_input]])。
+
+## AI カード成形
+
+`message-router.ts` の classify を拡張し `category` / `details` も抽出。
+`actions/task.ts` の createTask が category/details を受け、登録後に
+`card.ts` の単一タスクカードを reply する。
+
+## 非対象 (この PR では作らない)
+
+- 通知の既読/snooze 管理、 通知履歴 UI。
+- GPS の複数地点 geofence (自宅のみ)。
+- per-trigger の quiet-hours (グローバルな Bot announce 設定に従う)。


### PR DESCRIPTION
## 概要
#183 Discord Bot の上に、タスクの **AI カード成形** と **トリガー通知エンジン** を載せる。spec: `spec/feature/discord-task-notify.md`。

## AI カード成形
- #task への自然文を classify が `{title, category, due_at, details}` に解釈し、**確認カード**を返信。category/details も登録するよう拡張(`ai_process` OFF なら原文を title)。

## トリガー通知エンジン (`server/discord/notify/`)
- **trigger**: 時刻(`time`) / GPS 帰宅・出発(`gps`, 自宅 geofence) / ランダム時刻(`random`)
- **filter**: カテゴリ(`all` / 登録カテゴリ集合)+ 期限(今日締切・超過のみ / 全て)
- **channel**: announce/task/… から選択
- Bot ready 時に scheduler 起動(minute tick=time/random、5min tick=gps)。dedup は `app_settings`、全て best-effort。
- GPS は既存 `weather.fixed_lat/lon`(自宅)+ `readLatestGpsLatLon` を流用。複数 gps トリガーは単一 geofence(最小 radius)を共有。

## API
- `GET/PUT /api/discord/notify-triggers`(一覧+選択肢 / 一括保存)
- `POST /api/discord/notify-triggers/:id/test`(即時発火)

## 設定 UI
⚙設定 → 🤖Discord に「通知トリガー」セクション(追加 / 編集 / 削除 / テスト送信、`.foundation-form` 準拠)。

## モジュール (SRP 分割)
`types / config(load・save・normalize) / select(filter→task) / card(整形) / geofence(haversine+遷移) / engine(発火) / scheduler(interval)`

## 検証
`tsc --noEmit -p tsconfig.json`(server)/ `eslint --max-warnings 0 "**/*.ts"` いずれも green。Memoria は domain テスト基盤を持たないため committed テストは無し(純粋ロジックは型 + レビューで担保)。

## 補足
GPS トリガーは ⚙設定→天気 の固定座標(自宅)が前提。未設定なら gps トリガーは no-op。

🤖 Generated with [Claude Code](https://claude.com/claude-code)