### PR TITLE
docs(spec): Memoria Hub のデータ共有サーバ設計を整える

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -29,7 +29,8 @@ spec/
 - `data/` — 43 テーブル中 20 を文書化（残りは内部/キャッシュ系。Phase 0 段階移行中、gap）。
 - `interface/` — 24 ルート中 17 を文書化（packet-monitor / transit / weather / repo /
   staleness / review 等が gap）。
-- `feature/` — 32 ファイル（主要機能を網羅）。
+- `feature/` — 35 ファイル（主要機能を網羅。 Hub 共有サーバ層は `hub-social` /
+  `hub-worklog` / `hub-dig-rooms` の 3 本）。
 - `setup/` `test/` — 整備済（`test/` は本 PR で新設）。
 - 残りの table / route doc は `server/db.ts` / `server/routes/*` から追補する
   （[`test/test-design.md`](test/test-design.md) の gap 参照）。

--- a/spec/data/README.md
+++ b/spec/data/README.md
@@ -26,6 +26,20 @@ Memoria ローカルサーバ (`server/db.ts` で初期化される SQLite フ�
 | ワードクラウド | [wordcloud.md](wordcloud.md) | `word_clouds` |
 | ストップワード | [stopwords.md](stopwords.md) | `user_stopwords` |
 | ノート | [note.md](note.md) | `notes` / `note_blocks` |
+| 実績 (worklog) | [hub-social.md](hub-social.md) §8 | `worklog_sources` / `worklog_entries` / `worklog_redaction_terms` |
+
+## Hub (Postgres) 側のテーブル
+
+`spec/data/` は原則ローカル SQLite の仕様書だが、 共有サーバ層のテーブルは
+1 か所にまとまっている方が読めるので例外として同フォルダに置く。
+
+| ドメイン | spec | 関連テーブル |
+|---|---|---|
+| 共有サーバ層 | [hub-social.md](hub-social.md) | `subjects` / `comments` / `reactions` / `bookmark_renditions` / `notifications` / `worklog_entries` / `worklog_digests` / `dig_rooms` / `dig_contributions` / `dig_room_digests` / `dig_room_jobs` / `hub_members` |
+
+Hub の既存 7 型テーブル (`bookmarks` / `dig_sessions` / `dictionary_entries` /
+`implementation_notes` / `work_locations` / `domain_catalog` / `notes`) は
+`server/multi/migrations/00*.sql` が正本 ([feature/multi-hub.md](../feature/multi-hub.md))。
 
 ## 表記
 

--- a/spec/data/hub-social.md
+++ b/spec/data/hub-social.md
@@ -1,0 +1,464 @@
+# hub-social — 共有サーバ層のテーブル定義 (Hub Postgres + ローカル追加分)
+
+> ⚠ 本書は **Hub (`server/multi/`) の Postgres スキーマ**が主。
+> `spec/data/` の他ファイル (ローカル SQLite) とは DB が違う。
+> ローカル SQLite に足す分は §6 に分けて書く。
+>
+> 機能側: [`hub-social.md`](../feature/hub-social.md) /
+> [`hub-worklog.md`](../feature/hub-worklog.md) /
+> [`hub-dig-rooms.md`](../feature/hub-dig-rooms.md)
+> API: [`../interface/hub-social.md`](../interface/hub-social.md)
+
+## 0. migration 割り当て
+
+既存: `001_init` / `002_implementation_notes` / `004_work_locations` /
+`005_workplace_presence` / `007_data_types`。 本書は以下を新設する。
+
+| migration | 内容 |
+|---|---|
+| `008_social_core.sql` | `subjects` / `subject_aliases` / `url_canonical_rules` / `comments` / `reactions` / `bookmark_renditions` / `subject_activity` / `subject_watches` / `subject_mutes` / `notifications` / `hub_members` + `bookmarks.url_canonical` 追加 |
+| `009_worklog.sql` | `worklog_entries` / `worklog_digests` |
+| `010_dig_rooms.sql` | `dig_rooms` / `dig_room_members` / `dig_contributions` / `dig_room_digests` / `dig_room_jobs` |
+
+既存 7 型のテーブルは触らない (`bookmarks` への列追加のみ、 `IF NOT EXISTS` で冪等)。
+
+## 1. subject (話題)
+
+### `subjects`
+
+コメント・いいねが付く先の正規オブジェクト。 **owner を持たない**。
+
+| 列 | 型 | NotNull | Default | 役割 |
+|---|---|---|---|---|
+| `id` | UUID | ✓ | `gen_random_uuid()` | PK |
+| `kind` | TEXT | ✓ | — | `bookmark` / `note` / `note_block` / `dig_room` / `worklog_entry` / `worklog_digest` / `dictionary_term` |
+| `key` | TEXT | ✓ | — | kind ごとの正規キー ([feature §3.1](../feature/hub-social.md#31-subject-種別と-key))。 canonical URL 等の生値 |
+| `key_hash` | TEXT | ✓ | — | `sha256(key)` の hex。 UNIQUE index 用 (長い URL 対策) |
+| `title` | TEXT |  | NULL | 表示用タイトルのキャッシュ (元オブジェクト由来、 正本ではない) |
+| `excerpt` | TEXT |  | NULL | 一覧用の抜粋キャッシュ |
+| `comment_count` | INTEGER | ✓ | 0 | トリガ維持 (soft delete 済は数えない) |
+| `like_count` | INTEGER | ✓ | 0 | トリガ維持 |
+| `participant_count` | INTEGER | ✓ | 0 | コメント or reaction した distinct user 数。 トリガ維持 |
+| `first_seen_at` | TIMESTAMPTZ | ✓ | `now()` | subject が作られた時刻 |
+| `last_activity_at` | TIMESTAMPTZ | ✓ | `now()` | 最終コメント / reaction 時刻。 フィード並び順 |
+| `created_by` | TEXT |  | NULL | 最初に触った user id (情報列) |
+| `hidden_at` / `hidden_by` / `hidden_reason` | TIMESTAMPTZ / TEXT / TEXT |  | NULL | moderation (既存 7 型と同形式) |
+
+- UNIQUE: `(kind, key_hash)`
+- Index: `idx_subjects_activity` (`last_activity_at DESC`) /
+  `idx_subjects_kind_activity` (`kind, last_activity_at DESC`) /
+  `idx_subjects_hot` (`like_count DESC`)
+
+### `subject_aliases`
+
+canonical 化ルール変更で key が変わったときの旧 key。 迷子防止。
+
+| 列 | 型 | NotNull | 役割 |
+|---|---|---|---|
+| `kind` | TEXT | ✓ | |
+| `key_hash` | TEXT | ✓ | 旧 key の hash |
+| `key` | TEXT | ✓ | 旧 key の生値 |
+| `subject_id` | UUID | ✓ | FK → `subjects(id)` ON DELETE CASCADE |
+| `created_at` | TIMESTAMPTZ | ✓ | |
+
+PK: `(kind, key_hash)`。 resolve は `subjects` → 無ければ `subject_aliases` の順に引く。
+
+### `url_canonical_rules`
+
+host 単位の正規化上書き ([feature §3.3](../feature/hub-social.md#33-domain-別ルール))。
+**Hub 側が正**で、 ローカルは pull してキャッシュする。
+
+| 列 | 型 | NotNull | Default | 役割 |
+|---|---|---|---|---|
+| `host` | TEXT | ✓ | — | PK。 lowercase。 先頭 `.` でサブドメイン一括 (`.example.com`) |
+| `keep_query_json` | JSONB |  | NULL | `string[]` — このキーのみ残す (指定時は除去リストより優先) |
+| `drop_query_json` | JSONB |  | NULL | `string[]` — 追加で落とすキー |
+| `keep_hash` | BOOLEAN | ✓ | `false` | fragment を保持する |
+| `alias_host` | TEXT |  | NULL | この host に寄せる |
+| `strip_path_suffix_json` | JSONB |  | NULL | `string[]` — 末尾から落とす path 断片 (`/amp` 等) |
+| `note` | TEXT |  | NULL | なぜこのルールが要るか |
+| `updated_at` | TIMESTAMPTZ | ✓ | `now()` | ローカルの差分 pull 用 |
+
+### `subject_activity`
+
+フィード / 掘り尽くし度用の日次集計。
+
+| 列 | 型 | NotNull | 役割 |
+|---|---|---|---|
+| `subject_id` | UUID | ✓ | FK → `subjects(id)` CASCADE |
+| `day` | DATE | ✓ | UTC 日 |
+| `comment_count` | INTEGER | ✓ | その日のコメント数 |
+| `like_count` | INTEGER | ✓ | その日の like 数 |
+| `actor_count` | INTEGER | ✓ | その日の distinct actor |
+
+PK: `(subject_id, day)`。 Index: `idx_subject_activity_day` (`day DESC`)
+
+### `subject_watches` / `subject_mutes`
+
+| 列 | 型 | NotNull | 役割 |
+|---|---|---|---|
+| `subject_id` | UUID | ✓ | FK → `subjects(id)` CASCADE |
+| `user_id` | TEXT | ✓ | Cernere user id |
+| `created_at` | TIMESTAMPTZ | ✓ | |
+| `source` | TEXT | ✓ | (watches のみ) `auto` (コメント/like で自動) / `manual` |
+
+PK: `(subject_id, user_id)` (両テーブル)
+
+## 2. コメント / リアクション
+
+### `comments`
+
+| 列 | 型 | NotNull | Default | 役割 |
+|---|---|---|---|---|
+| `id` | UUID | ✓ | `gen_random_uuid()` | PK |
+| `subject_id` | UUID | ✓ | — | FK → `subjects(id)` ON DELETE CASCADE |
+| `author_user_id` | TEXT | ✓ | — | Cernere user id |
+| `author_user_name` | TEXT | ✓ | — | 表示名のスナップショット |
+| `parent_comment_id` | UUID |  | NULL | FK → `comments(id)` ON DELETE CASCADE。 **1 段のみ** (親が親を持つ行への insert は拒否) |
+| `anchor_json` | JSONB |  | NULL | 本文アンカー ([feature §4.3](../feature/hub-social.md#43-anchor--記事本文--ブロック本文へのコメント))。 NULL = subject 全体 |
+| `anchor_state` | TEXT | ✓ | `'none'` | `none` (アンカー無し) / `resolved` / `orphan` |
+| `rendition_id` | UUID |  | NULL | FK → `bookmark_renditions(id)`。 どの本文に対して打ったか |
+| `body_md` | TEXT | ✓ | `''` | 本文 (markdown、 ≤ 16 KiB)。 soft delete 時は `''` |
+| `like_count` | INTEGER | ✓ | 0 | トリガ維持 |
+| `created_at` | TIMESTAMPTZ | ✓ | `now()` | |
+| `updated_at` | TIMESTAMPTZ | ✓ | `now()` | 編集で bump |
+| `edited_at` | TIMESTAMPTZ |  | NULL | 非 NULL = 編集済 (UI に「編集済」 表示) |
+| `deleted_at` | TIMESTAMPTZ |  | NULL | soft delete |
+| `deleted_by` | TEXT |  | NULL | 作者 or moderator |
+| `origin_local_id` | TEXT |  | NULL | ローカル `note_comments.id` (UUID)。 push 由来の行の重複防止 |
+| `shared_origin` | TEXT |  | NULL | どのローカルサーバから来たか (既存 7 型と同じ情報列) |
+| `hidden_at` / `hidden_by` / `hidden_reason` | | | NULL | moderation |
+
+- Index: `idx_comments_subject_created` (`subject_id, created_at`) /
+  `idx_comments_author` (`author_user_id, created_at DESC`) /
+  `idx_comments_parent` (`parent_comment_id`) /
+  `idx_comments_rendition` (`rendition_id`)
+- UNIQUE: `idx_comments_origin` (`origin_local_id`) WHERE `origin_local_id IS NOT NULL`
+- CHECK: `parent_comment_id IS NULL OR anchor_json IS NULL` — 返信にアンカーは持たせない
+  (アンカーは親が持つ)
+
+> **set 構造は持たない**。 ローカルの `note_comment_sets` 相当は
+> `(subject_id, author_user_id)` でのグルーピングで表現する
+> ([feature §4.2](../feature/hub-social.md#42-既存-note_comment_sets-との整合))。
+
+### `reactions`
+
+| 列 | 型 | NotNull | Default | 役割 |
+|---|---|---|---|---|
+| `id` | BIGSERIAL | ✓ | — | PK |
+| `target_kind` | TEXT | ✓ | — | `subject` / `comment` |
+| `target_id` | UUID | ✓ | — | subject.id or comment.id (多態 FK なので DB 制約は張らず、 トリガで存在確認) |
+| `user_id` | TEXT | ✓ | — | |
+| `user_name` | TEXT | ✓ | — | 表示名スナップショット |
+| `kind` | TEXT | ✓ | `'like'` | v0.1 は `like` のみ。 アプリ側 allowlist で制限 |
+| `created_at` | TIMESTAMPTZ | ✓ | `now()` | |
+
+- UNIQUE: `(target_kind, target_id, user_id, kind)`
+- Index: `idx_reactions_target` (`target_kind, target_id`) /
+  `idx_reactions_user` (`user_id, created_at DESC`)
+
+### カウンタ維持トリガ
+
+`comments` / `reactions` の INSERT / UPDATE(`deleted_at`) / DELETE で:
+
+- `subjects.comment_count` / `like_count` / `participant_count` / `last_activity_at`
+- `comments.like_count`
+- `subject_activity` の該当日行を upsert
+
+を更新する。 **アプリ側でのインクリメントは禁止** (二重計上・欠落が出る)。
+整合確認用に全再計算 SQL を `009` 以降とは別の `sql/recount_social.sql` に置き、
+`POST /api/social/admin/recount` から実行する。
+
+## 3. 記事本文 (rendition)
+
+### `bookmark_renditions`
+
+全員が「同じ本文」 を見るための content-addressed スナップショット
+([feature §4.4](../feature/hub-social.md#44-記事本文の共有-rendition))。
+
+| 列 | 型 | NotNull | Default | 役割 |
+|---|---|---|---|---|
+| `id` | UUID | ✓ | `gen_random_uuid()` | PK |
+| `subject_id` | UUID | ✓ | — | FK → `subjects(id)` CASCADE (kind=`bookmark`) |
+| `content_hash` | TEXT | ✓ | — | `sha256(text_content)` hex。 同一本文の重複保存を防ぐ |
+| `text_content` | TEXT | ✓ | — | 抽出本文 (≤ 1 MiB)。 アンカー解決の対象 |
+| `outline_json` | JSONB |  | NULL | 見出し構造 `[{ level, text, offset }]` |
+| `html_content` | TEXT |  | NULL | **opt-in のみ** (案 C)。 サーバ設定 `allow_html_rendition=false` で常に NULL |
+| `extractor` | TEXT | ✓ | — | 抽出器の識別子 + version (`readability@0.5` 等)。 再現性のため |
+| `captured_at` | TIMESTAMPTZ | ✓ | — | 元ページを取得した時刻 |
+| `captured_by` | TEXT | ✓ | — | 取得した user id |
+| `byte_size` | INTEGER | ✓ | — | 容量管理用 |
+| `created_at` | TIMESTAMPTZ | ✓ | `now()` | |
+| `hidden_at` / `hidden_by` / `hidden_reason` | | | NULL | moderation |
+
+- UNIQUE: `(subject_id, content_hash)`
+- Index: `idx_renditions_subject` (`subject_id, captured_at DESC`)
+- 「最新 rendition」 = 同 subject で `captured_at` 最大の行。 UI の既定表示
+
+## 4. worklog
+
+### `worklog_entries` (Hub)
+
+ローカルから push された、 **共有ポリシー通過済**の行のみ
+([feature §4](../feature/hub-worklog.md#4-共有ゲート--漏らさないための機構))。
+
+| 列 | 型 | NotNull | Default | 役割 |
+|---|---|---|---|---|
+| `id` | BIGSERIAL | ✓ | — | PK (Hub 内部) |
+| `repo_key` | TEXT | ✓ | — | `<owner>/<name>` 正規化済。 `redacted` 時は alias 名 |
+| `repo_alias` | BOOLEAN | ✓ | `false` | `repo_key` が alias か (= 本名ではない) |
+| `provider` | TEXT | ✓ | — | `github` / `git_local` / `activity` / `impl_note` / `manual` (最初に取れた経路。 情報列) |
+| `kind` | TEXT | ✓ | — | `commit` / `pr` / `issue` / `review` / `release` / `impl_note` / `manual` |
+| `ref` | TEXT | ✓ | — | sha / `pr/123` / tag / note id |
+| `parent_ref` | TEXT |  | NULL | 属する PR の ref (畳み込み用) |
+| `title` | TEXT | ✓ | — | `redacted` 時は固有名を含まない要約文 |
+| `body_md` | TEXT |  | NULL | `redacted` 時は NULL |
+| `url` | TEXT |  | NULL | `redacted` 時は NULL |
+| `occurred_at` | TIMESTAMPTZ | ✓ | — | |
+| `stats_json` | JSONB |  | NULL | `{ additions, deletions, filesChanged, commentCount }` |
+| `labels_json` | JSONB |  | NULL | allowlist 通過分のみ |
+| `share_policy` | TEXT | ✓ | — | この行が push されたときのポリシー (`redacted` / `full`)。 監査用 |
+| `owner_user_id` | TEXT | ✓ | — | |
+| `owner_user_name` | TEXT | ✓ | — | |
+| `shared_at` | TIMESTAMPTZ | ✓ | `now()` | |
+| `shared_origin` | TEXT |  | NULL | |
+| `hidden_at` / `hidden_by` / `hidden_reason` | | | NULL | |
+
+- UNIQUE: `(owner_user_id, repo_key, kind, ref)` — 同じ実績を同じ人が二重に出さない。
+  **他人が同じ commit を出すのは許す** (共同作業のため)
+- Index: `idx_worklog_occurred` (`occurred_at DESC`) /
+  `idx_worklog_owner_occurred` (`owner_user_id, occurred_at DESC`) /
+  `idx_worklog_repo` (`repo_key, occurred_at DESC`) /
+  `idx_worklog_parent` (`parent_ref`)
+
+### `worklog_digests` (Hub)
+
+| 列 | 型 | NotNull | Default | 役割 |
+|---|---|---|---|---|
+| `id` | UUID | ✓ | `gen_random_uuid()` | PK (subject key になる) |
+| `scope_kind` | TEXT | ✓ | — | `user` / `repo` / `topic` |
+| `scope_key` | TEXT | ✓ | — | user id / repo_key / topic 文字列 |
+| `period_start` / `period_end` | DATE | ✓ | — | 対象期間 |
+| `rev` | INTEGER | ✓ | 1 | append-only。 同 (scope, period) で再生成すると +1 |
+| `summary_md` | TEXT | ✓ | — | 何をやったか |
+| `highlights_json` | JSONB |  | NULL | 代表 entry の ref 配列 |
+| `metrics_json` | JSONB |  | NULL | `{ prCount, commitCount, additions, deletions, activeDays }` |
+| `generated_by` | TEXT | ✓ | — | user id + モデル名 |
+| `owner_user_id` / `owner_user_name` | TEXT | ✓ | — | |
+| `created_at` | TIMESTAMPTZ | ✓ | `now()` | |
+| `hidden_at` / `hidden_by` / `hidden_reason` | | | NULL | |
+
+- UNIQUE: `(owner_user_id, scope_kind, scope_key, period_start, period_end, rev)`
+- Index: `idx_worklog_digests_scope` (`scope_kind, scope_key, period_end DESC`)
+
+## 5. dig room
+
+### `dig_rooms`
+
+| 列 | 型 | NotNull | Default | 役割 |
+|---|---|---|---|---|
+| `id` | UUID | ✓ | `gen_random_uuid()` | PK (subject key) |
+| `title` | TEXT | ✓ | — | |
+| `question` | TEXT | ✓ | — | 掘る問い (1 文) |
+| `theme` | TEXT |  | NULL | ローカル `dig_sessions.theme` と揃える軸 |
+| `state` | TEXT | ✓ | `'open'` | `open` / `digesting` / `converged` / `archived` |
+| `llm_policy` | TEXT | ✓ | `'any_member'` | `any_member` / `creator_only` / `local_model_only` |
+| `created_by` | TEXT | ✓ | — | |
+| `created_by_name` | TEXT | ✓ | — | |
+| `created_at` | TIMESTAMPTZ | ✓ | `now()` | |
+| `updated_at` | TIMESTAMPTZ | ✓ | `now()` | contribution / digest で bump |
+| `hidden_at` / `hidden_by` / `hidden_reason` | | | NULL | |
+
+Index: `idx_dig_rooms_state_updated` (`state, updated_at DESC`) / `idx_dig_rooms_theme`
+
+### `dig_room_members`
+
+| 列 | 型 | NotNull | Default | 役割 |
+|---|---|---|---|---|
+| `room_id` | UUID | ✓ | — | FK → `dig_rooms(id)` CASCADE |
+| `user_id` | TEXT | ✓ | — | |
+| `user_name` | TEXT | ✓ | — | |
+| `role` | TEXT | ✓ | `'digger'` | `owner` / `digger` |
+| `joined_at` | TIMESTAMPTZ | ✓ | `now()` | |
+| `last_seen_at` | TIMESTAMPTZ |  | NULL | 「未読 contribution」 算出用 |
+
+PK: `(room_id, user_id)`
+
+### `dig_contributions`
+
+**append-only**。 UPDATE / DELETE しない (取り消しは `kind='retract'` 行で表現)。
+
+| 列 | 型 | NotNull | Default | 役割 |
+|---|---|---|---|---|
+| `id` | UUID | ✓ | `gen_random_uuid()` | PK |
+| `room_id` | UUID | ✓ | — | FK → `dig_rooms(id)` CASCADE |
+| `seq` | BIGINT | ✓ | — | room 内の連番 (`room_id, seq` で順序確定。 差分取得に使う) |
+| `kind` | TEXT | ✓ | — | `query` / `source` / `finding` / `question` / `dead_end` / `dig_import` / `bookmark_ref` / `note_ref` / `retract` |
+| `payload_json` | JSONB | ✓ | — | kind ごとの shape ([feature §2.2](../feature/hub-dig-rooms.md#22-dig_contributions--append-only-の書き込み)) |
+| `canonical_url` | TEXT |  | NULL | `kind='source'` のとき正規化 URL を切り出して保持 (重複検出 index 用) |
+| `url_hash` | TEXT |  | NULL | `sha256(canonical_url)` |
+| `target_contribution_id` | UUID |  | NULL | `retract` / `finding`→`question` の解決対象 |
+| `author_user_id` / `author_user_name` | TEXT | ✓ | — | |
+| `created_at` | TIMESTAMPTZ | ✓ | `now()` | |
+| `hidden_at` / `hidden_by` / `hidden_reason` | | | NULL | |
+
+- UNIQUE: `(room_id, seq)` / `idx_dig_contrib_url` UNIQUE (`room_id, url_hash`)
+  WHERE `url_hash IS NOT NULL` — **同 room 内で同一 URL の source を二重登録させない**
+  (`?force=1` は `payload_json.forced=true` を立てた別 kind ではなく、
+  既存行への `finding` 追加に誘導する)
+- Index: `idx_dig_contrib_room_seq` (`room_id, seq`) / `idx_dig_contrib_kind` (`room_id, kind`)
+
+### `dig_room_digests`
+
+| 列 | 型 | NotNull | Default | 役割 |
+|---|---|---|---|---|
+| `id` | UUID | ✓ | `gen_random_uuid()` | PK (subject key にもなる) |
+| `room_id` | UUID | ✓ | — | FK → `dig_rooms(id)` CASCADE |
+| `rev` | INTEGER | ✓ | — | 1 から連番 |
+| `summary_md` | TEXT | ✓ | — | 問いに対する現時点の答え |
+| `sources_json` | JSONB |  | NULL | 採用 source (`[{ url, title, role }]`) |
+| `open_questions_json` | JSONB |  | NULL | |
+| `dead_ends_json` | JSONB |  | NULL | |
+| `metrics_json` | JSONB |  | NULL | `{ sourceCount, newSourceSinceLastRev, findingCount, openQuestionCount, contributorCount }` |
+| `covered_seq` | BIGINT | ✓ | — | この rev が読んだ contribution の最大 seq (次 rev の差分起点) |
+| `generated_by` | TEXT | ✓ | — | user id + モデル名 (Hub 生成時は `hub`) |
+| `created_at` | TIMESTAMPTZ | ✓ | `now()` | |
+
+UNIQUE: `(room_id, rev)`
+
+### `dig_room_jobs`
+
+digest 生成の依頼キュー ([feature §5](../feature/hub-dig-rooms.md#5-まとめ生成をどこで回すか))。
+
+| 列 | 型 | NotNull | Default | 役割 |
+|---|---|---|---|---|
+| `id` | UUID | ✓ | `gen_random_uuid()` | PK |
+| `room_id` | UUID | ✓ | — | FK → `dig_rooms(id)` CASCADE |
+| `state` | TEXT | ✓ | `'queued'` | `queued` / `claimed` / `done` / `failed` |
+| `requested_by` | TEXT | ✓ | — | |
+| `from_seq` | BIGINT | ✓ | — | 前 rev の `covered_seq` |
+| `claimed_by` | TEXT |  | NULL | user id または `hub` |
+| `claimed_at` | TIMESTAMPTZ |  | NULL | |
+| `lease_expires_at` | TIMESTAMPTZ |  | NULL | claim から 5 分。 期限切れは `queued` に戻す |
+| `attempts` | INTEGER | ✓ | 0 | 3 回失敗で `failed` 固定 |
+| `error` | TEXT |  | NULL | |
+| `result_digest_id` | UUID |  | NULL | FK → `dig_room_digests(id)` |
+| `created_at` / `updated_at` | TIMESTAMPTZ | ✓ | `now()` | |
+
+- Index: `idx_dig_jobs_queue` (`state, created_at`) — claim の取り合いは
+  `UPDATE ... WHERE state='queued' ... RETURNING` の 1 文で行う (row lock)
+- 同 room で `queued` / `claimed` の job は **同時に 1 本まで** (部分 UNIQUE index)
+
+## 6. Hub のメンバー / 通知
+
+### `hub_members`
+
+拠点ローカルの役割。 Cernere のユーザ属性とは別。
+
+| 列 | 型 | NotNull | Default | 役割 |
+|---|---|---|---|---|
+| `user_id` | TEXT | ✓ | — | PK (Cernere user id) |
+| `user_name` | TEXT | ✓ | — | 最終ログイン時の表示名 |
+| `role` | TEXT | ✓ | `'member'` | `member` / `moderator` / `admin` |
+| `first_login_at` / `last_login_at` | TIMESTAMPTZ | ✓ | `now()` | |
+| `disabled_at` | TIMESTAMPTZ |  | NULL | 非 NULL = 書き込み禁止 |
+
+初回ログイン時に upsert。 最初のユーザは `admin` を自動付与。
+
+### `notifications`
+
+| 列 | 型 | NotNull | Default | 役割 |
+|---|---|---|---|---|
+| `id` | BIGSERIAL | ✓ | — | PK |
+| `user_id` | TEXT | ✓ | — | 宛先 |
+| `kind` | TEXT | ✓ | — | `reply` / `mention` / `like` / `subject_activity` |
+| `subject_id` | UUID |  | NULL | FK → `subjects(id)` CASCADE |
+| `comment_id` | UUID |  | NULL | FK → `comments(id)` CASCADE |
+| `actor_user_id` / `actor_user_name` | TEXT | ✓ | — | 誰の行為か |
+| `created_at` | TIMESTAMPTZ | ✓ | `now()` | |
+| `read_at` | TIMESTAMPTZ |  | NULL | |
+
+- Index: `idx_notifications_user_unread` (`user_id, read_at NULLS FIRST, created_at DESC`)
+- 自分の行為で自分に通知は作らない (`actor_user_id <> user_id` をアプリ側で保証)
+- 保持は 90 日 (既読は 30 日) で削除するバッチを持つ
+
+## 7. 既存テーブルへの追加
+
+### `bookmarks` (Hub, migration 008)
+
+```sql
+ALTER TABLE bookmarks ADD COLUMN IF NOT EXISTS url_canonical TEXT;
+CREATE INDEX IF NOT EXISTS idx_bookmarks_url_canonical ON bookmarks(url_canonical);
+```
+
+既存行は起動時バックフィル (`url` → canonical 化)。 `url_canonical` は
+`subjects.key` と突き合わせるための列で、 **持ち主付きコピーの構造は変えない**
+(= 破壊的移行をしない)。
+
+## 8. ローカル SQLite 側の追加分
+
+正本は `server/db.ts` の CREATE TABLE。 spec としては以下を追加する。
+
+### `worklog_sources` (新規、 [`spec/data/`](./README.md) 側)
+
+| 列 | 型 | NotNull | Default | 役割 |
+|---|---|---|---|---|
+| `id` | INTEGER | ✓ | autoinc | PK |
+| `source_kind` | TEXT | ✓ | — | `github` / `git_local` / `activity` / `impl_note` / `manual` |
+| `repo_key` | TEXT |  | NULL | `<owner>/<name>` |
+| `local_path` | TEXT |  | NULL | `git_local` のクローンパス |
+| `alias` | TEXT |  | NULL | `redacted` 共有時の別名。 未設定で `redacted` は拒否 |
+| `share_policy` | TEXT | ✓ | `'none'` | `none` / `redacted` / `full` |
+| `llm_optout` | INTEGER | ✓ | 0 | 1 = digest / 要約の材料にも使わない |
+| `enabled` | INTEGER | ✓ | 1 | 取り込み有効 |
+| `last_ingested_at` | TEXT |  | NULL | UTC ISO |
+| `created_at` / `updated_at` | TEXT | ✓ | UTC | |
+
+UNIQUE: `(source_kind, repo_key, local_path)`
+
+### `worklog_entries` (ローカル)
+
+Hub 版 (§4) と同じ列に加えて:
+
+| 列 | 型 | 役割 |
+|---|---|---|
+| `source_id` | INTEGER | FK → `worklog_sources(id)` |
+| `pushed_at` | TEXT | Hub に push した時刻 (NULL = 未 push) |
+| `remote_id` | INTEGER | Hub 側 `worklog_entries.id` |
+| `redaction_state` | TEXT | `unchecked` / `passed` / `blocked` |
+| `redaction_hits_json` | TEXT | blocked の内訳 (どのフィールドにどの語) |
+
+UNIQUE: `(repo_key, kind, ref)`
+
+### `worklog_redaction_terms` (ローカル)
+
+| 列 | 型 | NotNull | 役割 |
+|---|---|---|---|
+| `term` | TEXT | ✓ | PK。 禁止語 (正規化前の原形) |
+| `origin` | TEXT | ✓ | `project_codes` / `manual` / `customer` |
+| `created_at` | TEXT | ✓ | |
+
+### 既存テーブルへの追加 (ローカル)
+
+| テーブル | 追加列 | 役割 |
+|---|---|---|
+| `bookmarks` | `url_canonical` TEXT | Hub subject との突き合わせ。 index 付き |
+| `notes` | (変更なし) | UUID なのでそのまま subject key になる |
+| `note_comments` | `remote_id` TEXT | Hub `comments.id`。 push 済かの判定 |
+| `note_comments` | `anchor_json` TEXT | Hub の anchor 形式に合わせる (既存 `target_block_uuid` は残す) |
+| `dig_sessions` | `shared_room_id` TEXT | 持ち込んだ room の UUID |
+
+## 9. 容量の目安
+
+| テーブル | 1 行の目安 | 想定 |
+|---|---|---|
+| `subjects` | ~300 B | 10k 行 = 3 MB |
+| `comments` | ~1 KB | 50k 行 = 50 MB |
+| `reactions` | ~120 B | 200k 行 = 24 MB |
+| `bookmark_renditions` | 20-80 KB | 2k 記事 = 40-160 MB (案 B の text のみ) |
+| `worklog_entries` | ~600 B | 100k 行 = 60 MB |
+| `dig_contributions` | ~800 B | 20k 行 = 16 MB |
+
+案 C (HTML) を有効にすると rendition が 1 行 200 KB-2 MB になるため、
+`html_content` は Postgres に直接持たず object storage 参照にする余地を残す
+(v0.1 では実装しない)。 詳細な見積は [`docs/db-perf-estimate.md`](../../docs/db-perf-estimate.md) の方式に合わせて別途。

--- a/spec/data/hub-social.md
+++ b/spec/data/hub-social.md
@@ -16,7 +16,7 @@
 
 | migration | 内容 |
 |---|---|
-| `008_social_core.sql` | `subjects` / `subject_aliases` / `url_canonical_rules` / `comments` / `reactions` / `bookmark_renditions` / `subject_activity` / `subject_watches` / `subject_mutes` / `notifications` / `hub_members` + `bookmarks.url_canonical` 追加 |
+| `008_social_core.sql` | `subjects` / `subject_aliases` / `url_canonical_rules` / `comments` / `reactions` / `bookmark_renditions` / `subject_activity` / `subject_watches` / `subject_mutes` / `unshare_audit` / `notifications` / `hub_members` + `bookmarks.url_canonical` 追加 |
 | `009_worklog.sql` | `worklog_entries` / `worklog_digests` |
 | `010_dig_rooms.sql` | `dig_rooms` / `dig_room_members` / `dig_contributions` / `dig_room_digests` / `dig_room_jobs` |
 
@@ -364,6 +364,32 @@ digest 生成の依頼キュー ([feature §5](../feature/hub-dig-rooms.md#5-ま
 | `disabled_at` | TIMESTAMPTZ |  | NULL | 非 NULL = 書き込み禁止 |
 
 初回ログイン時に upsert。 最初のユーザは `admin` を自動付与。
+
+### `unshare_audit`
+
+公開の取り下げ ([feature §8.1](../feature/hub-social.md#81-公開の取り下げ-unshare)) の監査記録。
+取り下げ自体を「なかったこと」 にしないため、 **この表からは削除しない**。
+
+| 列 | 型 | NotNull | Default | 役割 |
+|---|---|---|---|---|
+| `id` | BIGSERIAL | ✓ | — | PK |
+| `mode` | TEXT | ✓ | — | `hide` / `unshare` / `purge` |
+| `target_kind` | TEXT | ✓ | — | `subject` / `comment` / `rendition` / `worklog_entry` / `worklog_digest` / `dig_room` / `dig_contribution` / 共有 7 型のいずれか |
+| `target_id` | TEXT | ✓ | — | 対象の id (型が混在するので TEXT) |
+| `subject_id` | UUID |  | NULL | 分かる場合の subject (purge 後は解決できないため記録しておく) |
+| `subject_key` | TEXT |  | NULL | 同上。 purge されても「何が消えたか」 が追える |
+| `owner_user_id` | TEXT |  | NULL | 取り下げられた対象の持ち主 |
+| `actor_user_id` | TEXT | ✓ | — | 取り下げを実行した人 |
+| `actor_role` | TEXT | ✓ | — | 実行時の role (`owner` / `moderator` / `admin`) |
+| `reason` | TEXT |  | NULL | |
+| `cascade_counts_json` | JSONB |  | NULL | `purge` で消えた件数 `{ comments, reactions, renditions }` |
+| `created_at` | TIMESTAMPTZ | ✓ | `now()` | |
+
+- Index: `idx_unshare_audit_created` (`created_at DESC`) /
+  `idx_unshare_audit_owner` (`owner_user_id, created_at DESC`) /
+  `idx_unshare_audit_target` (`target_kind, target_id`)
+- ローカルの `shared_at` クリア同期 (`GET /api/social/unshares?since=`) は
+  この表を `created_at` で引く
 
 ### `notifications`
 

--- a/spec/feature/README.md
+++ b/spec/feature/README.md
@@ -40,6 +40,9 @@
 | ストップワード | [stopwords.md](stopwords.md) | 🏠 | wordcloud 除外語 |
 | ノート (WYSIWYG) | [note.md](note.md) | 🏠 | esa / DocBase 風ブロックベースエディタ。 markdown + 文字色 + テーブル + Mermaid |
 | Chrome 拡張 dispatch | [extension.md](extension.md) | 🏠 | chat / impl / shopping ドメインで追加ボタンを出し分け |
+| Hub 社会層 (コメント / いいね) | [hub-social.md](hub-social.md) | ✓ | subject 単位でコメント・いいね・フィード・通知。 記事本文への範囲コメント込み |
+| 実績共有 (worklog) | [hub-worklog.md](hub-worklog.md) | ✓ | GitHub / ローカル git / activity から「やった事」 を取り込み。 **既定は非共有**、 repo 単位 opt-in + 禁止語スキャン |
+| 共同 dig (dig room) | [hub-dig-rooms.md](hub-dig-rooms.md) | ✓ | みんなでディグる。 append-only の contribution + rev 付きまとめ |
 
 ## 凡例 (項目)
 各 feature ファイルは以下のセクションを順序固定で持つ:

--- a/spec/feature/hub-dig-rooms.md
+++ b/spec/feature/hub-dig-rooms.md
@@ -1,0 +1,234 @@
+# hub-dig-rooms — みんなでディグる (共同 dig)
+
+> 1 人の deep research を **複数人で掘り進める**ための設計。
+> 関連:
+> - [`dig.md`](./dig.md) — 個人の dig セッション (Phase 0 SERP → Phase 1 preview → Phase 2 deep)
+> - [`hub-social.md`](./hub-social.md) — room / digest は subject 化され、 コメント・いいねが付く
+> - schema: [`../data/hub-social.md`](../data/hub-social.md) / API: [`../interface/hub-social.md`](../interface/hub-social.md)
+
+## 1. 何を解決するか
+
+現状の [`dig_sessions`](../data/dig.md#dig_sessions) は **1 ユーザ 1 セッションの
+スナップショット**。 Hub にシェアできるが、 出るのは `query` + Phase 2 の
+`result_json` だけで、 受け取った側は **読むことしかできない**。
+
+やりたいのは「みんなでディグれる」 =
+
+- 同じテーマを複数人が別の角度から掘る (検索軸を分担する)
+- 誰かが見つけた source を全員が見られる
+- 「これは違った」 「ここが分かった」 が蓄積する
+- 掘った結果が **1 本のまとめ**に収束していく
+- **何が既に掘られたか**が分かる (同じ URL を 3 人が別々に読む無駄を消す)
+
+これは「セッションを共有する」 のではなく **「部屋 (room) を共有する」** モデル。
+
+## 2. モデル
+
+```
+dig_rooms ─┬─ dig_room_members    (誰が参加しているか)
+           ├─ dig_contributions   (append-only の書き込み: 検索軸 / source / 発見 / 疑問)
+           ├─ dig_room_digests    (rev 付きの収束まとめ)
+           └─ dig_room_jobs       (まとめ生成の依頼キュー)
+```
+
+### 2.1 `dig_rooms`
+
+| 概念 | 内容 |
+|---|---|
+| `id` | UUID (subject key になる) |
+| `title` | 部屋の題 (「Vulkan の descriptor indexing 実装事情」 等) |
+| `question` | **掘る問い**。 部屋の存在理由を 1 文で。 これがブレると部屋が発散する |
+| `theme` | 既存 `dig_sessions.theme` と同じ軸文字列 (ローカル dig と束ねる) |
+| `state` | `open` → `digesting` → `converged` → `archived` |
+| `created_by` / `created_at` / `updated_at` | |
+
+- `converged` = 「もう掘らなくていい」 と誰かが宣言した状態。 書き込みは
+  引き続き可 (再オープンは state を `open` に戻すだけ)
+- `archived` = 読み取り専用
+
+### 2.2 `dig_contributions` — append-only の書き込み
+
+**編集も削除もしない**。 間違いは「取り消し contribution」 で上書きする
+(掘る過程そのものが情報なので、 履歴を消さない)。
+
+| `kind` | payload の中身 | 意味 |
+|---|---|---|
+| `query` | `{ query, engine?, rationale }` | 「この軸で検索してみる」 の宣言 + 実行結果件数 |
+| `source` | `{ url, title, why, quality: 'primary'\|'secondary'\|'noise' }` | 見つけた資料。 `why` (なぜ重要か) は必須 |
+| `finding` | `{ claim, confidence, sourceRefs[] }` | 「〜だと分かった」。 根拠 source への参照必須 |
+| `question` | `{ text, resolvedBy? }` | 未解決の疑問。 後から `finding` が解決する |
+| `dead_end` | `{ text, sourceRefs[] }` | 「この方向は違った」。 **他人の無駄打ちを消す最重要種別** |
+| `dig_import` | `{ localDigId, query, result }` | 自分のローカル dig session の Phase 2 結果を持ち込む |
+| `bookmark_ref` / `note_ref` | `{ subjectKey }` | 既に共有済のブクマ / ノートを部屋に結びつける |
+| `retract` | `{ targetContributionId, reason }` | 上の取り消し |
+
+- `source` は投稿時に **canonical URL 正規化** ([`hub-social.md`](./hub-social.md) §3.2) を
+  かけ、 room 内で既出なら「既出 (誰がいつ出した)」 を返して重複投稿を防ぐ
+- `finding` の `sourceRefs` は同 room 内の `source` contribution id を指す。
+  根拠なし主張を構造的に作れないようにする
+
+### 2.3 `dig_room_digests` — 収束まとめ
+
+| 概念 | 内容 |
+|---|---|
+| `rev` | 1 から連番。 **append-only** |
+| `summary_md` | 現時点の答え (問い `question` に対する回答の形で書く) |
+| `sources_json` | 採用した source の一覧 (url + role) |
+| `open_questions_json` | 未解決の `question` |
+| `dead_ends_json` | 掘っても無駄だった方向 |
+| `metrics_json` | `{ sourceCount, newSourceSinceLastRev, findingCount, openQuestionCount, contributorCount }` |
+| `generated_by` | 生成したユーザ / モデル |
+
+**掘り尽くし度**は `metrics_json.newSourceSinceLastRev` の推移で見る。
+rev が進んでも新規 source が増えなくなったら収束。 これを UI に出すと
+「まだ掘るか / もういいか」 を全員で判断できる。
+
+## 3. 進行フロー
+
+```mermaid
+sequenceDiagram
+    participant A as user A (local)
+    participant Hub as Memoria Hub
+    participant B as user B (local)
+
+    A->>A: ローカルで dig 実行 (既存 Phase 0-2)
+    A->>Hub: POST /api/dig-rooms { title, question, theme }
+    A->>Hub: POST /api/dig-rooms/:id/contributions (kind=dig_import)
+    Note over Hub: room が subject 化 → フィードに出る
+
+    B->>Hub: GET /api/feed (kinds=dig_room) → 部屋を見つける
+    B->>Hub: POST /api/dig-rooms/:id/join
+    B->>Hub: GET /api/dig-rooms/:id  (既出 source / query / dead_end を確認)
+    B->>B: 既出でない軸でローカル dig 実行
+    B->>Hub: POST .../contributions (kind=query, source, finding, dead_end)
+
+    A->>Hub: POST /api/dig-rooms/:id/digests  (= まとめ依頼)
+    Hub->>Hub: dig_room_jobs に enqueue
+    A->>Hub: GET /api/dig-rooms/jobs (ローカルが polling)
+    A->>Hub: POST /api/dig-rooms/jobs/:jid/claim
+    A->>A: ローカル LLM で contributions → summary 生成
+    A->>Hub: POST /api/dig-rooms/jobs/:jid/complete { summary_md, ... }
+    Note over Hub: digest rev+1。 watch 中の全員に通知
+```
+
+## 4. 「無駄打ちを消す」 機構
+
+共同で掘るときのいちばんの損失は **同じところを別々に掘ること**。
+部屋を開いた時点で以下を必ず見せる。
+
+- **既出 source** — canonical URL で dedup した一覧 (quality 別)
+- **既出 query** — 誰がどの軸で検索したか。 engine 込み
+- **dead_end** — 掘って外れた方向。 これを最上部に出す
+- **open_questions** — 空いている担当。 「ここ誰も見てない」 が分かる
+
+さらに投稿時のガード:
+
+- `source` 投稿が既出 URL → `409 { error: 'duplicate_source', existing }` で
+  「既出です (誰がいつ)」 を返す。 強制投稿するなら `?force=1` (別の観点で
+  同じ資料を読むこと自体は有効なので禁止はしない)
+- `query` 投稿が既出クエリと高類似 (正規化 + 語集合の Jaccard ≥ 0.8) →
+  警告付きで通す
+
+## 5. まとめ生成をどこで回すか
+
+digest 生成には LLM が要る。 Hub に LLM creds を置きたくない
+(multi-hub.md §8 / hub-aggregation.md §6 と同方針) ので 3 案。
+
+主目的 = 「まとめが確実に出る / creds と本文を Hub に増やさない」。
+
+### A. Hub が自分の LLM を叩く
+
+| 指標 | 値 |
+|---|---|
+| AI 学習量 | ★★☆☆☆ |
+| 作業コスト | 小 — Hub に LLM クライアントを 1 本 |
+| 目的達成度 | ★★★★★ — 誰もオンラインでなくても出る |
+| 主目的一致度 | ★★☆☆☆ — Hub に API key が増える。 拠点管理者が LLM 費用も負う |
+
+### B. job queue をローカルが claim (pull 型)
+
+| 指標 | 値 |
+|---|---|
+| AI 学習量 | ★★★★☆ — job queue / claim / lease / 再実行 |
+| 作業コスト | 中 — `dig_room_jobs` + ローカル polling worker |
+| 目的達成度 | ★★★★☆ — 誰かのローカルが起きていれば出る。 全員オフラインなら待つ |
+| 主目的一致度 | ★★★★★ — creds は各自のローカルのまま。 既存 LLM 設定をそのまま使える |
+
+### C. 依頼した本人のローカルが同期的に生成して push
+
+| 指標 | 値 |
+|---|---|
+| AI 学習量 | ★★☆☆☆ |
+| 作業コスト | 小 |
+| 目的達成度 | ★★★☆☆ — 依頼者に LLM が無い / 遅いと詰まる。 自動 (定期) 生成ができない |
+| 主目的一致度 | ★★★★★ |
+
+### 推奨: **B (job claim)**。 C は B の退化形として同経路で扱う
+
+- `POST /api/dig-rooms/:id/digests` は **job を作るだけ** (`202 { jobId }`)
+- ローカルは Multi 接続中 60 秒ごとに `GET /api/dig-rooms/jobs` を polling。
+  自分がメンバーの room の job を `claim` (lease 5 分、 期限切れで再割当)
+- 依頼者のローカルが即 claim できたなら実質 C になる。 別経路にしない
+- Hub 側 LLM (案 A) は **将来の任意設定**として空けておく (`digest_worker=hub` 設定)。
+  実装しないが、 job テーブルの `claimed_by` に `hub` を入れられる形にしておく
+
+## 6. ローカルとの往復
+
+- **持ち込み**: ローカル dig session → `kind=dig_import` contribution。
+  ローカル行は残り、 `dig_sessions.shared_room_id` に room を記録
+- **持ち帰り**: `POST /api/dig-rooms/:id/import-local` で room の最新 digest を
+  ローカル `dig_sessions` に 1 行として落とす (`owner_user_id` = room 作成者、
+  `theme` = room の theme)。 以降ローカルの wordcloud / 辞書リンク生成に乗る
+- **source の一括ブクマ化**: 既存 `/api/dig/:id/save` と同じ機構で、
+  room の source を自分のローカル bookmark に落とす
+
+## 7. 権限
+
+| 操作 | 誰が |
+|---|---|
+| room 作成 | member |
+| join | member (公開部屋は自由参加。 v0.1 は招待制を持たない) |
+| contribution 投稿 | room member |
+| `retract` | 元 contribution の作者 |
+| digest 依頼 | room member |
+| state 変更 (`converged` / `archived`) | room 作成者 / moderator |
+
+## 8. プライバシー観点
+
+- **共有レベル**: ✓ Hub-shareable (room に投げたものは拠点内に公開される)
+- dig のクエリは調査意図を直接示す ([`dig.md`](./dig.md) §プライバシー)。
+  room に投げる `query` contribution は **明示投稿のみ**。 ローカル dig の
+  クエリ履歴が自動で room に流れることはない
+- `dig_import` で出るのは既存 dig の共有ポリシーと同じ範囲
+  (`query` + Phase 2 `result`)。 `raw_results_json` / `preview_json` は出さない
+- LLM に送る情報: digest 生成時、 room の contributions (他メンバーの投稿を含む) を
+  claim したユーザのローカル LLM に渡す。 **これは他人の書いたものを自分の
+  LLM provider に送ることになる**ので、 room 作成時に
+  `llm_policy` (`any_member` / `creator_only` / `local_model_only`) を選べるようにする
+- 削除: room は archive のみ (削除しない)。 誤って出した contribution は
+  `retract` + moderator による hide
+
+## 9. 実装フェーズ
+
+| Phase | 内容 |
+|---|---|
+| 1 | Hub `dig_rooms` / `dig_room_members` / `dig_contributions` + 作成 / join / 投稿 / 一覧 API |
+| 2 | 重複ガード (canonical URL dedup + query 類似) + 部屋ビュー (既出 source / query / dead_end / open questions) |
+| 3 | `dig_room_jobs` + ローカル claim worker + digest 生成 (rev append) |
+| 4 | ローカル往復 (`dig_import` / `import-local` / source 一括ブクマ化) |
+| 5 | subject 化 → room / digest へのコメント・いいね。 フィードに `dig_room` を出す |
+| 6 | 掘り尽くし度メトリクス表示 + `converged` 運用 + 通知 (新 source / 新 digest) |
+
+Phase 1-2 で「重複せず分担して掘れる」、 3 で「まとまる」、 4-6 で
+「ローカルに還って反応が付く」。
+
+## 10. オープン論点
+
+1. **招待制 room** — v0.1 は拠点内公開のみ。 センシティブな調査を閉じたい要求が出るか
+2. **リアルタイム性** — polling で足りるか、 SSE / WebSocket で「今誰が掘っているか」 を出すか
+3. **room と theme の関係** — 既存 `dig_sessions.theme` と room を 1:1 にするか、
+   theme 配下に複数 room を許すか
+4. **digest の自動生成トリガ** — 新規 source が N 件溜まったら自動で job を作るか
+   (作ると LLM 費用が読めなくなる)
+5. **`finding` の対立** — 相反する finding が並んだときの扱い。 digest 側で
+   「論点」 として両立させるか、 投票で決めるか

--- a/spec/feature/hub-dig-rooms.md
+++ b/spec/feature/hub-dig-rooms.md
@@ -206,7 +206,9 @@ digest 生成には LLM が要る。 Hub に LLM creds を置きたくない
   LLM provider に送ることになる**ので、 room 作成時に
   `llm_policy` (`any_member` / `creator_only` / `local_model_only`) を選べるようにする
 - 削除: room は archive のみ (削除しない)。 誤って出した contribution は
-  `retract` + moderator による hide
+  `retract` + moderator による hide。 room ごと消す必要がある場合は
+  [`hub-social.md`](./hub-social.md) §8.1 の **admin `purge`** のみ
+  (contribution は append-only なので、 個別行の物理削除経路は持たない)
 
 ## 9. 実装フェーズ
 

--- a/spec/feature/hub-social.md
+++ b/spec/feature/hub-social.md
@@ -286,6 +286,37 @@ UNIQUE (target_kind, target_id, user_id, kind)
   rendition upload = 60/hour/user。 超過は `429 { error: 'rate_limited', retryAfter }`
 - 本文サイズ: comment `body_md` ≤ 16 KiB、 rendition text ≤ 1 MiB
 
+### 8.1 公開の取り下げ (unshare)
+
+> **決定 (neco 2026-07-30)**: 拠点内のグループ単位の部分公開は **持たない**
+> (ログインできる = 拠点メンバー = 相互に読める)。 その代わり
+> **一度公開したものを取り下げられる**ことを保証する。 取り下げは
+> **管理権限 (moderator / admin) の操作**として設計する。
+
+取り下げは 3 段階。 段階が上がるほど不可逆になる。
+
+| 段階 | 何が起きるか | 実行できるのは |
+|---|---|---|
+| `hide` | `hidden_at` / `hidden_by` / `hidden_reason` を立てる。 一覧 / フィード / API から消えるが **DB 行は残る** (復帰可・監査可) | 出した本人 / moderator |
+| `unshare` | Hub の行を削除。 ローカル原本は残り、 ローカルの `shared_at` をクリアして「未共有」 に戻す | 出した本人 / moderator |
+| `purge` | subject ごと削除。 配下の `comments` / `reactions` / `bookmark_renditions` も CASCADE で消える。 **復帰不可** | admin のみ |
+
+- **本人取り下げ**: `owner_user_id` が自分の行 (共有 7 型 / `worklog_entries` /
+  `bookmark_renditions` / 自分の `comments`) は本人が `hide` / `unshare` できる。
+  moderator 権限を待たずに引っ込められる方が事故対応が速い
+- **他人のもの**の取り下げは moderator。 `purge` だけは admin に限る
+- **既定は subject を残す**。 元オブジェクトを取り下げても subject 行は残し、
+  `title` を「(取り下げ済)」 に置換する。 理由: **他人のコメントは他人のもの**なので、
+  出した人の一存で消えない。 議論ごと消す必要がある場合は admin の `purge`
+- **監査を残す**。 `unshare_audit` に「誰が・何を・いつ・どの段階で・理由」 を記録する。
+  取り下げ自体を「なかったこと」 にはしない
+- **ローカルへの伝播**: ローカルは Multi 接続時に
+  `GET /api/social/unshares?since=` を引き、 自分の行の `shared_at` を
+  クリア / 復元する。 他人が取り下げたものはローカルに何も無いので伝播不要
+  (§9 のとおり他人のデータをローカルに持たない設計が効いている)
+- 取り下げは **退会処理の代替ではない**。 ユーザ自体の削除は Cernere 側の
+  責務で、 Hub 側は `hub_members.disabled_at` + 本人の全 `unshare` までを担う
+
 ## 9. Local / Multi との関係 (どこにデータが在るか)
 
 social 層は **Hub 専用**。 v0.1 では他人のコメント / いいねを
@@ -332,7 +363,7 @@ social 層は **Hub 専用**。 v0.1 では他人のコメント / いいねを
 | 4 | `note_block` anchor + 既存ローカル `note_comment_sets` の push/pull 配線 (`remote_id` 記録) |
 | 5 | `subject_activity` + `GET /api/feed` + ミュート。 フィード UI |
 | 6 | `notifications` + watch + ローカル pull → WebPush 配送 |
-| 7 | moderation (hide / soft delete / role) + レート制限 + `recount` |
+| 7 | moderation (hide / soft delete / role) + **取り下げ 3 段階 (§8.1) + `unshare_audit`** + レート制限 + `recount` |
 | 8 | (opt-in) 案 C の HTML rendition + `CssPath` / `Point` anchor |
 
 Phase 1-3 で「ノート / ブクマを共有して記事にコメントしていいねする」 が成立する。
@@ -341,8 +372,8 @@ Phase 2 完了後に並走できる (subject + comment + reaction があれば�
 
 ## 12. オープン論点
 
-1. **拠点内は全部見える前提でよいか** — v0.1 は「Hub にログインできる = 拠点メンバー =
-   相互に読める」。 部分公開 (グループ単位) が要るなら `subject_visibility` が必要
+1. ~~**拠点内は全部見える前提でよいか**~~ → **決定済 (2026-07-30)**。 部分公開は
+   持たず、 代わりに取り下げ (§8.1) を用意する。 `subject_visibility` は作らない
 2. **AI ノートの取り込み経路** — 「ノート (AI ノート含む)」 のうち、 外部
    (Notion 等) で書いた記事を Memoria note として取り込むなら
    `notes.source_kind='notion'` + `source_ref=<page id>` で入れる想定。

--- a/spec/feature/hub-social.md
+++ b/spec/feature/hub-social.md
@@ -1,0 +1,354 @@
+# hub-social — 共有サーバの社会層 (subject / コメント / いいね / フィード)
+
+> Memoria Hub を「置き場」 から **共同ナレッジサーバ** に上げる層の設計。
+> 関連:
+> - [`multi-hub.md`](./multi-hub.md) — Hub の **データハブ役** (Memoria 共有 7 型の JSON CRUD)。 本書はその上に載る
+> - [`hub-worklog.md`](./hub-worklog.md) — GitHub / ローカルから「過去やった事」 を取り込んで共有する層
+> - [`hub-dig-rooms.md`](./hub-dig-rooms.md) — みんなでディグる (共同 dig)
+> - [`hub-aggregation.md`](./hub-aggregation.md) — 他 LUDIARS アプリの横断集約 (別レイヤ、 本書と非依存)
+> - schema: [`spec/data/hub-social.md`](../data/hub-social.md) / API: [`spec/interface/hub-social.md`](../interface/hub-social.md)
+
+## 1. 何を解決するか
+
+やりたいことは 4 つ。
+
+1. ノート (AI が書いたノート / 外部取り込みノートを含む) を共有する
+2. ブックマークを共有する
+3. **ブックマークや記事本文にコメントを書ける**
+4. **いいねできる**
+
+1 と 2 は multi-hub.md で既に動いている (`/api/data/notes` / `/api/data/bookmarks`)。
+3 と 4 が載らないのは、 現状の共有モデルに **共有オブジェクトの同一性 (identity)**
+が無いから。
+
+### 現状モデルの構造的な穴
+
+multi-hub.md の共有は「ローカル行を Hub へ push copy する」 モデルで、
+Hub 側の行は `BIGSERIAL id` + `owner_user_id` を持つ **持ち主付きコピー**。
+
+```
+user A が https://example.com/x をシェア  → hub.bookmarks(id=11, owner=A)
+user B が https://example.com/x をシェア  → hub.bookmarks(id=27, owner=B)
+user C が https://example.com/x をシェア  → hub.bookmarks(id=48, owner=C)
+```
+
+この上に素朴にコメントを足すと `comment.bookmark_id` が 11 / 27 / 48 に散り、
+**同じ記事についての議論が 3 つに割れる**。 いいねも 3 分割されるので
+「よく読まれている記事」 も出せない。 ノートは UUID なので割れないが、
+ブックマーク / 記事本文 / worklog / dig room では割れる。
+
+→ **社会層は「持ち主付きコピー」 ではなく「話題 (subject)」 に紐づける**。
+これが本書の中心的な設計判断。
+
+## 2. 用語
+
+- **subject (話題)** — コメント・いいねが付く先の正規オブジェクト。 `kind` + `key` の
+  組で一意。 誰の持ち物でもない (= owner を持たない)
+- **anchor (アンカー)** — コメントが本文のどこを指しているかの参照。 記事本文 /
+  ノートブロックの中の範囲を指す
+- **rendition (レンディション)** — 記事本文の共有スナップショット。 全員が
+  「同じ本文」 を見るための content-addressed な保存単位
+- **reaction** — いいね等の軽量反応。 v0.1 は `like` のみ
+- **feed** — 直近に動いた subject の一覧。 「みんなが今どこを掘っているか」 の入口
+
+## 3. subject モデル
+
+### 3.1 subject 種別と key
+
+| kind | key の形 | 由来 | 用途 |
+|---|---|---|---|
+| `bookmark` | `<canonical-url>` | URL 正規化 (§3.2) | ブックマーク / 記事そのもの |
+| `note` | `<note uuid>` | `notes.id` | ノート全体 |
+| `note_block` | `<note uuid>/<block uuid>` | `note_blocks.uuid` | ノートの特定ブロック |
+| `dig_room` | `<room uuid>` | `dig_rooms.id` | 共同 dig の部屋 ([`hub-dig-rooms.md`](./hub-dig-rooms.md)) |
+| `worklog_entry` | `<provider>:<owner>/<repo>:<kind>:<ref>` | `worklog_entries` | 個々の実績 (commit / PR / release) |
+| `worklog_digest` | `<digest uuid>` | `worklog_digests.id` | 期間まとめ ([`hub-worklog.md`](./hub-worklog.md)) |
+| `dictionary_term` | `<normalized term>` | `dictionary_entries.term` | 用語 (同じ語について全員で議論できる) |
+
+subject は **要求時に生成される** (get-or-create)。 コメント / いいねを付けようと
+した瞬間に `subjects` へ upsert され、 それまでは存在しない。 これにより
+「シェアされていない URL にコメントが付く」 (= 記事は共有されているが Hub 上に
+bookmark 行が無い) 状態も自然に扱える。
+
+> subject は **共有オブジェクトの有無に依存しない**。 `bookmark` subject が
+> あって Hub 上に `bookmarks` 行が 0 件でも成立する (URL だけが同一性の根拠)。
+> 逆に `bookmarks` 行が 3 件あっても subject は 1 つ。
+
+### 3.2 URL 正規化 (canonical URL)
+
+`bookmark` subject の同一性はここで決まるので、 **ローカルと Hub で同一実装**を
+使う。 実装は `server/shared/canonical-url.ts` に置き、 Hub (`server/multi/`) は
+それを import する (domain 間 cross-import 禁止のため `shared/` 配置)。
+
+手順 (決定的):
+
+1. scheme / host を lowercase、 `http` → `https`、 既定ポート (`:80` / `:443`) を除去
+2. host の末尾 `.` を除去、 IDN は punycode 正規化
+3. path: 連続スラッシュを 1 つに畳む。 末尾スラッシュを除去 (path が `/` 単体のときは残す)
+4. fragment を除去。 ただし `#!` 始まり、 および §3.3 の domain ルールで
+   「hash がルートを表す」 と宣言された host は保持
+5. query: **除去リスト**にマッチするキーを落とす —
+   `utm_*` / `gclid` / `gbraid` / `wbraid` / `fbclid` / `msclkid` / `igshid` /
+   `mc_cid` / `mc_eid` / `_ga` / `_gl` / `yclid` / `spm` / `ref` / `ref_src` /
+   `ref_url` / `share` / `s` (twitter/x のみ) / `si` (youtube のみ)
+6. 残った query を **キー昇順**でソート (同キーは値昇順)。 空値キー (`?a=`) は保持
+7. percent-encoding: unreserved 文字は decode、 残りは大文字 hex に統一
+8. 全体を Unicode NFC 正規化
+9. 結果文字列を `subjects.key`、 `sha256(key)` を `subjects.key_hash` に保存
+   (長い URL の index 効率と UNIQUE 制約のため。 UNIQUE は `(kind, key_hash)`)
+
+### 3.3 domain 別ルール
+
+一般則だけでは同一性を取り違えるサイトがあるので、 host 単位の上書きを持つ。
+
+| ルール | 例 |
+|---|---|
+| `keep_query` — 指定キーのみ残す | `youtube.com`: `v` `list` のみ / `docs.google.com`: `id` のみ |
+| `keep_hash` — fragment を保持 | SPA ルーティングのドキュメントサイト |
+| `strip_path_suffix` — 末尾を落とす | `/amp` / `/index.html` |
+| `alias_host` — host を寄せる | `m.example.com` → `example.com` / `youtu.be` → `youtube.com` (`/xxx` → `/watch?v=xxx`) |
+
+ルールは `url_canonical_rules` テーブル (Hub) + 同内容の既定 JSON (ローカル同梱) で持つ。
+**Hub 側ルールが正**で、 ローカルは起動時 / Multi 接続時に pull してキャッシュする。
+ルール変更で既存 subject の key が変わりうるので、 ルール更新は
+`subject_key_migrations` に記録し、 旧 key → 新 key の **別名解決** (`subject_aliases`)
+を残す (= 過去のコメントが迷子にならない)。
+
+## 4. コメント
+
+### 4.1 データ構造 — flat + 1 段返信
+
+```
+comments(id uuid, subject_id, author_user_id, parent_comment_id?, anchor_json?, body_md, ...)
+```
+
+- **flat**。 `parent_comment_id` は 1 段だけ許す (返信の返信は同じ親にぶら下げる)。
+  深いツリーは読みにくく、 UI コストが跳ねるので v0.1 では取らない
+- 本文は **markdown インライン + ブロック** (ノート本文と同じサブセット)。 HTML は保存しない
+- `anchor_json` が NULL = subject 全体へのコメント、 非 NULL = 本文内アンカー付き
+
+### 4.2 既存 `note_comment_sets` との整合
+
+ローカル SQLite には既に
+[`note_comment_sets`](../data/note.md#note_comment_sets) (1 note × 1 user) +
+`note_comments` の 2 段構造がある。 Hub 側では **set テーブルを持たない**。
+
+> **set = (subject, author) でグルーピングした comments の射影**として扱う。
+> `GET /api/social/comments?subject=<id>&group=author` が set 相当のレスポンスを返す。
+
+理由: worklog / bookmark / dig room にもコメントを付けるので、 「note 専用の
+set テーブル」 を全 kind ぶん増やすと table が kind 数だけ増える。 グルーピングは
+クエリで足りる。
+
+ローカル側の 2 段構造は **自分のコメントのローカル原本**として維持する
+(オフラインで書ける / Local モードで見える)。 共有時に
+`note_comment_sets` 配下の各行が Hub の `comments` 1 行として push され、
+`note_comments.remote_id` に Hub 側 id が記録される。
+
+### 4.3 anchor — 記事本文 / ブロック本文へのコメント
+
+「記事内容にコメント書ける」 の中核。 アンカーは
+**W3C Web Annotation Selector に倣った複数セレクタの束**にする。
+1 つの手段に賭けると本文がわずかに変わった時に全部迷子になるため。
+
+```ts
+type Anchor = {
+  /** 解決対象。 bookmark subject なら rendition、 note_block なら block 本文 */
+  target: { kind: 'rendition'; renditionId: string }
+        | { kind: 'note_block'; noteId: string; blockUuid: string };
+  selectors: Array<
+    | { type: 'TextQuote';    exact: string; prefix?: string; suffix?: string }
+    | { type: 'TextPosition'; start: number; end: number }
+    | { type: 'CssPath';      value: string; startOffset: number; endOffset: number }
+    | { type: 'Point';        x: number; y: number }   // canvas 用 (下記)
+  >;
+};
+```
+
+**解決順**: `TextQuote` → `TextPosition` → `CssPath`。 先に解決できたものを採る。
+
+- `TextQuote` は本文の差分に強い (prefix/suffix 32 文字で曖昧性を除去)
+- `TextPosition` は高速。 rendition が完全一致するとき有効
+- `CssPath` は画像やテーブルなど非テキスト要素へのアンカー用
+- `Point` は既存の
+  [`floating_text.anchor`](../data/note.md#floating_text-の-data_json-shape) の
+  `kind:'point'` 相当。 ブックマークノートの canvas に貼った付箋を社会層に
+  上げるときの互換用。 既存 `kind:'text'` (selector + startOffset/endOffset) は
+  `CssPath` セレクタに 1:1 で写せる
+
+**解決失敗時は消さない**。 `comments.anchor_state` を `resolved` / `orphan` に
+分け、 orphan は「本文にひもづかないコメント」 として一覧の末尾に出す。
+本文が更新されて再解決できたら `resolved` に戻す (再解決は表示時に試行)。
+
+### 4.4 記事本文の共有 (rendition)
+
+記事本文にアンカー付きコメントを打つには、 **全員が同じ本文を見ている**必要がある。
+ところが現状 Hub は HTML を持たない (migration 001 のコメント:
+`HTML body is *not* stored here; only the metadata.`)。 各自のローカル
+アーカイブは取得時刻もリーダー抽出結果も違うので、 そのままではアンカーが揃わない。
+
+3 案を LUDIARS 標準軸で比較 (主目的 =「同じ本文を指して議論できること」)。
+
+#### A. rendition を持たない (ライブページに対して解決)
+
+| 指標 | 値 |
+|---|---|
+| AI 学習量 | ★★☆☆☆ — セレクタ解決だけ |
+| 作業コスト | 小 — 追加ストア無し |
+| 目的達成度 | ★★☆☆☆ — ページ改変 / 消滅 / ログイン壁で壊れる。 各自の閲覧結果も揃わない |
+| 主目的一致度 | ★★☆☆☆ — 「同じ本文」 が保証されない |
+
+#### B. Hub が抽出本文 (text) のみ持つ
+
+| 指標 | 値 |
+|---|---|
+| AI 学習量 | ★★★☆☆ — 本文抽出の決定化 + content addressing |
+| 作業コスト | 中 — `bookmark_renditions` + 抽出パイプラインの共通化 |
+| 目的達成度 | ★★★★☆ — TextQuote / TextPosition が安定して効く。 図表は指せない |
+| 主目的一致度 | ★★★★★ — 保存するのは共有意図のある記事の本文のみ。 容量も小さい |
+
+#### C. Hub が HTML スナップショットも持つ
+
+| 指標 | 値 |
+|---|---|
+| AI 学習量 | ★★★★☆ — sanitize / 資産 rewrite / 容量管理 |
+| 作業コスト | 大 — object storage・sanitizer・容量上限・削除運用 |
+| 目的達成度 | ★★★★★ — 見た目ごと同一。 `CssPath` / `Point` も効く |
+| 主目的一致度 | ★★★☆☆ — 第三者ページの複製を共有サーバに置くことになる (再配布の色が付く) |
+
+#### 推奨: **B を v0.1、 C は opt-in 拡張**
+
+- **v0.1 = B**。 `bookmark_renditions` に「抽出本文 (text) + 見出し構造 + sha256」 を保存。
+  アンカーは `TextQuote` + `TextPosition` の 2 本で十分に効く
+- **C は per-bookmark の明示 opt-in** (`share_html=true`) にして、 サーバ設定で
+  機能自体を無効化できるようにする。 拠点ポリシーで「本文複製は置かない」 を選べる
+- rendition は **content-addressed** (`sha256(normalized_text)` を id 代わりの
+  `content_hash` に)。 同じ記事を 3 人がシェアしても本文は 1 つ。
+  取得時刻の違いで本文が変わった場合は rendition が 2 つ並び、
+  コメントは自分が打った rendition に紐づく。 UI は「最新 rendition」 を既定表示し、
+  他 rendition のコメントは TextQuote 再解決を試みてマージ表示する
+
+## 5. いいね (reaction)
+
+```
+reactions(id, target_kind('subject'|'comment'), target_id, user_id, kind, created_at)
+UNIQUE (target_kind, target_id, user_id, kind)
+```
+
+- v0.1 の `kind` は `like` のみ。 将来の絵文字リアクションのために列は残す
+  (`kind` を enum 化せず TEXT + アプリ側 allowlist)
+- **subject にも comment にも付く**。 「記事にいいね」 と「コメントにいいね」 は同じ経路
+- カウンタは `subjects.like_count` / `comments.like_count` に非正規化し、
+  **DB トリガで維持**する (アプリ側インクリメントは二重計上・欠落が出るため)。
+  整合確認用に `POST /api/social/admin/recount` を持つ
+- 取り消しは `DELETE` (行を消す)。 誰がいいねしたかは
+  `GET /api/social/reactions?target=...` で取れる (拠点内は相互に見える前提)
+
+## 6. フィード — 「みんなでディグれる」 の入口
+
+社会層があっても入口が無いと使われない。 `GET /api/feed` が
+**直近に動いた subject** を返す。
+
+- 並び: `active` (最終アクティビティ降順) / `new` (subject 作成降順) /
+  `liked` (期間内 like 数降順) / `hot` (like + comment を時間減衰させたスコア)
+- 絞り込み: `kinds` / `tags` / `repo` (worklog) / `author` / `since`
+- 各行は `{ subject, latestActivity, commentCount, likeCount, participants[], excerpt }`
+- `subject_activity` テーブル (subject × 日 の集計) を持ち、 フィードと
+  「掘り尽くし度」 表示の両方が使う
+- ミュート: `subject_mutes` (user × subject) — 自分のフィードから外す
+
+## 7. 通知
+
+- `notifications(id, user_id, kind, subject_id, comment_id?, actor_user_id, read_at)`
+- `kind`: `reply` (自分のコメントへの返信) / `mention` (`@user` 記法) /
+  `like` (自分のコメント / 自分がシェアしたオブジェクトへの like) /
+  `subject_activity` (watch している subject が動いた)
+- watch: 自分がコメント or like した subject は自動 watch。 `subject_watches` で明示追加も可
+- 配送は **ローカルが pull して自分の端末に出す**。 Hub は WebPush 鍵を持たない
+  (`push_subscriptions` はローカル専用テーブルのまま)。 ローカルが Multi 接続中に
+  `GET /api/notifications?unread=1` を定期取得し、 既存の
+  [push-notification](./push-notification.md) 経路で通知する
+
+## 8. 権限・モデレーション・濫用対策
+
+| 対象 | 作成 | 編集 | 削除 |
+|---|---|---|---|
+| comment | member | 作者のみ | 作者 / moderator |
+| reaction | member | — | 本人のみ |
+| subject | member (get-or-create) | moderator (title 等) | 不可 (hide のみ) |
+| rendition | member (シェア時) | — | moderator (hide) |
+
+- role は `hub_members(user_id, role)` — `member` / `moderator` / `admin`。
+  Cernere のユーザ属性ではなく **Hub ローカルの役割**として持つ (拠点ごとに違うため)
+- 削除は soft delete (`deleted_at` + 本文を空文字に置換)。 スレッドの構造を壊さない
+- moderator の hide は既存 7 型と同じ `hidden_at` / `hidden_by` / `hidden_reason` を踏襲
+- レート制限: comment = 30/10min/user、 reaction = 300/10min/user、
+  rendition upload = 60/hour/user。 超過は `429 { error: 'rate_limited', retryAfter }`
+- 本文サイズ: comment `body_md` ≤ 16 KiB、 rendition text ≤ 1 MiB
+
+## 9. Local / Multi との関係 (どこにデータが在るか)
+
+social 層は **Hub 専用**。 v0.1 では他人のコメント / いいねを
+ローカル SQLite に永続化しない。
+
+| データ | ローカル SQLite | Hub Postgres |
+|---|---|---|
+| 自分のコメント (note) | ✅ 原本 (`note_comment_sets` / `note_comments`) | ✅ push copy |
+| 自分のコメント (bookmark / worklog / dig room) | ❌ (v0.1 は Hub 直書き) | ✅ 原本 |
+| 他人のコメント | ❌ 保持しない | ✅ |
+| いいね | ❌ | ✅ |
+| rendition | ローカルの `html/` アーカイブ (既存) | ✅ 抽出本文 (共有分のみ) |
+| フィード / 通知 | ❌ | ✅ |
+
+- **Local モード**では社会層は見えない。 ただし「この記事は Hub に N 件コメント」 の
+  バッジだけは、 接続済 Hub があれば on-demand で問い合わせて出す
+  (`GET /api/social/subjects/resolve` を 1 回叩くだけ。 結果はメモリキャッシュ 60 秒)
+- **Multi モード**では社会層をライブ読み書きする (multi-hub.md §5.3 の proxy に相乗り)
+- 双方向同期エンジンは **作らない**。 「他人の書いたものはサーバにあり、
+  ローカルには落ちてこない」 を明示的な境界にする。 落としたくなったら
+  それは v0.2 以降の別設計 (conflict 解決が必要になる)
+
+## 10. プライバシー観点
+
+- 社会層に載るのは **共有意図のあるオブジェクトについての発言**だけ。
+  個人ログ (diary / GPS / meals / visits / activity) は subject 化しない
+  (multi-hub.md §4 の ❌ 群は kind として存在しない)
+- `dictionary_term` subject は用語文字列のみを key にする。 その語をいつ
+  どこで調べたか (= 検索意図) は Hub に出さない
+- rendition に載るのは第三者ページの抽出本文。 自分の memo / 要約は
+  既存 `bookmarks.memo` / `summary` の共有ポリシーに従う (= 明示シェア分のみ)
+- 通知は Hub 上で生成されるが、 端末への配送はローカル経由。 WebPush の
+  endpoint / 鍵は Hub に出さない
+- ログにはユーザ本文を出さない。 subject id / kind / 件数・所要時間まで
+  (hub-aggregation.md §10 と同方針)
+
+## 11. 実装フェーズ
+
+| Phase | 内容 |
+|---|---|
+| 1 | `server/shared/canonical-url.ts` + `subjects` / `subject_aliases` / `url_canonical_rules`。 `bookmarks.url_canonical` 列追加 + 既存行バックフィル。 `GET/POST /api/social/subjects/resolve` |
+| 2 | `comments` + `reactions` + トリガ (カウンタ)。 subject 全体コメント + いいね。 ローカル Multi モード UI (ノート / ブクマ詳細にコメント欄) |
+| 3 | `bookmark_renditions` (案 B: 抽出本文) + anchor 解決 (`TextQuote`/`TextPosition`)。 記事本文への範囲コメント |
+| 4 | `note_block` anchor + 既存ローカル `note_comment_sets` の push/pull 配線 (`remote_id` 記録) |
+| 5 | `subject_activity` + `GET /api/feed` + ミュート。 フィード UI |
+| 6 | `notifications` + watch + ローカル pull → WebPush 配送 |
+| 7 | moderation (hide / soft delete / role) + レート制限 + `recount` |
+| 8 | (opt-in) 案 C の HTML rendition + `CssPath` / `Point` anchor |
+
+Phase 1-3 で「ノート / ブクマを共有して記事にコメントしていいねする」 が成立する。
+[`hub-worklog.md`](./hub-worklog.md) / [`hub-dig-rooms.md`](./hub-dig-rooms.md) は
+Phase 2 完了後に並走できる (subject + comment + reaction があれば載る)。
+
+## 12. オープン論点
+
+1. **拠点内は全部見える前提でよいか** — v0.1 は「Hub にログインできる = 拠点メンバー =
+   相互に読める」。 部分公開 (グループ単位) が要るなら `subject_visibility` が必要
+2. **AI ノートの取り込み経路** — 「ノート (AI ノート含む)」 のうち、 外部
+   (Notion 等) で書いた記事を Memoria note として取り込むなら
+   `notes.source_kind='notion'` + `source_ref=<page id>` で入れる想定。
+   取り込み方向 (Notion → Memoria の一方向 pull か双方向か) は未決
+3. **rendition の保持期間** — 記事本文をいつまで持つか。 コメントが 1 件も無い
+   rendition を GC してよいか
+4. **`dictionary_term` の正規化** — 大文字小文字 / 全角半角 / 送り仮名の寄せをどこまでやるか
+5. **匿名 like を許すか** — 拠点が小さいと「誰がいいねしたか」 が常に分かる。
+   それを嫌う運用があるか

--- a/spec/feature/hub-worklog.md
+++ b/spec/feature/hub-worklog.md
@@ -191,7 +191,9 @@ Multi モードでは他メンバーの worklog も同じビューで見える (
 - 削除: `DELETE /api/worklog/entries/:id` はローカル行を消す。 Hub の push 済行は
   `DELETE /api/worklog/entries/:id?remote=1` で明示的に消す (自動追随はしない)。
   subject 化されたコメントは残る (発言は他人のもの) が、 subject の title は
-  「(削除済)」 に置換する
+  「(削除済)」 に置換する。 公開そのものの取り下げは
+  [`hub-social.md`](./hub-social.md) §8.1 の 3 段階 (`hide` / `unshare` / `purge`) に従う —
+  **entry の持ち主本人が `unshare` できる** (moderator を待たない)
 
 ## 9. 実装フェーズ
 

--- a/spec/feature/hub-worklog.md
+++ b/spec/feature/hub-worklog.md
@@ -1,0 +1,223 @@
+# hub-worklog — 「過去やった事」 の取り込みと共有
+
+> GitHub / ローカル git clone / Memoria 自身の活動ログを食わせて
+> **やった事をリストアップし、 共有する**層の設計。
+> 関連:
+> - [`hub-social.md`](./hub-social.md) — worklog entry / digest は subject 化され、 コメント・いいねが付く
+> - [`implementation-notes.md`](./implementation-notes.md) — 手動の「実装自慢ノート」。 worklog の手入力ソース
+> - [`../data/activity.md`](../data/activity.md) — ローカルの `activity_events` (既存の取り込み先)
+> - schema: [`../data/hub-social.md`](../data/hub-social.md) / API: [`../interface/hub-social.md`](../interface/hub-social.md)
+
+## 1. 何を解決するか
+
+「自分が過去に何をやったか」 は既にローカルに散在している —
+`activity_events` (git commit / AI prompt)、 `agent_runs`、 `repo_watch`、
+`implementation_notes`、 そしてローカル git clone 本体。 だが:
+
+- **粒度が細かすぎる**。 commit 1 行では「何をやったか」 が分からない
+- **一覧化されていない**。 「先月やった事」 を人に見せられる形が無い
+- **共有経路が無い**。 `implementation_notes` だけが手動で Hub に出せる
+
+なので 3 段で作る。
+
+```
+[取り込み]            [正規化]              [まとめ]              [共有]
+GitHub API      ─┐
+ローカル git log ─┼─► worklog_entries ──► worklog_digests ──► Hub (subject 化)
+activity_events ─┤     (1 事象 1 行)      (期間 × 範囲の要約)     └─ コメント / いいね
+implementation_ ─┘
+notes / 手入力
+```
+
+## 2. 取り込み (ingest)
+
+### 2.1 取り込みはローカルで走らせる
+
+Hub には **GitHub token もローカルクローンも無い**。 だから取り込みは
+必ずローカル Memoria 側で実行し、 正規化済み entry を Hub へ push する。
+
+> Hub が直接 GitHub を叩く経路は作らない。 token を Hub に置かないため
+> ([[feedback_secret_per_user_memory_only]] と同方針)。 public repo でも同じ。
+
+### 2.2 ソース種別
+
+| source | 取り方 | 取れるもの |
+|---|---|---|
+| `github` | GitHub REST/GraphQL (既存 [`repo-watch.ts`](../../server/lib/repo-watch.ts) のクライアントを流用) | commit / PR / issue / review / release |
+| `git_local` | 登録済ローカルクローンに `git log --author=<self> --no-merges` | commit (未 push 分も取れる) |
+| `activity` | ローカル `activity_events` | AI prompt 数 / タスク操作 (= 「どれだけ手を動かしたか」 の density) |
+| `impl_note` | `implementation_notes` (`shareable=1`) | 手書きの「これを作った」 |
+| `manual` | UI から直接入力 | GitHub に出ない仕事 (設計・資料・打ち合わせ) |
+
+登録は `worklog_sources` (ローカル SQLite)。 1 行 = 1 リポ (または 1 手動スコープ) で、
+**取り込み有効/無効**と**共有ポリシー** (§4) を持つ。
+
+### 2.3 スケジュール
+
+- 既定は **1 時間ごとの増分取り込み** (既存 `server/lib/queues.ts` の queue に載せる)
+- 増分の境界は source ごとの `last_ingested_at` + provider 側の `since` パラメータ
+- 手動全再取り込み (`POST /api/worklog/ingest?full=1`) は rate limit 考慮で
+  repo あたり 1 回/日
+
+## 3. 正規化 — `worklog_entries`
+
+1 事象 = 1 行。 provider 差を吸収した共通形にする。
+
+| 概念 | 内容 |
+|---|---|
+| 同一性 | `(provider, repo_key, kind, ref)` UNIQUE。 再取り込みは upsert |
+| `kind` | `commit` / `pr` / `issue` / `review` / `release` / `impl_note` / `manual` |
+| `ref` | commit sha / `pr/123` / `issue/45` / tag 名 / note id |
+| `occurred_at` | commit author date / PR merged_at (無ければ created_at) |
+| `title` | commit message 1 行目 / PR title |
+| `body_md` | PR body / commit body (共有ポリシーで落ちうる、 §4) |
+| `url` | html_url (Hub は本文ビューアを持たず、 元ホスティングへ飛ばす) |
+| `stats_json` | `{ additions, deletions, filesChanged, commentCount }` |
+| `labels_json` | PR/issue の label。 分類の手掛かり |
+| `parent_ref` | commit が属する PR の ref。 畳み込みに使う (§3.1) |
+
+### 3.1 畳み込み (roll-up)
+
+commit をそのまま並べると「やった事」 にならない。 表示・要約の既定単位は
+**PR / release**。
+
+- `parent_ref` が埋まっている commit は既定で一覧から隠し、 PR 行の配下に畳む
+- PR に属さない commit (main 直 push / ローカル未 push) は **単独行として出す**。
+  隠すと実際の作業が消えるため ([[project_ludiars_no_branch_protection]] のとおり
+  直 push は現実に発生している)
+- `git_local` 由来の commit が後から `github` 由来の PR に紐づいたら、
+  `parent_ref` を後追いで埋める (`ref` = sha が一致するので同一性は保てる)
+
+### 3.2 重複排除
+
+- 同じ commit が `git_local` と `github` の両方から来る → `(provider, ...)` が
+  違うので別行になってしまう。 これを避けるため **`repo_key` は provider 非依存**
+  (`<owner>/<name>` に正規化) にし、 UNIQUE は `(repo_key, kind, ref)` とする。
+  provider は「どの経路で最初に取れたか」 を記録する情報列に格下げする
+- `activity` 由来の `git_commit` イベントも同じ sha を持つので同一行に寄る
+
+## 4. 共有ゲート — 漏らさないための機構
+
+ここが本機能でいちばん壊れやすい。 worklog は **private repo 名・顧客名・
+社内固有名がそのまま入る**。 何もしないと Hub に出た瞬間に漏れる
+([[feedback_external_doc_redaction_rules]])。
+
+### 4.1 既定は非共有
+
+`worklog_sources.share_policy` の既定は `none`。 取り込みはしても Hub には出ない。
+「ローカルで自分の実績を眺める」 だけなら Hub は不要。
+
+| policy | Hub に出るもの |
+|---|---|
+| `none` (既定) | 何も出ない |
+| `redacted` | repo は **alias 名**、 title は要約後の文、 body/path/branch は出さない |
+| `full` | title / body / labels / stats / url まで出る |
+
+### 4.2 `redacted` の中身
+
+- `repo_alias` — `worklog_sources.alias` (例: `社内ツールA`)。 alias 未設定で
+  `redacted` を選ぼうとしたら **設定エラーで拒否** (うっかり本名が出るのを防ぐ)
+- `title` — 原文を出さず、 ローカル LLM で「固有名を含まない 1 行要約」 に置換
+- `url` — 出さない (private repo の URL は 404 だが repo 名が入るため)
+- `stats_json` — 出す (数値のみ)
+- `labels_json` — allowlist に載ったラベルのみ
+
+### 4.3 push 前の機械スキャン (必須ゲート)
+
+policy を通した後、 **push する JSON 全体に禁止語スキャンをかける**。
+
+- 禁止語辞書 = `LUDIARS/PROJECT-CODES.md` 由来の private リポ名 + 顧客名 +
+  ユーザ定義の追加語 (`worklog_redaction_terms`)
+- 大文字小文字無視 + 全角半角正規化 + よくある区切り (`-` / `_` / 空白) を無視して照合
+- **1 件でも hit したら push 全体を中止**し、 「どの entry のどのフィールドに
+  どの語が出たか」 を返す。 自動書き換えはしない (勝手に文意を変えないため)
+- スキャンは push 経路の内側 (`server/worklog/redaction.ts`) に置き、
+  UI からの手動 push も定期 push も同じ関数を通る。 バイパス経路を作らない
+
+> `grep` 相当の単純照合では文字列連結や表記ゆれをすり抜ける
+> ([[feedback_delegation_verification_beyond_grep]])。 スキャンは
+> **正規化後の全文**に対してかけ、 テストは「連結・全角・区切り違い」 を
+> 明示ケースとして持つ。
+
+## 5. まとめ — `worklog_digests`
+
+「過去やった事をリストアップ」 の成果物。 期間 × 範囲で 1 本のまとめを作る。
+
+- **範囲 (scope)**: `user` (自分の全リポ) / `repo` / `topic` (label や
+  キーワードで束ねた軸)
+- **期間**: 週 / 月 / 任意区間
+- 生成は **ローカル LLM** (Hub に LLM creds を置かない)。 入力は共有ポリシー
+  適用済の entry 群 (= 出せないものは要約の材料にもしない)
+- 出力: `summary_md` (何をやったか) + `highlights_json` (代表 entry の ref 配列) +
+  `metrics_json` (PR 数 / commit 数 / 変更行数 / 稼働日数)
+- **append-only の rev**。 同じ (scope, period) で作り直すと `rev` が増える。
+  過去 rev は消さない (後から見て「その時どう総括したか」 が残る)
+
+digest は subject 化される (`worklog_digest`) ので、 まとめに対して
+コメント・いいねが付く = 「先月これやりました」 に反応が返る。
+
+## 6. 表示
+
+| ビュー | 内容 |
+|---|---|
+| タイムライン | 日付降順。 PR 単位に畳んだ既定表示 + 「commit も出す」 トグル |
+| リポ別 | `repo_key` ごとの件数 + 最終活動 + digest 一覧 |
+| トピック別 | label / キーワード軸。 「認証まわりをいつやったか」 |
+| ヒートマップ | 日 × 件数。 `activity` 由来の density を重ねる |
+| digest | 期間まとめ (rev 切替 + コメント欄) |
+
+Multi モードでは他メンバーの worklog も同じビューで見える (共有分のみ)。
+「誰が何を作ってきた人か」 が分かるのがこの機能の価値。
+
+## 7. API
+
+[`../interface/hub-social.md`](../interface/hub-social.md) の worklog 節に集約。
+概要:
+
+| 側 | endpoint |
+|---|---|
+| ローカル | `GET /api/worklog` / `GET /api/worklog/sources` / `POST /api/worklog/sources` / `POST /api/worklog/ingest` / `POST /api/worklog/digests` / `POST /api/worklog/push` |
+| Hub | `GET /api/worklog` / `POST /api/worklog/entries:batch` / `GET /api/worklog/digests` / `POST /api/worklog/digests` |
+
+## 8. プライバシー観点
+
+- **共有レベル**: ✓ Hub-shareable (既定 `none`、 repo 単位 opt-in)
+- 個人データを保持するテーブル: `worklog_entries` (誰がいつ何を書いたかの記録)。
+  ローカルには全量、 Hub にはポリシー通過分のみ
+- **LLM に送る情報**: `redacted` の title 要約と digest 生成でローカル LLM に
+  entry の title / body を渡す。 送る先はローカル設定の provider
+  ([`llm-config.md`](./llm-config.md))。 `none` policy の source も digest 生成の
+  対象外にすれば LLM にも渡らない (`worklog_sources.llm_optout`)
+- 削除: `DELETE /api/worklog/entries/:id` はローカル行を消す。 Hub の push 済行は
+  `DELETE /api/worklog/entries/:id?remote=1` で明示的に消す (自動追随はしない)。
+  subject 化されたコメントは残る (発言は他人のもの) が、 subject の title は
+  「(削除済)」 に置換する
+
+## 9. 実装フェーズ
+
+| Phase | 内容 |
+|---|---|
+| 1 | ローカル `worklog_sources` / `worklog_entries` schema + `git_local` 取り込み (既存クローンから commit) + タイムライン表示 |
+| 2 | `github` 取り込み (commit / PR / issue / release) + 畳み込み (`parent_ref`) + 重複排除 |
+| 3 | `activity` / `impl_note` / `manual` ソース。 リポ別 / トピック別 / ヒートマップ |
+| 4 | 共有ゲート — `share_policy` + alias + `redaction.ts` の禁止語スキャン + テスト |
+| 5 | Hub `worklog_entries` テーブル + `POST /api/worklog/entries:batch` + push 配線 |
+| 6 | `worklog_digests` (ローカル生成 → Hub push) + digest ビュー |
+| 7 | subject 化 ([`hub-social.md`](./hub-social.md) Phase 2 以降) → コメント・いいね |
+
+Phase 1-3 で「自分の実績が一覧になる」、 4-5 で「安全に共有できる」、
+6-7 で「まとめに反応が付く」。
+
+## 10. オープン論点
+
+1. **`repo_key` の namespace 衝突** — GitHub 以外 (GitLab / 社内 Gitea) を足したとき
+   `<owner>/<name>` が衝突しうる。 `host` を key に含めるか
+2. **他人の commit をどう扱うか** — 既定は「自分が author の分だけ」。 レビューした
+   PR や共同作業をどこまで自分の worklog に入れるか
+3. **禁止語辞書の配布** — `PROJECT-CODES.md` 由来の private リポ名リストを
+   どこから取るか (Castra 参照 / 手動同期 / Hub から pull)
+4. **`full` policy を許すか** — 拠点ポリシーで `full` を禁止できるようにするか
+   (サーバ設定で最大許容ポリシーを縛る)
+5. **digest の生成主体** — 複数メンバーの worklog を横断した digest
+   (= 「チームの先月」) は誰の LLM で作るか。 [`hub-dig-rooms.md`](./hub-dig-rooms.md)
+   §5 の job claim と同じ仕組みに乗せるのが自然

--- a/spec/feature/multi-hub.md
+++ b/spec/feature/multi-hub.md
@@ -26,6 +26,22 @@ share/download する」 モデルだった。 これだと:
 > [`hub-shell.md`](./hub-shell.md) を参照。 2 役は Hub 内で同居するが
 > 互いに依存しない。
 
+### Hub の役割マップ
+
+Hub には現在 4 つの層がある。 本書は 1 番目。
+
+| 層 | 役割 | 設計 |
+|---|---|---|
+| **データハブ** | Memoria 自身の共有 7 型を Postgres で集中保持 | **本書** |
+| **社会層** | 共有物に対するコメント / いいね / フィード / 通知 | [`hub-social.md`](./hub-social.md) |
+| **横断集約** | 他 LUDIARS アプリのデータを横断 API として束ねる | [`hub-aggregation.md`](./hub-aggregation.md) |
+| **frontend shell** | 複数アプリの UI を 1 画面に集約レンダリング | [`hub-shell.md`](./hub-shell.md) |
+
+社会層の上に載る 2 つの応用機能:
+
+- [`hub-worklog.md`](./hub-worklog.md) — GitHub / ローカルから「過去やった事」 を取り込み共有する
+- [`hub-dig-rooms.md`](./hub-dig-rooms.md) — みんなでディグる (共同 dig)
+
 ## 2. アーキテクチャ
 
 ```
@@ -102,6 +118,23 @@ share/download する」 モデルだった。 これだと:
 | review targets | ❌ ローカル専用 | ローカル git clone を指す |
 
 Multi モード時、 ❌ のタブは **グレーアウト** (= 「この機能は Local モード専用」 と表示)。
+
+### Hub ネイティブなデータ型
+
+上表の 7 型は「ローカルに原本があり Hub に copy が出る」 型。 これとは別に、
+**Hub 上にしか存在しない** 型がある (社会層以降で追加)。
+
+| データ型 | 原本 | 設計 |
+|---|---|---|
+| subject (話題) | Hub のみ | [`hub-social.md`](./hub-social.md) |
+| comment / reaction | Hub のみ (ノートのコメントだけローカルにも原本がある) | 同上 |
+| rendition (記事本文) | Hub のみ (ローカルの `html/` アーカイブとは別物) | 同上 |
+| notification / feed | Hub のみ | 同上 |
+| worklog entry / digest | **ローカルに原本**、 ポリシー通過分のみ Hub へ | [`hub-worklog.md`](./hub-worklog.md) |
+| dig room / contribution | Hub のみ | [`hub-dig-rooms.md`](./hub-dig-rooms.md) |
+
+これらは Local モードでは触れない (worklog を除く)。 縮退動作は
+[`../interface/hub-social.md`](../interface/hub-social.md) §8。
 
 ## 5. シーケンス
 
@@ -193,6 +226,11 @@ sequenceDiagram
 `<type>` = `bookmarks | digs | dictionary | implementation-notes | work-locations | domain-catalog | notes`。
 旧 `/api/shared/*` は移行期間中残し、 Phase 6 で撤去。
 
+社会層 (`/api/social/*` / `/api/feed` / `/api/notifications` / `/api/worklog/*` /
+`/api/dig-rooms/*`) は本表とは別系統で、 契約は
+[`../interface/hub-social.md`](../interface/hub-social.md) にある。
+`/api/data/*` は変更しない。
+
 ### 6.2 ローカル側 (新規 / 変更)
 
 | method | path | 説明 |
@@ -222,6 +260,11 @@ endpoint は Multi モード時 `503 { error: 'local_only' }`。
 | 6 | cleanup — 旧 `/api/multi/{connect,finish,proxy,share,download}` + `/api/shared/*` 撤去 |
 
 各フェーズ完了で commit + 動作確認。
+
+社会層以降のフェーズは本書には含めない —
+[`hub-social.md`](./hub-social.md) §11 / [`hub-worklog.md`](./hub-worklog.md) §9 /
+[`hub-dig-rooms.md`](./hub-dig-rooms.md) §9 を参照。 いずれも本書 Phase 3
+(Hub の `/api/data/*`) が前提。
 
 ## 8. プライバシー観点
 

--- a/spec/interface/README.md
+++ b/spec/interface/README.md
@@ -44,6 +44,7 @@ spec/api/
 | GPS / アクセス | [visit.md](visit.md) | `/api/locations*`, `/api/visits*`, `/api/page-metadata*` |
 | 設定 | [config.md](config.md) | `/api/privacy/settings`, `/api/llm/config`, `/api/setup-docs*`, `/api/tracks/settings` |
 | マルチ | [multi.md](multi.md) | `/api/multi/*` |
+| 共有サーバ層 | [hub-social.md](hub-social.md) | `/api/social/*`, `/api/feed`, `/api/notifications*`, `/api/worklog*`, `/api/dig-rooms*` |
 | Push | [push.md](push.md) | `/api/push/*` |
 | Amazon Echo / Alexa | [alexa.md](alexa.md) | `/api/alexa/skill` |
 | 傾向 / ログ | [misc.md](misc.md) | `/api/trends/*`, `/api/events`, `/api/uptime`, `/api/recommendations*` |

--- a/spec/interface/hub-social.md
+++ b/spec/interface/hub-social.md
@@ -1,0 +1,282 @@
+# hub-social — 共有サーバ層の API 契約 (social / worklog / dig room)
+
+> 設計の全体像:
+> [`spec/feature/hub-social.md`](../feature/hub-social.md) (subject / コメント / いいね / フィード) /
+> [`hub-worklog.md`](../feature/hub-worklog.md) (実績) /
+> [`hub-dig-rooms.md`](../feature/hub-dig-rooms.md) (共同 dig)。
+> schema: [`spec/data/hub-social.md`](../data/hub-social.md)。
+> Hub 全体の入口は [`multi.md`](./multi.md)。
+
+## 0. 共通事項
+
+- **Hub 側 endpoint** はすべて Hub session 認証 (multi-hub §5.2 の Bearer token) 必須。
+  未認証は `401 { error: 'unauthorized' }`
+- **ローカル側 endpoint** は `:5180` 上。 Multi モード時は Hub の対応 endpoint に
+  proxy し、 Local モード時は §7 の縮退動作をする
+- 既存 `/api/data/*` (7 型 CRUD) は **変更しない**。 本書の endpoint はすべて追加
+- エラー形式は既存 Hub と同じ `{ error, code? }`。 レート超過は
+  `429 { error: 'rate_limited', retryAfter }`
+- ページングは `?limit=` (既定 50 / 最大 200) + `?cursor=` (opaque。
+  `created_at,id` の composite を base64)。 `{ items, nextCursor }` を返す
+- 時刻はすべて **UTC ISO 8601 文字列**でやり取りする (DB は TIMESTAMPTZ)
+
+## 1. subject 解決
+
+| method | path | req | res |
+|---|---|---|---|
+| POST | `/api/social/subjects/resolve` | `{ kind, key, title?, excerpt? }` | `{ subject }` |
+| GET | `/api/social/subjects/:id` | — | `{ subject }` |
+| GET | `/api/social/subjects?kind=&keys=` | — | `{ items: Subject[] }` (最大 100 key の一括解決) |
+| PATCH | `/api/social/subjects/:id` | `{ title?, excerpt? }` | `{ subject }` (moderator のみ) |
+| POST | `/api/social/subjects/:id/hide` | `{ reason }` | `{ ok }` (moderator) |
+
+- `resolve` は **get-or-create**。 既に別名 (`subject_aliases`) に一致すれば
+  既存 subject を返す
+- `key` はクライアントが正規化した値を送る。 サーバ側でも再正規化して
+  **一致しなければ `400 { error: 'key_not_canonical', canonical }`** を返す
+  (= ローカルとサーバの正規化実装のずれを検出する。 黙って直さない)
+- `GET /api/social/subjects?keys=` は一覧画面用。 「この 50 件のブクマにコメントが
+  何件あるか」 をまとめて取る
+
+```jsonc
+// Subject
+{
+  "id": "9f1c…", "kind": "bookmark",
+  "key": "https://example.com/article",
+  "title": "…", "excerpt": "…",
+  "commentCount": 4, "likeCount": 7, "participantCount": 3,
+  "lastActivityAt": "2026-07-30T02:11:00Z",
+  "liked": true,            // 呼び出しユーザが like 済か
+  "watching": true
+}
+```
+
+## 2. コメント
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/social/comments?subject=&author=&group=&anchored=` | — | `{ items: Comment[], nextCursor? }` |
+| GET | `/api/social/comments/:id` | — | `{ comment }` |
+| POST | `/api/social/comments` | `{ subjectId, bodyMd, parentCommentId?, anchor?, renditionId?, originLocalId? }` | `201 { comment }` |
+| PATCH | `/api/social/comments/:id` | `{ bodyMd }` | `{ comment }` (作者のみ) |
+| DELETE | `/api/social/comments/:id` | — | `{ ok }` (作者 / moderator。 soft delete) |
+| POST | `/api/social/comments/:id/hide` | `{ reason }` | `{ ok }` (moderator) |
+
+- `group=author` で「ユーザごとのコメント集合」 (= ローカル `note_comment_sets` 相当) を返す:
+  `{ groups: [{ author: { id, name }, comments: Comment[], updatedAt }] }`
+- `anchored=1` でアンカー付きのみ / `anchored=0` で subject 全体コメントのみ
+- `originLocalId` を送ると **冪等**。 同じ値で二度 POST しても 1 行しかできない
+  (`200 { comment, duplicate: true }` を返す)。 ローカル push のリトライ安全性のため
+- `parentCommentId` が既に親を持つコメントを指す場合 `400 { error: 'nested_reply' }`
+- アンカーが解決できない状態で作成された場合も `201`。 `anchorState: 'orphan'` が入る
+
+```jsonc
+// Comment
+{
+  "id": "3ab…", "subjectId": "9f1c…",
+  "author": { "id": "u_1", "name": "…" },
+  "parentCommentId": null,
+  "bodyMd": "ここの前提が変わってる",
+  "anchor": { "target": { "kind": "rendition", "renditionId": "…" },
+              "selectors": [ { "type": "TextQuote", "exact": "…", "prefix": "…", "suffix": "…" },
+                             { "type": "TextPosition", "start": 1840, "end": 1902 } ] },
+  "anchorState": "resolved",
+  "likeCount": 2, "liked": false,
+  "createdAt": "…", "editedAt": null, "deletedAt": null
+}
+```
+
+## 3. いいね (reaction)
+
+| method | path | req | res |
+|---|---|---|---|
+| POST | `/api/social/reactions` | `{ targetKind: 'subject'\|'comment', targetId, kind?: 'like' }` | `201 { ok, count }` |
+| DELETE | `/api/social/reactions` | `{ targetKind, targetId, kind?: 'like' }` | `{ ok, count }` |
+| GET | `/api/social/reactions?targetKind=&targetId=` | — | `{ items: [{ user, kind, createdAt }], count }` |
+
+- POST は冪等 (既に押していれば `200 { ok, count, already: true }`)
+- `kind` の allowlist はサーバ側定数。 v0.1 は `['like']`。 未知値は `400`
+
+## 4. rendition (記事本文)
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/social/renditions?subject=` | — | `{ items: Rendition[] }` (`captured_at` 降順) |
+| GET | `/api/social/renditions/:id` | — | `{ rendition }` (`textContent` 込み) |
+| POST | `/api/social/renditions` | `{ subjectId, textContent, outline?, extractor, capturedAt, htmlContent? }` | `201 { rendition }` |
+| POST | `/api/social/renditions/:id/hide` | `{ reason }` | `{ ok }` (moderator) |
+
+- `content_hash` はサーバが計算。 同 subject に同一 hash が既にあれば
+  `200 { rendition, duplicate: true }` (新規作成しない)
+- `htmlContent` はサーバ設定 `allow_html_rendition=false` のとき **無視して NULL 保存**
+  (`{ rendition, htmlIgnored: true }` を返す。 エラーにはしない)
+- `textContent` > 1 MiB は `413 { error: 'rendition_too_large' }`
+
+## 5. フィード / 通知 / watch
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/feed?sort=&kinds=&tags=&author=&since=&limit=&cursor=` | — | `{ items: FeedItem[], nextCursor? }` |
+| GET | `/api/notifications?unread=1&limit=` | — | `{ items, unreadCount }` |
+| POST | `/api/notifications/read` | `{ ids?: number[], all?: true }` | `{ ok, unreadCount }` |
+| POST | `/api/social/subjects/:id/watch` | — | `{ ok, watching: true }` |
+| DELETE | `/api/social/subjects/:id/watch` | — | `{ ok, watching: false }` |
+| POST | `/api/social/subjects/:id/mute` | — | `{ ok, muted: true }` |
+| DELETE | `/api/social/subjects/:id/mute` | — | `{ ok, muted: false }` |
+
+- `sort` = `active` (既定) / `new` / `liked` / `hot`
+- `kinds` はカンマ区切り (`bookmark,note,dig_room`)
+- ミュート済 subject はフィードから除外される (直接 GET は可)
+
+```jsonc
+// FeedItem
+{
+  "subject": { /* §1 の Subject */ },
+  "latestActivity": { "kind": "comment", "at": "…", "actor": { "id": "u_2", "name": "…" } },
+  "participants": [ { "id": "u_1", "name": "…" }, … ],   // 最大 5
+  "excerpt": "直近コメントの先頭 120 文字"
+}
+```
+
+## 6. worklog
+
+### 6.1 Hub 側
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/worklog?owner=&repo=&kinds=&from=&to=&rollup=` | — | `{ items: WorklogEntry[], nextCursor? }` |
+| POST | `/api/worklog/entries:batch` | `{ entries: WorklogEntryInput[], sharePolicy }` | `{ ok, upserted, skipped, ids }` |
+| DELETE | `/api/worklog/entries/:id` | — | `{ ok }` (owner / moderator) |
+| GET | `/api/worklog/digests?scopeKind=&scopeKey=&from=&to=&latestOnly=1` | — | `{ items: WorklogDigest[] }` |
+| POST | `/api/worklog/digests` | `{ scopeKind, scopeKey, periodStart, periodEnd, summaryMd, highlights?, metrics?, generatedBy }` | `201 { digest }` (`rev` はサーバが決める) |
+| GET | `/api/worklog/repos` | — | `{ items: [{ repoKey, repoAlias, entryCount, lastOccurredAt, owners[] }] }` |
+
+- `rollup=pr` (既定) — `parent_ref` を持つ commit を PR 行に畳んで返す。
+  `rollup=none` で全件
+- `entries:batch` は 1 リクエスト最大 500 件。 UNIQUE `(owner, repo_key, kind, ref)` で
+  upsert。 `sharePolicy` は各行の `share_policy` に記録される (監査用)
+- `entries:batch` は `redacted` かつ `repoAlias=false` の行を **拒否**する
+  (`400 { error: 'alias_required', refs: [...] }`)。 ゲートを Hub 側でも二重に張る
+
+### 6.2 ローカル側
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/worklog?...` | — | ローカル `worklog_entries` (共有前の全量) |
+| GET | `/api/worklog/sources` | — | `{ items: WorklogSource[] }` |
+| POST | `/api/worklog/sources` | `{ sourceKind, repoKey?, localPath?, alias?, sharePolicy?, llmOptout? }` | `201 { source }` |
+| PATCH | `/api/worklog/sources/:id` | 同上 (部分) | `{ source }` |
+| POST | `/api/worklog/ingest` | `{ sourceIds?: number[], full?: boolean }` | `202 { queued }` |
+| POST | `/api/worklog/redaction/check` | `{ sourceIds?: number[] }` | `{ ok, blocked: [{ entryId, field, term }] }` |
+| POST | `/api/worklog/push` | `{ sourceIds?: number[], dryRun?: boolean }` | `{ ok, pushed, blocked: [...] }` |
+| GET/POST | `/api/worklog/redaction/terms` | `{ term, origin }` | 禁止語辞書の CRUD |
+| POST | `/api/worklog/digests` | `{ scopeKind, scopeKey, periodStart, periodEnd, push?: boolean }` | `202 { queued }` (ローカル LLM で生成) |
+
+- `POST /api/worklog/push` は **必ず** redaction スキャンを通る。
+  1 件でも block があれば **push 全体を中止**し `409 { error: 'redaction_blocked', blocked }`
+- `dryRun=true` で「何が出るか」 の差分だけ返す (push しない)
+- `sharePolicy='none'` の source は push 対象から自動除外 (エラーにしない)
+
+## 7. dig room
+
+### 7.1 部屋
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/dig-rooms?state=&theme=&mine=1` | — | `{ items: DigRoom[], nextCursor? }` |
+| POST | `/api/dig-rooms` | `{ title, question, theme?, llmPolicy? }` | `201 { room }` |
+| GET | `/api/dig-rooms/:id` | — | `{ room, members, digest, board }` |
+| PATCH | `/api/dig-rooms/:id` | `{ title?, question?, state? }` | `{ room }` (作成者 / moderator) |
+| POST | `/api/dig-rooms/:id/join` | — | `{ ok, member }` |
+| DELETE | `/api/dig-rooms/:id/join` | — | `{ ok }` (leave) |
+
+`GET /api/dig-rooms/:id` の `board` が「無駄打ちを消す」 ためのブロック:
+
+```jsonc
+"board": {
+  "sources":       [ { "contributionId": "…", "url": "…", "title": "…", "quality": "primary", "by": {…}, "at": "…" } ],
+  "queries":       [ { "query": "…", "engine": "duckduckgo", "by": {…}, "at": "…", "hitCount": 12 } ],
+  "deadEnds":      [ { "text": "…", "by": {…} } ],
+  "openQuestions": [ { "contributionId": "…", "text": "…", "by": {…} } ],
+  "unreadSeq":     142        // 自分の last_seen_at 以降の contribution 数
+}
+```
+
+### 7.2 contribution
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/dig-rooms/:id/contributions?sinceSeq=&kinds=` | — | `{ items, maxSeq }` |
+| POST | `/api/dig-rooms/:id/contributions` | `{ kind, payload, targetContributionId? }` | `201 { contribution }` |
+| POST | `/api/dig-rooms/:id/seen` | `{ seq }` | `{ ok }` (`last_seen_at` 更新) |
+
+- `kind='source'` で既出 URL → `409 { error: 'duplicate_source', existing: { contributionId, by, at } }`
+- `kind='query'` で既出クエリと Jaccard ≥ 0.8 → `201 { contribution, warning: 'similar_query', similar: [...] }`
+  (通す。 止めない)
+- `kind='finding'` で `payload.sourceRefs` が空 → `400 { error: 'finding_requires_sources' }`
+- **UPDATE / DELETE は無い**。 取り消しは `kind='retract'` + `targetContributionId`
+
+### 7.3 digest と job
+
+| method | path | req | res |
+|---|---|---|---|
+| GET | `/api/dig-rooms/:id/digests` | — | `{ items: DigRoomDigest[] }` (rev 降順) |
+| POST | `/api/dig-rooms/:id/digests` | — | `202 { jobId }` (**生成はしない。 job を作るだけ**) |
+| GET | `/api/dig-rooms/jobs?state=queued` | — | `{ items: Job[] }` (自分がメンバーの room のみ) |
+| POST | `/api/dig-rooms/jobs/:jid/claim` | — | `{ job, input }` / `409 { error: 'already_claimed' }` |
+| POST | `/api/dig-rooms/jobs/:jid/complete` | `{ summaryMd, sources?, openQuestions?, deadEnds?, metrics?, coveredSeq, generatedBy }` | `201 { digest }` |
+| POST | `/api/dig-rooms/jobs/:jid/fail` | `{ error }` | `{ ok, willRetry }` |
+| POST | `/api/dig-rooms/jobs/:jid/heartbeat` | — | `{ ok, leaseExpiresAt }` (lease 延長) |
+
+- `claim` は `UPDATE ... WHERE state='queued' ... RETURNING` の 1 文で行い、
+  同時 claim は 1 人だけ成功する
+- `claim` の `input` に `fromSeq` 以降の contribution 全量 + 現行 digest が入る
+  (claim したローカルはそれを LLM に渡すだけでよい)
+- lease は 5 分。 `heartbeat` を打たないと `queued` に戻る。 3 回失敗で `failed`
+- room の `llm_policy` に反する claim は `403 { error: 'llm_policy_denied' }`
+
+### 7.4 ローカル側
+
+| method | path | req | res |
+|---|---|---|---|
+| POST | `/api/dig/:id/to-room` | `{ roomId? , title?, question? }` | `{ room, contribution }` (room 未指定なら新規作成 + `dig_import`) |
+| POST | `/api/dig-rooms/:id/import-local` | — | `{ digSessionId }` (最新 digest をローカル `dig_sessions` に落とす) |
+| POST | `/api/dig-rooms/:id/save-sources` | `{ contributionIds?: string[] }` | `{ savedBookmarkIds }` (source を自分のブクマに) |
+| GET | `/api/dig-rooms/worker/status` | — | `{ enabled, lastPollAt, claimed, completed, failed }` |
+
+## 8. Local モードでの縮退動作
+
+| endpoint | Local モードでの挙動 |
+|---|---|
+| `/api/social/subjects/resolve` | 接続済 Hub があれば **その Hub に問い合わせて件数だけ返す** (60 秒メモリキャッシュ)。 無ければ `{ subject: null }` |
+| `/api/social/comments` (GET) | ノートは自分のローカル `note_comments` を Comment 形に写して返す。 他 kind は `503 { error: 'local_only' }` |
+| `/api/social/comments` (POST) | ノートはローカル `note_comments` に書く (`remote_id=null`)。 他 kind は `503` |
+| `/api/social/reactions` | `503 { error: 'local_only' }` |
+| `/api/feed` / `/api/notifications` | `503 { error: 'local_only' }` |
+| `/api/worklog*` (ローカル分) | **通常動作** (取り込み・一覧・digest はローカルだけで完結する) |
+| `/api/worklog/push` | 接続済 Hub が無ければ `503 { error: 'no_hub' }` |
+| `/api/dig-rooms*` | `503 { error: 'local_only' }` (room は Hub 上のもの) |
+
+## 9. レート制限
+
+| endpoint | 制限 |
+|---|---|
+| `POST /api/social/comments` | 30 / 10 min / user |
+| `POST /api/social/reactions` | 300 / 10 min / user |
+| `POST /api/social/renditions` | 60 / hour / user |
+| `POST /api/worklog/entries:batch` | 20 / hour / user (1 回 500 件まで) |
+| `POST /api/dig-rooms/:id/contributions` | 120 / 10 min / user |
+| `POST /api/dig-rooms/:id/digests` | 6 / hour / room |
+| `GET /api/dig-rooms/jobs` | 120 / hour / user (= 30 秒間隔まで許容) |
+
+## 10. 管理
+
+| method | path | 権限 | 説明 |
+|---|---|---|---|
+| GET | `/api/social/admin/members` | admin | `hub_members` 一覧 |
+| PATCH | `/api/social/admin/members/:userId` | admin | `{ role?, disabled? }` |
+| POST | `/api/social/admin/recount` | admin | 非正規化カウンタの全再計算 |
+| GET | `/api/social/admin/url-rules` | member | `url_canonical_rules` 一覧 (ローカルが pull する) |
+| PUT | `/api/social/admin/url-rules/:host` | admin | ルール upsert |
+| GET | `/api/social/admin/settings` | admin | `{ allowHtmlRendition, maxSharePolicy, digestWorker }` |
+| PATCH | `/api/social/admin/settings` | admin | 同上の更新 |

--- a/spec/interface/hub-social.md
+++ b/spec/interface/hub-social.md
@@ -257,6 +257,29 @@
 | `/api/worklog/push` | 接続済 Hub が無ければ `503 { error: 'no_hub' }` |
 | `/api/dig-rooms*` | `503 { error: 'local_only' }` (room は Hub 上のもの) |
 
+## 8.5 公開の取り下げ (unshare)
+
+[feature §8.1](../feature/hub-social.md#81-公開の取り下げ-unshare) の 3 段階。
+
+| method | path | req | res |
+|---|---|---|---|
+| POST | `/api/social/unshare` | `{ targetKind, targetId, mode: 'hide'\|'unshare'\|'purge', reason? }` | `{ ok, mode, cascadeCounts? }` |
+| POST | `/api/social/unshare/restore` | `{ targetKind, targetId }` | `{ ok }` (`hide` の解除のみ。 `unshare` / `purge` は復元不可) |
+| GET | `/api/social/unshares?since=&mine=1` | — | `{ items: UnshareRecord[] }` (ローカルの `shared_at` 同期用) |
+| GET | `/api/social/admin/unshare-audit?limit=&targetKind=` | — | `{ items }` (moderator 以上) |
+
+- 権限: `hide` / `unshare` は **対象の持ち主本人 または moderator**、
+  `purge` は **admin のみ**。 不足時は `403 { error: 'forbidden', required: 'admin' }`
+- `mode='purge'` は破壊的なので `?confirm=<subjectKey>` を必須にする。
+  一致しなければ `400 { error: 'confirm_mismatch' }`
+- `unshare` の対象が共有 7 型の行のときは Hub 行を削除し、
+  レスポンスに `{ localHint: { table, ownerRowKey } }` を返す。 ローカルは
+  それを見て自分の `shared_at` / `shared_origin` を NULL に戻す
+- `purge` のレスポンス `cascadeCounts` は消えた件数
+  (`{ comments, reactions, renditions }`)。 `unshare_audit` にも同じ値が残る
+- `GET /api/social/unshares?mine=1` はローカルの定期同期が使う。
+  `since` は前回取得時刻 (`unshare_audit.created_at`)
+
 ## 9. レート制限
 
 | endpoint | 制限 |
@@ -268,6 +291,7 @@
 | `POST /api/dig-rooms/:id/contributions` | 120 / 10 min / user |
 | `POST /api/dig-rooms/:id/digests` | 6 / hour / room |
 | `GET /api/dig-rooms/jobs` | 120 / hour / user (= 30 秒間隔まで許容) |
+| `POST /api/social/unshare` | 60 / hour / user (`purge` は 10 / hour / admin) |
 
 ## 10. 管理
 


### PR DESCRIPTION
## 目的

Memoria Hub を「共有 7 型の置き場」 から **共同ナレッジサーバ** に上げるための設計を揃える。
やりたいこと 6 点に対応する。

| 要件 | 設計 |
|---|---|
| ノート (AI ノート含む) 共有 | 既存 `/api/data/notes` で動いている。 note UUID がそのまま subject key になる |
| ブックマーク共有 | 既存 `/api/data/bookmarks` + **canonical URL 正規化**で同一性を取る |
| ブックマーク / 記事本文にコメント | `subjects` + `comments` + anchor (多重セレクタ) + `bookmark_renditions` |
| いいね | `reactions` (subject / comment 両対応、 カウンタは DB トリガ維持) |
| GitHub / ローカルを食わせて過去やった事をリストアップし共有 | `hub-worklog.md` (取り込み → 畳み込み → 期間まとめ → ポリシー付き共有) |
| みんなでディグれる | `hub-dig-rooms.md` (append-only contribution + rev 付き収束まとめ) |

## いちばん重要な設計判断

現状の共有は「ローカル行を Hub に push copy する」 モデルで、 Hub 側の行は
`BIGSERIAL id` + `owner_user_id` を持つ **持ち主付きコピー**。 同じ URL を 3 人が
シェアすると 3 行になるので、 このまま `comment.bookmark_id` を足すと
**同じ記事についての議論が 3 つに割れる**。 いいねも 3 分割される。

→ 社会層は「持ち主付きコピー」 ではなく **話題 (subject)** に紐づける。
`subjects(kind, key)` を導入し、 ブックマークは **canonical URL** を key にする
(正規化は `server/shared/canonical-url.ts` にローカル / Hub 共通実装)。

既存の `/api/data/*` と 7 型テーブルは **変更しない**。 `bookmarks` への
`url_canonical` 列追加のみ (`IF NOT EXISTS`、 起動時バックフィル)。

## 追加ファイル

- `spec/feature/hub-social.md` — subject / コメント / いいね / フィード / 通知。
  記事本文の共有方式は 3 案比較して **抽出本文 (text) のみ保持**を v0.1 に採用
  (HTML スナップショットは opt-in 拡張。 第三者ページの複製を共有サーバに置く判断を
  拠点ポリシーで切れるようにする)
- `spec/feature/hub-worklog.md` — GitHub / ローカル git clone / `activity_events` /
  `implementation_notes` から取り込み、 PR 単位に畳んで一覧・期間まとめ化。
  **共有ゲートが本命**: 既定 `none` / repo 単位 opt-in / `redacted` は alias 必須 /
  push 前に禁止語スキャンして 1 件 hit で push 全体中止 (自動書き換えはしない)
- `spec/feature/hub-dig-rooms.md` — 共同 dig。 `source` / `finding` / `dead_end` /
  `question` の append-only contribution。 **無駄打ちを消す**のが価値なので、
  既出 source / 既出 query / dead_end を部屋を開いた時点で必ず見せ、
  重複 source 投稿は 409 で弾く。 まとめ生成は Hub に LLM creds を置かず job claim で
  各自のローカルに回す (3 案比較)
- `spec/data/hub-social.md` — Hub Postgres (migration 008-010) + ローカル SQLite 追加分
- `spec/interface/hub-social.md` — API 契約 + **Local モードの縮退動作** + レート制限

## 変更ファイル

- `spec/feature/multi-hub.md` — Hub の役割マップ (データハブ / 社会層 / 横断集約 /
  frontend shell) と「Hub ネイティブなデータ型」 の節を追加。 社会層のフェーズは各設計書へ委譲
- `spec/{README,data/README,feature/README,interface/README}.md` — index 更新

## プライバシー方針 (変えていない点)

- 個人ログ (diary / GPS / meals / visits / activity) は subject 化しない。 kind として存在しない
- 社会層は Hub 専用。 **他人のコメント / いいねをローカル SQLite に永続化しない**
  (双方向同期エンジンを作らない = conflict 解決を持ち込まない)
- LLM creds も GitHub token も Hub に置かない。 取り込み / 要約はローカルで実行
- worklog は既定非共有。 private repo 名 / 顧客名の漏洩は機械スキャンで止める

## この PR に含まれないもの

設計のみ。 実装 / migration SQL / コードは含まない。 未決の論点は各設計書の
「オープン論点」 節に残してある (特に: 拠点内の部分公開が要るか、
AI ノートの外部取り込み経路 (Notion → Memoria) の方向、 rendition の保持期間)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dr6Z75fcMvFDziCVFSD8KX
